### PR TITLE
fix(build): vite base for Pages deploy

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,8 +25,8 @@ function getGitCommitHashShort(): string {
 }
 
 // https://vite.dev/config/
-export default defineConfig({
-  base: "/",
+export default defineConfig(({ command }) => ({
+  base: command === 'build' ? '/kernelCAD-web/' : '/',
   plugins: [
     react(),
     tailwindcss(),
@@ -40,4 +40,4 @@ export default defineConfig({
   worker: {
     format: 'es',
   },
-})
+}))


### PR DESCRIPTION
## Summary
Pages deploy succeeded but the site rendered blank because Vite's base was '/' while Pages serves at /kernelCAD-web/. Asset paths 404'd. Fixed by setting base conditionally:

\`\`\`ts
base: command === 'build' ? '/kernelCAD-web/' : '/'
\`\`\`

Dev keeps '/' so \`npm run dev\` works unchanged.

## Test plan
- [x] \`npm run build\` produces HTML with /kernelCAD-web/-prefixed asset URLs
- [ ] After merge + workflow_dispatch deploy, site renders in chrome-devtools without 404s