### PR TITLE
feat(web): v0.1 demo — hide broken legacy toolbar, ship v0.1 starter

### DIFF
--- a/docs/superpowers/specs/2026-04-29-v0.2-alpha-fillet-chamfer-design.md
+++ b/docs/superpowers/specs/2026-04-29-v0.2-alpha-fillet-chamfer-design.md
@@ -47,7 +47,7 @@ box(60, 40, 5)
 |---|---|---|
 | Scope (Q1) | Both `fillet` AND `chamfer` | Sister operations sharing 90% of the implementation; demo value 2× for ~1.5× effort. |
 | Edge selection (Q2) | All-edges + per-canonical-face | Exercises `FaceRef` → edges resolution; face-pair-based selection deferred. |
-| Applicability (Q3) | Any shape; face-selection only on primitives | Most demo flexibility while preserving honest face-ref semantics. |
+| Applicability (Q3) | Any shape; face-selection only on **un-transformed** primitives (no `.translate()`/`.rotate()`/`.scale()`/`.mirror()` applied) | Most demo flexibility while preserving honest face-ref semantics. Face-ref under transforms is well-defined for translate but ambiguous for rotate; deferred to v0.2-beta. |
 | Chamfer signature | Symmetric only (single `distance`, 45° equal) | YAGNI for asymmetric; mirrors `fillet(radius)` exactly. |
 | Variable radii | Single radius/distance per call | Per-edge requires tracked refs (full v0.2). |
 | Failure mode | Error diagnostic + cascade (existing v0.1 behavior) | `UseLastGood` is a separate design problem. |
@@ -103,7 +103,7 @@ The `DependencyGraph` already iterates `feature|face|edge|vertex` input ref kind
 
 ## Lowering
 
-A new file `src/backends/occt/edgeFeatures.ts` (or expansion of `occtLowerer.ts`) handles the two new cases. Uses OCCT's `BRepFilletAPI_MakeFillet` and `BRepFilletAPI_MakeChamfer` exposed through the existing `replicad-opencascadejs` WASM.
+Adds two new cases to the existing switch in `src/backends/occt/occtLowerer.ts` (matches the established pattern for box/cylinder/sphere/extrude/revolve/boolean). The canonical-face → edges resolution lives in a new helper file `src/backends/occt/edgeSelection.ts` (single responsibility, easy to test in isolation). Uses OCCT's `BRepFilletAPI_MakeFillet` and `BRepFilletAPI_MakeChamfer` exposed through the existing `replicad-opencascadejs` WASM.
 
 Pseudocode (real implementation lives in the plan):
 
@@ -134,8 +134,9 @@ Three new pieces:
 
 3. **`pickEdges(record: FeatureRecord, base: OcctBackend): TopoDS_Edge[]`** — resolves the optional `inputs.face` filter:
     - No `inputs.face` → returns all edges of `base`'s shape (via OCCT's `TopExp_Explorer` with `TopAbs_EDGE`).
-    - `inputs.face` present + `base` is a primitive of compatible shape kind → returns the canonical face's edges per the table below.
-    - `inputs.face` present + `base` is a non-primitive (e.g., result of boolean) → returns error diagnostic `feature.edge-feature.face-ref-on-non-primitive`.
+    - `inputs.face` present + `base` is a primitive of compatible shape kind + **no transforms applied** → returns the canonical face's edges per the table below.
+    - `inputs.face` present + `base` is a non-primitive (e.g., result of boolean) → error diagnostic `feature.edge-feature.face-ref-on-non-primitive`.
+    - `inputs.face` present + base primitive **has transforms applied** → error diagnostic `feature.edge-feature.face-ref-on-transformed-primitive`. (Translate-preserves-orientation could be made to work but rotate/mirror cannot without history walking; ship the conservative rule for v0.2-alpha and revisit in v0.2-beta.)
     - `inputs.face` present + face name not applicable to this primitive (e.g. `'left'` on a cylinder) → diagnostic `feature.edge-feature.face-ref-not-applicable`.
 
 ### Canonical-face → edges resolution
@@ -183,6 +184,8 @@ The existing `createApi` factory in `src/modules/api.ts` does NOT need new top-l
 | Top-face fillet | `box(20,20,20).fillet(2, { face: 'top' })` | volume between full-fillet and no-fillet; bottom face still sharp (manual eyeball OK; assertion on volume bracket). |
 | Fillet on boolean result | `box.subtract(cylinder).fillet(1)` (no face) | succeeds; produces a smoother bracket. |
 | Face-ref on non-primitive | `box.subtract(cylinder).fillet(1, { face: 'top' })` | error diagnostic `feature.edge-feature.face-ref-on-non-primitive`. |
