### PR TITLE
refactor: stabilize sketch/history flow and id-based scene operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ kernelCAD consists of three main parts:
 ### Documentation Index
 
 - **[Architecture](./doc/ARCHITECTURE.md)**: High-level system design and component overview.
+- **[Refactoring Analysis](./doc/REFACTORING_ANALYSIS.md)**: Root-cause flow/logic gaps and staged refactor plan.
+- **[CAD Engineering Standards](./doc/CAD_ENGINEERING_STANDARDS.md)**: Best-in-class CAD practices translated into kernelCAD implementation standards.
 - **[Implementation Details](./doc/IMPLEMENTATION_DETAILS.md)**: Deep dive into the Visual Feedback System, Solver, and Code Generation.
 - **[Interfaces & APIs](./doc/INTERFACES.md)**: Detailed API references for Extensibility.
 - **[Roadmap](./doc/ROADMAP.md)**: Future plans and current status.

--- a/doc/CAD_ENGINEERING_STANDARDS.md
+++ b/doc/CAD_ENGINEERING_STANDARDS.md
@@ -1,0 +1,152 @@
+# CAD Engineering Standards
+
+## Purpose
+This document defines the engineering standards kernelCAD should follow to align with best-in-class CAD systems (Onshape, Fusion 360, NX, CATIA, SolidWorks, Creo).
+
+These are implementation standards, not product marketing goals.
+
+---
+
+## 1. Stable Geometric References
+
+### Standard
+- Never rely on volatile face/edge indices as long-term references.
+- Every downstream operation must reference:
+  - a stable selector, or
+  - explicit datum geometry (plane/axis/csys), or
+  - a persisted topological reference ID with repair strategy.
+
+### Required in kernelCAD
+- Treat `faceId` as ephemeral runtime data only.
+- Convert interactive face picks into stable references before commit.
+- Centralize reference generation in one service.
+
+---
+
+## 2. Transactional Modeling Operations
+
+### Standard
+Every modeling operation must be atomic:
+1. Build operation intent
+2. Validate/preflight
+3. Commit or reject as a unit
+
+No partial writes to source-of-truth model code/state.
+
+### Required in kernelCAD
+- Single mutation pipeline for all model code writes.
+- Parse/validate before commit.
+- Reject invalid mutation without modifying current model.
+
+---
+
+## 3. First-Class History Model
+
+### Standard
+Feature history must be authoritative and editable:
+- stable operation IDs
+- dependencies
+- ordered replay
+- suppress/reorder/delete support
+
+### Required in kernelCAD
+- Replace regex-based history extraction with AST-backed operation graph.
+- Delete/rename/reorder must target operation IDs, not fuzzy text matches.
+
+---
+
+## 4. Deterministic Regeneration
+
+### Standard
+Given the same inputs and feature order, regeneration must produce equivalent output and diagnostics.
+
+### Required in kernelCAD
+- One replay path for model evaluation.
+- Explicit dependency ordering.
+- Structured failure diagnostics (operation ID + reason + affected references).
+
+---
+
+## 5. Sketching Discipline
+
+### Standard
+- Constraint state must be explicit (under/fully/over constrained).
+- Sketch plane basis must be deterministic.
+- Commit must preserve WYSIWYG mapping from sketch canvas to 3D result.
+
+### Required in kernelCAD
+- Single plane/basis derivation service for all sketch entry points.
+- No duplicated xDir/origin derivation logic in UI components.
+
+---
+
+## 6. Selection & Command Semantics
+
+### Standard
+- Selection model must be explicit and typed (body/face/edge/sketch/vertex).
+- Keyboard shortcuts and editor input must never conflict on destructive actions.
+
+### Required in kernelCAD
+- Central key-routing policy with capture/consumption rules.
+- Destructive commands must be blocked in text-edit context unless explicitly intended.
+
+---
+
+## 7. Persistence Safety
+
+### Standard
+- Invalid model state must never be persisted as canonical project state.
+- Recovery from corrupted session must be deterministic.
+
+### Required in kernelCAD
+- Save only parse-valid model code.
+- On load failure, recover to last valid/default state with explicit notice.
+
+---
+
+## 8. Test Strategy for CAD Reliability
+
+### Standard
+Test pyramid must include:
+- unit tests for AST transforms/reference logic
+- integration tests for command and history flow
+- scenario tests for regressions (reload + autosave + delete + regenerate)
+
+### Required in kernelCAD
+- Add regression suites around:
+  - history delete after reload
+  - sketch on face stability after model change
+  - keyboard delete vs editor focus conflicts
+  - persistence/load recovery correctness
+
+---
+
+## 9. Implementation Rules (Do/Don’t)
+
+### Do
+- Use one authoritative service per domain boundary (mutation, references, history).
+- Prefer IDs and structured metadata over text heuristics.
+- Fail closed: keep prior valid state when mutation fails.
+
+### Don’t
+- Don’t mutate model code from multiple ad-hoc pathways.
+- Don’t use regex parsing for destructive history operations.
+- Don’t duplicate geometry/reference logic across UI entry points.
+
+---
+
+## 10. Adoption Plan
+
+### Phase 1: Safety
+- Enforce single code commit gate.
+- Remove non-transactional destructive mutations.
+
+### Phase 2: History
+- Introduce AST-backed operation model with stable IDs.
+
+### Phase 3: References
+- Centralize stable reference generation and repair.
+
+### Phase 4: Hardening
+- Expand regression scenarios and telemetry for command failures.
+

--- a/doc/REFACTORING_ANALYSIS.md
+++ b/doc/REFACTORING_ANALYSIS.md
@@ -1,0 +1,177 @@
+# Refactoring Analysis: Flow & Architecture Gaps
+
+## Scope
+This document captures the architecture and flow issues discovered while debugging sketch placement, deletion corruption, and reload/persistence regressions.
+
+It focuses on:
+- code mutation flow
+- history model and deletion logic
+- keyboard event routing
+- sketch plane/reference consistency
+- context boundaries and execution lifecycle
+
+See also: [CAD Engineering Standards](./CAD_ENGINEERING_STANDARDS.md) for target implementation standards.
+
+---
+
+## Executive Summary
+The main systemic issue is **lack of a single transactional code mutation boundary**.
+
+Code is currently changed through multiple pathways with different guarantees (AST mutation, editor text insertion, direct `setCode`), while downstream systems (history extraction, geometry execution, persistence) assume stable/valid code.
+
+This mismatch creates brittle behavior in edge cases, especially around sketch history deletion and reload.
+
+---
+
+## Critical Findings
+
+### F1. Multiple code mutation paths with inconsistent guarantees
+- `CodeContext.insertCode` appends text directly.
+- `useCodeInsertion` may use `InsertShapeCommand` (AST) or direct editor edits.
+- Other flows call `setCode` directly.
+
+Because these do not share one commit gate, invariants (parseability, return mapping, declaration consistency) can be violated.
+
+Refs:
+- `src/context/CodeContext.tsx`
+- `src/hooks/useCodeInsertion.ts`
+- `src/lib/ast.ts`
+
+### F2. History model is regex-based, but deletion is destructive
+History items come from line-based regex extraction (`extractVariables`), not from AST entity identity.
+That model is then used to perform destructive delete operations, causing ambiguity for multiline or transformed declarations.
+
+Refs:
+- `src/lib/codeAnalysis.ts`
+- `src/components/SceneBrowser.tsx`
+- `src/components/Layout/SidePanel.tsx`
+- `src/context/CodeContext.tsx`
+
+### F3. Delete pipeline contains fallback heuristics instead of one deterministic command
+Current delete tries multiple strategies and selects the first parseable result.
+This is useful as a guardrail but indicates the primary command is not yet authoritative.
+
+Refs:
+- `src/context/CodeContext.tsx`
+- `src/lib/ast.ts`
+
+### F4. Keyboard Delete/Backspace routing intersects editor behavior
+Global shortcuts were able to overlap with editor key handling in some states.
+This can produce unexpected text edits while app-level delete also executes.
+
+Refs:
+- `src/hooks/useKeyboardShortcuts.ts`
+- `src/components/Layout/WorkbenchLayout.tsx`
+
+### F5. Sketch plane construction logic duplicated in multiple places
+Plane/xDir derivation for face sketching exists in more than one component/hook.
+This invites drift and inconsistent behavior.
+
+Refs:
+- `src/hooks/useFaceSelection.ts`
+- `src/components/Toolbar.tsx`
+- `src/components/Layout/WorkbenchLayout.tsx`
+
+### F6. Geometry execution loop is not centrally parse-gated
+`GeometryContext` executes code on debounce and handles errors reactively.
+App-level persistence introduced parse gating, but execution remains largely optimistic.
+
+Refs:
+- `src/context/GeometryContext.tsx`
+- `src/App.tsx`
+
+---
+
+## Root Cause Pattern
+**Representation mismatch**:
+1. UI history uses heuristic declaration extraction.
+2. Core code mutation requires AST-precise semantics.
+3. Execution/persistence assume validity.
+
+When these representations diverge, bug fixes become local patches rather than durable system behavior.
+
+---
+
+## Target Architecture (Refactor Direction)
+
+### 1) Introduce a single Code Transaction Boundary
+All code writes go through one service:
+- input: mutation intent/command
+- process: AST transform
+- validate: parse + structural constraints
+- commit: `setCode`
+- emit: mutation event metadata
+
+No direct editor text mutations for modeling operations.
+
+### 2) Replace regex history extraction with AST scene graph
+Generate history items from AST with stable IDs:
+- declaration ID
+- node location
+- dependencies
+- operation kind
+
+Use these IDs for selection, rename, delete, reorder (future).
+
+### 3) Deterministic delete command (ID-based)
+Delete by AST node identity, not by fuzzy name/line matching.
+Fallback heuristics should be temporary safety only, not primary logic.
+
+### 4) Unify sketch plane/reference service
+Create one shared utility/service for:
+- face -> plane conversion
+- xDir derivation
+- detached vs parametric sketch codegen rules
+
+All entry points must call the same service.
+
+### 5) Tighten keyboard routing contract
+- global shortcuts in capture phase
+- explicit scope rules (editor-focused vs canvas-focused vs dialogs)
+- no dual handling for destructive keys
+
+### 6) Execution + persistence validity contract
+Use the same validity policy for:
+- persistence save/load
+- geometry execution trigger
+- command commit acceptance
+
+---
+
+## Suggested Implementation Phases
+
+### Phase A (Safety + Determinism)
+- Add `CodeMutationService` and route delete/insert through it.
+- Keep existing fallback paths behind a feature flag (`safetyFallback=true`).
+- Add telemetry/logging for fallback usage.
+
+### Phase B (History Model)
+- Implement AST-backed `extractHistoryItems`.
+- Migrate Scene Browser to AST history items.
+- Remove line-regex dependency from deletion path.
+
+### Phase C (Sketch Reference Unification)
+- Build shared `SketchPlaneService`.
+- Refactor `Toolbar`, `useFaceSelection`, and sketch completion to consume it.
+
+### Phase D (Cleanup)
+- Remove fallback heuristics after zero-fallback burn-in.
+- Remove duplicate insertion pathways.
+- Harden E2E around reload + autosave + delete flows.
+
+---
+
+## Regression Tests to Keep/Add
+- delete sketch after reload with autosaved session
+- delete multiline detached sketch declaration
+- delete from keyboard while editor focused (must not corrupt text)
+- face sketch commit remains stable after model recomputation
+- invalid code must not be persisted
+
+---
+
+## Success Criteria
+- One authoritative mutation pipeline for modeling code.
+- History operations use AST identity, not text heuristics.
+- No code corruption from delete in reload/autosave scenarios.
+- Sketch placement logic comes from one service and is reproducible.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,16 @@ import { DevLab } from './devlab/DevLab';
 import { devLabScenarios } from './devlab/scenarios';
 import { useEffect, useState } from 'react';
 import { projectService } from './lib/projectService';
+import { parseCode } from './lib/ast';
 
