### PR TITLE
CI: dedupe PR checks + fix sketch naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,9 @@ name: CI
 on:
   push:
     branches:
-      - main
       - master
-      - develop
   pull_request:
     branches:
-      - main
       - master
       - develop
   workflow_dispatch:
@@ -48,9 +45,9 @@ jobs:
     timeout-minutes: 30
     needs: qc
     if: >
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'pull_request' && github.base_ref == 'main') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+      (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'master') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master')
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/doc/RELEASE_STRATEGY.md
+++ b/doc/RELEASE_STRATEGY.md
@@ -15,26 +15,26 @@ We follow [Semantic Versioning](https://semver.org/):
 We follow the **Git Flow** branching model.
 
 ### Branch Roles
-- **`main`**: Production-ready code. Represents the latest stable release.
+- **`master`**: Production-ready code. Represents the latest stable release.
 - **`develop`**: Integration branch for the next release. Contains the latest development changes.
 - **`feature/*`**: Feature branches branched from `develop` and merged back into `develop`.
-- **`release/*`**: Release branches branched from `develop` for preparing a new production release. Merged into both `main` and `develop`.
-- **`hotfix/*`**: Hotfix branches branched from `main` for critical bug fixes. Merged into both `main` and `develop`.
+- **`release/*`**: Release branches branched from `develop` for preparing a new production release. Merged into both `master` and `develop`.
+- **`hotfix/*`**: Hotfix branches branched from `master` for critical bug fixes. Merged into both `master` and `develop`.
 
 ### Branch Protection Rules
 
-To ensure code quality and stability, direct pushes to `main` and `develop` are **disabled**.
+To ensure code quality and stability, direct pushes to `master` are **disabled**.
 
-#### `main` Branch
+#### `master` Branch
 - **No direct pushes allowed.**
 - **Pull Request Required**:
-  - Must pass all status checks (CI/Build/Tests).
-  - Requires at least **1** approving review.
+  - Must pass required status checks: **`CI / qc`** and **`CI / e2e`**.
+  - Approving reviews required: **0** (solo maintainer workflow).
 
 #### `develop` Branch
-- **No direct pushes allowed.**
-- **Pull Request Required**:
-  - CI checks are recommended but optional.
+- Direct pushes are allowed.
+- Pull Requests are recommended for larger changes:
+  - CI checks run on PRs into `develop`.
 
 ## Release Checklist
 
@@ -197,11 +197,11 @@ This script will:
 
 For critical bugs requiring immediate patching:
 
-1. Create hotfix branch from `main`: `git checkout -b hotfix/v0.x.1`
+1. Create hotfix branch from `master`: `git checkout -b hotfix/v0.x.1`
 2. Fix the bug with minimal changes
 3. Update `CHANGELOG.md` with patch notes
 4. Bump patch version in `package.json`
-5. Merge to `main` and tag immediately
+5. Merge to `master` and tag immediately
 6. Deploy ASAP
 7. Backport fix to `develop` if using gitflow
 

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -18,7 +18,7 @@
 - [x] **Keyboard Shortcuts**: Added CAD-style tool hotkeys and Undo/Redo (Ctrl/Cmd+Z, Ctrl/Cmd+Shift+Z / Ctrl/Cmd+Y) with “don’t trigger while typing” guards.
 - [x] **Preference Persistence**: Persist view modes and sketch visibility across reloads.
 - [x] **QC Gate**: Added `npm run qc` / `npm run qc:full` and wired into release automation.
-- [x] **CI Enforcement**: CI runs `qc` + Build, runs Playwright E2E on `main`, and uploads Playwright reports/traces.
+- [x] **CI Enforcement**: CI runs `qc` + Build on PRs, runs Playwright E2E only on `master`, uploads Playwright reports/traces, and avoids duplicate push+PR runs.
 
 ### v0.1-0.4: Foundation & CAD Visualization
 - [x] Workbench layout system (Header, SidePanel, Workspace)

--- a/src/context/GeometryContext.tsx
+++ b/src/context/GeometryContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useMemo, useState, useEffect, type ReactNode } from 'react';
 import { GeometryEngine, type GeometryResult, type SketchGeometry } from '../lib/geometryEngine';
+import { getSketchVariablesAST } from '../lib/ast';
 
 export interface GeometryContextType {
     geometries: GeometryResult[];
@@ -65,7 +66,28 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
             try {
                 const result = await engine.executeCode(code);
                 setGeometries(result.geometries);
-                setSketchesGeometries(result.sketches);
+                const sketchVarNames = (() => {
+                    try {
+                        return getSketchVariablesAST(code);
+                    } catch {
+                        return [];
+                    }
+                })();
+
+                // Worker assigns tracked sketch ids like `sketch-${index}-${Date.now()}`.
+                // Remap those names to the real variable names from user code so viewport
+                // selection can drive feature dialogs (extrude/revolve) correctly.
+                const remappedSketches = result.sketches.map((s) => {
+                    const m = /^sketch-(\d+)-/.exec(s.id);
+                    if (!m) return s;
+                    const idx = Number(m[1]);
+                    const name = sketchVarNames[idx];
+                    if (!name) return s;
+                    if (s.name === name) return s;
+                    return { ...s, name };
+                });
+
+                setSketchesGeometries(remappedSketches);
                 setError(null);
             } catch (err: unknown) {
                 console.error(err);
@@ -98,7 +120,25 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
         try {
             const result = await engine.executeCode(codeToExecute);
             setGeometries(result.geometries);
-            setSketchesGeometries(result.sketches);
+            const sketchVarNames = (() => {
+                try {
+                    return getSketchVariablesAST(codeToExecute);
+                } catch {
+                    return [];
+                }
+            })();
+
+            const remappedSketches = result.sketches.map((s) => {
+                const m = /^sketch-(\d+)-/.exec(s.id);
+                if (!m) return s;
+                const idx = Number(m[1]);
+                const name = sketchVarNames[idx];
+                if (!name) return s;
+                if (s.name === name) return s;
+                return { ...s, name };
+            });
+
+            setSketchesGeometries(remappedSketches);
             setError(null);
         } catch (err: unknown) {
             setError(err instanceof Error ? err.message : String(err));

--- a/tests/extrude_from_code_sketch.spec.ts
+++ b/tests/extrude_from_code_sketch.spec.ts
@@ -88,6 +88,10 @@ return replicad.makeBox(10, 10, 10);
         await page.evaluate((c) => (window as any).setCode?.(c), code);
         await waitForStability(page, count);
 
+        // Regression guard: worker sketch geometry names should match code variable names.
+        const sketchNames = await page.evaluate(() => ((window as any).getSketches?.() || []).map((s: any) => s.name));
+        expect(sketchNames).toContain('sketch');
+
         // Select the sketch via test hook (mirrors clicking the sketch in the viewport).
         await page.evaluate(() => (window as any).__TEST_SELECT_SKETCH?.('sketch'));
 


### PR DESCRIPTION
Stops duplicate CI runs on develop->master PRs by removing develop from push triggers; runs Playwright E2E only when targeting/pushing to master; remaps worker sketch names to code variable names so viewport selection drives dialogs; aligns docs (branch naming + CI notes).