+| Face-ref on transformed primitive | `box(20,20,20).translate(5,0,0).fillet(1, { face: 'top' })` | error diagnostic `feature.edge-feature.face-ref-on-transformed-primitive`. |
+| Face-ref applied before transform | `box(20,20,20).fillet(2, { face: 'top' }).translate(5,0,0)` | succeeds; rounded box is translated. |
 | Face-ref not applicable | `cylinder(10, 5).fillet(1, { face: 'left' })` | error diagnostic `feature.edge-feature.face-ref-not-applicable`. |
 | Radius too large | `box(10,10,10).fillet(100)` | error diagnostic `feature.fillet.failed`. |
 
@@ -251,7 +254,7 @@ No changes to `src/intent/`, `src/compute/`, `src/script-runtime/`, `src/cli/`, 
 
 3. **Identifying a primitive at lowering time.** Plan needs to settle Option A (kind-tag on `OcctBackend`) vs Option B (look up `FeatureRecord` kind via the `inputs.base` id). A is recommended but final call belongs in the plan.
 
-4. **Canonical face semantics under `.translate()`/`.rotate()`.** If the user does `box(10,10,10).rotate('z', 45).fillet(2, { face: 'top' })`, is "top" still the +Z face of the box, or the rotated face? Decision: **canonical refs are pre-transform** — they refer to the primitive's local frame, not the world frame. The `pickEdges` function looks up edges on the un-transformed primitive shape; transforms apply only to the final lowered result. This matches user intuition ("top of the box" doesn't change when you rotate the box) and is implementable with the kind-tag approach.
+4. **Canonical face semantics under transforms.** If the user does `box(10,10,10).translate(5,0,0).fillet(2, { face: 'top' })`, what's "top"? Decision for v0.2-alpha: **canonical face refs require zero transforms on the base primitive**. Any `.translate()`/`.rotate()`/`.scale()`/`.mirror()` makes the face filter invalid (`feature.edge-feature.face-ref-on-transformed-primitive` diagnostic). User-facing workaround: apply the fillet *before* transforms — `box(10,10,10).fillet(2, { face: 'top' }).translate(5,0,0)` is fine because translate happens on the fillet's output, not its input. v0.2-beta can relax this for translation-only (translate preserves orientation, so "top" survives) but rotate/mirror can't be relaxed without history walking (full v0.2 territory).
 
 ## Acceptance
 

--- a/src/backends/occt/worker.ts
+++ b/src/backends/occt/worker.ts
@@ -4,6 +4,7 @@ import { chamfer, extrude, fillet, makeCompound, sketchOnFace } from '../../lib/
 import { createSafeReplicad, SafeSketcher } from '../../lib/safeSketch';
 import { withTemporaryGlobals } from '../../lib/withTemporaryGlobals';
 import { createUserGlobals } from '../../lib/userGlobals';