+function isCodeParsable(code: string): boolean {
+  try {
+    parseCode(code);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 
 function AppContent({ isDevLab }: { isDevLab: boolean }) {
@@ -21,7 +30,21 @@ function AppContent({ isDevLab }: { isDevLab: boolean }) {
 
     const savedProject = projectService.loadFromLocalStorage();
     if (savedProject) {
-      setCode(savedProject.code);
+      const savedCode = savedProject.code;
+      if (isCodeParsable(savedCode)) {
+        setCode(savedCode);
+        if (savedProject.viewState?.viewMode === 'gui' || savedProject.viewState?.viewMode === 'code') {
+          setViewMode(savedProject.viewState.viewMode);
+        }
+        if (typeof savedProject.viewState?.viewMode3D === 'string') {
+          setViewMode3D(savedProject.viewState.viewMode3D as typeof viewMode3D);
+        }
+      } else {
+        // Avoid reload loops where invalid code is restored forever.
+        projectService.clearLocalStorage();
+        setViewMode('code');
+        console.warn('Recovered from invalid saved project code in localStorage.');
+      }
     }
     setTimeout(() => setIsLoaded(true), 0);
   }, [isDevLab, setCode, setViewMode, setViewMode3D]);
@@ -29,6 +52,7 @@ function AppContent({ isDevLab }: { isDevLab: boolean }) {
   // Auto-save on changes
   useEffect(() => {
     if (!isLoaded || isDevLab) return;
+    if (!isCodeParsable(code)) return;
 
     const timeoutId = setTimeout(() => {
       const project = projectService.createProject(code, {

--- a/src/components/Layout/SidePanel.test.tsx
+++ b/src/components/Layout/SidePanel.test.tsx
@@ -1,0 +1,53 @@
+/** @vitest-environment jsdom */
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SidePanel } from './SidePanel';
+
+const mockDeleteHistoryItem = vi.fn();
+const mockSetSelectedItemId = vi.fn();
+const mockSetHoveredItemId = vi.fn();
+
+vi.mock('../../context/WorkbenchContext', () => ({
+    useWorkbench: () => ({
+        code: 'const box = replicad.makeBox(1, 1, 1);',
+        setViewMode: vi.fn(),
+        planes: [],
+        togglePlaneVisibility: vi.fn(),
+        selectedItemId: 'sketch',
+        setSelectedItemId: mockSetSelectedItemId,
+        hoveredItemId: 'sketch',
+        setHoveredItemId: mockSetHoveredItemId,
+        hiddenIds: [],
+        toggleVisibility: vi.fn(),
+        selectedItemIds: [],
+        toggleSelection: vi.fn(),
+        renameItem: vi.fn(),
+        deleteHistoryItem: mockDeleteHistoryItem
+    })
+}));
+
+vi.mock('../SceneBrowser', () => ({
+    default: ({ onDelete }: { onDelete: (item: { id: string; name: string; type: string; line: number }) => void }) => (
+        <button
+            data-testid="trigger-delete"
+            onClick={() => onDelete({ id: 'sketch:1:1:1', name: 'sketch', type: 'Sketch', line: 1 })}
+        >
+            Delete
+        </button>
+    )
+}));
+
+vi.mock('../../features/ai/AIAssistant', () => ({
+    AIAssistant: () => null
+}));
+
+describe('SidePanel', () => {
+    it('clears selected and hovered item when deleting currently selected history item', () => {
+        const { getByTestId } = render(<SidePanel onJumpToLine={vi.fn()} />);
+        getByTestId('trigger-delete').click();
+
+        expect(mockDeleteHistoryItem).toHaveBeenCalledTimes(1);
+        expect(mockSetSelectedItemId).toHaveBeenCalledWith(null);
+        expect(mockSetHoveredItemId).toHaveBeenCalledWith(null);
+    });
+});

--- a/src/components/Layout/SidePanel.test.tsx
+++ b/src/components/Layout/SidePanel.test.tsx
@@ -9,7 +9,10 @@ const mockSetHoveredItemId = vi.fn();
 
 vi.mock('../../context/WorkbenchContext', () => ({
     useWorkbench: () => ({
-        code: 'const box = replicad.makeBox(1, 1, 1);',
+        code: `
+const box = replicad.makeBox(1, 1, 1);
+const sketch = new Sketcher('XY').lineTo([1, 1]).done();
+`.trim(),
         setViewMode: vi.fn(),
         planes: [],
         togglePlaneVisibility: vi.fn(),
@@ -27,10 +30,10 @@ vi.mock('../../context/WorkbenchContext', () => ({
 }));
 
 vi.mock('../SceneBrowser', () => ({
-    default: ({ onDelete }: { onDelete: (item: { id: string; name: string; type: string; line: number }) => void }) => (
+    default: ({ items, onDelete }: { items: Array<{ id: string; name: string; type: string; line: number }>; onDelete: (item: { id: string; name: string; type: string; line: number }) => void }) => (
         <button
             data-testid="trigger-delete"
-            onClick={() => onDelete({ id: 'sketch:1:1:1', name: 'sketch', type: 'Sketch', line: 1 })}
+            onClick={() => onDelete(items.find((i) => i.name === 'sketch') ?? items[0])}
         >
             Delete
         </button>

--- a/src/components/Layout/SidePanel.tsx
+++ b/src/components/Layout/SidePanel.tsx
@@ -22,7 +22,8 @@ export function SidePanel({ onJumpToLine }: SidePanelProps) {
         toggleVisibility,
         selectedItemIds,
         toggleSelection,
-        renameItem
+        renameItem,
+        deleteItem
     } = useWorkbench();
 
     const [activeTab, setActiveTab] = useState<'scene' | 'ai'>('scene');
@@ -70,6 +71,7 @@ export function SidePanel({ onJumpToLine }: SidePanelProps) {
                         onTogglePlane={togglePlaneVisibility}
                         onSelectPlane={(id) => setSelectedItemId(id)}
                         onRename={renameItem}
+                        onDelete={(item) => deleteItem(item.name, item.line)}
                     />
                 ) : (
                     <AIAssistant />

--- a/src/components/Layout/SidePanel.tsx
+++ b/src/components/Layout/SidePanel.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import SceneBrowser from '../SceneBrowser';
 import { useWorkbench } from '../../context/WorkbenchContext';
-import { extractVariables, type VariableDefinition } from '../../lib/codeAnalysis';
+import { extractHistoryItems, type HistoryItem } from '../../lib/codeAnalysis';
 import { AIAssistant } from '../../features/ai/AIAssistant';
 
 interface SidePanelProps {
@@ -30,7 +30,7 @@ export function SidePanel({ onJumpToLine }: SidePanelProps) {
 
     // We compute items on the fly. 
     // In a real app we might memoize this or put it in context.
-    const items = extractVariables(code);
+    const items = extractHistoryItems(code);
 
     return (
         <div className="flex flex-col h-full bg-[#111] border-b border-[#333]">
@@ -60,7 +60,7 @@ export function SidePanel({ onJumpToLine }: SidePanelProps) {
                         selectedItemIds={selectedItemIds}
                         hoveredItemId={hoveredItemId}
                         hiddenIds={hiddenIds}
-                        onSelect={(item: VariableDefinition) => {
+                        onSelect={(item: HistoryItem) => {
                             setViewMode('code');
                             setSelectedItemId(item.name);
                             onJumpToLine(item.line);

--- a/src/components/Layout/SidePanel.tsx
+++ b/src/components/Layout/SidePanel.tsx
@@ -23,7 +23,7 @@ export function SidePanel({ onJumpToLine }: SidePanelProps) {
         selectedItemIds,
         toggleSelection,
         renameItem,
-        deleteItem
+        deleteHistoryItem
     } = useWorkbench();
 
     const [activeTab, setActiveTab] = useState<'scene' | 'ai'>('scene');
@@ -71,7 +71,7 @@ export function SidePanel({ onJumpToLine }: SidePanelProps) {
                         onTogglePlane={togglePlaneVisibility}
                         onSelectPlane={(id) => setSelectedItemId(id)}
                         onRename={renameItem}
-                        onDelete={(item) => deleteItem(item.name, item.line)}
+                        onDelete={deleteHistoryItem}
                     />
                 ) : (
                     <AIAssistant />

--- a/src/components/Layout/SidePanel.tsx
+++ b/src/components/Layout/SidePanel.tsx
@@ -71,7 +71,15 @@ export function SidePanel({ onJumpToLine }: SidePanelProps) {
                         onTogglePlane={togglePlaneVisibility}
                         onSelectPlane={(id) => setSelectedItemId(id)}
                         onRename={renameItem}
-                        onDelete={deleteHistoryItem}
+                        onDelete={(item) => {
+                            deleteHistoryItem(item);
+                            if (selectedItemId === item.name) {
+                                setSelectedItemId(null);
+                            }
+                            if (hoveredItemId === item.name) {
+                                setHoveredItemId(null);
+                            }
+                        }}
                     />
                 ) : (
                     <AIAssistant />

--- a/src/components/Layout/SidePanel.tsx
+++ b/src/components/Layout/SidePanel.tsx
@@ -31,6 +31,20 @@ export function SidePanel({ onJumpToLine }: SidePanelProps) {
     // We compute items on the fly. 
     // In a real app we might memoize this or put it in context.
     const items = extractHistoryItems(code);
+    const selectedHistoryId = selectedItemId
+        ? (items.find((item) => item.id === selectedItemId)?.id
+            ?? items.find((item) => item.name === selectedItemId)?.id
+            ?? selectedItemId)
+        : null;
+    const hoveredHistoryId = hoveredItemId
+        ? (items.find((item) => item.id === hoveredItemId)?.id
+            ?? items.find((item) => item.name === hoveredItemId)?.id
+            ?? hoveredItemId)
+        : null;
+    const selectedHistoryIds = selectedItemIds
+        .map((id) => items.find((item) => item.id === id)?.id
+            ?? items.find((item) => item.name === id)?.id
+            ?? id);
 
     return (
         <div className="flex flex-col h-full bg-[#111] border-b border-[#333]">
@@ -56,9 +70,9 @@ export function SidePanel({ onJumpToLine }: SidePanelProps) {
                     <SceneBrowser
                         items={items}
                         planes={planes}
-                        selectedItemId={selectedItemId}
-                        selectedItemIds={selectedItemIds}
-                        hoveredItemId={hoveredItemId}
+                        selectedItemId={selectedHistoryId}
+                        selectedItemIds={selectedHistoryIds}
+                        hoveredItemId={hoveredHistoryId}
                         hiddenIds={hiddenIds}
                         onSelect={(item: HistoryItem) => {
                             setViewMode('code');
@@ -80,10 +94,10 @@ export function SidePanel({ onJumpToLine }: SidePanelProps) {
                         onRename={renameItem}
                         onDelete={(item) => {
                             deleteHistoryItem(item);
-                            if (selectedItemId === item.id || selectedItemId === item.name) {
+                            if (selectedHistoryId === item.id) {
                                 setSelectedItemId(null);
                             }
-                            if (hoveredItemId === item.id || hoveredItemId === item.name) {
+                            if (hoveredHistoryId === item.id) {
                                 setHoveredItemId(null);
                             }
                         }}

--- a/src/components/Layout/SidePanel.tsx
+++ b/src/components/Layout/SidePanel.tsx
@@ -62,21 +62,28 @@ export function SidePanel({ onJumpToLine }: SidePanelProps) {
                         hiddenIds={hiddenIds}
                         onSelect={(item: HistoryItem) => {
                             setViewMode('code');
-                            setSelectedItemId(item.name);
+                            setSelectedItemId(item.id);
                             onJumpToLine(item.line);
                         }}
                         onToggleSelection={toggleSelection}
-                        onHover={setHoveredItemId}
+                        onHover={(id) => {
+                            if (!id) {
+                                setHoveredItemId(null);
+                                return;
+                            }
+                            const item = items.find((entry) => entry.id === id);
+                            setHoveredItemId(item?.name ?? id);
+                        }}
                         onToggleVisibility={toggleVisibility}
                         onTogglePlane={togglePlaneVisibility}
                         onSelectPlane={(id) => setSelectedItemId(id)}
                         onRename={renameItem}
                         onDelete={(item) => {
                             deleteHistoryItem(item);
-                            if (selectedItemId === item.name) {
+                            if (selectedItemId === item.id || selectedItemId === item.name) {
                                 setSelectedItemId(null);
                             }
-                            if (hoveredItemId === item.name) {
+                            if (hoveredItemId === item.id || hoveredItemId === item.name) {
                                 setHoveredItemId(null);
                             }
                         }}

--- a/src/components/Layout/WorkbenchLayout.tsx
+++ b/src/components/Layout/WorkbenchLayout.tsx
@@ -60,6 +60,9 @@ export function WorkbenchLayout() {
         closePanel,
         selectedSketchName,
         setSelectedSketchName,
+        setSelectedItemId,
+        setHoveredItemId,
+        hoveredItemId,
         toggleSketchVisibility,
         activePanels,
         setViewMode,
@@ -106,10 +109,18 @@ export function WorkbenchLayout() {
             w.__TEST_SELECT_SKETCH = (name: string | null) => {
                 setSelectedSketchName(name);
             };
+            w.__TEST_SELECT_ITEM = (id: string | null) => {
+                setSelectedItemId(id);
+            };
+            w.__TEST_SET_HOVERED = (id: string | null) => {
+                setHoveredItemId(id);
+            };
+            w.getHoveredItemId = () => hoveredItemId;
+            w.selectedItemId = () => selectedItemId;
 
             w.setActiveDialog = setActiveDialog;
         }
-    }, [setCode, code, editorInstance, setActiveDialog, setViewMode, geometries, previewGeometries, sketchesGeometries, isComputing, executionCount, error, setSelectedFace, selectedFace, startFaceSelection, setSelectedSketchName]);
+    }, [setCode, code, editorInstance, setActiveDialog, setViewMode, geometries, previewGeometries, sketchesGeometries, isComputing, executionCount, error, setSelectedFace, selectedFace, startFaceSelection, setSelectedSketchName, setSelectedItemId, setHoveredItemId, hoveredItemId, selectedItemId]);
 
     // Recovery guard: never keep the editor hidden while code/execution is in error.
     React.useEffect(() => {

--- a/src/components/Layout/WorkbenchLayout.tsx
+++ b/src/components/Layout/WorkbenchLayout.tsx
@@ -14,7 +14,7 @@ import { type SketchData, type SketchPlane } from '../../types/sketch';
 import type { SketchPlaneEntity } from '../../types/plane';
 import { generateSketchCode, generateSketchBody } from '../../lib/sketchCodegen';
 import { Loader2 } from 'lucide-react';
-import { extractVariables } from '../../lib/codeAnalysis';
+import { extractHistoryItems, extractVariables } from '../../lib/codeAnalysis';
 
 // Modular Panels
 import { EditorPanel } from './EditorPanel';
@@ -54,6 +54,7 @@ export function WorkbenchLayout() {
         showAll,
         selectedItemId,
         deleteItem,
+        deleteHistoryItem,
         toggleVisibility,
         openPanel,
         closePanel,
@@ -129,6 +130,12 @@ export function WorkbenchLayout() {
         extractVariables(code).forEach((v) => map.set(v.name, v.line));
         return map;
     }, [code]);
+    const historyItems = useMemo(() => extractHistoryItems(code), [code]);
+    const historyItemById = useMemo(() => {
+        const map = new Map<string, { id: string; name: string; line: number; type: string; detail?: string }>();
+        historyItems.forEach((item) => map.set(item.id, item));
+        return map;
+    }, [historyItems]);
 
     const featureShortcuts = useMemo(() => {
         const shortcuts: Record<string, () => void> = {};
@@ -215,7 +222,10 @@ export function WorkbenchLayout() {
         },
         'h': () => {
             if (activeDialog) return;
-            if (selectedItemId) hideItem(selectedItemId);
+            if (selectedItemId) {
+                const visibilityTarget = historyItemById.get(selectedItemId)?.name ?? selectedItemId;
+                hideItem(visibilityTarget);
+            }
         },
         'shift+h': () => {
             if (activeDialog) return;
@@ -223,20 +233,33 @@ export function WorkbenchLayout() {
         },
         'space': () => {
             if (activeDialog) return;
-            if (selectedItemId) toggleVisibility(selectedItemId);
+            if (selectedItemId) {
+                const visibilityTarget = historyItemById.get(selectedItemId)?.name ?? selectedItemId;
+                toggleVisibility(visibilityTarget);
+            }
         },
         'backspace': (e) => {
             if (activeDialog) return;
             if (selectedItemId) {
                 e.preventDefault();
-                deleteItem(selectedItemId, variableIndex.get(selectedItemId));
+                const historyItem = historyItemById.get(selectedItemId);
+                if (historyItem) {
+                    deleteHistoryItem(historyItem);
+                } else {
+                    deleteItem(selectedItemId, variableIndex.get(selectedItemId));
+                }
             }
         },
         'delete': (e) => {
             if (activeDialog) return;
             if (selectedItemId) {
                 e.preventDefault();
-                deleteItem(selectedItemId, variableIndex.get(selectedItemId));
+                const historyItem = historyItemById.get(selectedItemId);
+                if (historyItem) {
+                    deleteHistoryItem(historyItem);
+                } else {
+                    deleteItem(selectedItemId, variableIndex.get(selectedItemId));
+                }
             }
         },
         'alt+s': () => {

--- a/src/components/Layout/WorkbenchLayout.tsx
+++ b/src/components/Layout/WorkbenchLayout.tsx
@@ -14,6 +14,7 @@ import { type SketchData, type SketchPlane } from '../../types/sketch';
 import type { SketchPlaneEntity } from '../../types/plane';
 import { generateSketchCode, generateSketchBody } from '../../lib/sketchCodegen';
 import { Loader2 } from 'lucide-react';
+import { extractVariables } from '../../lib/codeAnalysis';
 
 // Modular Panels
 import { EditorPanel } from './EditorPanel';
@@ -52,6 +53,7 @@ export function WorkbenchLayout() {
         hideItem,
         showAll,
         selectedItemId,
+        deleteItem,
         toggleVisibility,
         openPanel,
         closePanel,
@@ -60,6 +62,8 @@ export function WorkbenchLayout() {
         toggleSketchVisibility,
         activePanels,
         setViewMode,
+        setSidePanelVisible,
+        clearAll,
         isComputing,
         executionCount,
         setSelectedFace,
@@ -106,11 +110,25 @@ export function WorkbenchLayout() {
         }
     }, [setCode, code, editorInstance, setActiveDialog, setViewMode, geometries, previewGeometries, sketchesGeometries, isComputing, executionCount, error, setSelectedFace, selectedFace, startFaceSelection, setSelectedSketchName]);
 
+    // Recovery guard: never keep the editor hidden while code/execution is in error.
+    React.useEffect(() => {
+        if (!error) return;
+        if (viewMode === 'gui') {
+            setViewMode('code');
+        }
+        setSidePanelVisible(true);
+    }, [error, viewMode, setViewMode, setSidePanelVisible]);
+
     const { insertCode } = useCodeInsertion();
 
     const features = useMemo(() => featureRegistry.getAll(), []);
 
     const activeFeature = useMemo(() => activeDialog ? featureRegistry.get(activeDialog) : null, [activeDialog]);
+    const variableIndex = useMemo(() => {
+        const map = new Map<string, number>();
+        extractVariables(code).forEach((v) => map.set(v.name, v.line));
+        return map;
+    }, [code]);
 
     const featureShortcuts = useMemo(() => {
         const shortcuts: Record<string, () => void> = {};
@@ -207,22 +225,29 @@ export function WorkbenchLayout() {
             if (activeDialog) return;
             if (selectedItemId) toggleVisibility(selectedItemId);
         },
-        'backspace': () => {
+        'backspace': (e) => {
             if (activeDialog) return;
             if (selectedItemId) {
-                console.log('Delete item:', selectedItemId);
-                // Implementation pending for real delete logic
+                e.preventDefault();
+                deleteItem(selectedItemId, variableIndex.get(selectedItemId));
             }
         },
-        'delete': () => {
+        'delete': (e) => {
             if (activeDialog) return;
             if (selectedItemId) {
-                console.log('Delete item:', selectedItemId);
-                // Implementation pending for real delete logic
+                e.preventDefault();
+                deleteItem(selectedItemId, variableIndex.get(selectedItemId));
             }
         },
         'alt+s': () => {
             toggleSketchVisibility();
+        },
+        'mod+1': () => {
+            setViewMode('code');
+            setSidePanelVisible(true);
+        },
+        'mod+2': () => {
+            setViewMode('gui');
         }
     });
 
@@ -364,62 +389,71 @@ export function WorkbenchLayout() {
                 <SketchCanvas
                     plane={sketchMode.plane}
                     onComplete={(entities) => {
-                        // CRITICAL: Validate entities before proceeding
-                        if (!entities || entities.length === 0) {
-                            console.error('Cannot create sketch: No geometry drawn');
-                            alert('Please draw some geometry before completing the sketch.');
-                            return;
+                        try {
+                            // CRITICAL: Validate entities before proceeding
+                            if (!entities || entities.length === 0) {
+                                console.error('Cannot create sketch: No geometry drawn');
+                                alert('Please draw some geometry before completing the sketch.');
+                                return;
+                            }
+
+                            // Use the name from the active sketch session if available
+                            const sketchName = sketchMode.currentSketch?.name || codeContext.generateUniqueName('sketch');
+
+                            // Parse plane name correctly
+                            let planeName: SketchPlane = 'XY';
+                            if (typeof sketchMode.plane === 'string') {
+                                planeName = sketchMode.plane;
+                            } else if (sketchMode.plane && typeof sketchMode.plane === 'object') {
+                                planeName = sketchMode.plane.name;
+                            }
+
+                            const sketchData: SketchData = {
+                                id: sketchMode.currentSketch?.id || `sketch_${Date.now()}`,
+                                name: sketchName,
+                                plane: planeName,
+                                entities,
+                                closed: false,
+                                createdAt: sketchMode.currentSketch?.createdAt || Date.now(),
+                            };
+
+                            const planeEntity: SketchPlaneEntity | null =
+                                sketchMode.plane && typeof sketchMode.plane === 'object' ? sketchMode.plane : null;
+                            let sketchCode = '';
+
+                            // Case 1: Detached sketch on captured face plane.
+                            // Prefer stable plane data over faceId because topology reindexing can move face indices.
+                            if (planeEntity && planeEntity.type === 'face' && planeEntity.origin && planeEntity.normal) {
+                                const xDir = planeEntity.xDir;
+                                const xDirStr = xDir ? JSON.stringify(xDir) : 'null';
+                                const planeCode = `new replicad.Plane(${JSON.stringify(planeEntity.origin)}, ${xDirStr}, ${JSON.stringify(planeEntity.normal)})`;
+                                const startCode = `const ${sketchName} = new Sketcher(${planeCode})\n`;
+                                const bodyCode = generateSketchBody(entities);
+                                sketchCode = startCode + bodyCode + ';\n';
+                            }
+                            // Case 2: Parametric sketch on face index (fallback when no plane data is available)
+                            else if (planeEntity && planeEntity.type === 'face' && planeEntity.faceId !== undefined && planeEntity.parentId && planeEntity.parentId !== 'unknown' && planeEntity.parentId !== 'shape') {
+                                const startCode = `const ${sketchName} = sketchOnFace(${planeEntity.parentId}, ${planeEntity.faceId})\n`;
+                                const bodyCode = generateSketchBody(entities);
+                                sketchCode = startCode + bodyCode + ';\n';
+                            }
+                            // Case 3: Standard base plane sketch
+                            else {
+                                sketchCode = generateSketchCode(sketchData);
+                            }
+
+                            insertCode(sketchCode);
+                            addSketch(sketchData);
+                            clearAll();
+                            setSketchMode({ active: false, plane: null, currentSketch: null, tool: 'select' });
+                        } catch (err) {
+                            const message = err instanceof Error ? err.message : String(err);
+                            console.error('Failed to complete sketch:', err);
+                            alert(`Failed to complete sketch: ${message}`);
                         }
-
-                        // Use the name from the active sketch session if available
-                        const sketchName = sketchMode.currentSketch?.name || codeContext.generateUniqueName('sketch');
-
-                        // Parse plane name correctly
-                        let planeName: SketchPlane = 'XY';
-                        if (typeof sketchMode.plane === 'string') {
-                            planeName = sketchMode.plane;
-                        } else if (sketchMode.plane && typeof sketchMode.plane === 'object') {
-                            planeName = sketchMode.plane.name;
-                        }
-
-                        const sketchData: SketchData = {
-                            id: sketchMode.currentSketch?.id || `sketch_${Date.now()}`,
-                            name: sketchName,
-                            plane: planeName,
-                            entities,
-                            closed: false,
-                            createdAt: sketchMode.currentSketch?.createdAt || Date.now(),
-                        };
-
-                        const planeEntity: SketchPlaneEntity | null =
-                            sketchMode.plane && typeof sketchMode.plane === 'object' ? sketchMode.plane : null;
-                        let sketchCode = '';
-
-                        // Case 1: Parametric Sketch on Face
-                        if (planeEntity && planeEntity.type === 'face' && planeEntity.faceId !== undefined && planeEntity.parentId && planeEntity.parentId !== 'unknown' && planeEntity.parentId !== 'shape') {
-                            const startCode = `const ${sketchName} = sketchOnFace(${planeEntity.parentId}, ${planeEntity.faceId})\n`;
-                            const bodyCode = generateSketchBody(entities);
-                            sketchCode = startCode + bodyCode + ';\n';
-                        }
-                        // Case 2: Detached Sketch on a specific Plane object/origin
-                        else if (planeEntity && planeEntity.type === 'face' && planeEntity.origin && planeEntity.normal) {
-                            const xDir = planeEntity.xDir;
-                            const xDirStr = xDir ? JSON.stringify(xDir) : 'null';
-                            const planeCode = `new replicad.Plane(${JSON.stringify(planeEntity.origin)}, ${xDirStr}, ${JSON.stringify(planeEntity.normal)})`;
-                            const startCode = `const ${sketchName} = new Sketcher(${planeCode})\n`;
-                            const bodyCode = generateSketchBody(entities);
-                            sketchCode = startCode + bodyCode + ';\n';
-                        }
-                        // Case 3: Standard Plane Sketch
-                        else {
-                            sketchCode = generateSketchCode(sketchData);
-                        }
-
-                        insertCode(sketchCode);
-                        addSketch(sketchData);
-                        setSketchMode({ active: false, plane: null, currentSketch: null, tool: 'select' });
                     }}
                     onCancel={() => {
+                        clearAll();
                         setSketchMode({ active: false, plane: null, currentSketch: null, tool: 'select' });
                     }}
                 />

--- a/src/components/Layout/WorkbenchLayout.tsx
+++ b/src/components/Layout/WorkbenchLayout.tsx
@@ -109,6 +109,7 @@ export function WorkbenchLayout() {
     const { insertCode } = useCodeInsertion();
 
     const features = useMemo(() => featureRegistry.getAll(), []);
+
     const activeFeature = useMemo(() => activeDialog ? featureRegistry.get(activeDialog) : null, [activeDialog]);
 
     const featureShortcuts = useMemo(() => {
@@ -131,6 +132,42 @@ export function WorkbenchLayout() {
         });
         return shortcuts;
     }, [features, activeDialog, insertCode, setCode, code, setActiveDialog, openPanel, closePanel, codeContext]);
+
+    const handleToolClick = React.useCallback((feature: Feature) => {
+        if (activeDialog) return;
+
+        if (feature.id === 'extrudeFromFace') {
+            openPanel('extrudeFromFace');
+        } else if (feature.id === 'sketchOnFace') {
+            openPanel('sketchOnFace');
+        } else {
+            // Original logic for other features
+            if (['extrude', 'revolve', 'fillet', 'chamfer', 'union', 'cut', 'intersect', 'offsetPlane', 'midplane', 'tangentPlane'].includes(feature.id)) {
+                openPanel(feature.id);
+                return;
+            }
+
+            if (feature.parameters && feature.parameters.length > 0) {
+                setActiveDialog(feature.id);
+            } else {
+                feature.execute({
+                    insertCode,
+                    setCode,
+                    setActiveDialog,
+                    openPanel,
+                    closePanel,
+                    code,
+                    codeContext
+                }, undefined);
+            }
+        }
+    }, [openPanel, setActiveDialog, insertCode, setCode, closePanel, code, codeContext, activeDialog]);
+
+    // Use a ref for handleToolClick to avoid re-registering commands when it changes due to code updates
+    const handleToolClickRef = React.useRef(handleToolClick);
+    React.useEffect(() => {
+        handleToolClickRef.current = handleToolClick;
+    }, [handleToolClick]);
 
     // Keyboard Shortcuts
     useKeyboardShortcuts({
@@ -193,90 +230,39 @@ export function WorkbenchLayout() {
     // Register Commands for Palette
     const { registerCommand } = useCommandRegistry();
 
-    // Use a ref to store the latest values needed by command actions
-    const actionContextRef = React.useRef({
-        selectedFace,
-        insertCode,
-        setCode,
-        setActiveDialog,
-        code,
-        codeContext
-    });
 
-    // Update the ref on every render
-    React.useEffect(() => {
-        actionContextRef.current = {
-            selectedFace,
-            insertCode,
-            setCode,
-            setActiveDialog,
-            code,
-            codeContext
-        };
-    });
 
-    const handleToolClick = React.useCallback((feature: Feature) => {
-        if (feature.id === 'extrudeFromFace') {
-            openPanel('extrudeFromFace');
-        } else if (feature.id === 'sketchOnFace') {
-            openPanel('sketchOnFace');
-        } else {
-            // Original logic for other features
-            if (['extrude', 'revolve', 'fillet', 'chamfer', 'union', 'cut', 'intersect', 'offsetPlane', 'planeSelector', 'midplane', 'tangentPlane'].includes(feature.id)) {
-                openPanel(feature.id);
-                return;
-            }
 
-            if (feature.parameters && feature.parameters.length > 0) {
-                setActiveDialog(feature.id);
-            } else {
-                feature.execute({
-                    insertCode,
-                    setCode,
-                    setActiveDialog,
-                    openPanel,
-                    closePanel,
-                    code,
-                    codeContext
-                }, undefined);
-            }
-        }
-    }, [openPanel, setActiveDialog, insertCode, setCode, closePanel, code, codeContext]);
 
     React.useEffect(() => {
         const unregisters: (() => void)[] = [];
 
-        // Dynamic Feature Commands
+        // Register feature commands
         features.forEach(f => {
-            if (['sketchOnFace', 'extrudeFromFace'].includes(f.id)) return; // Handled specially or excluded if redundant
-
             unregisters.push(registerCommand({
                 id: f.id,
                 label: f.label,
+                icon: f.icon ? <f.icon className="w-4 h-4" /> : undefined,
+                shortcut: f.shortcut,
                 section: 'Modeling',
-                shortcut: f.shortcut?.toUpperCase(),
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                icon: React.createElement(f.icon as any, { className: "w-4 h-4" }),
-                action: () => handleToolClick(f)
+                action: () => handleToolClickRef.current(f)
             }));
         });
 
-        // View & Utility Commands
+        // Register utility commands
         unregisters.push(registerCommand({
-            id: 'toggle-sketches',
+            id: 'toggleSketchVisibility',
             label: 'Toggle Sketches',
+            shortcut: 'Alt+S', // Example
             section: 'View',
-            shortcut: 'Alt+S',
             icon: <Layers className="w-4 h-4" />,
-            action: () => {
-                toggleSketchVisibility();
-            }
+            action: toggleSketchVisibility
         }));
 
         unregisters.push(registerCommand({
-            id: 'sketch-plane-selector',
-            label: 'New Sketch (Select Plane)',
-            section: 'General',
+            id: 'planeSelector',
+            label: 'Select Plane',
+            section: 'Navigation',
             shortcut: 'S',
             icon: <Square className="w-4 h-4" />,
             action: () => {
@@ -285,7 +271,7 @@ export function WorkbenchLayout() {
         }));
 
         return () => unregisters.forEach(u => u());
-    }, [registerCommand, toggleSketchVisibility, openPanel, features, handleToolClick]); // Only stable dependencies
+    }, [registerCommand, toggleSketchVisibility, openPanel, features]); // Removed handleToolClick to prevent loop
 
 
 

--- a/src/components/SceneBrowser.test.tsx
+++ b/src/components/SceneBrowser.test.tsx
@@ -2,16 +2,16 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import SceneBrowser from './SceneBrowser';
-import type { VariableDefinition } from '../lib/codeAnalysis';
+import type { HistoryItem } from '../lib/codeAnalysis';
 // React unused
 
 afterEach(() => {
     cleanup();
 });
 
-const mockItems: VariableDefinition[] = [
-    { name: 'box1', type: 'Box', line: 1 },
-    { name: 'cyl1', type: 'Cylinder', line: 5 },
+const mockItems: HistoryItem[] = [
+    { id: 'box1:1:1:10', name: 'box1', type: 'Box', line: 1 },
+    { id: 'cyl1:5:11:20', name: 'cyl1', type: 'Cylinder', line: 5 },
 ];
 
 describe('SceneBrowser', () => {

--- a/src/components/SceneBrowser.test.tsx
+++ b/src/components/SceneBrowser.test.tsx
@@ -70,4 +70,13 @@ describe('SceneBrowser', () => {
         expect(screen.getByText('Delete')).toBeDefined();
         expect(screen.getByText('Isolate')).toBeDefined();
     });
+
+    it('should call onDelete from context menu', () => {
+        const onDelete = vi.fn();
+        render(<SceneBrowser items={mockItems} planes={[]} selectedItemId={null} hoveredItemId={null} hiddenIds={[]} onSelect={vi.fn()} onHover={vi.fn()} onToggleVisibility={vi.fn()} onTogglePlane={vi.fn()} onDelete={onDelete} />);
+
+        fireEvent.contextMenu(screen.getByText('box1'));
+        fireEvent.click(screen.getByText('Delete'));
+        expect(onDelete).toHaveBeenCalledWith(mockItems[0]);
+    });
 });

--- a/src/components/SceneBrowser.test.tsx
+++ b/src/components/SceneBrowser.test.tsx
@@ -55,7 +55,7 @@ describe('SceneBrowser', () => {
 
         const item = screen.getByText('box1');
         fireEvent.mouseEnter(item);
-        expect(onHover).toHaveBeenCalledWith('box1');
+        expect(onHover).toHaveBeenCalledWith('box1:1:1:10');
 
         fireEvent.mouseLeave(item);
         expect(onHover).toHaveBeenCalledWith(null);

--- a/src/components/SceneBrowser.tsx
+++ b/src/components/SceneBrowser.tsx
@@ -193,8 +193,10 @@ const SceneBrowser: React.FC<SceneBrowserProps> = ({
                             <div className="px-6 py-4 text-gray-500 italic">No operations yet.</div>
                         ) : (
                             items.map((item, idx) => {
-                                const isSelected = selectedItemIds ? selectedItemIds.includes(item.name) : selectedItemId === item.name;
-                                const isHovered = hoveredItemId === item.name;
+                                const isSelected = selectedItemIds
+                                    ? selectedItemIds.includes(item.id) || selectedItemIds.includes(item.name)
+                                    : selectedItemId === item.id || selectedItemId === item.name;
+                                const isHovered = hoveredItemId === item.id || hoveredItemId === item.name;
                                 const isHidden = hiddenIds.includes(item.name);
                                 return (
                                     <div
@@ -202,12 +204,12 @@ const SceneBrowser: React.FC<SceneBrowserProps> = ({
                                         data-testid={`scene-item-${item.id ?? item.name}`}
                                         onClick={(e) => {
                                             if (onToggleSelection && (e.metaKey || e.ctrlKey || e.shiftKey)) {
-                                                onToggleSelection(item.name, true);
+                                                onToggleSelection(item.id, true);
                                             } else {
                                                 onSelect(item);
                                             }
                                         }}
-                                        onMouseEnter={() => onHover(item.name)}
+                                        onMouseEnter={() => onHover(item.id)}
                                         onMouseLeave={() => onHover(null)}
                                         onContextMenu={(e) => handleContextMenu(e, item)}
                                         className={`w-full flex items-center gap-2 px-6 py-2 text-gray-300 hover:bg-[#222] hover:text-white transition-colors text-left group cursor-pointer ${isSelected ? 'bg-selection-blue/20 text-white border-l-2 border-selection-blue' : isHovered ? 'bg-[#333] text-white' : ''}`}

--- a/src/components/SceneBrowser.tsx
+++ b/src/components/SceneBrowser.tsx
@@ -194,9 +194,9 @@ const SceneBrowser: React.FC<SceneBrowserProps> = ({
                         ) : (
                             items.map((item, idx) => {
                                 const isSelected = selectedItemIds
-                                    ? selectedItemIds.includes(item.id) || selectedItemIds.includes(item.name)
-                                    : selectedItemId === item.id || selectedItemId === item.name;
-                                const isHovered = hoveredItemId === item.id || hoveredItemId === item.name;
+                                    ? selectedItemIds.includes(item.id)
+                                    : selectedItemId === item.id;
+                                const isHovered = hoveredItemId === item.id;
                                 const isHidden = hiddenIds.includes(item.name);
                                 return (
                                     <div

--- a/src/components/SceneBrowser.tsx
+++ b/src/components/SceneBrowser.tsx
@@ -1,24 +1,24 @@
 import React from 'react';
-import type { VariableDefinition } from '../lib/codeAnalysis';
+import type { HistoryItem } from '../lib/codeAnalysis';
 import type { SketchPlaneEntity } from '../types/plane';
 import { Box, Cylinder, Layers, SquaresSubtract, SquaresUnite, SquaresIntersect, SquareRoundCorner, Circle, Square, Plane, Eye, EyeOff, ChevronRight, ChevronDown, SquareArrowUp, Rotate3D } from 'lucide-react';
 import { ChamferIcon } from '../icons/cad';
 
 interface SceneBrowserProps {
-    items: VariableDefinition[];
+    items: HistoryItem[];
     planes: SketchPlaneEntity[];
     selectedItemId: string | null;
     selectedItemIds?: string[];
     hoveredItemId: string | null;
     hiddenIds: string[];
-    onSelect: (item: VariableDefinition) => void;
+    onSelect: (item: HistoryItem) => void;
     onToggleSelection?: (id: string, multi: boolean) => void;
     onHover: (id: string | null) => void;
     onToggleVisibility: (id: string) => void;
     onTogglePlane: (id: string) => void;
     onSelectPlane?: (id: string) => void;
     onRename?: (oldName: string, newName: string) => void;
-    onDelete?: (item: VariableDefinition) => void;
+    onDelete?: (item: HistoryItem) => void;
 }
 
 const getIconForType = (type: string) => {
@@ -57,9 +57,9 @@ const SceneBrowser: React.FC<SceneBrowserProps> = ({
     const [constructionOpen, setConstructionOpen] = React.useState(true);
     const [historyOpen, setHistoryOpen] = React.useState(true);
 
-    const [contextMenu, setContextMenu] = React.useState<{ x: number, y: number, item: VariableDefinition } | null>(null);
+    const [contextMenu, setContextMenu] = React.useState<{ x: number, y: number, item: HistoryItem } | null>(null);
 
-    const handleContextMenu = (e: React.MouseEvent, item: VariableDefinition) => {
+    const handleContextMenu = (e: React.MouseEvent, item: HistoryItem) => {
         e.preventDefault();
         setContextMenu({ x: e.clientX, y: e.clientY, item });
     };
@@ -198,8 +198,8 @@ const SceneBrowser: React.FC<SceneBrowserProps> = ({
                                 const isHidden = hiddenIds.includes(item.name);
                                 return (
                                     <div
-                                        key={`${item.name}-${idx}`}
-                                        data-testid={`scene-item-${item.name}`}
+                                        key={item.id ?? `${item.name}-${idx}`}
+                                        data-testid={`scene-item-${item.id ?? item.name}`}
                                         onClick={(e) => {
                                             if (onToggleSelection && (e.metaKey || e.ctrlKey || e.shiftKey)) {
                                                 onToggleSelection(item.name, true);

--- a/src/components/SceneBrowser.tsx
+++ b/src/components/SceneBrowser.tsx
@@ -18,6 +18,7 @@ interface SceneBrowserProps {
     onTogglePlane: (id: string) => void;
     onSelectPlane?: (id: string) => void;
     onRename?: (oldName: string, newName: string) => void;
+    onDelete?: (item: VariableDefinition) => void;
 }
 
 const getIconForType = (type: string) => {
@@ -50,7 +51,8 @@ const SceneBrowser: React.FC<SceneBrowserProps> = ({
     onToggleVisibility,
     onTogglePlane,
     onSelectPlane,
-    onRename
+    onRename,
+    onDelete
 }) => {
     const [constructionOpen, setConstructionOpen] = React.useState(true);
     const [historyOpen, setHistoryOpen] = React.useState(true);
@@ -79,8 +81,7 @@ const SceneBrowser: React.FC<SceneBrowserProps> = ({
                     <button
                         className="w-full text-left px-3 py-1.5 hover:bg-blue-600 text-gray-200"
                         onClick={() => {
-                            // In a real app we'd have a delete command
-                            console.log('Delete', contextMenu.item.name);
+                            onDelete?.(contextMenu.item);
                             setContextMenu(null);
                         }}
                     >

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -2,6 +2,7 @@ import { PenTool, ArrowUpFromLine, Eye, EyeOff, Layers } from 'lucide-react';
 import { type Feature } from '../features/types';
 import { useWorkbench } from '../context/WorkbenchContext';
 import { FEATURE_SHORTCUTS, SHORTCUT_HINTS, formatTooltip } from '../constants/shortcuts';
+import { buildFaceSketchPlaneEntity } from '../lib/sketchPlane';
 
 interface ToolbarProps {
     features: Feature[];
@@ -44,16 +45,12 @@ export default function Toolbar({ features, onToolClick }: ToolbarProps) {
         // Enter sketch mode on this face plane
         setSketchMode({
             active: true,
-            plane: {
-                id: `face-${selectedFace.faceId}-${Date.now()}`,
-                name: targetName ? `Face ${selectedFace.faceId} of ${targetName}` : `Face ${selectedFace.faceId} of Anonymous Shape`,
-                type: 'face',
+            plane: buildFaceSketchPlaneEntity({
+                faceId: selectedFace.faceId,
+                targetName,
                 origin: selectedFacePlane.origin,
-                normal: selectedFacePlane.normal,
-                visible: true,
-                parentId: targetName as string | undefined, // Cast to match expected type (string | undefined)
-                faceId: selectedFace.faceId
-            },
+                normal: selectedFacePlane.normal
+            }),
             currentSketch: null,
             tool: 'line'
         });

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -836,7 +836,7 @@ export default function Viewer({ geometries, previewGeometries, sketchesGeometri
                 )}
 
                 <PlaneLayer planes={planes} />
-                <ParametricLayer />
+                {sketchMode.active && <ParametricLayer />}
                 <OrbitControls makeDefault enabled={!sketchMode.active} />
                 <CameraHandler geometries={geometries} />
             </Canvas>

--- a/src/context/CodeContext.tsx
+++ b/src/context/CodeContext.tsx
@@ -3,7 +3,8 @@ import { CommandManager } from '../commands/CommandManager';
 import { defaultCode } from '../lib/geometryEngine';
 import type { EditorLike } from '../types/editor';
 import { CodeAnalyzer, type CodeGenerationContext } from '../lib/codeGeneration';
-import { deleteVariableDeclarationAST, deleteVariableDeclarationByNameAndLineAST, parseCode } from '../lib/ast';
+import { deleteVariableDeclarationAST, deleteVariableDeclarationByLineFallback, deleteVariableDeclarationByNameAndLineAST, parseCode } from '../lib/ast';
+import type { HistoryItem } from '../lib/codeAnalysis';
 
 export interface CodeContextType {
     code: string;
@@ -15,6 +16,7 @@ export interface CodeContextType {
     codeContext: CodeGenerationContext;
     renameItem: (oldName: string, newName: string) => void;
     deleteItem: (name: string, lineHint?: number) => void;
+    deleteHistoryItem: (item: HistoryItem) => void;
     applyCodeSafe: (code: string) => Promise<boolean>;
 }
 
@@ -88,6 +90,20 @@ export function CodeProvider({ children, initialCode = defaultCode }: { children
         }, 'deleteItem');
     }, [commitMutation]);
 
+    const deleteHistoryItem = useCallback((item: HistoryItem) => {
+        commitMutation((prev) => {
+            try {
+                const byIdentity = deleteVariableDeclarationByNameAndLineAST(prev, item.name, item.line);
+                parseCode(byIdentity);
+                return byIdentity;
+            } catch {
+                const recovered = deleteVariableDeclarationByLineFallback(prev, item.name, item.line);
+                parseCode(recovered);
+                return recovered;
+            }
+        }, 'deleteHistoryItem');
+    }, [commitMutation]);
+
     const applyCodeSafe = useCallback(async (newCode: string): Promise<boolean> => {
         try {
             const { agentAPI } = await import('../agent/AgentAPI');
@@ -155,8 +171,9 @@ export function CodeProvider({ children, initialCode = defaultCode }: { children
         codeContext,
         renameItem,
         deleteItem,
+        deleteHistoryItem,
         applyCodeSafe
-    }), [code, insertCode, editorInstance, commandManager, codeContext, renameItem, deleteItem, applyCodeSafe]);
+    }), [code, insertCode, editorInstance, commandManager, codeContext, renameItem, deleteItem, deleteHistoryItem, applyCodeSafe]);
 
     return <CodeContext.Provider value={value}>{children}</CodeContext.Provider>;
 }

--- a/src/context/CodeContext.tsx
+++ b/src/context/CodeContext.tsx
@@ -3,7 +3,7 @@ import { CommandManager } from '../commands/CommandManager';
 import { defaultCode } from '../lib/geometryEngine';
 import type { EditorLike } from '../types/editor';
 import { CodeAnalyzer, type CodeGenerationContext } from '../lib/codeGeneration';
-import { deleteVariableDeclarationAST, deleteVariableDeclarationByLineFallback, deleteVariableDeclarationFallback, parseCode } from '../lib/ast';
+import { deleteVariableDeclarationAST, deleteVariableDeclarationByNameAndLineAST, parseCode } from '../lib/ast';
 
 export interface CodeContextType {
     code: string;
@@ -76,29 +76,15 @@ export function CodeProvider({ children, initialCode = defaultCode }: { children
 
     const deleteItem = useCallback((name: string, lineHint?: number) => {
         commitMutation((prev) => {
-            const candidates: string[] = [];
-
-            // 1) AST path
-            candidates.push(deleteVariableDeclarationAST(prev, name));
-
-            // 2) Line-aware fallback (if we know where declaration is in History)
             if (typeof lineHint === 'number') {
-                candidates.push(deleteVariableDeclarationByLineFallback(prev, name, lineHint));
+                const byIdentity = deleteVariableDeclarationByNameAndLineAST(prev, name, lineHint);
+                parseCode(byIdentity);
+                return byIdentity;
             }
 
-            // 3) Name-only fallback
-            candidates.push(deleteVariableDeclarationFallback(prev, name));
-
-            for (const candidate of candidates) {
-                try {
-                    parseCode(candidate);
-                    return candidate;
-                } catch {
-                    // try next strategy
-                }
-            }
-
-            throw new Error(`All delete strategies failed for "${name}"`);
+            const byName = deleteVariableDeclarationAST(prev, name);
+            parseCode(byName);
+            return byName;
         }, 'deleteItem');
     }, [commitMutation]);
 

--- a/src/context/CodeContext.tsx
+++ b/src/context/CodeContext.tsx
@@ -3,6 +3,7 @@ import { CommandManager } from '../commands/CommandManager';
 import { defaultCode } from '../lib/geometryEngine';
 import type { EditorLike } from '../types/editor';
 import { CodeAnalyzer, type CodeGenerationContext } from '../lib/codeGeneration';
+import { deleteVariableDeclarationAST, deleteVariableDeclarationByLineFallback, deleteVariableDeclarationFallback, parseCode } from '../lib/ast';
 
 export interface CodeContextType {
     code: string;
@@ -13,6 +14,7 @@ export interface CodeContextType {
     commandManager: CommandManager;
     codeContext: CodeGenerationContext;
     renameItem: (oldName: string, newName: string) => void;
+    deleteItem: (name: string, lineHint?: number) => void;
     applyCodeSafe: (code: string) => Promise<boolean>;
 }
 
@@ -29,13 +31,26 @@ export function CodeProvider({ children, initialCode = defaultCode }: { children
         commandManager.setContextProvider(() => ({ code, setCode }));
     }, [commandManager, code]);
 
-    const insertCode = useCallback((snippet: string | ((name: string) => string), baseName?: string) => {
+    const commitMutation = useCallback((mutate: (prev: string) => string, mutationName: string): void => {
         setCode(prev => {
+            try {
+                const next = mutate(prev);
+                parseCode(next);
+                return next;
+            } catch (e) {
+                console.error(`${mutationName} failed; keeping previous code`, e);
+                return prev;
+            }
+        });
+    }, []);
+
+    const insertCode = useCallback((snippet: string | ((name: string) => string), baseName?: string) => {
+        commitMutation((prev) => {
             const resolvedSnippet = typeof snippet === 'function' ? snippet(baseName || 'shape') : snippet;
             const trimmed = prev.trimEnd();
             return trimmed + (trimmed ? '\n' : '') + resolvedSnippet;
-        });
-    }, []);
+        }, 'insertCode');
+    }, [commitMutation]);
 
     // Generic Code Context for Features
     const codeContext = useMemo(() => {
@@ -55,12 +70,37 @@ export function CodeProvider({ children, initialCode = defaultCode }: { children
 
     const renameItem = useCallback((oldName: string, newName: string) => {
         import('../features/modeling/RefactoringManager').then(({ refactoringManager }) => {
-            const newCode = refactoringManager.renameVariable(code, oldName, newName);
-            if (newCode !== code) {
-                setCode(newCode);
-            }
+            commitMutation((prev) => refactoringManager.renameVariable(prev, oldName, newName), 'renameItem');
         });
-    }, [code]);
+    }, [commitMutation]);
+
+    const deleteItem = useCallback((name: string, lineHint?: number) => {
+        commitMutation((prev) => {
+            const candidates: string[] = [];
+
+            // 1) AST path
+            candidates.push(deleteVariableDeclarationAST(prev, name));
+
+            // 2) Line-aware fallback (if we know where declaration is in History)
+            if (typeof lineHint === 'number') {
+                candidates.push(deleteVariableDeclarationByLineFallback(prev, name, lineHint));
+            }
+
+            // 3) Name-only fallback
+            candidates.push(deleteVariableDeclarationFallback(prev, name));
+
+            for (const candidate of candidates) {
+                try {
+                    parseCode(candidate);
+                    return candidate;
+                } catch {
+                    // try next strategy
+                }
+            }
+
+            throw new Error(`All delete strategies failed for "${name}"`);
+        }, 'deleteItem');
+    }, [commitMutation]);
 
     const applyCodeSafe = useCallback(async (newCode: string): Promise<boolean> => {
         try {
@@ -128,8 +168,9 @@ export function CodeProvider({ children, initialCode = defaultCode }: { children
         commandManager,
         codeContext,
         renameItem,
+        deleteItem,
         applyCodeSafe
-    }), [code, insertCode, editorInstance, commandManager, codeContext, renameItem, applyCodeSafe]);
+    }), [code, insertCode, editorInstance, commandManager, codeContext, renameItem, deleteItem, applyCodeSafe]);
 
     return <CodeContext.Provider value={value}>{children}</CodeContext.Provider>;
 }

--- a/src/context/CodeContext.tsx
+++ b/src/context/CodeContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState, t
 import { CommandManager } from '../commands/CommandManager';
 import { defaultCode } from '../lib/geometryEngine';
 import type { EditorLike } from '../types/editor';
+import { CodeAnalyzer, type CodeGenerationContext } from '../lib/codeGeneration';
 
 export interface CodeContextType {
     code: string;
@@ -10,6 +11,9 @@ export interface CodeContextType {
     editorInstance: EditorLike | null;
     setEditorInstance: (instance: EditorLike | null) => void;
     commandManager: CommandManager;
+    codeContext: CodeGenerationContext;
+    renameItem: (oldName: string, newName: string) => void;
+    applyCodeSafe: (code: string) => Promise<boolean>;
 }
 
 const CodeContext = createContext<CodeContextType | undefined>(undefined);
@@ -33,6 +37,53 @@ export function CodeProvider({ children, initialCode = defaultCode }: { children
         });
     }, []);
 
+    // Generic Code Context for Features
+    const codeContext = useMemo(() => {
+        try {
+            const analyzer = new CodeAnalyzer(code);
+            return analyzer.createContext();
+        } catch (e) {
+            console.warn('CodeContext: Failed to analyze code (likely syntax error):', e);
+            // Return a minimal context
+            return {
+                variables: [],
+                getVariableAtIndex: () => 'shape',
+                generateUniqueName: (prefix: string) => `${prefix}_${Date.now()}`
+            } as unknown as CodeGenerationContext;
+        }
+    }, [code]);
+
+    const renameItem = useCallback((oldName: string, newName: string) => {
+        import('../features/modeling/RefactoringManager').then(({ refactoringManager }) => {
+            const newCode = refactoringManager.renameVariable(code, oldName, newName);
+            if (newCode !== code) {
+                setCode(newCode);
+            }
+        });
+    }, [code]);
+
+    const applyCodeSafe = useCallback(async (newCode: string): Promise<boolean> => {
+        try {
+            const { agentAPI } = await import('../agent/AgentAPI');
+            const result = await agentAPI.evaluateCode(newCode);
+
+            if (result.errors && result.errors.length > 0) {
+                const msg = "AI Validation Failed:\n" + result.errors.join('\n');
+                console.error(msg);
+                alert(msg);
+                return false;
+            }
+
+            setCode(newCode);
+            return true;
+        } catch (e: unknown) {
+            const message = e instanceof Error ? e.message : String(e);
+            console.error("Safety Check Error:", e);
+            alert("Safety Check Error: " + message);
+            return false;
+        }
+    }, []);
+
     // Magic Comment Detection
     useEffect(() => {
         const magicCommentRegex = /\/\/ @ai:(.+)(\n|$)/;
@@ -44,31 +95,19 @@ export function CodeProvider({ children, initialCode = defaultCode }: { children
             const isFinished = fullMatch.endsWith('\n');
 
             if (isFinished && instruction) {
-                // Prevent infinite loops or re-triggering
-                // We'll immediately "mark" it as processing by replacing it or adding a loader comment
-                // For now, simpler: replace with "Generating..."
-
                 const processingPlaceholder = `// @ai-processing: ${instruction}...\n`;
                 const newCodeWithPlaceholder = code.replace(fullMatch, processingPlaceholder);
                 setCode(newCodeWithPlaceholder);
 
-                // Import LLM Service dynamically to avoid circular dependency issues at top level if any
                 import('../features/ai/LLMService').then(async ({ llmService }) => {
                     try {
-                        // We pass the *current code* as context so it knows what to do
-                        // We exclude the magic comment line itself from the context to avoid confusing the AI
                         const contextCode = code.replace(fullMatch, '');
-
                         const prompt = `Generate code for: "${instruction}". return ONLY the code.`;
-
                         const response = await llmService.sendMessage(
                             [{ role: 'user', content: prompt }],
                             { code: contextCode }
                         );
-
-                        // Clean up response (remove markdown blocks if present)
                         const cleanCode = response.replace(/```javascript/g, '').replace(/```/g, '').trim();
-
                         setCode(prev => prev.replace(processingPlaceholder, cleanCode + '\n'));
                     } catch (error) {
                         console.error("Magic Comment Error:", error);
@@ -79,6 +118,7 @@ export function CodeProvider({ children, initialCode = defaultCode }: { children
         }
     }, [code]);
 
+
     const value: CodeContextType = useMemo(() => ({
         code,
         setCode,
@@ -86,7 +126,10 @@ export function CodeProvider({ children, initialCode = defaultCode }: { children
         editorInstance,
         setEditorInstance,
         commandManager,
-    }), [code, insertCode, editorInstance, commandManager]);
+        codeContext,
+        renameItem,
+        applyCodeSafe
+    }), [code, insertCode, editorInstance, commandManager, codeContext, renameItem, applyCodeSafe]);
 
     return <CodeContext.Provider value={value}>{children}</CodeContext.Provider>;
 }

--- a/src/context/GeometryContext.tsx
+++ b/src/context/GeometryContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useMemo, useState, useEffect, type ReactNode } from 'react';
 import { GeometryEngine, type GeometryResult, type SketchGeometry } from '../lib/geometryEngine';
 import { remapSketchNames } from '../lib/sketchNaming';
+import { parseCode } from '../lib/ast';
 
 export interface GeometryContextType {
     geometries: GeometryResult[];
@@ -63,6 +64,13 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
         if (!isReady) return;
 
         const run = async () => {
+            try {
+                parseCode(code);
+            } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                setError(message);
+                return;
+            }
             setIsComputing(true);
             try {
                 const result = await engine.executeCode(code);
@@ -104,6 +112,8 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
 
         const runPreview = async () => {
             try {
+                parseCode(code);
+                parseCode(`${code}\n${previewCode}`);
                 // Combine current code (as library) with preview code
                 // Or just run the preview code if it's independent
                 // For live modeling, it's usually current code + the new operation
@@ -121,6 +131,12 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
 
     const executeGeometry = useCallback(async (codeToExecute: string) => {
         if (!isReady) return;
+        try {
+            parseCode(codeToExecute);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+            return;
+        }
         setIsComputing(true);
         try {
             const result = await engine.executeCode(codeToExecute);

--- a/src/context/SketchingContext.tsx
+++ b/src/context/SketchingContext.tsx
@@ -11,6 +11,7 @@ export interface SketchingContextType {
     addConstraint: (constraint: Constraint) => void;
     selectEntity: (id: string, multi?: boolean) => void;
     clearSelection: () => void;
+    clearAll: () => void;
     solve: () => void;
 }
 
@@ -83,6 +84,13 @@ export function SketchingProvider({ children }: { children: ReactNode }) {
         setSelectedEntityIds([]);
     }, []);
 
+    const clearAll = useCallback(() => {
+        setEntities(new Map());
+        setConstraints([]);
+        constraintsRef.current = [];
+        setSelectedEntityIds([]);
+    }, []);
+
     const value: SketchingContextType = useMemo(() => ({
         entities,
         constraints,
@@ -92,8 +100,9 @@ export function SketchingProvider({ children }: { children: ReactNode }) {
         addConstraint,
         selectEntity,
         clearSelection,
+        clearAll,
         solve
-    }), [entities, constraints, selectedEntityIds, addEntity, updateEntity, addConstraint, selectEntity, clearSelection, solve]);
+    }), [entities, constraints, selectedEntityIds, addEntity, updateEntity, addConstraint, selectEntity, clearSelection, clearAll, solve]);
 
     return <SketchingContext.Provider value={value}>{children}</SketchingContext.Provider>;
 }

--- a/src/context/WorkbenchContext.tsx
+++ b/src/context/WorkbenchContext.tsx
@@ -29,6 +29,7 @@ export interface WorkbenchContextType extends
 
     // Commands
     renameItem: (oldName: string, newName: string) => void;
+    deleteItem: (name: string, lineHint?: number) => void;
 
     // Safety
     applyCodeSafe: (code: string) => Promise<boolean>;
@@ -121,6 +122,7 @@ function WorkbenchInnerProvider({ children }: { children: ReactNode }) {
         openPanel: uiCtx.openPanel,
         closePanel: uiCtx.closePanel,
         renameItem: codeCtx.renameItem,
+        deleteItem: codeCtx.deleteItem,
         // Geometry context
         geometries: geometryCtx.geometries,
         sketchesGeometries: geometryCtx.sketchesGeometries,
@@ -142,6 +144,7 @@ function WorkbenchInnerProvider({ children }: { children: ReactNode }) {
         addConstraint: sketchingCtx.addConstraint,
         selectEntity: sketchingCtx.selectEntity,
         clearSelection: sketchingCtx.clearSelection,
+        clearAll: sketchingCtx.clearAll,
         solve: sketchingCtx.solve,
         // New: Code generation context
         codeContext: codeCtx.codeContext,
@@ -211,6 +214,7 @@ function WorkbenchInnerProvider({ children }: { children: ReactNode }) {
         sketchingCtx.addConstraint,
         sketchingCtx.selectEntity,
         sketchingCtx.clearSelection,
+        sketchingCtx.clearAll,
         sketchingCtx.solve,
     ]);
 

--- a/src/context/WorkbenchContext.tsx
+++ b/src/context/WorkbenchContext.tsx
@@ -12,7 +12,7 @@ import { SelectionProvider, useSelection, type SelectionContextType } from './Se
 import { GeometryProvider, useGeometry, type GeometryContextType } from './GeometryContext';
 import { useFaceSelection } from '../hooks/useFaceSelection';
 import { SketchingProvider, useSketching, type SketchingContextType } from './SketchingContext';
-import { CodeAnalyzer, type CodeGenerationContext } from '../lib/codeGeneration';
+import { type CodeGenerationContext } from '../lib/codeGeneration';
 
 // Combined type for backward compatibility
 export interface WorkbenchContextType extends
@@ -49,33 +49,26 @@ function WorkbenchInnerProvider({ children }: { children: ReactNode }) {
     const sketchingCtx = useSketching();
 
     // Use face selection hook with geometry dependencies
-    const faceSelection = useFaceSelection({
+    const {
+        selectedFace,
+        selectedFacePlane,
+        setSelectedFace,
+        isFaceSelecting,
+        startFaceSelection,
+        cancelFaceSelection,
+    } = useFaceSelection({
         geometries: geometryCtx.geometries,
         code: codeCtx.code,
         onSketchModeChange: selectionCtx.setSketchMode
     });
 
-    // Create code context for feature generators
-    const codeContext = useMemo(() => {
-        try {
-            const analyzer = new CodeAnalyzer(codeCtx.code);
-            return analyzer.createContext();
-        } catch (e) {
-            console.warn('WorkbenchContext: Failed to analyze code (likely syntax error):', e);
-            // Return a minimal context for features to still function with fallbacks
-            return {
-                variables: [],
-                getVariableAtIndex: () => 'shape',
-                generateUniqueName: (prefix: string) => `${prefix}_${Date.now()}`
-            } as unknown as CodeGenerationContext;
-        }
-    }, [codeCtx.code]);
+    // Code context is now handled by CodeProvider
 
     // Wrap startFaceSelection to also close the dialog
     const startFaceSelectionWithDialog = useCallback(() => {
-        faceSelection.startFaceSelection();
+        startFaceSelection();
         uiCtx.setActiveDialog(null);
-    }, [faceSelection, uiCtx]);
+    }, [startFaceSelection, uiCtx]);
 
     // Combine all contexts into unified interface
     const value: WorkbenchContextType = useMemo(() => ({
@@ -100,12 +93,12 @@ function WorkbenchInnerProvider({ children }: { children: ReactNode }) {
         contextMenu: uiCtx.contextMenu,
         setContextMenu: uiCtx.setContextMenu,
         // Selection context
-        selectedFace: faceSelection.selectedFace,
-        selectedFacePlane: faceSelection.selectedFacePlane,
-        setSelectedFace: faceSelection.setSelectedFace,
-        isFaceSelecting: faceSelection.isFaceSelecting,
+        selectedFace,
+        selectedFacePlane,
+        setSelectedFace,
+        isFaceSelecting,
         startFaceSelection: startFaceSelectionWithDialog,
-        cancelFaceSelection: faceSelection.cancelFaceSelection,
+        cancelFaceSelection,
         sketchMode: selectionCtx.sketchMode,
         setSketchMode: selectionCtx.setSketchMode,
         sketches: selectionCtx.sketches,
@@ -127,18 +120,7 @@ function WorkbenchInnerProvider({ children }: { children: ReactNode }) {
         toggleVisibility: selectionCtx.toggleVisibility,
         openPanel: uiCtx.openPanel,
         closePanel: uiCtx.closePanel,
-        renameItem: (oldName: string, newName: string) => {
-            if (!codeCtx.code) return;
-            // Lazy load or import refactoring manager to avoid circular deps if needed?
-            // But we can import it directly.
-            // Ideally we should move this logic to a helper or hook, but here is fine for now.
-            import('../features/modeling/RefactoringManager').then(({ refactoringManager }) => {
-                const newCode = refactoringManager.renameVariable(codeCtx.code, oldName, newName);
-                if (newCode !== codeCtx.code) {
-                    codeCtx.setCode(newCode);
-                }
-            });
-        },
+        renameItem: codeCtx.renameItem,
         // Geometry context
         geometries: geometryCtx.geometries,
         sketchesGeometries: geometryCtx.sketchesGeometries,
@@ -162,33 +144,12 @@ function WorkbenchInnerProvider({ children }: { children: ReactNode }) {
         clearSelection: sketchingCtx.clearSelection,
         solve: sketchingCtx.solve,
         // New: Code generation context
-        codeContext,
+        codeContext: codeCtx.codeContext,
         /**
          * Safely applies code after validating it with the Agent API.
          * Returns true if successful, false if validation failed.
          */
-        applyCodeSafe: async (newCode: string): Promise<boolean> => {
-            try {
-                // Dynamic import to avoid circular dependency if AgentAPI depends on things that depend on this
-                const { agentAPI } = await import('../agent/AgentAPI');
-                const result = await agentAPI.evaluateCode(newCode);
-
-                if (result.errors && result.errors.length > 0) {
-                    const msg = "AI Validation Failed:\n" + result.errors.join('\n');
-                    console.error(msg);
-                    alert(msg);
-                    return false;
-                }
-
-                codeCtx.setCode(newCode);
-                return true;
-            } catch (e: unknown) {
-                const message = e instanceof Error ? e.message : String(e);
-                console.error("Safety Check Error:", e);
-                alert("Safety Check Error: " + message);
-                return false;
-            }
-        }
+        applyCodeSafe: codeCtx.applyCodeSafe
     }), [
         codeCtx,
         uiCtx.viewMode,
@@ -205,12 +166,13 @@ function WorkbenchInnerProvider({ children }: { children: ReactNode }) {
         uiCtx.closePanel,
         uiCtx.contextMenu,
         uiCtx.setContextMenu,
-        faceSelection.selectedFace,
-        faceSelection.selectedFacePlane,
-        faceSelection.setSelectedFace,
-        faceSelection.isFaceSelecting,
+        // faceSelection removed
+        selectedFace,
+        selectedFacePlane,
+        setSelectedFace,
+        isFaceSelecting,
         startFaceSelectionWithDialog,
-        faceSelection.cancelFaceSelection,
+        cancelFaceSelection,
         selectionCtx.sketchMode,
         selectionCtx.setSketchMode,
         selectionCtx.sketches,
@@ -250,7 +212,6 @@ function WorkbenchInnerProvider({ children }: { children: ReactNode }) {
         sketchingCtx.selectEntity,
         sketchingCtx.clearSelection,
         sketchingCtx.solve,
-        codeContext,
     ]);
 
     return <WorkbenchContext.Provider value={value}>{children}</WorkbenchContext.Provider>;

--- a/src/context/WorkbenchContext.tsx
+++ b/src/context/WorkbenchContext.tsx
@@ -30,6 +30,7 @@ export interface WorkbenchContextType extends
     // Commands
     renameItem: (oldName: string, newName: string) => void;
     deleteItem: (name: string, lineHint?: number) => void;
+    deleteHistoryItem: CodeContextType['deleteHistoryItem'];
 
     // Safety
     applyCodeSafe: (code: string) => Promise<boolean>;
@@ -123,6 +124,7 @@ function WorkbenchInnerProvider({ children }: { children: ReactNode }) {
         closePanel: uiCtx.closePanel,
         renameItem: codeCtx.renameItem,
         deleteItem: codeCtx.deleteItem,
+        deleteHistoryItem: codeCtx.deleteHistoryItem,
         // Geometry context
         geometries: geometryCtx.geometries,
         sketchesGeometries: geometryCtx.sketchesGeometries,

--- a/src/hooks/useFaceSelection.ts
+++ b/src/hooks/useFaceSelection.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { getReturnedVariables } from '../lib/ast';
 import type { GeometryResult } from '../lib/geometryEngine';
 import type { SketchModeState } from '../types/sketch';
@@ -42,15 +42,15 @@ export function useFaceSelection({
     const [selectedFacePlane, setSelectedFacePlane] = useState<FacePlane | null>(null);
     const [isFaceSelecting, setIsFaceSelecting] = useState(false);
 
-    const startFaceSelection = () => {
+    const startFaceSelection = useCallback(() => {
         setIsFaceSelecting(true);
-    };
+    }, []);
 
-    const cancelFaceSelection = () => {
+    const cancelFaceSelection = useCallback(() => {
         setIsFaceSelecting(false);
-    };
+    }, []);
 
-    const setSelectedFace = (selection: FaceSelection | null) => {
+    const setSelectedFace = useCallback((selection: FaceSelection | null) => {
         setSelectedFaceState(selection);
 
         if (selection && geometries[selection.shapeIndex]) {
@@ -91,18 +91,26 @@ export function useFaceSelection({
                     currentSketch: null,
                     tool: 'line'
                 });
-                setIsFaceSelecting(false);
+                // We should ideally use a ref for isFaceSelecting if we want to avoid dependency loop,
+                // but since this is an event handler, it's tricky.
+                // Actually, isFaceSelecting is state.
+                // We can't access current state in useCallback without adding it to deps.
+                // If we add it to deps, function changes when state changes.
+                // That's acceptable.
             } else if (isFaceSelecting && !isValidPlane) {
-                // Invalid plane - cancel face selection and show error
                 if (import.meta.env.DEV && import.meta.env.MODE !== 'test') {
                     console.error('Selected face does not have a valid planar surface. Only flat faces can be sketched on.');
                 }
+            }
+            // Always turn off face selection after a click in selection mode?
+            // Original logic:
+            if (isFaceSelecting) {
                 setIsFaceSelecting(false);
             }
         } else {
             setSelectedFacePlane(null);
         }
-    };
+    }, [geometries, code, onSketchModeChange, isFaceSelecting]);
 
     return {
         selectedFace,

--- a/src/hooks/useFaceSelection.ts
+++ b/src/hooks/useFaceSelection.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import { getReturnedVariables } from '../lib/ast';
 import type { GeometryResult } from '../lib/geometryEngine';
 import type { SketchModeState } from '../types/sketch';
+import { buildFaceSketchPlaneEntity } from '../lib/sketchPlane';
 
 export interface FaceSelection {
     shapeIndex: number;
@@ -77,17 +78,13 @@ export function useFaceSelection({
 
                 onSketchModeChange({
                     active: true,
-                    plane: {
-                        id: `face-${selection.faceId}-${Date.now()}`,
-                        name: targetName ? `Face ${selection.faceId} of ${targetName}` : `Face ${selection.faceId}`,
-                        type: 'face',
+                    plane: buildFaceSketchPlaneEntity({
+                        faceId: selection.faceId,
+                        targetName,
                         origin: plane!.origin,
                         normal: plane!.normal,
-                        xDir: plane!.xDir,
-                        visible: true,
-                        parentId: targetName || undefined,
-                        faceId: selection.faceId
-                    },
+                        xDir: plane!.xDir
+                    }),
                     currentSketch: null,
                     tool: 'line'
                 });

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -11,7 +11,11 @@ function isTypingTarget(target: EventTarget | null): boolean {
     if (!el) return false;
     if (el.isContentEditable) return true;
     const tag = el.tagName?.toLowerCase();
-    return tag === 'input' || tag === 'textarea' || tag === 'select';
+    if (tag === 'input' || tag === 'textarea' || tag === 'select') return true;
+    // Monaco and similar editors often use div-based textboxes.
+    if (el.getAttribute('role') === 'textbox') return true;
+    if (el.closest('.monaco-editor')) return true;
+    return false;
 }
 
 function normalizeKey(e: KeyboardEvent): string {
@@ -38,11 +42,17 @@ export function useKeyboardShortcuts(shortcuts: ShortcutConfig) {
             const handler = shortcuts[combo] ?? shortcuts[key];
             if (handler) {
                 e.preventDefault();
+                e.stopPropagation();
+                // Prevent downstream handlers (including editors) from also processing the key.
+                if (typeof e.stopImmediatePropagation === 'function') {
+                    e.stopImmediatePropagation();
+                }
                 handler(e);
             }
         };
 
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
+        // Capture phase lets us consume app shortcuts before nested widgets.
+        window.addEventListener('keydown', handleKeyDown, true);
+        return () => window.removeEventListener('keydown', handleKeyDown, true);
     }, [shortcuts]);
 }

--- a/src/integration/hover_sync.test.tsx
+++ b/src/integration/hover_sync.test.tsx
@@ -34,7 +34,7 @@ const TestComponent = () => {
     } = useWorkbench();
 
     const mockItems = [
-        { name: 'box1', type: 'Box', line: 1 },
+        { id: 'box1:1:1:10', name: 'box1', type: 'Box', line: 1 },
     ];
 
     return (

--- a/src/integration/hover_sync.test.tsx
+++ b/src/integration/hover_sync.test.tsx
@@ -39,7 +39,7 @@ const TestComponent = () => {
 
     return (
         <div>
-            <button data-testid="trigger-hover" onClick={() => setHoveredItemId('box1')}>Trigger</button>
+            <button data-testid="trigger-hover" onClick={() => setHoveredItemId('box1:1:1:10')}>Trigger</button>
             <button data-testid="clear-hover" onClick={() => setHoveredItemId(null)}>Clear</button>
             <SceneBrowser
                 items={mockItems}

--- a/src/integration/ui_workflows.test.tsx
+++ b/src/integration/ui_workflows.test.tsx
@@ -148,6 +148,24 @@ export default function main() {
         });
     });
 
+    it('should expose test window helpers for selection and hover', async () => {
+        render(<App />);
+
+        await waitFor(() => {
+            expect(typeof window.__TEST_SELECT_ITEM).toBe('function');
+            expect(typeof window.__TEST_SET_HOVERED).toBe('function');
+            expect(typeof window.selectedItemId).toBe('function');
+            expect(typeof window.getHoveredItemId).toBe('function');
+        });
+
+        const historyId = 'box:1:1:10';
+        window.__TEST_SELECT_ITEM?.(historyId);
+        expect(window.selectedItemId?.()).toBe(historyId);
+
+        window.__TEST_SET_HOVERED?.(historyId);
+        expect(window.getHoveredItemId?.()).toBe(historyId);
+    });
+
     it('should recover after reload and delete an autosaved sketch without syntax errors', async () => {
         const autosavedCode = `
 export default function main() {

--- a/src/integration/ui_workflows.test.tsx
+++ b/src/integration/ui_workflows.test.tsx
@@ -133,8 +133,8 @@ export default function main() {
 }
 `.trim();
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (window as any).setCode(initialCode);
+        expect(typeof window.setCode).toBe('function');
+        window.setCode?.(initialCode);
 
         expect(await screen.findByText('sketch')).toBeTruthy();
         fireEvent.click(screen.getByText('sketch'));

--- a/src/integration/ui_workflows.test.tsx
+++ b/src/integration/ui_workflows.test.tsx
@@ -6,6 +6,7 @@ import App from '../App';
 import * as GeometryEngine from '../lib/geometryEngine';
 import { initFeatures } from '../features/init';
 import type { EditorLike } from '../types/editor';
+import { parseCode } from '../lib/ast';
 
 const runUIE2E = process.env.KERNELCAD_UI_E2E === '1';
 const describeUI = runUIE2E ? describe : describe.skip;
@@ -20,6 +21,14 @@ vi.mock('../lib/geometryEngine', () => ({
     exportSTEP: vi.fn().mockResolvedValue(new Blob()),
     exportSTL: vi.fn().mockResolvedValue(new Blob()),
     defaultCode: '// KernelCAD Start',
+    GeometryEngine: {
+        getInstance: () => ({
+            initialize: vi.fn().mockResolvedValue(true),
+            executeCode: vi.fn().mockResolvedValue({ geometries: [], sketches: [] }),
+            exportSTEP: vi.fn().mockResolvedValue(new Blob()),
+            exportSTL: vi.fn().mockResolvedValue(new Blob()),
+        }),
+    },
 }));
 
 vi.mock('../components/Editor', () => ({
@@ -104,5 +113,37 @@ describeUI('UI Workflows E2E', () => {
             expect(generatedCode).toContain('.lineTo(');
             expect(generatedCode).toContain('.extrude(50)');
         }, { timeout: 10000 });
+    });
+
+    it('should delete a sketch from history without corrupting code', async () => {
+        render(<App />);
+
+        const initialCode = `
+export default function main() {
+  function drawPart() {
+    const box = replicad.makeBox(10, 10, 10);
+    const sketch = new Sketcher('XY')
+      .movePointerTo([0, 0])
+      .lineTo([10, 0])
+      .done();
+    return [box, sketch];
+  }
+  return drawPart();
+}
+`.trim();
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).setCode(initialCode);
+
+        expect(await screen.findByText('sketch')).toBeTruthy();
+        fireEvent.click(screen.getByText('sketch'));
+        fireEvent.keyDown(window, { key: 'Delete' });
+
+        await waitFor(() => {
+            const editor = screen.getByTestId('code-editor') as HTMLTextAreaElement;
+            expect(editor.value).not.toContain('const sketch');
+            expect(editor.value).toContain('return [box]');
+            expect(() => parseCode(editor.value)).not.toThrow();
+        });
     });
 });

--- a/src/integration/ui_workflows.test.tsx
+++ b/src/integration/ui_workflows.test.tsx
@@ -72,6 +72,7 @@ if (typeof window !== 'undefined') {
 describeUI('UI Workflows E2E', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        localStorage.clear();
         initFeatures();
     });
 
@@ -144,6 +145,52 @@ export default function main() {
             expect(editor.value).not.toContain('const sketch');
             expect(editor.value).toContain('return [box]');
             expect(() => parseCode(editor.value)).not.toThrow();
+        });
+    });
+
+    it('should recover after reload and delete an autosaved sketch without syntax errors', async () => {
+        const autosavedCode = `
+export default function main() {
+  function drawPart() {
+    const box = replicad.makeBox(10, 10, 10);
+    const sketch = new Sketcher('XY')
+      .movePointerTo([0, 0])
+      .lineTo([10, 0])
+      .done();
+    return [box, sketch];
+  }
+  return drawPart();
+}
+`.trim();
+
+        localStorage.setItem('kernelcad_current_project', JSON.stringify({
+            version: '1.0',
+            name: 'Auto-saved Project',
+            code: autosavedCode,
+            viewState: {
+                viewMode: 'code',
+                viewMode3D: 'shaded',
+                sidePanelVisible: true,
+                showSketches: true
+            },
+            lastUpdated: new Date('2026-02-12T00:00:00.000Z').toISOString()
+        }));
+
+        const { unmount } = render(<App />);
+        expect(await screen.findByText('sketch')).toBeTruthy();
+        unmount();
+
+        render(<App />);
+
+        expect(await screen.findByText('sketch')).toBeTruthy();
+        fireEvent.click(screen.getByText('sketch'));
+        fireEvent.keyDown(window, { key: 'Delete' });
+
+        await waitFor(() => {
+            const editor = screen.getByTestId('code-editor') as HTMLTextAreaElement;
+            expect(editor.value).not.toContain('const sketch');
+            expect(() => parseCode(editor.value)).not.toThrow();
+            expect(screen.queryByText(/SyntaxError:/i)).toBeNull();
         });
     });
 });

--- a/src/lib/ast.delete.test.ts
+++ b/src/lib/ast.delete.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { deleteVariableDeclarationAST, deleteVariableDeclarationFallback, parseCode } from './ast';
+import { deleteVariableDeclarationAST, deleteVariableDeclarationByNameAndLineAST, deleteVariableDeclarationFallback, parseCode } from './ast';
 
 describe('deleteVariableDeclarationAST', () => {
     it('deletes sketch declaration and removes it from return array', () => {
@@ -68,6 +68,27 @@ return [replicad.makeBox(10, 10, 10), sketch];
         const next = deleteVariableDeclarationFallback(code, 'sketch');
         expect(next).not.toContain('sketch =');
         expect(next).toContain('return [replicad.makeBox(10, 10, 10)]');
+        expect(() => parseCode(next)).not.toThrow();
+    });
+
+    it('deletes by declaration identity (name + line) deterministically', () => {
+        const code = `
+export default function main() {
+  function drawPart() {
+    const box = replicad.makeBox(10, 10, 10);
+    const sketch = new Sketcher('XY')
+      .movePointerTo([2, 2])
+      .lineTo([6, 2])
+      .close();
+    return [box, sketch];
+  }
+  return drawPart();
+}
+`.trim();
+
+        const next = deleteVariableDeclarationByNameAndLineAST(code, 'sketch', 4);
+        expect(next).not.toContain('const sketch');
+        expect(next).toContain('return [box]');
         expect(() => parseCode(next)).not.toThrow();
     });
 });

--- a/src/lib/ast.delete.test.ts
+++ b/src/lib/ast.delete.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { deleteVariableDeclarationAST, deleteVariableDeclarationFallback, parseCode } from './ast';
+
+describe('deleteVariableDeclarationAST', () => {
+    it('deletes sketch declaration and removes it from return array', () => {
+        const code = `
+export default function main() {
+    function drawPart() {
+        const box = replicad.makeBox(10, 10, 10);
+        const sketch = new Sketcher('XY')
+            .movePointerTo([0, 0])
+            .lineTo([10, 0])
+            .done();
+        return [box, sketch];
+    }
+    return drawPart();
+}
+`.trim();
+
+        const next = deleteVariableDeclarationAST(code, 'sketch');
+        expect(next).not.toContain('const sketch');
+        expect(next).toContain('return [box]');
+        expect(() => parseCode(next)).not.toThrow();
+    });
+
+    it('keeps code unchanged when variable does not exist', () => {
+        const code = `
+export default function main() {
+    function drawPart() {
+        const box = replicad.makeBox(10, 10, 10);
+        return [box];
+    }
+    return drawPart();
+}
+`.trim();
+
+        const next = deleteVariableDeclarationAST(code, 'missingSketch');
+        expect(next).toBe(code);
+        expect(() => parseCode(next)).not.toThrow();
+    });
+
+    it('fallback removes multiline fluent sketch declaration and keeps code parseable', () => {
+        const code = `
+export default function main() {
+  function drawPart() {
+    const box = replicad.makeBox(10, 10, 10);
+    const sketch = new Sketcher(new replicad.Plane([5, -5, 10], null, [0, 0, 1]))
+      .movePointerTo([3.6284, 0])
+      .lineTo([8, 0])
+      .done();
+    return [box, sketch];
+  }
+  return drawPart();
+}
+`.trim();
+
+        const next = deleteVariableDeclarationFallback(code, 'sketch');
+        expect(next).not.toContain('const sketch');
+        expect(next).toContain('return [box]');
+        expect(() => parseCode(next)).not.toThrow();
+    });
+
+    it('fallback handles corrupted autosave token (onst sketch) and removes sketch cleanly', () => {
+        const code = `'onst sketch = new Sketcher(new replicad.Plane([-1.1102230246251565e-16, 1.3322676295501878e-16, 10], [1, 0, 0], [0, 0, 1])).movePointerTo([2, 2]).lineTo([6, 2]).lineTo([6, -1]).lineTo([2, -1]).lineTo([2, 2]).close();
+return [replicad.makeBox(10, 10, 10), sketch];
+`;
+
+        const next = deleteVariableDeclarationFallback(code, 'sketch');
+        expect(next).not.toContain('sketch =');
+        expect(next).toContain('return [replicad.makeBox(10, 10, 10)]');
+        expect(() => parseCode(next)).not.toThrow();
+    });
+});

--- a/src/lib/ast.ts
+++ b/src/lib/ast.ts
@@ -568,3 +568,159 @@ export function insertShape(code: string, statement: string): string {
 
     return generateCode(astNode);
 }
+
+/**
+ * Deletes a top-level variable declaration by name and removes it from drawPart/top-level return.
+ * Keeps resulting code syntactically valid.
+ */
+export function deleteVariableDeclarationAST(code: string, variableName: string): string {
+    const astNode = parseCode(code);
+    let changed = false;
+
+    const removeFromReturn = (returnStmt: ReturnStatementNode) => {
+        const arg = returnStmt.argument;
+        if (!arg) return;
+
+        if (isArrayExpressionNode(arg)) {
+            const next = arg.elements.filter((el: unknown) => resolveVariableName(el) !== variableName);
+            if (next.length !== arg.elements.length) {
+                (returnStmt as unknown as { argument: unknown }).argument = {
+                    type: 'ArrayExpression',
+                    elements: next
+                };
+                changed = true;
+            }
+            return;
+        }
+
+        if (resolveVariableName(arg) === variableName) {
+            (returnStmt as unknown as { argument: unknown }).argument = {
+                type: 'ArrayExpression',
+                elements: []
+            };
+            changed = true;
+        }
+    };
+
+    const removeDeclFromBody = (body: acorn.Node[]) => {
+        for (let i = body.length - 1; i >= 0; i--) {
+            const node = body[i];
+            if (!hasType(node) || node.type !== 'VariableDeclaration') continue;
+            const declNode = node as unknown as { declarations?: unknown[] };
+            if (!Array.isArray(declNode.declarations) || declNode.declarations.length === 0) continue;
+
+            const remainingDecls = declNode.declarations.filter((decl) => {
+                if (!isRecord(decl) || !isRecord(decl.id)) return true;
+                return !(decl.id.type === 'Identifier' && decl.id.name === variableName);
+            });
+
+            if (remainingDecls.length === declNode.declarations.length) continue;
+
+            if (remainingDecls.length === 0) {
+                body.splice(i, 1);
+            } else {
+                (node as unknown as { declarations: unknown[] }).declarations = remainingDecls;
+            }
+            changed = true;
+        }
+
+        body.forEach((n) => {
+            if (isReturnStatementNode(n)) removeFromReturn(n);
+        });
+    };
+
+    let processedDrawPart = false;
+    walk.simple(astNode, {
+        FunctionDeclaration(node: acorn.Node) {
+            const fn = node as unknown as NodeWithId & NodeWithBody;
+            if (!fn.id || fn.id.name !== 'drawPart') return;
+            const body = (fn.body as { body: acorn.Node[] }).body;
+            removeDeclFromBody(body);
+            processedDrawPart = true;
+        }
+    });
+
+    if (!processedDrawPart) {
+        removeDeclFromBody(getProgramBody(astNode));
+    }
+
+    return changed ? generateCode(astNode) : code;
+}
+
+/**
+ * Fallback text-based deletion for malformed edge cases:
+ * removes a `const <name> = ...;` statement block (including multiline fluent chains)
+ * and prunes `<name>` from `return [ ... ]` lists.
+ */
+export function deleteVariableDeclarationFallback(code: string, variableName: string): string {
+    const escaped = variableName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+    // Remove multiline const statement until terminating semicolon.
+    // Tolerant to malformed token variants seen in corrupted autosaves (e.g. "onst sketch = ...")
+    // and accidental leading quote characters.
+    const declBlock = new RegExp(`(^|\\n)\\s*['"]?\\s*(?:const|onst|let|var)\\s+${escaped}\\s*=([\\s\\S]*?);\\s*(?=\\n|$)`, 'm');
+    let next = code.replace(declBlock, '\n');
+
+    // Remove variable from return array while keeping commas sane.
+    const returnArrayRe = /return\s*\[([\s\S]*?)\];/m;
+    next = next.replace(returnArrayRe, (_full, inner: string) => {
+        const elements = inner
+            .split(',')
+            .map(s => s.trim())
+            .filter(Boolean)
+            .filter(el => el !== variableName);
+        return `return [${elements.join(', ')}];`;
+    });
+
+    // Remove now-useless standalone identifier expression statements.
+    const standaloneRef = new RegExp(`(^|\\n)\\s*${escaped}\\s*;\\s*(?=\\n|$)`, 'g');
+    next = next.replace(standaloneRef, '\n');
+
+    return next;
+}
+
+/**
+ * Line-aware fallback deletion used by History panel items.
+ * Starts from a known declaration line and removes until the terminating semicolon.
+ */
+export function deleteVariableDeclarationByLineFallback(code: string, variableName: string, line: number): string {
+    const lines = code.split('\n');
+    if (line < 1 || line > lines.length) return deleteVariableDeclarationFallback(code, variableName);
+
+    const escaped = variableName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const declStartRe = new RegExp(`^\\s*['"]?\\s*(?:const|onst|let|var)\\s+${escaped}\\s*=`);
+
+    let start = line - 1;
+    if (!declStartRe.test(lines[start] ?? '')) {
+        for (let i = Math.max(0, line - 3); i < Math.min(lines.length, line + 3); i++) {
+            if (declStartRe.test(lines[i] ?? '')) {
+                start = i;
+                break;
+            }
+        }
+    }
+    if (!declStartRe.test(lines[start] ?? '')) {
+        return deleteVariableDeclarationFallback(code, variableName);
+    }
+
+    let end = start;
+    while (end < lines.length && !(lines[end] ?? '').includes(';')) {
+        end++;
+    }
+    if (end >= lines.length) end = lines.length - 1;
+
+    const nextLines = [...lines.slice(0, start), ...lines.slice(end + 1)];
+    let next = nextLines.join('\n');
+
+    const returnArrayRe = /return\s*\[([\s\S]*?)\];/m;
+    next = next.replace(returnArrayRe, (_full, inner: string) => {
+        const elements = inner
+            .split(',')
+            .map(s => s.trim())
+            .filter(Boolean)
+            .filter(el => el !== variableName);
+        return `return [${elements.join(', ')}];`;
+    });
+
+    return next;
+}

--- a/src/lib/ast.ts
+++ b/src/lib/ast.ts
@@ -117,7 +117,8 @@ export function parseCode(code: string): acorn.Node {
             ecmaVersion: 'latest',
             sourceType: 'module',
             // Allow return outside function (needed for our template code)
-            allowReturnOutsideFunction: true
+            allowReturnOutsideFunction: true,
+            locations: true
         });
     } catch (error) {
         if (import.meta.env.DEV && import.meta.env.MODE !== 'test') {
@@ -642,6 +643,76 @@ export function deleteVariableDeclarationAST(code: string, variableName: string)
 
     if (!processedDrawPart) {
         removeDeclFromBody(getProgramBody(astNode));
+    }
+
+    return changed ? generateCode(astNode) : code;
+}
+
+/**
+ * Deterministic deletion by declaration identity (name + source line).
+ * Preferred for History-based delete operations.
+ */
+export function deleteVariableDeclarationByNameAndLineAST(code: string, variableName: string, line: number): string {
+    const astNode = parseCode(code);
+    let changed = false;
+
+    const removeFromReturn = (returnStmt: ReturnStatementNode) => {
+        const arg = returnStmt.argument;
+        if (!arg) return;
+        if (!isArrayExpressionNode(arg)) return;
+
+        const next = arg.elements.filter((el: unknown) => resolveVariableName(el) !== variableName);
+        if (next.length !== arg.elements.length) {
+            (returnStmt as unknown as { argument: unknown }).argument = {
+                type: 'ArrayExpression',
+                elements: next
+            };
+            changed = true;
+        }
+    };
+
+    const removeFromBody = (body: acorn.Node[]) => {
+        for (let i = body.length - 1; i >= 0; i--) {
+            const node = body[i];
+            if (!hasType(node) || node.type !== 'VariableDeclaration') continue;
+            const varDecl = node as unknown as {
+                loc?: { start?: { line?: number } };
+                declarations?: Array<{
+                    id?: { type?: string; name?: string; loc?: { start?: { line?: number } } };
+                }>;
+            };
+            if (!Array.isArray(varDecl.declarations) || varDecl.declarations.length === 0) continue;
+
+            const matches = varDecl.declarations.some((decl) => {
+                if (!isRecord(decl) || !isRecord(decl.id)) return false;
+                if (decl.id.type !== 'Identifier' || decl.id.name !== variableName) return false;
+                const idLine = decl.id.loc?.start?.line;
+                const declLine = varDecl.loc?.start?.line;
+                return idLine === line || declLine === line;
+            });
+
+            if (!matches) continue;
+            body.splice(i, 1);
+            changed = true;
+        }
+
+        body.forEach((n) => {
+            if (isReturnStatementNode(n)) removeFromReturn(n);
+        });
+    };
+
+    let processedDrawPart = false;
+    walk.simple(astNode, {
+        FunctionDeclaration(node: acorn.Node) {
+            const fn = node as unknown as NodeWithId & NodeWithBody;
+            if (!fn.id || fn.id.name !== 'drawPart') return;
+            removeFromBody((fn.body as { body: acorn.Node[] }).body);
+            processedDrawPart = true;
+        }
+    });
+
+    if (!processedDrawPart) {
+        removeFromBody(getProgramBody(astNode));
     }
 
     return changed ? generateCode(astNode) : code;

--- a/src/lib/codeAnalysis.test.ts
+++ b/src/lib/codeAnalysis.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, it, expect } from 'vitest';
-import { generateUniqueName, extractVariables } from './codeAnalysis';
+import { generateUniqueName, extractVariables, extractHistoryItems } from './codeAnalysis';
 
 describe('codeAnalysis', () => {
     describe('generateUniqueName', () => {
@@ -45,6 +45,19 @@ const res = box.cut(cyl);
             expect(vars[0]).toEqual({ name: 'box', type: 'Box', line: 1 });
             expect(vars[1]).toEqual({ name: 'cyl', type: 'Cylinder', line: 2 });
             expect(vars[2]).toEqual({ name: 'res', type: 'Cut', line: 3 });
+        });
+    });
+
+    describe('extractHistoryItems', () => {
+        it('should return stable ids for AST-extracted items', () => {
+            const code = `
+const box = replicad.makeBox(10, 10, 10);
+const sketch = new Sketcher('XY').lineTo([1, 1]).done();
+            `.trim();
+            const items = extractHistoryItems(code);
+            expect(items).toHaveLength(2);
+            expect(items[0].id).toContain('box:1:');
+            expect(items[1].id).toContain('sketch:2:');
         });
     });
 });

--- a/src/lib/codeAnalysis.ts
+++ b/src/lib/codeAnalysis.ts
@@ -11,6 +11,8 @@ export interface InsertionContext {
 }
 
 import { getDeclaredVariablesAST } from './ast';
+import * as acorn from 'acorn';
+import * as walk from 'acorn-walk';
 
 /**
  * Generates a unique variable name to avoid collisions.
@@ -41,43 +43,63 @@ export interface VariableDefinition {
  * - Guesses type based on keywords (makeBox, makeCylinder, fillet, etc.)
  */
 export function extractVariables(code: string): VariableDefinition[] {
-    const lines = code.split('\n');
     const variables: VariableDefinition[] = [];
+    try {
+        const ast = acorn.parse(code, {
+            ecmaVersion: 'latest',
+            sourceType: 'module',
+            allowReturnOutsideFunction: true,
+            locations: true
+        }) as unknown as acorn.Node;
 
-    lines.forEach((lineContent, index) => {
-        const line = lineContent.trim();
-        // Match `const name = ...`
-        const match = line.match(/^const\s+(\w+)\s*=/);
-        if (match) {
-            const name = match[1];
-            let type = 'Shape'; // Default
-            let detail: string | undefined;
+        walk.simple(ast, {
+            VariableDeclarator(node: acorn.Node) {
+                const decl = node as unknown as {
+                    id?: { type?: string; name?: string };
+                    init?: { start?: number; end?: number; type?: string; callee?: unknown; arguments?: unknown[] };
+                    loc?: { start?: { line?: number } };
+                };
+                if (!decl.id || decl.id.type !== 'Identifier' || typeof decl.id.name !== 'string') return;
 
-            // Simple keyword matching for type guessing
-            if (line.includes('makeBox')) type = 'Box';
-            else if (line.includes('makeCylinder')) type = 'Cylinder';
-            else if (line.includes('makeSphere')) type = 'Sphere';
-            else if (line.includes('fillet')) type = 'Fillet';
-            else if (line.includes('chamfer')) type = 'Chamfer';
-            else if (line.includes('cut')) type = 'Cut';
-            else if (line.includes('fuse')) type = 'Union';
-            else if (line.includes('intersect')) type = 'Intersect';
-            else if (line.includes('extrude')) type = 'Extrude';
-            else if (line.includes('revolve')) type = 'Revolve';
-            else if (line.includes('Sketcher')) {
-                type = 'Sketch';
-                const planeMatch = line.match(/new Sketcher\(['"](\w+)['"]\)/);
-                if (planeMatch) detail = planeMatch[1];
+                const name = decl.id.name;
+                const line = decl.loc?.start?.line ?? 1;
+                const init = decl.init;
+                const initSrc = init && typeof init.start === 'number' && typeof init.end === 'number'
+                    ? code.slice(init.start, init.end)
+                    : '';
+
+                let type = 'Shape';
+                let detail: string | undefined;
+
+                if (initSrc.includes('makeBox')) type = 'Box';
+                else if (initSrc.includes('makeCylinder')) type = 'Cylinder';
+                else if (initSrc.includes('makeSphere')) type = 'Sphere';
+                else if (initSrc.includes('fillet')) type = 'Fillet';
+                else if (initSrc.includes('chamfer')) type = 'Chamfer';
+                else if (initSrc.includes('cut')) type = 'Cut';
+                else if (initSrc.includes('fuse')) type = 'Union';
+                else if (initSrc.includes('intersect')) type = 'Intersect';
+                else if (initSrc.includes('extrude')) type = 'Extrude';
+                else if (initSrc.includes('revolve')) type = 'Revolve';
+                else if (initSrc.includes('Sketcher')) {
+                    type = 'Sketch';
+                    const firstArg = Array.isArray(init?.arguments) ? init.arguments[0] : null;
+                    const arg = firstArg as unknown as { type?: string; value?: unknown } | null;
+                    if (arg && arg.type === 'Literal' && typeof arg.value === 'string') {
+                        detail = arg.value;
+                    } else {
+                        const planeMatch = initSrc.match(/new Sketcher\(['"](\w+)['"]\)/);
+                        if (planeMatch) detail = planeMatch[1];
+                    }
+                }
+
+                variables.push({ name, type, line, detail });
             }
-
-            variables.push({
-                name,
-                type,
-                line: index + 1,
-                detail
-            });
-        }
-    });
+        });
+    } catch {
+        // On syntax errors keep behavior non-throwing; return best effort (empty list).
+        return [];
+    }
 
     return variables;
 }

--- a/src/lib/codeAnalysis.ts
+++ b/src/lib/codeAnalysis.ts
@@ -30,10 +30,15 @@ export function generateUniqueName(code: string, baseName: string): string {
 }
 
 export interface VariableDefinition {
+    id?: string;
     name: string;
     type: string;
     line: number; // 1-indexed
     detail?: string;
+}
+
+export interface HistoryItem extends VariableDefinition {
+    id: string;
 }
 
 /**
@@ -42,8 +47,40 @@ export interface VariableDefinition {
  * - Looks for `const varName = ...`
  * - Guesses type based on keywords (makeBox, makeCylinder, fillet, etc.)
  */
-export function extractVariables(code: string): VariableDefinition[] {
-    const variables: VariableDefinition[] = [];
+function classifyVariable(initSrc: string, init?: { arguments?: unknown[] }): { type: string; detail?: string } {
+    let type = 'Shape';
+    let detail: string | undefined;
+
+    if (initSrc.includes('makeBox')) type = 'Box';
+    else if (initSrc.includes('makeCylinder')) type = 'Cylinder';
+    else if (initSrc.includes('makeSphere')) type = 'Sphere';
+    else if (initSrc.includes('fillet')) type = 'Fillet';
+    else if (initSrc.includes('chamfer')) type = 'Chamfer';
+    else if (initSrc.includes('cut')) type = 'Cut';
+    else if (initSrc.includes('fuse')) type = 'Union';
+    else if (initSrc.includes('intersect')) type = 'Intersect';
+    else if (initSrc.includes('extrude')) type = 'Extrude';
+    else if (initSrc.includes('revolve')) type = 'Revolve';
+    else if (initSrc.includes('Sketcher')) {
+        type = 'Sketch';
+        const firstArg = Array.isArray(init?.arguments) ? init.arguments[0] : null;
+        const arg = firstArg as unknown as { type?: string; value?: unknown } | null;
+        if (arg && arg.type === 'Literal' && typeof arg.value === 'string') {
+            detail = arg.value;
+        } else {
+            const planeMatch = initSrc.match(/new Sketcher\(['"](\w+)['"]\)/);
+            if (planeMatch) detail = planeMatch[1];
+        }
+    }
+
+    return { type, detail };
+}
+
+/**
+ * AST-backed history extraction with stable IDs for UI identity.
+ */
+export function extractHistoryItems(code: string): HistoryItem[] {
+    const items: HistoryItem[] = [];
     try {
         const ast = acorn.parse(code, {
             ecmaVersion: 'latest',
@@ -67,39 +104,34 @@ export function extractVariables(code: string): VariableDefinition[] {
                 const initSrc = init && typeof init.start === 'number' && typeof init.end === 'number'
                     ? code.slice(init.start, init.end)
                     : '';
-
-                let type = 'Shape';
-                let detail: string | undefined;
-
-                if (initSrc.includes('makeBox')) type = 'Box';
-                else if (initSrc.includes('makeCylinder')) type = 'Cylinder';
-                else if (initSrc.includes('makeSphere')) type = 'Sphere';
-                else if (initSrc.includes('fillet')) type = 'Fillet';
-                else if (initSrc.includes('chamfer')) type = 'Chamfer';
-                else if (initSrc.includes('cut')) type = 'Cut';
-                else if (initSrc.includes('fuse')) type = 'Union';
-                else if (initSrc.includes('intersect')) type = 'Intersect';
-                else if (initSrc.includes('extrude')) type = 'Extrude';
-                else if (initSrc.includes('revolve')) type = 'Revolve';
-                else if (initSrc.includes('Sketcher')) {
-                    type = 'Sketch';
-                    const firstArg = Array.isArray(init?.arguments) ? init.arguments[0] : null;
-                    const arg = firstArg as unknown as { type?: string; value?: unknown } | null;
-                    if (arg && arg.type === 'Literal' && typeof arg.value === 'string') {
-                        detail = arg.value;
-                    } else {
-                        const planeMatch = initSrc.match(/new Sketcher\(['"](\w+)['"]\)/);
-                        if (planeMatch) detail = planeMatch[1];
-                    }
-                }
-
-                variables.push({ name, type, line, detail });
+                const { type, detail } = classifyVariable(initSrc, init);
+                const start = init?.start ?? line;
+                const end = init?.end ?? line;
+                items.push({
+                    id: `${name}:${line}:${start}:${end}`,
+                    name,
+                    type,
+                    line,
+                    detail
+                });
             }
         });
     } catch {
-        // On syntax errors keep behavior non-throwing; return best effort (empty list).
+        // On syntax errors keep behavior non-throwing.
         return [];
     }
 
+    return items;
+}
+
+/**
+ * Backward-compatible variable extraction.
+ */
+export function extractVariables(code: string): VariableDefinition[] {
+    const items = extractHistoryItems(code);
+    const variables: VariableDefinition[] = items.map(({ name, type, line, detail }) => {
+        if (detail !== undefined) return { name, type, line, detail };
+        return { name, type, line };
+    });
     return variables;
 }

--- a/src/lib/sketchPlane.ts
+++ b/src/lib/sketchPlane.ts
@@ -1,0 +1,45 @@
+import type { SketchPlaneEntity } from '../types/plane';
+
+type Vec3 = [number, number, number];
+
+function cross(a: Vec3, b: Vec3): Vec3 {
+    return [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0]
+    ];
+}
+
+function normalize(v: Vec3): Vec3 | undefined {
+    const n = Math.sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+    if (n < 1e-9) return undefined;
+    return [v[0] / n, v[1] / n, v[2] / n];
+}
+
+export function deriveScreenAlignedXDir(normal: Vec3): Vec3 | undefined {
+    const worldUp: Vec3 = [0, 1, 0];
+    const altUp: Vec3 = [1, 0, 0];
+    return normalize(cross(worldUp, normal)) ?? normalize(cross(altUp, normal));
+}
+
+export function buildFaceSketchPlaneEntity(params: {
+    faceId: number;
+    targetName?: string | null;
+    origin: Vec3;
+    normal: Vec3;
+    xDir?: Vec3;
+}): SketchPlaneEntity {
+    const { faceId, targetName, origin, normal, xDir } = params;
+    return {
+        id: `face-${faceId}-${Date.now()}`,
+        name: targetName ? `Face ${faceId} of ${targetName}` : `Face ${faceId}`,
+        type: 'face',
+        origin,
+        normal,
+        xDir: deriveScreenAlignedXDir(normal) ?? xDir,
+        visible: true,
+        parentId: targetName || undefined,
+        faceId
+    };
+}
+

--- a/src/lib/worker.ts
+++ b/src/lib/worker.ts
@@ -135,6 +135,19 @@ function tryVec3(v: unknown): [number, number, number] | null {
   return [x, y, z];
 }
 
+function tryExtractFaceCenter(face: unknown): [number, number, number] | null {
+  if (!isRecord(face)) return null;
+  const centerFn = getFn(face, 'center');
+  if (centerFn) {
+    try {
+      return tryVec3(centerFn.call(face));
+    } catch {
+      // ignore and continue with property-based fallback
+    }
+  }
+  return tryVec3((face as UnknownRecord).center);
+}
+
 function tryExtractPlaneFromFace(face: unknown): FaceGeometry['plane'] {
   if (!isRecord(face)) return undefined;
   const geomType = getString(face, 'geomType');
@@ -171,7 +184,10 @@ function tryExtractPlaneFromFace(face: unknown): FaceGeometry['plane'] {
         const yDir = tryVec3(yDirFn ? (yDirFn as () => unknown).call(planeObj) : planeObj.yDir);
 
         if (origin && norm) {
-          return { origin, normal: norm, xDir: xDir ?? undefined, yDir: yDir ?? undefined };
+          // Anchor plane to a point guaranteed to lie on the selected face.
+          // Some plane origins are generic/canonical and can shift committed sketches.
+          const anchoredOrigin = tryExtractFaceCenter(face) ?? origin;
+          return { origin: anchoredOrigin, normal: norm, xDir: xDir ?? undefined, yDir: yDir ?? undefined };
         }
       }
     }
@@ -204,7 +220,8 @@ function tryExtractPlaneFromFace(face: unknown): FaceGeometry['plane'] {
         const yDir = planeNode && isRecord(planeNode) ? tryVec3((planeNode as UnknownRecord).yDir || (typeof (planeNode as UnknownRecord).yDir === 'function' ? ((planeNode as UnknownRecord).yDir as () => unknown)() : null)) : undefined;
 
         if (origin && norm) {
-          return { origin, normal: norm, xDir: xDir ?? undefined, yDir: yDir ?? undefined };
+          const anchoredOrigin = tryExtractFaceCenter(face) ?? origin;
+          return { origin: anchoredOrigin, normal: norm, xDir: xDir ?? undefined, yDir: yDir ?? undefined };
         }
       }
     } catch (e) {
@@ -236,7 +253,8 @@ function tryExtractPlaneFromFace(face: unknown): FaceGeometry['plane'] {
     tryVec3((p as UnknownRecord).yDirection) ??
     tryVec3((p as UnknownRecord).yAxis);
 
-  return { origin, normal, xDir: xDir ?? undefined, yDir: yDir ?? undefined };
+  const anchoredOrigin = tryExtractFaceCenter(face) ?? origin;
+  return { origin: anchoredOrigin, normal, xDir: xDir ?? undefined, yDir: yDir ?? undefined };
 }
 
 function tryExtractCylinderFromFace(face: unknown): FaceGeometry['cylinder'] {
@@ -368,12 +386,28 @@ function meshFaceToGeometry(face: unknown, faceId: number): FaceGeometry | null 
   const normals = Array.isArray(mesh.normals) ? (mesh.normals as number[]) : null;
   if (!vertices || !triangles || !normals) return null;
 
+  const plane = tryExtractPlaneFromFace(face);
+  if (plane) {
+    let cx = 0;
+    let cy = 0;
+    let cz = 0;
+    const count = Math.floor(vertices.length / 3);
+    if (count > 0) {
+      for (let i = 0; i < vertices.length; i += 3) {
+        cx += vertices[i] ?? 0;
+        cy += vertices[i + 1] ?? 0;
+        cz += vertices[i + 2] ?? 0;
+      }
+      plane.origin = [cx / count, cy / count, cz / count];
+    }
+  }
+
   return {
     vertices: new Float32Array(vertices),
     indices: new Uint32Array(triangles),
     normals: new Float32Array(normals),
     faceId,
-    plane: tryExtractPlaneFromFace(face),
+    plane,
     cylinder: tryExtractCylinderFromFace(face),
   };
 }

--- a/tests/features.spec.ts
+++ b/tests/features.spec.ts
@@ -47,7 +47,7 @@ return [box1, box2];
         await page.evaluate((c) => (window as any).setCode(c), code);
         await page.waitForTimeout(1000);
 
-        const joinBtn = page.getByTitle('Join');
+        const joinBtn = page.getByTitle('Union');
         await expect(joinBtn).toBeVisible();
         await joinBtn.click();
 


### PR DESCRIPTION
## Summary
- harden code mutation/deletion flow with AST identity-based paths and parse gates
- switch scene history to AST-backed items with stable IDs
- make scene selection interactions ID-native and fix stale selection cleanup
- add regression coverage for autosave/reload sketch delete path and window test helper API contract

## Validation
- lint + typecheck
- full unit/integration qc suite passed locally (305 tests)
