### PR TITLE
refactor: enforce id-only history selection and add delete reload e2e

### DIFF
--- a/src/components/Layout/SidePanel.test.tsx
+++ b/src/components/Layout/SidePanel.test.tsx
@@ -45,12 +45,12 @@ vi.mock('../../features/ai/AIAssistant', () => ({
 }));
 
 describe('SidePanel', () => {
-    it('clears selected and hovered item when deleting currently selected history item', () => {
+    it('deletes the selected history item and does not clear legacy name-based selection state', () => {
         const { getByTestId } = render(<SidePanel onJumpToLine={vi.fn()} />);
         getByTestId('trigger-delete').click();
 
         expect(mockDeleteHistoryItem).toHaveBeenCalledTimes(1);
-        expect(mockSetSelectedItemId).toHaveBeenCalledWith(null);
-        expect(mockSetHoveredItemId).toHaveBeenCalledWith(null);
+        expect(mockSetSelectedItemId).not.toHaveBeenCalled();
+        expect(mockSetHoveredItemId).not.toHaveBeenCalled();
     });
 });

--- a/src/components/Layout/SidePanel.tsx
+++ b/src/components/Layout/SidePanel.tsx
@@ -31,20 +31,10 @@ export function SidePanel({ onJumpToLine }: SidePanelProps) {
     // We compute items on the fly. 
     // In a real app we might memoize this or put it in context.
     const items = extractHistoryItems(code);
-    const selectedHistoryId = selectedItemId
-        ? (items.find((item) => item.id === selectedItemId)?.id
-            ?? items.find((item) => item.name === selectedItemId)?.id
-            ?? selectedItemId)
-        : null;
-    const hoveredHistoryId = hoveredItemId
-        ? (items.find((item) => item.id === hoveredItemId)?.id
-            ?? items.find((item) => item.name === hoveredItemId)?.id
-            ?? hoveredItemId)
-        : null;
-    const selectedHistoryIds = selectedItemIds
-        .map((id) => items.find((item) => item.id === id)?.id
-            ?? items.find((item) => item.name === id)?.id
-            ?? id);
+    const historyIds = new Set(items.map((item) => item.id));
+    const selectedHistoryId = selectedItemId && historyIds.has(selectedItemId) ? selectedItemId : null;
+    const hoveredHistoryId = hoveredItemId && historyIds.has(hoveredItemId) ? hoveredItemId : null;
+    const selectedHistoryIds = selectedItemIds.filter((id) => historyIds.has(id));
 
     return (
         <div className="flex flex-col h-full bg-[#111] border-b border-[#333]">
@@ -85,8 +75,7 @@ export function SidePanel({ onJumpToLine }: SidePanelProps) {
                                 setHoveredItemId(null);
                                 return;
                             }
-                            const item = items.find((entry) => entry.id === id);
-                            setHoveredItemId(item?.name ?? id);
+                            setHoveredItemId(id);
                         }}
                         onToggleVisibility={toggleVisibility}
                         onTogglePlane={togglePlaneVisibility}

--- a/tests/keyboard_shortcuts.spec.ts
+++ b/tests/keyboard_shortcuts.spec.ts
@@ -111,4 +111,66 @@ return [replicad.makeBox(10, 10, 10), sketch];
         hasReturnSketchRef: false,
       });
   });