+import { createV01ApiGlobals, unwrapV01Shape } from '../../lib/v01ApiShim';
 import {
   type ExecutionResult,
   type FaceGeometry,
@@ -545,6 +546,12 @@ self.onmessage = (e: MessageEvent<unknown>) => {
           safeReplicad as unknown as { Sketcher: new (plane?: unknown) => SafeSketcher },
         );
 
+        // v0.1 API globals: `param`, `box`, `cylinder`, `sphere`. The shim
+        // returns Replicad-shape proxies that expose v0.1's `subtract`/
+        // `union`/`intersect`/`translate` while still supporting the worker's
+        // existing mesh / blob extraction paths.
+        const v01Api = createV01ApiGlobals(replicad);
+
         const func = new Function(
           'replicad',
           'startSketch',
@@ -553,6 +560,10 @@ self.onmessage = (e: MessageEvent<unknown>) => {
           'chamfer',
           'sketchOnFace',
           'extrude',
+          'param',
+          'box',
+          'cylinder',
+          'sphere',
           code,
         ) as unknown as (...args: unknown[]) => unknown;
 
@@ -561,6 +572,7 @@ self.onmessage = (e: MessageEvent<unknown>) => {
             // Convenience globals for generated snippets and common user code.
             // Safe per-execution: restored after this run to avoid leaking callbacks/closures.
             ...userGlobals,
+            ...v01Api,
           },
           () =>
             func(
@@ -571,9 +583,15 @@ self.onmessage = (e: MessageEvent<unknown>) => {
               chamfer,
               wrappedSketchOnFace,
               extrude,
+              v01Api.param,
+              v01Api.box,
+              v01Api.cylinder,
+              v01Api.sphere,
             ),
         );
-        const shapes = (Array.isArray(result) ? result : [result]).filter(Boolean);
+        const shapes = (Array.isArray(result) ? result : [result])
+          .map(unwrapV01Shape)
+          .filter(Boolean);
 
         const geometries: GeometryResult[] = [];
         const returnedSketches: SketchGeometry[] = [];
@@ -737,6 +755,8 @@ self.onmessage = (e: MessageEvent<unknown>) => {
           return new SketcherCtor();
         };
 
+        const v01Api = createV01ApiGlobals(replicad);
+
         const func = new Function(
           'replicad',
           'startSketch',
@@ -745,6 +765,10 @@ self.onmessage = (e: MessageEvent<unknown>) => {
           'chamfer',
           'sketchOnFace',
           'extrude',
+          'param',
+          'box',
+          'cylinder',
+          'sphere',
           code,
         ) as unknown as (...args: unknown[]) => unknown;
 
@@ -752,10 +776,23 @@ self.onmessage = (e: MessageEvent<unknown>) => {
           safeReplicad as unknown as { Sketcher: new (plane?: unknown) => SafeSketcher },
         );
 
-        const result = withTemporaryGlobals(userGlobals, () =>
-          func(safeReplicad, wrappedStartSketch, makeCompound, fillet, chamfer, sketchOnFace, extrude),
+        const result = withTemporaryGlobals({ ...userGlobals, ...v01Api }, () =>
+          func(
+            safeReplicad,
+            wrappedStartSketch,
+            makeCompound,
+            fillet,
+            chamfer,
+            sketchOnFace,
+            extrude,
+            v01Api.param,
+            v01Api.box,
+            v01Api.cylinder,
+            v01Api.sphere,
+          ),
         );
-        const shape = Array.isArray(result) ? result[0] : result;
+        const rawResult = Array.isArray(result) ? result[0] : result;
+        const shape = unwrapV01Shape(rawResult);
         if (!shape) throw new Error('No shape returned');
 
         const blobFn = type === 'EXPORT_STEP' ? getFn(shape, 'blobSTEP') : getFn(shape, 'blobSTL');

--- a/src/components/Toolbar.test.tsx
+++ b/src/components/Toolbar.test.tsx
@@ -41,6 +41,8 @@ beforeEach(() => {
         addSketch: vi.fn(),
         selectedFace: null,
         setSelectedFace: vi.fn(),
+        sidePanelVisible: true,
+        toggleSidePanel: vi.fn(),
     } as unknown as WorkbenchContext.WorkbenchContextType);
 });
 
@@ -66,92 +68,30 @@ const mockFeatures: Feature[] = [
     }
 ];
 
-describe('Toolbar', () => {
-    it('should render feature buttons', () => {
+describe('Toolbar (v0.1 web demo)', () => {
+    it('renders only the Toggle Scene Browser button', () => {
         const onToolClick = vi.fn();
         render(<Toolbar features={mockFeatures} onToolClick={onToolClick} />);
 
-        expect(screen.getByRole('button', { name: 'Box' })).toBeDefined();
-        expect(screen.getByRole('button', { name: 'Fillet' })).toBeDefined();
+        // Per v0.1 NORTHSTAR spec, Studio UI commands (Box, Cylinder, Sketch,
+        // Extrude, Fillet, etc.) are deferred to v0.5. The toolbar in the
+        // deployed demo shows only the Toggle Scene Browser button.
+        expect(screen.getByRole('button', { name: 'Toggle Scene Browser' })).toBeDefined();
+        expect(screen.queryByRole('button', { name: 'Box' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Fillet' })).toBeNull();
+        expect(screen.queryByLabelText('Sketch')).toBeNull();
+        expect(screen.queryByLabelText('Sketch Visibility')).toBeNull();
     });
 
-    it('should call onToolClick with feature object', () => {
-        const onToolClick = vi.fn();
-        render(<Toolbar features={mockFeatures} onToolClick={onToolClick} />);
-
-        fireEvent.click(screen.getByRole('button', { name: 'Box' }));
-        expect(onToolClick).toHaveBeenCalledWith(mockFeatures[0]);
-    });
-    it('should call setSketchMode when Sketch button clicked with selected face', () => {
-        const setSketchMode = vi.fn();
-        const selectedFace = { shapeIndex: 0, faceId: 12 };
-        const selectedFacePlane = { origin: [0, 0, 10], normal: [0, 0, 1] };
-
-        // Override mock for this test
+    it('toggles the side panel when the Toggle Scene Browser button is clicked', () => {
+        const toggleSidePanel = vi.fn();
         vi.spyOn(WorkbenchContext, 'useWorkbench').mockReturnValue({
-            viewMode: 'code',
-            setViewMode: vi.fn(),
-            viewMode3D: 'shadedWithEdges',
-            setViewMode3D: vi.fn(),
-            code: 'return [];',
-            setCode: vi.fn(),
-            insertCode: vi.fn(),
-            editorInstance: null,
-            setEditorInstance: vi.fn(),
-            commandManager: {} as unknown as CommandManager,
-            activeDialog: null,
-            setActiveDialog: vi.fn(),
-            geometries: [],
-            sketchesGeometries: [],
-            showSketches: true,
-            toggleSketchVisibility: vi.fn(),
-            error: null,
-            isReady: true,
-            isComputing: false,
-            sketchMode: { active: false, plane: null, currentSketch: null, tool: 'select' },
-            selectedFace,
-            selectedFacePlane,
-            setSketchMode,
-            addSketch: vi.fn(),
-            planes: [],
-            addPlane: vi.fn(),
-            togglePlaneVisibility: vi.fn(),
-            setSelectedFace: vi.fn(),
-            isFaceSelecting: false,
-            startFaceSelection: vi.fn(),
-            cancelFaceSelection: vi.fn(),
-            // Sketching context (not used by Toolbar)
-            entities: new Map(),
-            constraints: [],
-            selectedEntityIds: [],
-            addEntity: vi.fn(),
-            updateEntity: vi.fn(),
-            addConstraint: vi.fn(),
-            selectEntity: vi.fn(),
-            clearSelection: vi.fn(),
-            solve: vi.fn(),
-            // Code generation context (required by Toolbar)
-            codeContext: {
-                code: 'return [];',
-                declaredVariables: new Set(),
-                returnedVariables: ['shape0'],
-                generateUniqueName: (base: string) => base,
-                getVariableAtIndex: (_index: number) => 'shape0',
-            },
-        } as any);
+            sidePanelVisible: true,
+            toggleSidePanel,
+        } as unknown as WorkbenchContext.WorkbenchContextType);
 
-        render(<Toolbar features={mockFeatures} onToolClick={vi.fn()} />);
-
-        const sketchBtn = screen.getByLabelText('Sketch');
-        fireEvent.click(sketchBtn);
-
-        expect(setSketchMode).toHaveBeenCalledWith(expect.objectContaining({
-            active: true,
-            plane: expect.objectContaining({
-                id: expect.stringContaining('face-12'),
-                origin: selectedFacePlane.origin,
-                normal: selectedFacePlane.normal
-            })
-        }));
+        render(<Toolbar features={[]} onToolClick={vi.fn()} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Toggle Scene Browser' }));
+        expect(toggleSidePanel).toHaveBeenCalled();
     });
 });

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,60 +1,35 @@
-import { PenTool, ArrowUpFromLine, Eye, EyeOff, Layers } from 'lucide-react';
+import { Layers } from 'lucide-react';
 import { type Feature } from '../features/types';
 import { useWorkbench } from '../context/WorkbenchContext';
-import { FEATURE_SHORTCUTS, SHORTCUT_HINTS, formatTooltip } from '../constants/shortcuts';
-import { buildFaceSketchPlaneEntity } from '../lib/sketchPlane';
+import { formatTooltip } from '../constants/shortcuts';
 
 interface ToolbarProps {
     features: Feature[];
     onToolClick: (feature: Feature) => void;
 }
 
-export default function Toolbar({ features, onToolClick }: ToolbarProps) {
+/**
+ * v0.1 web demo toolbar.
+ *
+ * Per the v0.1 NORTHSTAR spec, kernelCAD is script-as-source-of-truth and
+ * Studio UI commands are deferred to v0.5. The legacy 0.10.0 creation /
+ * construction / modification buttons (Box, Cylinder, Sketch, Extrude,
+ * Revolve, Fillet, Chamfer, Cut, Union, Intersect, Sketch Visibility) all
+ * generated AST mutations against a `drawPart()` envelope that the v0.1
+ * script-runtime no longer recognizes. Until v0.5 designs the new GUI, the
+ * deployed app only shows the Toggle Scene Browser button so users can still
+ * inspect the auto-derived feature tree from their script.
+ *
+ * The legacy command-driven toolbar code stays in git history (and the
+ * feature registry / `onToolClick` prop are still accepted for
+ * compatibility) so v0.5 can revive whichever pieces it wants.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export default function Toolbar({ features: _features, onToolClick: _onToolClick }: ToolbarProps) {
     const {
-        selectedFace,
-        selectedFacePlane,
-        setSketchMode,
-        showSketches,
-        toggleSketchVisibility,
-        codeContext,
         toggleSidePanel,
         sidePanelVisible,
-        openPanel
     } = useWorkbench();
-
-    // Separate creation tools vs construction vs modification tools
-    const creationTools = features.filter(f => ['box', 'cylinder'].includes(f.id));
-    const constructionTools = features.filter(f => ['offsetPlane'].includes(f.id));
-    const modificationTools = features.filter(f => ['extrude', 'revolve', 'fillet', 'chamfer', 'cut', 'union', 'intersect'].includes(f.id));
-
-    // Start sketch mode
-    const handleSketchClick = () => {
-        if (selectedFace) {
-            handleSketchOnFaceClick();
-        } else {
-            openPanel('planeSelector');
-        }
-    };
-
-    const handleSketchOnFaceClick = () => {
-        if (!selectedFace || !selectedFacePlane) return;
-
-        // Map shapeIndex to variable name using unified context
-        const targetName = codeContext.returnedVariables[selectedFace.shapeIndex];
-
-        // Enter sketch mode on this face plane
-        setSketchMode({
-            active: true,
-            plane: buildFaceSketchPlaneEntity({
-                faceId: selectedFace.faceId,
-                targetName,
-                origin: selectedFacePlane.origin,
-                normal: selectedFacePlane.normal
-            }),
-            currentSketch: null,
-            tool: 'line'
-        });
-    };
 
     return (
         <div className="flex flex-col gap-2 p-2 bg-[#111] border-r border-[#333] w-14 items-center">
@@ -67,107 +42,6 @@ export default function Toolbar({ features, onToolClick }: ToolbarProps) {
             >
                 <Layers size={20} />
             </button>
-
-            <div className="w-full h-px bg-[#333] my-1" />
-
-            {/* Sketch button */}
-            <button
-                onClick={handleSketchClick}
-                data-testid="toolbar-sketch"
-                className="p-2 rounded hover:bg-[#333] text-gray-400 hover:text-white transition-colors"
-                aria-label="Sketch"
-                title={formatTooltip(
-                    selectedFace ? "Sketch on Face" : "Sketch",
-                    SHORTCUT_HINTS.sketch
-                )}
-            >
-                <PenTool size={20} className={selectedFace ? "text-blue-400" : ""} />
-            </button>
-
-            {/* Visibility toggle button */}
-            <button
-                onClick={toggleSketchVisibility}
-                className={`p-2 rounded hover:bg-[#333] transition-colors ${showSketches ? 'text-blue-400' : 'text-gray-500'}`}
-                aria-label="Sketch Visibility"
-                title={formatTooltip(showSketches ? "Hide Sketches" : "Show Sketches", undefined)}
-            >
-                {showSketches ? <Eye size={20} /> : <EyeOff size={20} />}
-            </button>
-
-            {/* Contextual Tools (only Extrude Face now) */}
-            {selectedFacePlane && (
-                <>
-                    {/* Contextual Extrude Face button */}
-                    <button
-                        onClick={() => {
-                            const feature = features.find(f => f.id === 'extrudeFromFace');
-                            if (feature) onToolClick(feature);
-                        }}
-                        data-testid="toolbar-extrude-face"
-                        className="p-2 rounded bg-blue-600/20 hover:bg-blue-600/40 text-blue-400 hover:text-blue-300 transition-colors mt-1"
-                        aria-label="Extrude Face"
-                        title="Extrude Face"
-                    >
-                        <ArrowUpFromLine size={20} />
-                    </button>
-                    <div className="w-full h-px bg-[#333] my-1" />
-                </>
-            )}
-
-            <div className="w-full h-px bg-[#333] my-1" />
-
-            {creationTools.length > 0 && (
-                <>
-                    <span className="text-[10px] uppercase text-gray-500 font-bold mb-1">Add</span>
-                    {creationTools.map(feature => (
-                        <button
-                            key={feature.id}
-                            onClick={() => onToolClick(feature)}
-                            className="p-2 rounded hover:bg-[#333] text-gray-400 hover:text-white transition-colors"
-                            aria-label={feature.label}
-                            title={formatTooltip(feature.label, FEATURE_SHORTCUTS[feature.id], feature.description)}
-                        >
-                            <feature.icon size={20} />
-                        </button>
-                    ))}
-                    <div className="w-full h-px bg-[#333] my-1" />
-                </>
-            )}
-
-            {constructionTools.length > 0 && (
-                <>
-                    <span className="text-[10px] uppercase text-gray-500 font-bold mb-1 text-center">Cons</span>
-                    {constructionTools.map(feature => (
-                        <button
-                            key={feature.id}
-                            onClick={() => onToolClick(feature)}
-                            className="p-2 rounded hover:bg-[#333] text-gray-400 hover:text-white transition-colors"
-                            aria-label={feature.label}
-                            title={formatTooltip(feature.label, FEATURE_SHORTCUTS[feature.id], feature.description)}
-                        >
-                            <feature.icon size={20} />
-                        </button>
-                    ))}
-                    <div className="w-full h-px bg-[#333] my-1" />
-                </>
-            )}
-
-            {modificationTools.length > 0 && (
-                <>
-                    <span className="text-[10px] uppercase text-gray-500 font-bold mb-1">Mod</span>
-                    {modificationTools.map(feature => (
-                        <button
-                            key={feature.id}
-                            onClick={() => onToolClick(feature)}
-                            className="p-2 rounded hover:bg-[#333] text-gray-400 hover:text-white transition-colors"
-                            aria-label={feature.label}
-                            title={formatTooltip(feature.label, FEATURE_SHORTCUTS[feature.id], feature.description)}
-                        >
-                            <feature.icon size={20} />
-                        </button>
-                    ))}
-                </>
-            )}
         </div>
     );
 }

--- a/src/context/ProjectContext.tsx
+++ b/src/context/ProjectContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { projectService, type KernelCADProject, type ProjectMetadata } from '../lib/projectService';
+import { defaultCode } from '../lib/geometryEngine';
 
 interface ProjectContextType {
     activeProjectId: string | null;
@@ -39,7 +40,7 @@ export function ProjectProvider({ children }: { children: React.ReactNode }) {
             }
         } else {
             const id = projectService.generateId();
-            const defaultProj = projectService.createProject('// New Project\n', {
+            const defaultProj = projectService.createProject(defaultCode, {
                 viewMode: 'code',
                 viewMode3D: 'shadedWithEdges',
                 sidePanelVisible: true,
@@ -69,7 +70,7 @@ export function ProjectProvider({ children }: { children: React.ReactNode }) {
 
     const createProject = useCallback((name: string = 'Untitled Project') => {
         const id = projectService.generateId();
-        const newProj = projectService.createProject('// New Project\n', {
+        const newProj = projectService.createProject(defaultCode, {
             viewMode: 'code',
             viewMode3D: 'shadedWithEdges',
             sidePanelVisible: true,

--- a/src/lib/geometryEngine.ts
+++ b/src/lib/geometryEngine.ts
@@ -15,12 +15,21 @@ import {
 // Re-export types for consumers
 export type { ExecutionResult, GeometryResult, SketchGeometry, FaceGeometry };
 
-export const defaultCode = `
-// You can use standard Replicad API here.
-// The variable 'replicad' is available in the scope.
-// Helpers available: startSketch(), makeCompound(), fillet(), chamfer()
-// You must return a Shape or an array of Shapes.
-return replicad.makeBox(10, 10, 10);
+/**
+ * Default starter script — kernelCAD v0.1 web demo.
+ *
+ * v0.1 is script-as-source-of-truth (`.kcad.ts` files): top-level statements
+ * with a final `return` of the root shape. The browser worker exposes the
+ * v0.1 API (`param`, `box`, `cylinder`, `sphere`) alongside the legacy
+ * Replicad globals so existing 0.10.0 projects keep working.
+ */
+export const defaultCode = `const w = param('Width', 60, { unit: 'mm' });
+const h = param('Height', 40, { unit: 'mm' });
+const t = param('Thickness', 5, { unit: 'mm' });
+
+const base = box(w, h, t);
+const hole = cylinder(t + 2, 4).translate(w / 2, h / 2, -1);
+return base.subtract(hole);
 `;
 
 type PendingMessage = {

--- a/src/lib/safeSketch.ts
+++ b/src/lib/safeSketch.ts
@@ -41,7 +41,13 @@ export function createSafeReplicad<T extends ReplicadLike>(
   replicad: T,
   onSketchCreated?: (s: SafeSketcher) => void,
 ): T {
-  const safeReplicad = Object.create(replicad) as T;
+  // NOTE: We deliberately do NOT use `Object.create(replicad)` here. When
+  // `replicad` is an ES Module namespace (the case in the production worker),
+  // its exports are non-writable, non-configurable getters; in strict mode
+  // an assignment to a property whose prototype-chain entry is non-writable
+  // throws `TypeError: Cannot assign to read only property`. Copying the
+  // enumerable bindings into a fresh object sidesteps that.
+  const safeReplicad = { ...(replicad as unknown as Record<string, unknown>) } as T;
 
   const SafeSketcherWrapper = class {
     constructor(plane?: unknown) {

--- a/src/lib/v01ApiShim.ts
+++ b/src/lib/v01ApiShim.ts
@@ -1,0 +1,142 @@
+/**
+ * Browser-side compatibility shim for the kernelCAD v0.1 script API.
+ *
+ * The v0.1 kernel (`src/modules/api.ts`, `src/script-runtime/*`) executes
+ * `.kcad.ts` scripts in a Node `vm` context that doesn't exist in browsers.
+ * Until v0.5 lands a real browser-side script-runtime, the deployed web demo
+ * needs to evaluate the v0.1 starter script (and any v0.1-style code the
+ * user writes) inside the existing Replicad worker.
+ *
+ * This module wires a minimal `param` / `box` / `cylinder` / `sphere` global
+ * surface — backed directly by Replicad — that returns shapes whose
+ * `.subtract()` / `.union()` / `.intersect()` / `.translate()` methods match
+ * the v0.1 `Shape` proxy in `src/capture/proxy.ts`. The Replicad shape
+ * underneath still exposes `blobSTL()` / `blobSTEP()` for the export path,
+ * so the existing `EXPORT_STL` / `EXPORT_STEP` worker handlers keep working.
+ *
+ * Anchoring matches `src/backends/occt/occtBackend.ts`:
+ *   - `box(w, h, t)` corner-anchored at the origin (spans [0,w]×[0,h]×[0,t]).
+ *   - `cylinder(h, r)` axis along Z, base at z=0.
+ *   - `sphere(r)` centered at the origin.
+ */
+
+type ReplicadLike = {
+  makeBaseBox: (x: number, y: number, z: number) => unknown;
+  makeCylinder: (r: number, h: number) => unknown;
+  makeSphere: (r: number) => unknown;
+};
+
+type RawShape = {
+  translate: (x: number, y: number, z: number) => RawShape;
+  rotate?: (angle: number, pivot: [number, number, number], axis: [number, number, number]) => RawShape;
+  fuse: (other: RawShape) => RawShape;
+  cut: (other: RawShape) => RawShape;
+  intersect: (other: RawShape) => RawShape;
+};
+
+/**
+ * Wrap a Replicad shape in a Proxy that adds v0.1's `subtract` / `union`
+ * names (mapped to `cut` / `fuse`), redirects `translate` so it returns
+ * a wrapped shape, and forwards everything else (notably `blobSTL`,
+ * `blobSTEP`, `mesh`, `faces`) to the underlying shape unchanged.
+ */
+function wrap(raw: unknown): unknown {
+  const target = raw as RawShape;
+  return new Proxy(target, {
+    get(t, prop, receiver) {
+      if (prop === 'subtract') {
+        return (...others: unknown[]) => {
+          let out: unknown = t;
+          for (const o of others) {
+            const cut = (out as RawShape).cut.bind(out);
+            out = cut(unwrap(o) as RawShape);
+          }
+          return wrap(out);
+        };
+      }
+      if (prop === 'union') {
+        return (...others: unknown[]) => {
+          let out: unknown = t;
+          for (const o of others) {
+            const fuse = (out as RawShape).fuse.bind(out);
+            out = fuse(unwrap(o) as RawShape);
+          }
+          return wrap(out);
+        };
+      }
+      if (prop === 'intersect') {
+        return (...others: unknown[]) => {
+          let out: unknown = t;
+          for (const o of others) {
+            const intersect = (out as RawShape).intersect.bind(out);
+            out = intersect(unwrap(o) as RawShape);
+          }
+          return wrap(out);
+        };
+      }
+      if (prop === 'translate') {
+        return (x: number, y: number, z: number) => wrap(t.translate(x, y, z));
+      }
+      if (prop === 'rotate' && typeof t.rotate === 'function') {
+        return (axis: [number, number, number], degrees: number, pivot: [number, number, number] = [0, 0, 0]) =>
+          wrap((t.rotate as NonNullable<RawShape['rotate']>)(degrees, pivot, axis));
+      }
+      // unwrap() sentinel — used internally to recover the raw shape from a proxy.
+      if (prop === '__v01Raw__') {
+        return t;
+      }
+      const value = Reflect.get(t, prop, receiver);
+      // Bind methods so callers don't see the proxy as `this`.
+      return typeof value === 'function' ? (value as (...args: unknown[]) => unknown).bind(t) : value;
+    },
+  });
+}
+
+function unwrap(maybeProxy: unknown): unknown {
+  if (maybeProxy && typeof maybeProxy === 'object' && '__v01Raw__' in (maybeProxy as Record<string, unknown>)) {
+    return (maybeProxy as Record<string, unknown>).__v01Raw__;
+  }
+  return maybeProxy;
+}
+
+export interface V01ApiGlobals {
+  param: (name: string, value: number | string, opts?: unknown) => number;
+  box: (x: number, y: number, z: number, centered?: boolean) => unknown;
+  cylinder: (h: number, r: number) => unknown;
+  sphere: (r: number) => unknown;
+}
+
+/**
+ * Build the v0.1 API globals that get injected into user scripts. The
+ * `param` shim is a no-op in the browser (no UI to render the form yet) —
+ * it just returns the default value. v0.5 will wire it through
+ * `ParamRegistry`. Numeric defaults are returned as-is; string expressions
+ * are evaluated as JS `Number(expr)` since v0.1 uses `String(n)` literals.
+ */
+export function createV01ApiGlobals(replicad: ReplicadLike): V01ApiGlobals {
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    param(_name, value, _opts) {
+      if (typeof value === 'number') return value;
+      const n = Number(value);
+      return Number.isFinite(n) ? n : 0;
+    },
+    box(x, y, z, centered = false) {
+      const b = replicad.makeBaseBox(x, y, z) as RawShape;
+      // Match OcctBackend.box: makeBaseBox is centered in X/Y, anchored at z=0.
+      const placed = centered ? b.translate(0, 0, -z / 2) : b.translate(x / 2, y / 2, 0);
+      return wrap(placed);
+    },
+    cylinder(h, r) {
+      return wrap(replicad.makeCylinder(r, h));
+    },
+    sphere(r) {
+      return wrap(replicad.makeSphere(r));
+    },
+  };
+}
+
+/** Recover the underlying Replicad shape from a wrapped v0.1 shape. */
+export function unwrapV01Shape(maybeProxy: unknown): unknown {
+  return unwrap(maybeProxy);
+}


### PR DESCRIPTION
## Summary

- **Hide legacy 0.10.0 toolbar buttons** that broke during the v0.1 kernel rewrite. Per the NORTHSTAR spec, Studio UI is deferred to v0.5; until then, only Toggle Scene Browser remains. The Header (Code/Design mode, shading, Undo/Redo, Export STL/STEP) is unchanged.
- **Pre-fill the code editor with a working v0.1 starter** (`box(w,h,t).subtract(cylinder)` with `param`s) so the first-load demo matches v0.1's actual capability. Existing user projects in localStorage are preserved.
- **Bridge `box` / `cylinder` / `sphere` / `param` to the existing Replicad worker** so the v0.1 starter — and any v0.1-style code a user writes — runs end-to-end (preview, mesh, Export STL, Export STEP). The browser-side `runAndExport` from the v0.1 kernel uses Node's `vm`, which doesn't ship in browsers, so this PR adds a small `v01ApiShim` instead of rebuilding the whole script-runtime.
- **Fix a hidden strict-mode bug** in `safeSketch.ts`: `Object.create(replicad)` over an ES-module namespace hit `TypeError: Cannot assign to read only property 'Sketcher'` on the first `EXECUTE`. Replaced with a flat copy.

The legacy command-driven toolbar code stays in git history (and the feature registry / `onToolClick` prop are still accepted) so v0.5 can revive whichever pieces it wants.

## Files changed

- `src/components/Toolbar.tsx` — strip legacy buttons; render only Toggle Scene Browser.
- `src/components/Toolbar.test.tsx` — update tests for the new shape.
- `src/context/ProjectContext.tsx` — new projects use the v0.1 starter, not `// New Project`.
- `src/lib/geometryEngine.ts` — `defaultCode` is the v0.1 starter.
- `src/lib/v01ApiShim.ts` (new) — `param` / `box` / `cylinder` / `sphere` plus a Proxy wrapping Replicad shapes with v0.1's `subtract`/`union`/`intersect`/`translate`.
- `src/backends/occt/worker.ts` — inject the v0.1 globals into both EXECUTE and EXPORT paths; unwrap proxies before mesh / `blobSTL` / `blobSTEP`.
- `src/lib/safeSketch.ts` — flat-copy replicad namespace instead of `Object.create`, to dodge strict-mode `Cannot assign to read only property 'Sketcher'`.
- `docs/superpowers/specs/2026-04-29-v0.2-alpha-fillet-chamfer-design.md` — small post-self-review tightening (separate commit, included here because branch protection blocks pushes to develop).

## Test plan

- [x] `npm run qc` (lint + typecheck + 377 tests) green locally
- [x] `npm run build` produces a valid bundle
- [x] `npm run dev` + chrome-devtools verification:
    - [x] Toolbar shows only Toggle Scene Browser — no Box/Cylinder/Sketch/Extrude/Fillet/etc
    - [x] Editor pre-filled with the v0.1 starter on fresh `localStorage.clear()`
    - [x] Geometry renders without console errors
    - [x] Export STL: 205 KB ASCII STL, anchor download fires (`Untitled_Project.stl`), starts with `solid \n facet normal …`
    - [x] Export STEP: 20 KB STEP, anchor download fires (`Untitled_Project.step`), starts with `ISO-10303-21;`

## Deploy

GitHub Pages deploy is `workflow_dispatch`-only, so after this merges someone needs to manually trigger the deploy workflow.

## Notes for v0.5 Studio

- The v0.1 API shim is a deliberately thin compatibility bridge. The proper home for `param` / `box` / `cylinder` is `src/script-runtime/runScript.ts` running inside a browser-safe isolation primitive (Web Worker or `new Function` with sandboxed globals). v0.5 should retire `v01ApiShim.ts` and wire the editor directly through `runAndExport` once browser isolation is in place.
- `param` in the shim is a no-op — it just returns the default value. There's no UI for parameter inputs yet; v0.5 should wire it through `ParamRegistry`.
- The freeze-fix in `safeSketch.ts` is independently load-bearing — without it the legacy Replicad path also throws on first execute. Worth keeping even after the shim is replaced.