### PR TITLE
Tooltips: show shortcut hints

### DIFF
--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -55,7 +55,7 @@
 ### 1.3 UI/UX Polish
 - [ ] **Icon Redesign**: Replace current icons with professional, consistent icon set (e.g., Lucide, Heroicons).
 - [ ] **Visual Hierarchy**: Improve toolbar and panel layouts for better usability.
-- [ ] **Tooltips**: Add comprehensive tooltips for all tools and features.
+- [x] **Tooltips**: Add comprehensive tooltips for tools/features (including keyboard shortcut hints).
 - [x] **Keyboard Shortcuts**: Industry-standard shortcuts (E/S/P + R/F/C + J/X/I + Undo/Redo) with typing-safe guards.
 
 ---

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -1,6 +1,7 @@
 import { useWorkbench } from '../../context/WorkbenchContext';
 import { Loader2, Download, FileDown, Code, Monitor, Undo2, Redo2, Box, Grid as GridIcon, Circle } from 'lucide-react';
 import { exportSTEP, exportSTL } from '../../lib/geometryEngine';
+import { formatTooltip, SHORTCUT_HINTS } from '../../constants/shortcuts';
 
 export function Header() {
     const { viewMode, setViewMode, viewMode3D, setViewMode3D, isComputing, code, commandManager } = useWorkbench();
@@ -83,22 +84,24 @@ export function Header() {
 
                 <div className="h-6 w-px bg-[#333] mx-2" />
 
-                <button
-                    onClick={() => commandManager.undo()}
-                    disabled={!commandManager.canUndo}
-                    className={`p-1 rounded transition-colors ${!commandManager.canUndo ? 'text-gray-600 cursor-not-allowed' : 'text-gray-400 hover:text-white hover:bg-[#333]'}`}
-                    title="Undo"
-                >
-                    <Undo2 className="w-4 h-4" />
-                </button>
-                <button
-                    onClick={() => commandManager.redo()}
-                    disabled={!commandManager.canRedo}
-                    className={`p-1 rounded transition-colors ${!commandManager.canRedo ? 'text-gray-600 cursor-not-allowed' : 'text-gray-400 hover:text-white hover:bg-[#333]'}`}
-                    title="Redo"
-                >
-                    <Redo2 className="w-4 h-4" />
-                </button>
+                    <button
+                        onClick={() => commandManager.undo()}
+                        disabled={!commandManager.canUndo}
+                        className={`p-1 rounded transition-colors ${!commandManager.canUndo ? 'text-gray-600 cursor-not-allowed' : 'text-gray-400 hover:text-white hover:bg-[#333]'}`}
+                        aria-label="Undo"
+                        title={formatTooltip('Undo', SHORTCUT_HINTS.undo)}
+                    >
+                        <Undo2 className="w-4 h-4" />
+                    </button>
+                    <button
+                        onClick={() => commandManager.redo()}
+                        disabled={!commandManager.canRedo}
+                        className={`p-1 rounded transition-colors ${!commandManager.canRedo ? 'text-gray-600 cursor-not-allowed' : 'text-gray-400 hover:text-white hover:bg-[#333]'}`}
+                        aria-label="Redo"
+                        title={formatTooltip('Redo', SHORTCUT_HINTS.redo)}
+                    >
+                        <Redo2 className="w-4 h-4" />
+                    </button>
 
                 <div className="h-6 w-px bg-[#333] mx-2" />
 
@@ -107,6 +110,7 @@ export function Header() {
                     disabled={isComputing}
                     className="p-1 hover:bg-[#333] rounded text-gray-400 hover:text-white transition-colors"
                     title="Export STEP"
+                    aria-label="Export STEP"
                 >
                     <FileDown className="w-4 h-4" />
                 </button>
@@ -115,6 +119,7 @@ export function Header() {
                     disabled={isComputing}
                     className="p-1 hover:bg-[#333] rounded text-gray-400 hover:text-white transition-colors"
                     title="Export STL"
+                    aria-label="Export STL"
                 >
                     <Download className="w-4 h-4" />
                 </button>

--- a/src/components/Toolbar.test.tsx
+++ b/src/components/Toolbar.test.tsx
@@ -71,15 +71,15 @@ describe('Toolbar', () => {
         const onToolClick = vi.fn();
         render(<Toolbar features={mockFeatures} onToolClick={onToolClick} />);
 
-        expect(screen.getByTitle('Box')).toBeDefined();
-        expect(screen.getByTitle('Fillet')).toBeDefined();
+        expect(screen.getByRole('button', { name: 'Box' })).toBeDefined();
+        expect(screen.getByRole('button', { name: 'Fillet' })).toBeDefined();
     });
 
     it('should call onToolClick with feature object', () => {
         const onToolClick = vi.fn();
         render(<Toolbar features={mockFeatures} onToolClick={onToolClick} />);
 
-        fireEvent.click(screen.getByTitle('Box'));
+        fireEvent.click(screen.getByRole('button', { name: 'Box' }));
         expect(onToolClick).toHaveBeenCalledWith(mockFeatures[0]);
     });
     it('should call setSketchMode when Sketch button clicked with selected face', () => {
@@ -142,9 +142,7 @@ describe('Toolbar', () => {
 
         render(<Toolbar features={mockFeatures} onToolClick={vi.fn()} />);
 
-        // Find sketch button (PenTool icon)
-        // Lucide icons usually don't have text, but we added title attribute "Sketch on Selected Face"
-        const sketchBtn = screen.getByTitle('Sketch on Selected Face');
+        const sketchBtn = screen.getByLabelText('Sketch');
         fireEvent.click(sketchBtn);
 
         expect(setSketchMode).toHaveBeenCalledWith(expect.objectContaining({

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,6 +1,7 @@
 import { PenTool, ArrowUpFromLine, Eye, EyeOff } from 'lucide-react';
 import { type Feature } from '../features/types';
 import { useWorkbench } from '../context/WorkbenchContext';
+import { FEATURE_SHORTCUTS, formatTooltip, SHORTCUT_HINTS } from '../constants/shortcuts';
 
 interface ToolbarProps {
     features: Feature[];
@@ -62,7 +63,12 @@ export default function Toolbar({ features, onToolClick }: ToolbarProps) {
             <button
                 onClick={handleSketchClick}
                 className="p-2 rounded hover:bg-[#333] text-gray-400 hover:text-white transition-colors"
-                title={selectedFace ? "Sketch on Selected Face" : "Start Sketch (Select Plane)"}
+                aria-label="Sketch"
+                title={
+                    selectedFace
+                        ? formatTooltip('Sketch on Face', SHORTCUT_HINTS.sketch, 'Create a sketch on the selected face')
+                        : formatTooltip('Sketch', SHORTCUT_HINTS.sketch, 'Start a sketch by selecting a plane (or a face)')
+                }
             >
                 <PenTool size={20} className={selectedFace ? "text-blue-400" : ""} />
             </button>
@@ -71,6 +77,7 @@ export default function Toolbar({ features, onToolClick }: ToolbarProps) {
             <button
                 onClick={toggleSketchVisibility}
                 className={`p-2 rounded hover:bg-[#333] transition-colors ${showSketches ? 'text-blue-400' : 'text-gray-500'}`}
+                aria-label="Sketch Visibility"
                 title={showSketches ? "Hide Sketches" : "Show Sketches"}
             >
                 {showSketches ? <Eye size={20} /> : <EyeOff size={20} />}
@@ -86,7 +93,8 @@ export default function Toolbar({ features, onToolClick }: ToolbarProps) {
                             if (feature) onToolClick(feature);
                         }}
                         className="p-2 rounded bg-blue-600/20 hover:bg-blue-600/40 text-blue-400 hover:text-blue-300 transition-colors mt-1"
-                        title="Extrude Selected Face"
+                        aria-label="Extrude Face"
+                        title={formatTooltip('Extrude Face', SHORTCUT_HINTS.extrude, 'Extrude the selected face')}
                     >
                         <ArrowUpFromLine size={20} />
                     </button>
@@ -104,7 +112,8 @@ export default function Toolbar({ features, onToolClick }: ToolbarProps) {
                             key={feature.id}
                             onClick={() => onToolClick(feature)}
                             className="p-2 rounded hover:bg-[#333] text-gray-400 hover:text-white transition-colors"
-                            title={feature.label}
+                            aria-label={feature.label}
+                            title={formatTooltip(feature.label, FEATURE_SHORTCUTS[feature.id], feature.description)}
                         >
                             <feature.icon size={20} />
                         </button>
@@ -121,7 +130,8 @@ export default function Toolbar({ features, onToolClick }: ToolbarProps) {
                             key={feature.id}
                             onClick={() => onToolClick(feature)}
                             className="p-2 rounded hover:bg-[#333] text-gray-400 hover:text-white transition-colors"
-                            title={feature.label}
+                            aria-label={feature.label}
+                            title={formatTooltip(feature.label, FEATURE_SHORTCUTS[feature.id], feature.description)}
                         >
                             <feature.icon size={20} />
                         </button>
@@ -138,7 +148,8 @@ export default function Toolbar({ features, onToolClick }: ToolbarProps) {
                             key={feature.id}
                             onClick={() => onToolClick(feature)}
                             className="p-2 rounded hover:bg-[#333] text-gray-400 hover:text-white transition-colors"
-                            title={feature.label}
+                            aria-label={feature.label}
+                            title={formatTooltip(feature.label, FEATURE_SHORTCUTS[feature.id], feature.description)}
                         >
                             <feature.icon size={20} />
                         </button>

--- a/src/constants/shortcuts.ts
+++ b/src/constants/shortcuts.ts
@@ -1,0 +1,31 @@
+export const SHORTCUT_HINTS = {
+    sketch: 'S',
+    extrude: 'E',
+    revolve: 'R',
+    fillet: 'F',
+    chamfer: 'C',
+    union: 'J',
+    cut: 'X',
+    intersect: 'I',
+    offsetPlane: 'P',
+    undo: 'Ctrl/Cmd+Z',
+    redo: 'Ctrl/Cmd+Shift+Z / Ctrl/Cmd+Y',
+} as const;
+
+export const FEATURE_SHORTCUTS: Record<string, string | undefined> = {
+    extrude: SHORTCUT_HINTS.extrude,
+    extrudeFromFace: SHORTCUT_HINTS.extrude,
+    revolve: SHORTCUT_HINTS.revolve,
+    fillet: SHORTCUT_HINTS.fillet,
+    chamfer: SHORTCUT_HINTS.chamfer,
+    union: SHORTCUT_HINTS.union,
+    cut: SHORTCUT_HINTS.cut,
+    intersect: SHORTCUT_HINTS.intersect,
+    offsetPlane: SHORTCUT_HINTS.offsetPlane,
+};
+
+export function formatTooltip(label: string, shortcutHint?: string, description?: string): string {
+    const firstLine = shortcutHint ? `${label} (${shortcutHint})` : label;
+    return description ? `${firstLine}\n${description}` : firstLine;
+}
+

--- a/tests/tooltips_shortcuts.spec.ts
+++ b/tests/tooltips_shortcuts.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test('tooltips include keyboard shortcuts', async ({ page }) => {
+    await page.goto('/');
+
+    await page.waitForSelector('canvas', { timeout: 20000 });
+    await page.waitForFunction(() => (window as any).isEditorReady === true, { timeout: 30000 });
+
+    const sketchTitle = await page.getByRole('button', { name: 'Sketch', exact: true }).getAttribute('title');
+    expect(sketchTitle).toContain('(S)');
+
+    const extrudeTitle = await page.getByRole('button', { name: 'Extrude' }).getAttribute('title');
+    expect(extrudeTitle).toContain('(E)');
+
+    const constructionPlaneTitle = await page.getByRole('button', { name: 'Construction Plane' }).getAttribute('title');
+    expect(constructionPlaneTitle).toContain('(P)');
+
+    const undoTitle = await page.getByRole('button', { name: 'Undo' }).getAttribute('title');
+    expect(undoTitle).toContain('Ctrl/Cmd+Z');
+
+    const redoTitle = await page.getByRole('button', { name: 'Redo' }).getAttribute('title');
+    expect(redoTitle).toContain('Ctrl/Cmd+Shift+Z');
+});


### PR DESCRIPTION
Implements the ROADMAP Tooltips item.

- Adds consistent tooltip titles that include keyboard shortcuts (e.g. Extrude (E), Undo (Ctrl/Cmd+Z)).
- Adds aria-labels to icon-only buttons for better accessibility and testability.
- Adds Playwright coverage: `tests/tooltips_shortcuts.spec.ts`.
- Marks Tooltips as completed in `doc/ROADMAP.md`.