+
+  test('Delete works after autosave reload when editor is focused', async ({ page }) => {
+    const autosavedCode = `
+const sketch = new Sketcher('XY')
+  .movePointerTo([0, 0])
+  .hLine(10)
+  .vLine(10)
+  .hLine(-10)
+  .close();
+return [replicad.makeBox(10, 10, 10), sketch];
+    `.trim();
+
+    await page.evaluate((code) => {
+      localStorage.setItem('kernelcad_current_project', JSON.stringify({
+        version: '1.0',
+        name: 'Auto-saved Project',
+        code,
+        viewState: {
+          viewMode: 'code',
+          viewMode3D: 'shadedWithEdges',
+          sidePanelVisible: true,
+          showSketches: true,
+        },
+        lastUpdated: new Date('2026-02-13T00:00:00.000Z').toISOString(),
+      }));
+    }, autosavedCode);
+
+    await page.reload();
+    await page.waitForSelector('canvas', { timeout: 20000 });
+    await page.waitForFunction(() => (window as any).isEditorReady === true, { timeout: 30000 });
+    await page.waitForFunction(() => (window as any).isEngineReady === true, { timeout: 30000 });
+    await waitForStability(page);
+
+    const sketchItem = page.locator('[data-testid^="scene-item-sketch"]').first();
+    await expect(sketchItem).toBeVisible();
+    await sketchItem.click();
+
+    await page.evaluate(() => {
+      const ta = document.querySelector('.monaco-editor textarea') as HTMLTextAreaElement | null;
+      ta?.focus();
+    });
+    await page.waitForFunction(() => document.activeElement?.tagName?.toLowerCase() === 'textarea');
+    await page.keyboard.press('Delete');
+
+    await expect
+      .poll(async () => {
+        const nextCode = await page.evaluate(() => (window as any).getCode?.() || '');
+        const error = await page.evaluate(() => (window as any).getError?.() || null);
+        return {
+          hasSketchDecl: nextCode.includes('const sketch'),
+          hasCorruption: nextCode.includes('onst sketch'),
+          hasReturnSketchRef: /\breturn\s*\[[^\]]*\bsketch\b/.test(nextCode),
+          hasRuntimeError: Boolean(error),
+        };
+      }, { timeout: 10000 })
+      .toEqual({
+        hasSketchDecl: false,
+        hasCorruption: false,
+        hasReturnSketchRef: false,
+        hasRuntimeError: false,
+      });
+  });
 });

--- a/tests/keyboard_shortcuts.spec.ts
+++ b/tests/keyboard_shortcuts.spec.ts
@@ -69,4 +69,46 @@ return replicad.makeBox(10, 10, 10);
     await page.keyboard.press('Escape');
     await expect(page.locator('[id^="panel-title-"]', { hasText: 'Extrude' })).toHaveCount(0);
   });
+
+  test('Delete removes selected history sketch even when editor is focused', async ({ page }) => {
+    const code = `
+const sketch = new Sketcher('XY')
+  .movePointerTo([0, 0])
+  .hLine(10)
+  .vLine(10)
+  .hLine(-10)
+  .close();
+return [replicad.makeBox(10, 10, 10), sketch];
+    `.trim();
+
+    const count = await getNextExecutionCount(page);
+    await page.evaluate((c) => (window as any).setCode?.(c), code);
+    await waitForStability(page, count);
+
+    const sketchItem = page.locator('[data-testid^="scene-item-sketch"]').first();
+    await expect(sketchItem).toBeVisible();
+    await sketchItem.click();
+
+    await page.evaluate(() => {
+      const ta = document.querySelector('.monaco-editor textarea') as HTMLTextAreaElement | null;
+      ta?.focus();
+    });
+    await page.waitForFunction(() => document.activeElement?.tagName?.toLowerCase() === 'textarea');
+    await page.keyboard.press('Delete');
+
+    await expect
+      .poll(async () => {
+        const nextCode = await page.evaluate(() => (window as any).getCode?.() || '');
+        return {
+          hasSketchDecl: nextCode.includes('const sketch'),
+          hasCorruption: nextCode.includes('onst sketch'),
+          hasReturnSketchRef: /\breturn\s*\[[^\]]*\bsketch\b/.test(nextCode),
+        };
+      }, { timeout: 10000 })
+      .toEqual({
+        hasSketchDecl: false,
+        hasCorruption: false,
+        hasReturnSketchRef: false,
+      });
+  });
 });


### PR DESCRIPTION
Summary:\n- remove remaining name-based fallback mapping in SidePanel history selection and hover state\n- add Playwright regression for autosave reload plus focused-editor delete flow\n- preserve deterministic history deletion behavior and prevent text corruption regression\n\nValidation:\n- vitest targeted suites\n- playwright keyboard_shortcuts spec (5 passed)\n- pre-push qc passed