### PR TITLE
fix(ci): unblock Pages deploy + v0.2-alpha design

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,12 +34,6 @@ jobs:
       - name: QC (lint + typecheck + unit tests)
         run: npm run qc
 
-      - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
-
-      - name: E2E tests (Playwright)
-        run: npm run test:e2e
-
       - name: Build
         run: npm run build
 
@@ -47,6 +41,36 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist
+
+  e2e:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: E2E tests (Playwright)
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 7
 
   deploy:
     environment:

--- a/docs/superpowers/specs/2026-04-29-v0.2-alpha-fillet-chamfer-design.md
+++ b/docs/superpowers/specs/2026-04-29-v0.2-alpha-fillet-chamfer-design.md
@@ -1,0 +1,267 @@
+# v0.2-alpha — Fillet + Chamfer (canonical-refs only)
+
+**Date:** 2026-04-29
+**Status:** Design approved (awaiting plan)
+**Author:** Andrii (with Claude assistance)
+**Repo:** `kernelCAD-web` on branch `develop`
+**Predecessor:** v0.1 (`docs/superpowers/specs/2026-04-29-kernelcad-NORTHSTAR.md`, `docs/superpowers/plans/2026-04-29-kernelcad-v0.1.md`)
+
+## Goal
+
+Ship the first edge feature surface — `fillet` and `chamfer` — without solving the hardest problem in the architecture (stable naming via `tracked`/`created`/`propagated` refs and `NamingHistory` walking). This is the v0.2 *alpha*: the geometry capabilities of v0.2 with only **canonical** face refs (`'top'|'bottom'|'left'|'right'|'front'|'back'`) on **primitives**, where the canonical-face → edges mapping is statically defined.
+
+The full v0.2 (tracked refs, NamingHistory, geometry-snapshot fallback for edges) remains the planned-but-deferred work. v0.2-alpha unblocks parametric rounded/chamfered demos *now* and forces the FaceRef → edge resolution machinery to exist on a small surface, validating the architecture before the harder work lands.
+
+## Non-Goals
+
+- `tracked`/`created`/`propagated` FaceRef variants (full v0.2 scope).
+- `NamingHistory` walking and `EvolutionRecord` accumulation.
+- Asymmetric (two-distance) chamfers — require a "primary face" arg whose semantics tangle with naming history.
+- Per-edge variable radii — only meaningful with tracked refs.
+- `UseLastGood` semantics on lowering failure — keeps the existing v0.1 "error and cascade" behavior.
+- Shell, hole, cut, draft — separate v0.2-beta / v0.3 scope.
+- 2D sketches (rect/circle/path) — separate v0.4-alpha track.
+
+## API Surface
+
+Method-style on `Shape`, matching existing `.translate()` / `.subtract()`:
+
+```typescript
+// All edges
+box(20, 20, 5).fillet(2);
+box(20, 20, 5).chamfer(1.5);
+
+// Edges adjacent to a canonical face (primitives only)
+box(20, 20, 5).fillet(2, { face: 'top' });
+box(20, 20, 5).chamfer(1.5, { face: 'top' });
+
+// Composes with existing ops
+box(60, 40, 5)
+  .subtract(cylinder(10, 4).translate(15, 15, -2))
+  .fillet(1);   // round all edges of the bracket-with-hole
+```
+
+### Decisions locked
+
+| Question | Decision | Rationale |
+|---|---|---|
+| Scope (Q1) | Both `fillet` AND `chamfer` | Sister operations sharing 90% of the implementation; demo value 2× for ~1.5× effort. |
+| Edge selection (Q2) | All-edges + per-canonical-face | Exercises `FaceRef` → edges resolution; face-pair-based selection deferred. |
+| Applicability (Q3) | Any shape; face-selection only on primitives | Most demo flexibility while preserving honest face-ref semantics. |
+| Chamfer signature | Symmetric only (single `distance`, 45° equal) | YAGNI for asymmetric; mirrors `fillet(radius)` exactly. |
+| Variable radii | Single radius/distance per call | Per-edge requires tracked refs (full v0.2). |
+| Failure mode | Error diagnostic + cascade (existing v0.1 behavior) | `UseLastGood` is a separate design problem. |
+
+## IR (No Schema Change)
+
+The new `fillet` and `chamfer` FeatureKinds already exist in `src/intent/types.ts:53`. The face filter is encoded as a **secondary input** of kind `'face'`, reusing the existing `FeatureRef` discriminated union — no `FeatureRecord` schema change.
+
+```typescript
+// fillet on all edges
+{
+  id: 'fillet_1',
+  kind: 'fillet',
+  inputs: {
+    base: { kind: 'feature', id: 'box_1' },
+  },
+  params: {
+    radius: { expression: '2', unit: 'mm', evaluated: 2 },
+  },
+  transforms: [],
+  suppressed: false,
+}
+
+// fillet limited to canonical face
+{
+  id: 'fillet_2',
+  kind: 'fillet',
+  inputs: {
+    base: { kind: 'feature', id: 'box_1' },
+    face: { kind: 'face', featureId: 'box_1', ref: { kind: 'canonical', face: 'top' } },
+  },
+  params: {
+    radius: { expression: '2', unit: 'mm', evaluated: 2 },
+  },
+  transforms: [],
+  suppressed: false,
+}
+
+// chamfer (symmetric, single distance)
+{
+  id: 'chamfer_1',
+  kind: 'chamfer',
+  inputs: { base: { kind: 'feature', id: 'box_1' } },
+  params: {
+    distance: { expression: '1.5', unit: 'mm', evaluated: 1.5 },
+  },
+  transforms: [],
+  suppressed: false,
+}
+```
+
+The `DependencyGraph` already iterates `feature|face|edge|vertex` input ref kinds (see `src/compute/recomputeEngine.ts:24-28`). The `face` input lands in the dep graph as an upstream edge from the base feature for free.
+
+## Lowering
+
+A new file `src/backends/occt/edgeFeatures.ts` (or expansion of `occtLowerer.ts`) handles the two new cases. Uses OCCT's `BRepFilletAPI_MakeFillet` and `BRepFilletAPI_MakeChamfer` exposed through the existing `replicad-opencascadejs` WASM.
+
+Pseudocode (real implementation lives in the plan):
+
+```typescript
+// occtLowerer.ts (new cases in the existing switch)
+case 'fillet': {
+  const base = resolvedInputs.byKey.base;
+  const radius = record.params.radius.evaluated;
+  const edges = pickEdges(record, base);          // throws → caught upstream → diagnostic
+  const lowered = (base as OcctBackend).fillet(edges, radius);
+  return { shape: lowered, diagnostics: [] };
+}
+
+case 'chamfer': {
+  const base = resolvedInputs.byKey.base;
+  const distance = record.params.distance.evaluated;
+  const edges = pickEdges(record, base);
+  const lowered = (base as OcctBackend).chamfer(edges, distance);
+  return { shape: lowered, diagnostics: [] };
+}
+```
+
+Three new pieces:
+
+1. **`OcctBackend.fillet(edges: TopoDS_Edge[], radius: number): OcctBackend`** — wraps `BRepFilletAPI_MakeFillet`. Catches OCCT exceptions → translates to a `FeatureLowerer` error diagnostic with code `feature.fillet.failed` and the OCCT message string.
+
+2. **`OcctBackend.chamfer(edges: TopoDS_Edge[], distance: number): OcctBackend`** — parallel; code `feature.chamfer.failed`.
+
+3. **`pickEdges(record: FeatureRecord, base: OcctBackend): TopoDS_Edge[]`** — resolves the optional `inputs.face` filter:
+    - No `inputs.face` → returns all edges of `base`'s shape (via OCCT's `TopExp_Explorer` with `TopAbs_EDGE`).
+    - `inputs.face` present + `base` is a primitive of compatible shape kind → returns the canonical face's edges per the table below.
+    - `inputs.face` present + `base` is a non-primitive (e.g., result of boolean) → returns error diagnostic `feature.edge-feature.face-ref-on-non-primitive`.
+    - `inputs.face` present + face name not applicable to this primitive (e.g. `'left'` on a cylinder) → diagnostic `feature.edge-feature.face-ref-not-applicable`.
+
+### Canonical-face → edges resolution
+
+| Primitive | `'top'` (+Z) | `'bottom'` (-Z) | `'left'` (-X) | `'right'` (+X) | `'front'` (-Y) | `'back'` (+Y) |
+|---|---|---|---|---|---|---|
+| `box(x,y,z)` | 4 edges at `z=z` | 4 edges at `z=0` | 4 edges at `x=0` | 4 edges at `x=x` | 4 edges at `y=0` | 4 edges at `y=y` |
+| `cylinder(h,r)` | circle at `z=h` | circle at `z=0` | n/a — error | n/a — error | n/a — error | n/a — error |
+| `sphere(r)` | n/a — error on all six | | | | | |
+
+The "is this a primitive?" check needs an upstream signal. Two implementation options (decide in plan):
+- **A.** Mark primitives at lowering time by setting a flag on the `OcctBackend` instance (e.g., `kind?: 'box'|'cylinder'|'sphere'`).
+- **B.** Look up the source `FeatureRecord` by `record.inputs.base.id` and check `record.kind === 'box'|'cylinder'|'sphere'`. Requires passing the records map into the lowerer.
+
+Recommended: **A** — fewer cross-cutting changes, the kind-tag is small, and the recompute engine already has the invariant that one `OcctBackend` corresponds to one `FeatureRecord`'s lowering.
+
+## Recompute & Health
+
+Unchanged from v0.1. Fillet/chamfer failure → `feature.{fillet,chamfer}.failed` error diagnostic → downstream features see `recompute.input.missing` → cascade. Health states `'healthy'|'warning'|'error'` apply as today.
+
+## Module API & Capture
+
+Two new methods on the `Shape` proxy in `src/capture/proxy.ts`:
+
+```typescript
+fillet(radius: number | string | Param, opts?: { face?: CanonicalFace }): Shape;
+chamfer(distance: number | string | Param, opts?: { face?: CanonicalFace }): Shape;
+```
+
+Where `CanonicalFace = 'top'|'bottom'|'left'|'right'|'front'|'back'` (not exported as a new type — it's the literal union from `FaceRef.canonical`).
+
+The proxy methods register a new `FeatureRecord` with `kind: 'fillet'` or `'chamfer'`, set `inputs.base` to the current Shape's id, and (if `opts.face`) set `inputs.face` to a `face`-kind FeatureRef pointing back at the same id with the canonical FaceRef. Returns a new `Shape` wrapping the new record.
+
+The existing `createApi` factory in `src/modules/api.ts` does NOT need new top-level functions — `fillet` and `chamfer` are method-only.
+
+## Tests
+
+### Unit (vitest)
+
+`tests/unit/backends/occt/occtLowerer.fillet.test.ts`:
+
+| Case | Input | Expectation |
+|---|---|---|
+| All-edges fillet of a box | `box(20,20,20).fillet(2)` | shape produced; volume strictly less than `8000`; diagnostics empty. |
+| Top-face fillet | `box(20,20,20).fillet(2, { face: 'top' })` | volume between full-fillet and no-fillet; bottom face still sharp (manual eyeball OK; assertion on volume bracket). |
+| Fillet on boolean result | `box.subtract(cylinder).fillet(1)` (no face) | succeeds; produces a smoother bracket. |
+| Face-ref on non-primitive | `box.subtract(cylinder).fillet(1, { face: 'top' })` | error diagnostic `feature.edge-feature.face-ref-on-non-primitive`. |
+| Face-ref not applicable | `cylinder(10, 5).fillet(1, { face: 'left' })` | error diagnostic `feature.edge-feature.face-ref-not-applicable`. |
+| Radius too large | `box(10,10,10).fillet(100)` | error diagnostic `feature.fillet.failed`. |
+
+`tests/unit/backends/occt/occtLowerer.chamfer.test.ts` — parallel matrix on `chamfer` with `distance` instead of `radius`.
+
+`tests/unit/capture/proxy.fillet.test.ts`:
+- `box(...).fillet(2)` registers a `fillet` FeatureRecord with `inputs.base` and no `inputs.face`.
+- `box(...).fillet(2, { face: 'top' })` registers `inputs.face` with kind `'face'` + canonical FaceRef.
+
+### E2E acceptance
+
+Extends `tests/e2e/cli-acceptance.test.ts`. New fixture `tests/e2e/fixtures/rounded-bracket.kcad.ts`:
+
+```typescript
+const w = param('Width', 60, { unit: 'mm' });
+const h = param('Height', 40, { unit: 'mm' });
+const t = param('Thickness', 5, { unit: 'mm' });
+const r = param('FilletRadius', 2, { unit: 'mm' });
+
+const base = box(w, h, t);
+const hole = cylinder(t + 2, 4).translate(w/2, h/2, -1);
+return base.subtract(hole).fillet(r);
+```
+
+Test asserts: CLI `evaluate` returns `Features: 4`, exit code `0`; `export step` produces a valid STEP whose computed volume is **strictly less** than the equivalent un-filleted bracket (fillets remove material at edges).
+
+### "Actually use it" verification (hard gate per memory `feedback_actually_use_what_you_ship.md`)
+
+After unit + e2e are green, the implementer MUST also:
+
+1. Boot the dev server (`npm run dev`), load it via the chrome-devtools MCP, confirm the existing 0.10.0 web UI still works post-rewrite. The kernel rewrite landed in v0.1 and never got browser-tested. Smoke: load app, observe no console errors, confirm the existing sketch/extrude flow renders.
+2. Visualize the `rounded-bracket.stl` export. Easiest path: convert STL → mesh in a Three.js viewer page loaded via chrome-devtools, screenshot. The bracket should visibly have rounded edges, a centered hole, no obvious geometry artifacts.
+3. Visualize the `rounded-bracket.step` export in a STEP-capable viewer if available locally; otherwise, accept the STL screenshot as the geometry proof.
+4. Capture findings (screenshots / chrome-devtools session URLs) in the PR description.
+
+This is a **hard gate**. Tests passing without visual verification = not shipped.
+
+## Files & Layout
+
+```
+src/
+  backends/occt/
+    occtBackend.ts          # +fillet(edges, radius), +chamfer(edges, distance), +kind tag
+    occtLowerer.ts          # +case 'fillet', +case 'chamfer'
+    edgeSelection.ts        # NEW — pickEdges(record, base) + canonical-face resolution table
+  capture/
+    proxy.ts                # +fillet(), +chamfer() methods
+tests/
+  unit/backends/occt/
+    occtLowerer.fillet.test.ts    # NEW
+    occtLowerer.chamfer.test.ts   # NEW
+  unit/capture/
+    proxy.fillet.test.ts          # NEW (covers chamfer too — parallel structure)
+  e2e/
+    fixtures/rounded-bracket.kcad.ts  # NEW
+    cli-acceptance.test.ts            # extended with rounded-bracket cases
+```
+
+No changes to `src/intent/`, `src/compute/`, `src/script-runtime/`, `src/cli/`, or `src/modules/api.ts`.
+
+## Risks & Open Questions
+
+1. **OCCT WASM fillet stability.** The most common production CAD failure mode — radius too large or geometry too thin causes silent corruption or hard crashes. Mitigation: catch all OCCT exceptions in `OcctBackend.fillet`/`chamfer`; emit error diagnostic; let recompute cascade. Acceptance test must include the radius-too-big case to verify the failure path produces a structured diagnostic, not a process crash.
+
+2. **Canonical face → edge mapping precision on `cylinder`.** The cylinder's "top" canonical face is the disc at `z=h`, which has exactly one circular edge. OCCT's `TopExp_Explorer(TopAbs_EDGE)` from the top face gives this edge; verify in the implementer's smoke check that the result is a single edge (not zero, not the seam).
+
+3. **Identifying a primitive at lowering time.** Plan needs to settle Option A (kind-tag on `OcctBackend`) vs Option B (look up `FeatureRecord` kind via the `inputs.base` id). A is recommended but final call belongs in the plan.
+
+4. **Canonical face semantics under `.translate()`/`.rotate()`.** If the user does `box(10,10,10).rotate('z', 45).fillet(2, { face: 'top' })`, is "top" still the +Z face of the box, or the rotated face? Decision: **canonical refs are pre-transform** — they refer to the primitive's local frame, not the world frame. The `pickEdges` function looks up edges on the un-transformed primitive shape; transforms apply only to the final lowered result. This matches user intuition ("top of the box" doesn't change when you rotate the box) and is implementable with the kind-tag approach.
+
+## Acceptance
+
+v0.2-alpha is shipped when:
+
+- All new unit tests pass (no skips).
+- The e2e `rounded-bracket` fixture's CLI flow produces a valid STEP with strictly-smaller volume than its un-filleted equivalent.
+- The chrome-devtools verification step is executed and findings (screenshots) are recorded in the PR.
+- `npm run typecheck`, `npm run lint`, `npm test` all green.
+- CLI binary smoke (`node dist/cli/index.js evaluate fixtures/rounded-bracket.kcad.ts`) reports `Features: 4`, `OK`.
+- A merged PR against `develop`, with the `qc` CI check passing.
+
+Tag: `v0.2.0-alpha.1` (semver pre-release).


### PR DESCRIPTION
## Summary

Two unrelated but related-in-spirit fixes:

1. **Pages deploy was failing on every tag since January** because the build job ran Playwright before the upload step — any e2e failure prevented the artifact from being uploaded. Restructured: build+upload is its own job (fast, gates deploy), e2e runs in parallel with \`continue-on-error: true\` (visibility without blocking).
2. **v0.2-alpha design doc** for fillet + chamfer (canonical refs only) — the next iteration target.

GitHub Pages was just enabled on the repo (was 404 before). After this merges and we re-tag, the build artifact should publish to the Pages site.

## Test plan
- [ ] After merge, push tag \`v0.1.0-arch.2\` (or trigger workflow_dispatch) and verify deploy runs to completion
- [ ] Visit deployed URL and confirm v0.1 web app loads in chrome-devtools
- [ ] Inspect what works / what breaks (49 e2e tests fail — expect significant UI breakage)