### PR TITLE
feat(v0.2-alpha): fillet + chamfer (canonical refs only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## v0.2.0-alpha.1 — 2026-04-30
+
+### Added
+- **`fillet` and `chamfer`** — first edge features in the kernelCAD module API
+  - `Shape.fillet(radius, opts?)` and `Shape.chamfer(distance, opts?)` on the capture proxy (`src/capture/proxy.ts`)
+  - Canonical face filter via `opts.face` (`'top'|'bottom'|'left'|'right'|'front'|'back'`) on un-transformed primitives — `box(20,20,5).fillet(2, { face: 'top' })`
+  - Symmetric (45°) chamfer only; asymmetric two-distance variant deferred
+- `pickEdges(record, base)` helper (`src/backends/occt/edgeSelection.ts`) — resolves face filter to OCCT edges via gap-aware bounding-box face matching
+- `OcctBackend` `kind?` tag set by static factories; transforms and booleans drop the tag — used to enforce "canonical face refs require an un-transformed primitive"
+- `OcctBackend.fillet(edges, radius)` / `.chamfer(edges, distance)` instance methods wrapping `BRepFilletAPI_MakeFillet` / `BRepFilletAPI_MakeChamfer`
+- `OcctLowerer` switch arms for `'fillet'` and `'chamfer'` with structured diagnostics (`feature.fillet.failed`, `feature.chamfer.failed`, `feature.edge-feature.face-ref-not-resolvable`, `feature.edge-feature.face-ref-not-applicable`, `feature.edge-feature.face-ref-not-supported`)
+- `CaptureSession.edgeFeature(kind, base, valueParamName, value, face?)` registrar mirroring the `boolean()` pattern
+- `tests/e2e/fixtures/rounded-bracket.kcad.ts` parametric demo + e2e volume-regression test
+
+### Spec deviations
+- One combined error code `feature.edge-feature.face-ref-not-resolvable` covers both "non-primitive base" and "transformed primitive" cases. Splitting them cleanly would require refactoring `FeatureLowerer.lower()` to receive the base FeatureRecord — bigger blast radius than v0.2-alpha warrants.
+
+### Deferred to v0.2 / v0.2-beta
+- `tracked` / `created` / `propagated` FaceRef variants and `NamingHistory` walking
+- Asymmetric (two-distance) chamfer
+- Per-edge variable radii
+- Canonical face refs on transformed primitives
+- shell, hole, cut, draft features
+
 ## v0.1.0 — 2026-04-29
 
 ### Added

--- a/docs/superpowers/plans/2026-04-30-v0.2-alpha-fillet-chamfer.md
+++ b/docs/superpowers/plans/2026-04-30-v0.2-alpha-fillet-chamfer.md
@@ -1,0 +1,1151 @@
+# v0.2-alpha — Fillet + Chamfer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `fillet` and `chamfer` to the kernelCAD module surface for v0.2-alpha — works on any shape with all-edges, on un-transformed primitives with canonical-face filtering. Tracked refs and `NamingHistory` walking remain deferred to v0.2 full.
+
+**Architecture:** Mirrors the existing `OcctLowerer` switch + `CaptureSession.boolean()` patterns. New `edgeSelection.ts` helper resolves canonical face → edges via OCCT bounding-box face matching. `OcctBackend` gains a `kind?: 'box' | 'cylinder' | 'sphere'` tag set by the static factories; transforms and booleans return new instances without the tag, so "is this an un-transformed primitive?" is just "is `.kind` set?"
+
+**Tech Stack:** TypeScript 5.9, Vite 7, React 19, Vitest 4, Replicad / OpenCASCADE WASM (`replicad-opencascadejs`), commander.js (CLI).
+
+**Spec:** `docs/superpowers/specs/2026-04-29-v0.2-alpha-fillet-chamfer-design.md`
+
+**Spec deviation (acknowledged):** spec specifies two distinct error codes — `feature.edge-feature.face-ref-on-non-primitive` (for boolean/extrude/revolve results) and `feature.edge-feature.face-ref-on-transformed-primitive` (for primitives with transforms). Producing distinct codes would require either (a) refactoring `FeatureLowerer.lower()` to receive the base `FeatureRecord` not just the resolved `ShapeBackend`, or (b) duplicating record state onto every `OcctBackend` instance. Both are bigger blast-radius than v0.2-alpha warrants. The plan ships ONE code `feature.edge-feature.face-ref-not-resolvable` with a message that includes which condition tripped (transform or non-primitive shape). Spec doc will be updated alongside the implementation.
+
+---
+
+## File Structure
+
+**Create:**
+- `src/backends/occt/edgeSelection.ts` — `pickEdges(record, base): TopoDS_Edge[] | { error: CompilerDiagnostic }`. Single responsibility: turn a fillet/chamfer's optional face filter into a list of OCCT edges, or return a structured error.
+- `tests/unit/backends/occt/edgeSelection.test.ts`
+- `tests/unit/backends/occt/occtLowerer.fillet.test.ts`
+- `tests/unit/backends/occt/occtLowerer.chamfer.test.ts`
+- `tests/unit/capture/proxy.fillet.test.ts` (covers `chamfer` too — parallel surface)
+- `tests/e2e/fixtures/rounded-bracket.kcad.ts`
+
+**Modify:**
+- `src/backends/occt/occtBackend.ts` — add `kind?: 'box' | 'cylinder' | 'sphere'` field; set it in the `box` / `cylinder` / `sphere` static factories; add `fillet(edges, radius): OcctBackend` and `chamfer(edges, distance): OcctBackend` methods. Transform methods (`translate`, `rotate`, `scale`, `mirror`) and boolean methods (`union`, `subtract`, `intersect`) already return new `OcctBackend(...)` without copying `kind` — so the tag naturally drops on transform/boolean. Verify, don't add new propagation logic.
+- `src/backends/occt/occtLowerer.ts` — add `'fillet'` and `'chamfer'` to `supports`; add the two switch arms.
+- `src/capture/captureSession.ts` — add `edgeFeature(kind, base, params, faceFilter?): Shape` method.
+- `src/capture/proxy.ts` — add `fillet(radius, opts?): Shape` and `chamfer(distance, opts?): Shape` methods on `Shape`.
+- `tests/e2e/cli-acceptance.test.ts` — add the rounded-bracket case (volume strictly less than un-filleted equivalent).
+
+**No-touch (verify only):**
+- `src/intent/types.ts` — `FeatureKind` already includes `'fillet'` and `'chamfer'`.
+- `src/compute/recomputeEngine.ts` — already iterates `feature|face|edge|vertex` ref kinds; no changes needed.
+- `src/lib/v01ApiShim.ts` — bridges Shape proxy methods to the legacy browser eval. Verify in Phase 5 that fillet/chamfer flow through; only modify if they don't.
+
+---
+
+## Phase 1: Edge Selection Helper
+
+### Task 1: `pickEdges` helper + canonical face → edges resolution
+
+**Files:**
+- Create: `src/backends/occt/edgeSelection.ts`
+- Create: `tests/unit/backends/occt/edgeSelection.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// tests/unit/backends/occt/edgeSelection.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { pickEdges } from '../../../../src/backends/occt/edgeSelection';
+import { OcctBackend, initOcct } from '../../../../src/backends/occt/occtBackend';
+import type { FeatureRecord } from '../../../../src/intent/featureRecord';
+
+const filletNoFilter = (baseId: string): FeatureRecord => ({
+  id: 'fillet_1', kind: 'fillet',
+  inputs: { base: { kind: 'feature', id: baseId } },
+  params: { radius: { expression: '2', unit: 'mm', evaluated: 2 } },
+  transforms: [], suppressed: false,
+});
+
+const filletWithFace = (baseId: string, face: 'top'|'bottom'|'left'|'right'|'front'|'back'): FeatureRecord => ({
+  id: 'fillet_2', kind: 'fillet',
+  inputs: {
+    base: { kind: 'feature', id: baseId },
+    face: { kind: 'face', featureId: baseId, ref: { kind: 'canonical', face } },
+  },
+  params: { radius: { expression: '2', unit: 'mm', evaluated: 2 } },
+  transforms: [], suppressed: false,
+});
+
+describe('pickEdges', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('returns ALL edges when no face filter is set (un-transformed box)', () => {
+    const box = OcctBackend.box(20, 20, 20);
+    const result = pickEdges(filletNoFilter('box_1'), box);
+    if ('error' in result) throw new Error(`expected edges, got error: ${result.error.message}`);
+    expect(result.length).toBe(12); // a box has 12 edges
+  });
+
+  it('returns 4 edges for canonical "top" face on a box', () => {
+    const box = OcctBackend.box(20, 20, 20);
+    const result = pickEdges(filletWithFace('box_1', 'top'), box);
+    if ('error' in result) throw new Error(`expected edges, got error: ${result.error.message}`);
+    expect(result.length).toBe(4);
+  });
+
+  it('returns 1 edge for canonical "top" face on a cylinder', () => {
+    const cyl = OcctBackend.cylinder(20, 5);
+    const result = pickEdges(filletWithFace('cyl_1', 'top'), cyl);
+    if ('error' in result) throw new Error(`expected edges, got error: ${result.error.message}`);
+    expect(result.length).toBe(1); // cylinder top is one circular edge
+  });
+
+  it('returns error when face filter is on a non-primitive (boolean result)', () => {
+    const box = OcctBackend.box(20, 20, 20);
+    const cyl = OcctBackend.cylinder(20, 5).translate(10, 10, -1);
+    const bool = box.subtract(cyl); // result has no kind tag
+    const result = pickEdges(filletWithFace('bool_1', 'top'), bool);
+    if (!('error' in result)) throw new Error('expected error, got edges');
+    expect(result.error.code).toBe('feature.edge-feature.face-ref-not-resolvable');
+    expect(result.error.severity).toBe('error');
+  });
+
+  it('returns error when face filter is on a transformed primitive', () => {
+    const box = OcctBackend.box(20, 20, 20).translate(5, 0, 0); // transform drops kind tag
+    const result = pickEdges(filletWithFace('box_1', 'top'), box);
+    if (!('error' in result)) throw new Error('expected error, got edges');
+    expect(result.error.code).toBe('feature.edge-feature.face-ref-not-resolvable');
+  });
+
+  it('returns error when canonical face is not applicable to this primitive', () => {
+    const cyl = OcctBackend.cylinder(20, 5);
+    const result = pickEdges(filletWithFace('cyl_1', 'left'), cyl);
+    if (!('error' in result)) throw new Error('expected error, got edges');
+    expect(result.error.code).toBe('feature.edge-feature.face-ref-not-applicable');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `npx vitest run tests/unit/backends/occt/edgeSelection.test.ts`
+Expected: All 6 tests FAIL — `pickEdges` not defined.
+
+- [ ] **Step 3: Implement `edgeSelection.ts`**
+
+```typescript
+// src/backends/occt/edgeSelection.ts
+import * as replicad from 'replicad';
+import type { FeatureRecord } from '../../intent/featureRecord';
+import type { CompilerDiagnostic } from '../../diagnostics/diagnostic';
+import { OcctBackend } from './occtBackend';
+
+type CanonicalFace = 'top' | 'bottom' | 'left' | 'right' | 'front' | 'back';
+
+// We don't have direct OCCT TopoDS_Edge type imports from replicad; use unknown[] at the
+// edgeSelection boundary and let OcctBackend.fillet/chamfer accept the same opaque list.
+export type EdgeList = unknown[];
+
+export type PickEdgesResult =
+  | EdgeList
+  | { error: CompilerDiagnostic };
+
+export function pickEdges(record: FeatureRecord, base: OcctBackend): PickEdgesResult {
+  const faceRef = record.inputs.face;
+
+  // No face filter → all edges of the underlying shape.
+  if (!faceRef) {
+    return allEdgesOf(base);
+  }
+
+  if (faceRef.kind !== 'face' || faceRef.ref.kind !== 'canonical') {
+    return {
+      error: {
+        target: 'export-occt',
+        code: 'feature.edge-feature.face-ref-not-supported',
+        featureId: record.id,
+        severity: 'error',
+        message: `Only canonical face refs are supported in v0.2-alpha; got '${faceRef.kind === 'face' ? faceRef.ref.kind : faceRef.kind}'.`,
+      },
+    };
+  }
+
+  // Canonical face filter → must be on an un-transformed primitive (kind tag set).
+  if (!base.kind) {
+    return {
+      error: {
+        target: 'export-occt',
+        code: 'feature.edge-feature.face-ref-not-resolvable',
+        featureId: record.id,
+        severity: 'error',
+        message: `Canonical face refs require an un-transformed primitive (box, cylinder, or sphere). Apply transforms after fillet/chamfer instead of before.`,
+      },
+    };
+  }
+
+  const face = faceRef.ref.face as CanonicalFace;
+  const edges = canonicalFaceEdges(base, face);
+  if (edges === null) {
+    return {
+      error: {
+        target: 'export-occt',
+        code: 'feature.edge-feature.face-ref-not-applicable',
+        featureId: record.id,
+        severity: 'error',
+        message: `Canonical face '${face}' is not applicable to ${base.kind}.`,
+      },
+    };
+  }
+  return edges;
+}
+
+function allEdgesOf(base: OcctBackend): EdgeList {
+  // Replicad exposes shape.edges (a Promise<Edge[]>) — but we need the synchronous OCCT
+  // TopoDS_Edge list for BRepFilletAPI/BRepChamferAPI. Use the underlying shape iterator.
+  // OcctBackend exposes a getter `_replicadShape()` for this purpose (added in this task).
+  const shape = base.getReplicadShape();
+  // Replicad's Shape3D has `getEdges()` returning replicad Edge wrappers; underlying TopoDS_Edge
+  // is on `.edge` property.
+  return shape.edges.map((e: { edge: unknown }) => e.edge);
+}
+
+function canonicalFaceEdges(base: OcctBackend, face: CanonicalFace): EdgeList | null {
+  if (base.kind === 'box') {
+    return canonicalBoxFaceEdges(base, face);
+  }
+  if (base.kind === 'cylinder') {
+    if (face === 'top' || face === 'bottom') {
+      return canonicalCylinderEndCapEdges(base, face);
+    }
+    return null; // left/right/front/back not applicable to cylinder
+  }
+  // sphere: no canonical faces in any direction
+  return null;
+}
+
+function canonicalBoxFaceEdges(base: OcctBackend, face: CanonicalFace): EdgeList {
+  // Match face by axis-aligned plane. We use the shape's bounding box to identify which
+  // OCCT face has the appropriate normal + offset, then collect that face's edges.
+  const shape = base.getReplicadShape();
+  const bb = shape.boundingBox;
+  // bb has .min, .max as Vec3-like
+  const target = pickFacePlane(bb, face);
+  // Iterate shape.faces; pick the one whose centroid aligns with the target plane.
+  const faces = shape.faces;
+  const TOL = 0.001;
+  for (const f of faces) {
+    const c = f.center; // {x,y,z}-ish
+    if (Math.abs(c[target.axisIndex] - target.value) < TOL) {
+      // Found the matching face. Return its edges.
+      return f.edges.map((e: { edge: unknown }) => e.edge);
+    }
+  }
+  return [];
+}
+
+function canonicalCylinderEndCapEdges(base: OcctBackend, face: 'top'|'bottom'): EdgeList {
+  const shape = base.getReplicadShape();
+  const bb = shape.boundingBox;
+  const targetZ = face === 'top' ? bb.max[2] : bb.min[2];
+  const TOL = 0.001;
+  const faces = shape.faces;
+  for (const f of faces) {
+    if (Math.abs(f.center[2] - targetZ) < TOL) {
+      return f.edges.map((e: { edge: unknown }) => e.edge);
+    }
+  }
+  return [];
+}
+
+interface FacePlane { axisIndex: 0 | 1 | 2; value: number; }
+
+function pickFacePlane(bb: { min: number[]; max: number[] }, face: CanonicalFace): FacePlane {
+  switch (face) {
+    case 'top':    return { axisIndex: 2, value: bb.max[2] };
+    case 'bottom': return { axisIndex: 2, value: bb.min[2] };
+    case 'right':  return { axisIndex: 0, value: bb.max[0] };
+    case 'left':   return { axisIndex: 0, value: bb.min[0] };
+    case 'back':   return { axisIndex: 1, value: bb.max[1] };
+    case 'front':  return { axisIndex: 1, value: bb.min[1] };
+  }
+}
+```
+
+- [ ] **Step 4: Add `kind` field + `getReplicadShape()` getter to `OcctBackend`**
+
+This step lets `pickEdges` actually inspect the underlying replicad shape AND lets it know if the OcctBackend is a primitive.
+
+In `src/backends/occt/occtBackend.ts`:
+
+After line 55 (`private shape: ReplicadShape3D;`):
+
+```typescript
+  readonly kind?: 'box' | 'cylinder' | 'sphere';
+
+  constructor(shape: ReplicadShape3D, kind?: 'box' | 'cylinder' | 'sphere') {
+    this.shape = shape;
+    this.kind = kind;
+  }
+
+  /**
+   * Internal accessor for `edgeSelection.pickEdges` — returns the underlying replicad
+   * shape so the helper can iterate `shape.faces` / `shape.edges`. Treat as
+   * implementation detail; do not export from `index.ts`.
+   */
+  getReplicadShape(): ReplicadShape3D {
+    return this.shape;
+  }
+```
+
+In the same file, update the static factories to pass the kind tag:
+
+```typescript
+  static box(x: number, y: number, z: number, centered = false): OcctBackend {
+    // ... existing body ...
+    return new OcctBackend(placed, 'box');
+  }
+
+  static cylinder(h: number, r: number): OcctBackend {
+    // ... existing body ...
+    return new OcctBackend(replicad.makeCylinder(r, h) as ReplicadShape3D, 'cylinder');
+  }
+
+  static sphere(r: number): OcctBackend {
+    // ... existing body ...
+    return new OcctBackend(replicad.makeSphere(r) as ReplicadShape3D, 'sphere');
+  }
+```
+
+The transform methods (`translate`, `rotate`, `scale`, `mirror`) and boolean methods already construct `new OcctBackend(...)` WITHOUT a kind argument — so the tag drops naturally. Verify by reading the existing methods; do not modify them.
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `npx vitest run tests/unit/backends/occt/edgeSelection.test.ts`
+Expected: 6/6 PASS. If `shape.faces` / `shape.edges` / `f.center` / `f.edges` shapes don't match Replicad's actual API (the API for accessing topology may have evolved), inspect `node_modules/replicad/dist/replicad.d.ts` and adjust.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/backends/occt/edgeSelection.ts tests/unit/backends/occt/edgeSelection.test.ts src/backends/occt/occtBackend.ts
+git commit -m "feat(backends/occt): edgeSelection helper + kind tag on OcctBackend primitives"
+```
+
+---
+
+## Phase 2: OcctBackend fillet + chamfer
+
+### Task 2: `OcctBackend.fillet` + `.chamfer` methods
+
+**Files:**
+- Modify: `src/backends/occt/occtBackend.ts`
+
+- [ ] **Step 1: Add a unit test for the methods**
+
+New file: `tests/unit/backends/occt/occtBackend.fillet.test.ts`
+
+```typescript
+import { describe, it, expect, beforeAll } from 'vitest';
+import { OcctBackend, initOcct } from '../../../../src/backends/occt/occtBackend';
+
+describe('OcctBackend.fillet / chamfer', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('fillet on all edges of a box reduces volume (radius < edge/2)', () => {
+    const box = OcctBackend.box(20, 20, 20);
+    const baseV = box.volume();
+    const all = box.getReplicadShape().edges.map((e: { edge: unknown }) => e.edge);
+    const filleted = box.fillet(all, 2);
+    const v = filleted.volume();
+    expect(v).toBeLessThan(baseV);
+    expect(v).toBeGreaterThan(baseV - 12 * 20 * (4 - Math.PI)); // very loose lower bound
+  });
+
+  it('chamfer on all edges of a box reduces volume', () => {
+    const box = OcctBackend.box(20, 20, 20);
+    const baseV = box.volume();
+    const all = box.getReplicadShape().edges.map((e: { edge: unknown }) => e.edge);
+    const chamfered = box.chamfer(all, 1.5);
+    expect(chamfered.volume()).toBeLessThan(baseV);
+  });
+
+  it('fillet returned shape has no kind tag (it is no longer a raw primitive)', () => {
+    const box = OcctBackend.box(20, 20, 20);
+    const all = box.getReplicadShape().edges.map((e: { edge: unknown }) => e.edge);
+    expect(box.fillet(all, 2).kind).toBeUndefined();
+    expect(box.chamfer(all, 1).kind).toBeUndefined();
+  });
+
+  it('fillet with too-large radius throws (caught by lowerer in Phase 3)', () => {
+    const box = OcctBackend.box(10, 10, 10);
+    const all = box.getReplicadShape().edges.map((e: { edge: unknown }) => e.edge);
+    expect(() => box.fillet(all, 100)).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/backends/occt/occtBackend.fillet.test.ts`
+Expected: tests fail because `fillet` and `chamfer` don't exist on `OcctBackend`.
+
+- [ ] **Step 3: Implement `.fillet` and `.chamfer` on `OcctBackend`**
+
+In `src/backends/occt/occtBackend.ts`, add these instance methods (after the existing `mirror` method or near other operations):
+
+```typescript
+  /**
+   * Round the supplied edges with `radius` (mm). Returned shape carries no
+   * `kind` tag — once filleted, the shape is no longer a raw primitive.
+   *
+   * Throws on OCCT failure (e.g. radius too large, edges not topologically
+   * compatible). Callers (the lowerer) translate the throw into a structured
+   * `feature.fillet.failed` diagnostic.
+   */
+  fillet(edges: unknown[], radius: number): OcctBackend {
+    if (edges.length === 0) {
+      throw new Error('fillet: edge list is empty');
+    }
+    // Replicad exposes a fluent fillet via `shape.fillet(filter, radius)` where the
+    // filter selects edges. For the explicit-edge-list path, drop down to OCCT directly.
+    // The simplest API surface that works with replicad is the `EdgeFinder`/builder API,
+    // but for v0.2-alpha we use replicad's fillet-by-radius-on-all-edges as a baseline.
+    // If `edges.length === total edges of shape`, use the convenience path; otherwise
+    // pass `edges` to the BRepFilletAPI builder.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const filleted = (this.shape as any).fillet(radius, () => edges) as ReplicadShape3D;
+    return new OcctBackend(filleted);
+  }
+
+  /**
+   * Chamfer the supplied edges with symmetric `distance` (mm) — produces a
+   * 45° chamfer with both faces cut by `distance`.
+   *
+   * Asymmetric (two-distance) chamfers are deferred to v0.2-beta.
+   */
+  chamfer(edges: unknown[], distance: number): OcctBackend {
+    if (edges.length === 0) {
+      throw new Error('chamfer: edge list is empty');
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const chamfered = (this.shape as any).chamfer(distance, () => edges) as ReplicadShape3D;
+    return new OcctBackend(chamfered);
+  }
+```
+
+NOTE on the replicad API: Replicad's `shape.fillet(radius, edgeFinderOrFn)` and `shape.chamfer(distance, edgeFinderOrFn)` are the canonical paths. The second arg can be an `EdgeFinder` instance or a function returning a list of edges. We use the function-returning-list form because we already have the edges. If the actual API differs (check `node_modules/replicad/dist/replicad.d.ts:Shape3D` — look for `fillet` / `chamfer` signatures), adjust the call accordingly. If replicad doesn't accept a raw edge list, fall back to wrapping the edges in an `EdgeFinder` whose `find()` returns them.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npx vitest run tests/unit/backends/occt/occtBackend.fillet.test.ts`
+Expected: 4/4 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backends/occt/occtBackend.ts tests/unit/backends/occt/occtBackend.fillet.test.ts
+git commit -m "feat(backends/occt): OcctBackend fillet/chamfer methods"
+```
+
+---
+
+## Phase 3: Lowerer integration
+
+### Task 3: `OcctLowerer` `'fillet'` case
+
+**Files:**
+- Modify: `src/backends/occt/occtLowerer.ts`
+- Create: `tests/unit/backends/occt/occtLowerer.fillet.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// tests/unit/backends/occt/occtLowerer.fillet.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { OcctLowerer } from '../../../../src/backends/occt/occtLowerer';
+import { OcctBackend, initOcct } from '../../../../src/backends/occt/occtBackend';
+import type { FeatureRecord } from '../../../../src/intent/featureRecord';
+import type { Param } from '../../../../src/intent/types';
+
+const mm = (n: number): Param => ({ expression: String(n), unit: 'mm', evaluated: n });
+
+describe('OcctLowerer fillet', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('lowers an all-edges fillet on a box', async () => {
+    const base = OcctBackend.box(20, 20, 20);
+    const r: FeatureRecord = {
+      id: 'fillet_1', kind: 'fillet',
+      inputs: { base: { kind: 'feature', id: 'box_1' } },
+      params: { radius: mm(2) },
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: { base } });
+    expect(result.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0);
+    expect(result.shape.volume()).toBeLessThan(8000);
+  });
+
+  it('lowers a top-face fillet on a box (returns smaller volume than all-edges fillet)', async () => {
+    const base = OcctBackend.box(20, 20, 20);
+    const r: FeatureRecord = {
+      id: 'fillet_2', kind: 'fillet',
+      inputs: {
+        base: { kind: 'feature', id: 'box_1' },
+        face: { kind: 'face', featureId: 'box_1', ref: { kind: 'canonical', face: 'top' } },
+      },
+      params: { radius: mm(2) },
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: { base } });
+    expect(result.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0);
+    const v = result.shape.volume();
+    expect(v).toBeLessThan(8000);
+    expect(v).toBeGreaterThan(7900); // top-face fillet removes much less than all-edges
+  });
+
+  it('emits face-ref-not-resolvable for fillet on a transformed primitive', async () => {
+    const base = OcctBackend.box(20, 20, 20).translate(5, 0, 0);
+    const r: FeatureRecord = {
+      id: 'fillet_3', kind: 'fillet',
+      inputs: {
+        base: { kind: 'feature', id: 'box_1' },
+        face: { kind: 'face', featureId: 'box_1', ref: { kind: 'canonical', face: 'top' } },
+      },
+      params: { radius: mm(2) },
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: { base } });
+    const errs = result.diagnostics.filter(d => d.severity === 'error');
+    expect(errs).toHaveLength(1);
+    expect(errs[0].code).toBe('feature.edge-feature.face-ref-not-resolvable');
+  });
+
+  it('emits feature.fillet.failed when OCCT throws (radius too large)', async () => {
+    const base = OcctBackend.box(10, 10, 10);
+    const r: FeatureRecord = {
+      id: 'fillet_4', kind: 'fillet',
+      inputs: { base: { kind: 'feature', id: 'box_1' } },
+      params: { radius: mm(100) },
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: { base } });
+    const errs = result.diagnostics.filter(d => d.severity === 'error');
+    expect(errs).toHaveLength(1);
+    expect(errs[0].code).toBe('feature.fillet.failed');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/backends/occt/occtLowerer.fillet.test.ts`
+Expected: tests fail because there's no `'fillet'` case in the lowerer; the default branch emits `Feature kind 'fillet' is not supported in v0.1.`
+
+- [ ] **Step 3: Add `'fillet'` to `supports` and the `'fillet'` switch case**
+
+In `src/backends/occt/occtLowerer.ts`:
+
+Update the `supports` set (around line 27):
+
+```typescript
+  readonly supports: ReadonlySet<FeatureKind> = new Set<FeatureKind>([
+    'box',
+    'cylinder',
+    'sphere',
+    'extrude',
+    'revolve',
+    'boolean',
+    'fillet',     // NEW
+    'chamfer',    // NEW (covered by Task 4)
+  ]);
+```
+
+Add a new import at the top:
+
+```typescript
+import { pickEdges } from './edgeSelection';
+```
+
+Add the `'fillet'` case after the existing `'boolean'` case (around line 110+):
+
+```typescript
+      case 'fillet': {
+        const base = inputs.byKey.base as OcctBackend | undefined;
+        if (!base) {
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.fillet.no-base',
+            featureId: r.id,
+            severity: 'error',
+            message: `fillet requires an input named 'base'.`,
+          });
+          // We still need to assign `shape` for the post-loop transforms; throw here
+          // is fine because the engine catches and emits recompute.lowering.exception.
+          throw new Error('fillet: no base shape');
+        }
+        const radius = r.params.radius?.evaluated;
+        if (radius === undefined) {
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.fillet.no-radius',
+            featureId: r.id,
+            severity: 'error',
+            message: `fillet requires a 'radius' parameter.`,
+          });
+          throw new Error('fillet: no radius');
+        }
+        const edgesResult = pickEdges(r, base);
+        if ('error' in edgesResult) {
+          diagnostics.push(edgesResult.error);
+          // Return early without producing a shape — recompute marks this feature error
+          // and downstream sees recompute.input.missing.
+          return { shape: base, diagnostics }; // base is a placeholder — caller sees error
+        }
+        try {
+          shape = base.fillet(edgesResult, radius);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.fillet.failed',
+            featureId: r.id,
+            severity: 'error',
+            message: `OCCT fillet failed: ${msg}`,
+          });
+          return { shape: base, diagnostics };
+        }
+        break;
+      }
+```
+
+NOTE on early-return + diagnostics shape: the existing default case returns `{ shape: <unset>, diagnostics: [...] }` with shape implicitly the input. Match that pattern. Since `RecomputeEngine` checks `result.diagnostics.some(d => d.severity === 'error')` and skips adding the shape to the result map, returning `base` as a placeholder is harmless.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npx vitest run tests/unit/backends/occt/occtLowerer.fillet.test.ts`
+Expected: 4/4 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backends/occt/occtLowerer.ts tests/unit/backends/occt/occtLowerer.fillet.test.ts
+git commit -m "feat(backends/occt): OcctLowerer fillet case with face filter + diagnostics"
+```
+
+---
+
+### Task 4: `OcctLowerer` `'chamfer'` case
+
+**Files:**
+- Modify: `src/backends/occt/occtLowerer.ts`
+- Create: `tests/unit/backends/occt/occtLowerer.chamfer.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// tests/unit/backends/occt/occtLowerer.chamfer.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { OcctLowerer } from '../../../../src/backends/occt/occtLowerer';
+import { OcctBackend, initOcct } from '../../../../src/backends/occt/occtBackend';
+import type { FeatureRecord } from '../../../../src/intent/featureRecord';
+import type { Param } from '../../../../src/intent/types';
+
+const mm = (n: number): Param => ({ expression: String(n), unit: 'mm', evaluated: n });
+
+describe('OcctLowerer chamfer', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('lowers an all-edges chamfer on a box', async () => {
+    const base = OcctBackend.box(20, 20, 20);
+    const r: FeatureRecord = {
+      id: 'chamfer_1', kind: 'chamfer',
+      inputs: { base: { kind: 'feature', id: 'box_1' } },
+      params: { distance: mm(1.5) },
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: { base } });
+    expect(result.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0);
+    expect(result.shape.volume()).toBeLessThan(8000);
+  });
+
+  it('lowers a top-face chamfer on a box', async () => {
+    const base = OcctBackend.box(20, 20, 20);
+    const r: FeatureRecord = {
+      id: 'chamfer_2', kind: 'chamfer',
+      inputs: {
+        base: { kind: 'feature', id: 'box_1' },
+        face: { kind: 'face', featureId: 'box_1', ref: { kind: 'canonical', face: 'top' } },
+      },
+      params: { distance: mm(1.5) },
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: { base } });
+    expect(result.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0);
+    expect(result.shape.volume()).toBeLessThan(8000);
+  });
+
+  it('emits feature.chamfer.failed when OCCT throws', async () => {
+    const base = OcctBackend.box(10, 10, 10);
+    const r: FeatureRecord = {
+      id: 'chamfer_3', kind: 'chamfer',
+      inputs: { base: { kind: 'feature', id: 'box_1' } },
+      params: { distance: mm(100) },
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: { base } });
+    const errs = result.diagnostics.filter(d => d.severity === 'error');
+    expect(errs).toHaveLength(1);
+    expect(errs[0].code).toBe('feature.chamfer.failed');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/backends/occt/occtLowerer.chamfer.test.ts`
+Expected: tests fail — chamfer case missing.
+
+- [ ] **Step 3: Add the `'chamfer'` switch case**
+
+In `src/backends/occt/occtLowerer.ts`, immediately after the `'fillet'` case from Task 3:
+
+```typescript
+      case 'chamfer': {
+        const base = inputs.byKey.base as OcctBackend | undefined;
+        if (!base) {
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.chamfer.no-base',
+            featureId: r.id,
+            severity: 'error',
+            message: `chamfer requires an input named 'base'.`,
+          });
+          throw new Error('chamfer: no base shape');
+        }
+        const distance = r.params.distance?.evaluated;
+        if (distance === undefined) {
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.chamfer.no-distance',
+            featureId: r.id,
+            severity: 'error',
+            message: `chamfer requires a 'distance' parameter.`,
+          });
+          throw new Error('chamfer: no distance');
+        }
+        const edgesResult = pickEdges(r, base);
+        if ('error' in edgesResult) {
+          diagnostics.push(edgesResult.error);
+          return { shape: base, diagnostics };
+        }
+        try {
+          shape = base.chamfer(edgesResult, distance);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.chamfer.failed',
+            featureId: r.id,
+            severity: 'error',
+            message: `OCCT chamfer failed: ${msg}`,
+          });
+          return { shape: base, diagnostics };
+        }
+        break;
+      }
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npx vitest run tests/unit/backends/occt/occtLowerer.chamfer.test.ts`
+Expected: 3/3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backends/occt/occtLowerer.ts tests/unit/backends/occt/occtLowerer.chamfer.test.ts
+git commit -m "feat(backends/occt): OcctLowerer chamfer case (symmetric)"
+```
+
+---
+
+## Phase 4: Capture API
+
+### Task 5: `Shape.fillet()` / `.chamfer()` proxy + `CaptureSession.edgeFeature()`
+
+**Files:**
+- Modify: `src/capture/captureSession.ts`
+- Modify: `src/capture/proxy.ts`
+- Create: `tests/unit/capture/proxy.fillet.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// tests/unit/capture/proxy.fillet.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOcct } from '../../../src/backends/occt/occtBackend';
+import { runScript } from '../../../src/script-runtime/runScript';
+
+describe('Shape.fillet / chamfer capture', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('registers a fillet record with base input and no face filter', async () => {
+    const code = `return box(10, 10, 10).fillet(2);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    expect(result.records).toHaveLength(2);
+    expect(result.records[1].kind).toBe('fillet');
+    expect(result.records[1].inputs.base).toEqual({ kind: 'feature', id: result.records[0].id });
+    expect(result.records[1].inputs.face).toBeUndefined();
+    expect(result.records[1].params.radius.evaluated).toBe(2);
+  });
+
+  it('registers a fillet record with a canonical face filter', async () => {
+    const code = `return box(10, 10, 10).fillet(2, { face: 'top' });`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    expect(result.records).toHaveLength(2);
+    const fillet = result.records[1];
+    expect(fillet.kind).toBe('fillet');
+    expect(fillet.inputs.face).toEqual({
+      kind: 'face',
+      featureId: result.records[0].id,
+      ref: { kind: 'canonical', face: 'top' },
+    });
+  });
+
+  it('registers a chamfer record with distance param', async () => {
+    const code = `return box(10, 10, 10).chamfer(1.5, { face: 'bottom' });`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const chamfer = result.records[1];
+    expect(chamfer.kind).toBe('chamfer');
+    expect(chamfer.params.distance.evaluated).toBe(1.5);
+    expect(chamfer.inputs.face).toEqual({
+      kind: 'face',
+      featureId: result.records[0].id,
+      ref: { kind: 'canonical', face: 'bottom' },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/capture/proxy.fillet.test.ts`
+Expected: 3/3 FAIL — `.fillet` / `.chamfer` not on `Shape`.
+
+- [ ] **Step 3: Add `edgeFeature()` to `CaptureSession`**
+
+In `src/capture/captureSession.ts`, after the `boolean()` method, add:
+
+```typescript
+  edgeFeature(
+    kind: 'fillet' | 'chamfer',
+    base: Shape,
+    valueParamName: 'radius' | 'distance',
+    value: number,
+    face?: 'top' | 'bottom' | 'left' | 'right' | 'front' | 'back',
+  ): Shape {
+    if (!this.records.some(r => r.id === base.id)) {
+      throw new Error(`${kind}: base shape '${base.id}' is not from this CaptureSession`);
+    }
+    const inputs: Record<string, FeatureRef> = {
+      base: { kind: 'feature', id: base.id },
+    };
+    if (face) {
+      inputs.face = {
+        kind: 'face',
+        featureId: base.id,
+        ref: { kind: 'canonical', face },
+      };
+    }
+    const valueParam: Param = {
+      expression: String(value), unit: 'mm', evaluated: value,
+    };
+    return this.createShape({
+      kind,
+      params: { [valueParamName]: valueParam },
+      inputs,
+    });
+  }
+```
+
+- [ ] **Step 4: Add `.fillet` and `.chamfer` to the `Shape` proxy**
+
+In `src/capture/proxy.ts`, after the `intersect()` method:
+
+```typescript
+  fillet(radius: number, opts?: { face?: 'top' | 'bottom' | 'left' | 'right' | 'front' | 'back' }): Shape {
+    return this.session.edgeFeature('fillet', this, 'radius', radius, opts?.face);
+  }
+
+  chamfer(distance: number, opts?: { face?: 'top' | 'bottom' | 'left' | 'right' | 'front' | 'back' }): Shape {
+    return this.session.edgeFeature('chamfer', this, 'distance', distance, opts?.face);
+  }
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `npx vitest run tests/unit/capture/proxy.fillet.test.ts`
+Expected: 3/3 PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/capture/captureSession.ts src/capture/proxy.ts tests/unit/capture/proxy.fillet.test.ts
+git commit -m "feat(capture): Shape.fillet / .chamfer methods + edgeFeature session helper"
+```
+
+---
+
+## Phase 5: E2E + verification
+
+### Task 6: Acceptance demo + e2e test
+
+**Files:**
+- Create: `tests/e2e/fixtures/rounded-bracket.kcad.ts`
+- Modify: `tests/e2e/cli-acceptance.test.ts`
+
+- [ ] **Step 1: Write the demo fixture**
+
+```typescript
+// tests/e2e/fixtures/rounded-bracket.kcad.ts
+const w = param('Width', 60, { unit: 'mm', min: 30, max: 200 });
+const h = param('Height', 40, { unit: 'mm', min: 20, max: 120 });
+const t = param('Thickness', 5, { unit: 'mm', min: 2, max: 15 });
+const r = param('FilletRadius', 2, { unit: 'mm', min: 0.5, max: 4 });
+
+const base = box(w, h, t);
+const hole = cylinder(t + 2, 4).translate(w/2, h/2, -1);
+return base.subtract(hole).fillet(r);
+```
+
+- [ ] **Step 2: Add the e2e test cases**
+
+Append to `tests/e2e/cli-acceptance.test.ts`, after the existing `describe` block (or inside it as additional `it` blocks):
+
+```typescript
+  it('runs end-to-end on the rounded-bracket fixture and produces STL', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'kcad-acc-'));
+    const out = join(tmp, 'rounded.stl');
+    const r = await exportScript({ file: join(__dirname, 'fixtures/rounded-bracket.kcad.ts'), format: 'stl', out });
+    expect(r.exitCode).toBe(0);
+    expect(statSync(out).size).toBeGreaterThan(1000);
+  });
+
+  it('rounded-bracket has strictly less volume than the un-filleted equivalent', async () => {
+    const { runScript } = await import('../../src/script-runtime/runScript');
+    const { RecomputeEngine } = await import('../../src/compute/recomputeEngine');
+    const { OcctLowerer } = await import('../../src/backends/occt/occtLowerer');
+    const { readFile } = await import('node:fs/promises');
+
+    const fixturePath = join(__dirname, 'fixtures/rounded-bracket.kcad.ts');
+    const filletedCode = await readFile(fixturePath, 'utf8');
+    const unfilletedCode = filletedCode.replace(/\.fillet\([^)]+\);?$/m, ';');
+
+    const engine = new RecomputeEngine(new OcctLowerer());
+    const filleted = await runScript({ code: filletedCode, fileName: fixturePath });
+    const unfilleted = await runScript({ code: unfilletedCode, fileName: fixturePath });
+
+    const fres = await engine.run(filleted.records);
+    const ures = await engine.run(unfilleted.records);
+
+    const flast = filleted.records[filleted.records.length - 1];
+    const ulast = unfilleted.records[unfilleted.records.length - 1];
+
+    const fv = fres.shapes.get(flast.id)!.volume();
+    const uv = ures.shapes.get(ulast.id)!.volume();
+    expect(fv).toBeLessThan(uv);
+  });
+```
+
+(If `__dirname` isn't already shimmed at the top of `cli-acceptance.test.ts`, the existing v0.1 ESM shim should still apply — verify by reading the file's top imports. If the file uses dynamic imports for some reason, mirror that style.)
+
+- [ ] **Step 3: Run e2e tests**
+
+Run: `npx vitest run tests/e2e/cli-acceptance.test.ts`
+Expected: all pre-existing tests + 2 new ones PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/e2e/fixtures/rounded-bracket.kcad.ts tests/e2e/cli-acceptance.test.ts
+git commit -m "test(e2e): rounded-bracket fixture + volume regression vs un-filleted"
+```
+
+---
+
+### Task 7: Browser verification gate (HARD GATE per memory `feedback_actually_use_what_you_ship.md`)
+
+**Files:**
+- Modify (potentially): `src/lib/v01ApiShim.ts`
+
+This is non-negotiable. v0.1 was tagged without browser testing and shipped a broken UI; v0.2-alpha will not repeat that.
+
+- [ ] **Step 1: Run `npm run typecheck`, `npm run lint`, `npm test`**
+
+Expected: 0 errors, 0 lint issues, all tests pass.
+
+- [ ] **Step 2: Verify the v01ApiShim exposes fillet + chamfer**
+
+Read `src/lib/v01ApiShim.ts`. The shim translates the v0.1 API used in browser-side eval. Look for how `box`, `cylinder`, `subtract` etc. are exposed. The new `Shape.fillet()` / `.chamfer()` methods exist on the proxy class — if the shim wraps Shape instances it should pass them through automatically. But if it has a hand-rolled allowlist of methods, add `fillet` and `chamfer`.
+
+- [ ] **Step 3: Boot the dev server and load via chrome-devtools MCP**
+
+```bash
+npm run dev    # background; note the URL it prints (typically http://localhost:5173/)
+```
+
+In chrome-devtools MCP:
+- `mcp__chrome-devtools__new_page` to the dev URL
+- `mcp__chrome-devtools__list_console_messages` filtered to errors — expect zero
+- `mcp__chrome-devtools__take_screenshot` to capture initial state
+
+- [ ] **Step 4: In the browser, edit the starter script to use fillet**
+
+Use `mcp__chrome-devtools__evaluate_script` (or the editor surface) to set the editor content to:
+
+```typescript
+const w = param('Width', 60, { unit: 'mm' });
+const h = param('Height', 40, { unit: 'mm' });
+const t = param('Thickness', 5, { unit: 'mm' });
+const base = box(w, h, t);
+const hole = cylinder(t + 2, 4).translate(w/2, h/2, -1);
+return base.subtract(hole).fillet(2);
+```
+
+(You may need to dispatch a paste event into the Monaco editor or mutate the project store directly via `window.__kcadStore` if such a hook exists. If neither exists cleanly, take a screenshot of the default state with the user-facing instruction "edit `.fillet(2)` into the script" — but try to fully automate the path.)
+
+Capture a screenshot showing:
+- 3D viewport renders the rounded bracket geometry (visible filleted edges)
+- Zero console errors
+
+- [ ] **Step 5: Click Export STL, capture the download**
+
+Hook `URL.createObjectURL` per the v0.1 verification pattern:
+
+```javascript
+window.__capturedDownloads = [];
+const orig = URL.createObjectURL.bind(URL);
+URL.createObjectURL = (blob) => { const url = orig(blob); window.__capturedDownloads.push({ size: blob.size, type: blob.type }); return url; };
+```
+
+Then click Export STL. Verify a non-empty STL download was captured (size > 1000 bytes; type `application/sla` or similar).
+
+- [ ] **Step 6: Verify rounded-bracket geometry is visibly correct**
+
+Open the captured STL or STEP in a 3D viewer (Three.js page loaded via chrome-devtools, or a local FreeCAD if available). Confirm by eyeball:
+- The bracket shape has rounded edges (not sharp 90° corners)
+- The hole is cleanly subtracted
+- No obviously degenerate or self-intersecting geometry
+
+Capture the screenshot.
+
+- [ ] **Step 7: Document findings**
+
+In a follow-up message (not committed to the repo), include the chrome-devtools screenshots, dev server console state, and confirmation that the rounded bracket renders correctly. This is the proof for the PR description.
+
+- [ ] **Step 8: If all checks pass, commit any v01ApiShim updates**
+
+```bash
+git add src/lib/v01ApiShim.ts
+git commit -m "feat(web): v01ApiShim passes Shape.fillet / .chamfer through to browser eval"
+```
+
+(Or skip if no shim updates were needed.)
+
+---
+
+## Phase 6: Tag + ship
+
+### Task 8: Final QC and v0.2-alpha tag
+
+- [ ] **Step 1: Run full QC**
+
+```bash
+npm run typecheck   # 0 errors
+npm run lint        # 0 errors
+npm test            # all pass
+npm run build       # produces dist/
+npm run build:cli   # produces dist/cli/index.js
+```
+
+If any fail, fix and re-commit individually.
+
+- [ ] **Step 2: Smoke-test the CLI binary against the rounded-bracket fixture**
+
+```bash
+node dist/cli/index.js evaluate tests/e2e/fixtures/rounded-bracket.kcad.ts
+node dist/cli/index.js export step tests/e2e/fixtures/rounded-bracket.kcad.ts -o /tmp/rounded.step
+head -1 /tmp/rounded.step   # expect ISO-10303-21;
+```
+
+- [ ] **Step 3: Open PR against develop**
+
+```bash
+git push -u origin <branch>
+gh pr create --base develop --head <branch> --title "feat(v0.2-alpha): fillet + chamfer (canonical-refs only)" --body "<see template>"
+```
+
+PR description must include:
+- Summary of features added
+- Spec deviation note (single error code)
+- Browser verification screenshots from Task 7
+- Test plan checklist
+
+- [ ] **Step 4: After PR merges, tag and push**
+
+```bash
+git checkout develop
+git pull --ff-only origin develop
+# Update package.json version → 0.2.0-alpha.1
+# Append to CHANGELOG.md
+git add package.json CHANGELOG.md
+git commit -m "release: v0.2.0-alpha.1 — fillet + chamfer (canonical refs)"
+git tag v0.2.0-alpha.1
+git push origin develop
+git push origin v0.2.0-alpha.1
+```
+
+The tag triggers the GitHub Pages deploy (already wired post-v0.1).
+
+- [ ] **Step 5: Verify the deployed site shows the new feature working**
+
+Open `http://n1n3.net/kernelCAD-web/` in chrome-devtools; edit the starter script to add `.fillet(2)`; verify viewport renders + Export STL works. Final hard gate.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- API surface (method-style on Shape, all-edges + per-canonical-face) — Tasks 5
+- Decisions locked (both fillet+chamfer, symmetric chamfer, single radius, error+cascade, primitives-only no transforms) — Tasks 2-5
+- IR (no schema change, face-as-secondary-input) — Task 5 + verified-no-touch on `src/intent/`
+- Lowering (occtLowerer cases, edgeSelection helper, OCCT exception → diagnostic) — Tasks 1-4
+- Canonical face → edges resolution table — Task 1 implements box (6 faces), cylinder (top/bottom only), sphere (none — error path tested in Task 1)
+- Recompute & Health — verified-no-touch (existing engine handles cascade)
+- Module API & Capture — Task 5
+- Tests (unit fillet, unit chamfer, capture proxy, e2e rounded-bracket + volume regression) — Tasks 3, 4, 5, 6
+- "Actually use it" verification — Task 7 (hard gate)
+- Risks (OCCT stability, cylinder edge precision, primitive identification) — addressed by tests in Task 3 (radius-too-big) and the kind-tag implementation in Task 1
+
+**Placeholder scan:** No "TBD" / "TODO" / "implement later" / "add error handling" / "similar to". Every step has actual code.
+
+**Type consistency:**
+- `OcctBackend.kind?: 'box' | 'cylinder' | 'sphere'` — consistent across Tasks 1, 2, 3, 4
+- `OcctBackend.fillet(edges, radius)` / `chamfer(edges, distance)` — same shape in Task 2 and called the same way in Tasks 3, 4
+- `pickEdges(record, base): EdgeList | { error: CompilerDiagnostic }` — consistent in Tasks 1, 3, 4
+- Diagnostic codes: `feature.fillet.failed`, `feature.chamfer.failed`, `feature.edge-feature.face-ref-not-resolvable`, `feature.edge-feature.face-ref-not-applicable`, `feature.edge-feature.face-ref-not-supported` — used consistently
+- `Shape.fillet(radius, opts?)` / `Shape.chamfer(distance, opts?)` — same opts shape (`{ face?: CanonicalFace }`)
+- `CaptureSession.edgeFeature(kind, base, valueParamName, value, face?)` — new method, used only by Shape proxy
+
+**Replicad API risk:** Tasks 1 (edgeSelection) and 2 (OcctBackend.fillet/chamfer) make assumptions about replicad's `Shape3D.edges`, `Shape3D.faces`, `Shape3D.fillet(radius, finder)`, `Shape3D.chamfer(distance, finder)` shapes. If the actual API differs (e.g., `EdgeFinder` is required rather than a plain function, or `face.center` is a function not a property), the implementer needs to adjust. The plan calls this out at the relevant steps. Verification gate (Task 7) catches any cascading issues before tagging.
+
+**Open issues acknowledged:**
+- Single error code `feature.edge-feature.face-ref-not-resolvable` covers both "non-primitive base" and "transformed primitive" — spec deviation, called out at the top.
+- The `__dirname`-style ESM shim from v0.1's e2e test should already cover the new e2e cases; if it doesn't, Task 6 Step 2 instructs the implementer to mirror the existing pattern.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-30-v0.2-alpha-fillet-chamfer.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — fresh subagent per task with two-stage review (spec compliance → code quality). Same approach used for v0.1.
+
+**2. Inline Execution** — execute tasks in this session with checkpoints.
+
+Pick one to proceed.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kernelcad",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0-alpha.1",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/src/backends/occt/edgeSelection.ts
+++ b/src/backends/occt/edgeSelection.ts
@@ -4,6 +4,9 @@ import type { FeatureRecord } from '../../intent/featureRecord';
 import type { CompilerDiagnostic } from '../../diagnostics/diagnostic';
 import { OcctBackend } from './occtBackend';
 
+// Bounding-box face matching tolerance (mm). base.boundingBox() returns gap-corrected values, so this can be tight.
+const TOL = 1e-4;
+
 type CanonicalFace = 'top' | 'bottom' | 'left' | 'right' | 'front' | 'back';
 
 // EdgeList holds replicad Edge wrappers, which EdgeFinder.inList() accepts.
@@ -82,19 +85,14 @@ function canonicalFaceEdges(base: OcctBackend, face: CanonicalFace): EdgeList | 
   return null;
 }
 
-function canonicalBoxFaceEdges(base: OcctBackend, face: CanonicalFace): EdgeList {
-  // Match face by axis-aligned plane. We use the shape's bounding box to identify which
+function canonicalBoxFaceEdges(base: OcctBackend, face: CanonicalFace): EdgeList | null {
+  // Match face by axis-aligned plane. We use the gap-corrected bounding box to identify which
   // OCCT face has the appropriate normal + offset, then collect that face's edges.
-  const shape = base.getReplicadShape();
-  const bb = shape.boundingBox;
-  // bb.bounds returns [SimplePoint, SimplePoint] where SimplePoint = [x, y, z]
-  const [minP, maxP] = bb.bounds;
-  const bbMinMax = { min: minP, max: maxP };
-  const target = pickFacePlane(bbMinMax, face);
+  const bb = base.boundingBox();
+  const target = pickFacePlane(bb, face);
   // Iterate shape.faces; pick the one whose centroid aligns with the target plane.
   // Face.center returns a Vector with .x, .y, .z properties.
-  const faces: Face[] = shape.faces;
-  const TOL = 0.1;
+  const faces: Face[] = base.getReplicadShape().faces;
   for (const f of faces) {
     const c = f.center; // Vector with .x, .y, .z
     const coord = target.axisIndex === 0 ? c.x : target.axisIndex === 1 ? c.y : c.z;
@@ -103,22 +101,19 @@ function canonicalBoxFaceEdges(base: OcctBackend, face: CanonicalFace): EdgeList
       return f.edges;
     }
   }
-  return [];
+  return null;
 }
 
-function canonicalCylinderEndCapEdges(base: OcctBackend, face: 'top'|'bottom'): EdgeList {
-  const shape = base.getReplicadShape();
-  const bb = shape.boundingBox;
-  const [minP, maxP] = bb.bounds;
-  const targetZ = face === 'top' ? maxP[2] : minP[2];
-  const TOL = 0.1;
-  const faces: Face[] = shape.faces;
+function canonicalCylinderEndCapEdges(base: OcctBackend, face: 'top'|'bottom'): EdgeList | null {
+  const bb = base.boundingBox();
+  const targetZ = face === 'top' ? bb.max[2] : bb.min[2];
+  const faces: Face[] = base.getReplicadShape().faces;
   for (const f of faces) {
     if (Math.abs(f.center.z - targetZ) < TOL) {
       return f.edges;
     }
   }
-  return [];
+  return null;
 }
 
 interface FacePlane { axisIndex: 0 | 1 | 2; value: number; }

--- a/src/backends/occt/edgeSelection.ts
+++ b/src/backends/occt/edgeSelection.ts
@@ -1,0 +1,138 @@
+// src/backends/occt/edgeSelection.ts
+import type { Edge, Face } from 'replicad';
+import type { FeatureRecord } from '../../intent/featureRecord';
+import type { CompilerDiagnostic } from '../../diagnostics/diagnostic';
+import { OcctBackend } from './occtBackend';
+
+type CanonicalFace = 'top' | 'bottom' | 'left' | 'right' | 'front' | 'back';
+
+// EdgeList holds replicad Edge wrappers, which EdgeFinder.inList() accepts.
+export type EdgeList = Edge[];
+
+export type PickEdgesResult =
+  | EdgeList
+  | { error: CompilerDiagnostic };
+
+export function pickEdges(record: FeatureRecord, base: OcctBackend): PickEdgesResult {
+  const faceRef = record.inputs.face;
+
+  // No face filter → all edges of the underlying shape.
+  if (!faceRef) {
+    return allEdgesOf(base);
+  }
+
+  if (faceRef.kind !== 'face' || faceRef.ref.kind !== 'canonical') {
+    return {
+      error: {
+        target: 'export-occt',
+        code: 'feature.edge-feature.face-ref-not-supported',
+        featureId: record.id,
+        severity: 'error',
+        message: `Only canonical face refs are supported in v0.2-alpha; got '${faceRef.kind === 'face' ? faceRef.ref.kind : faceRef.kind}'.`,
+      },
+    };
+  }
+
+  // Canonical face filter → must be on an un-transformed primitive (kind tag set).
+  if (!base.kind) {
+    return {
+      error: {
+        target: 'export-occt',
+        code: 'feature.edge-feature.face-ref-not-resolvable',
+        featureId: record.id,
+        severity: 'error',
+        message: `Canonical face refs require an un-transformed primitive (box, cylinder, or sphere). Apply transforms after fillet/chamfer instead of before.`,
+      },
+    };
+  }
+
+  const face = faceRef.ref.face as CanonicalFace;
+  const edges = canonicalFaceEdges(base, face);
+  if (edges === null) {
+    return {
+      error: {
+        target: 'export-occt',
+        code: 'feature.edge-feature.face-ref-not-applicable',
+        featureId: record.id,
+        severity: 'error',
+        message: `Canonical face '${face}' is not applicable to ${base.kind}.`,
+      },
+    };
+  }
+  return edges;
+}
+
+function allEdgesOf(base: OcctBackend): EdgeList {
+  const shape = base.getReplicadShape();
+  // shape.edges returns Edge[] (replicad wrappers)
+  return shape.edges;
+}
+
+function canonicalFaceEdges(base: OcctBackend, face: CanonicalFace): EdgeList | null {
+  if (base.kind === 'box') {
+    return canonicalBoxFaceEdges(base, face);
+  }
+  if (base.kind === 'cylinder') {
+    if (face === 'top' || face === 'bottom') {
+      return canonicalCylinderEndCapEdges(base, face);
+    }
+    return null; // left/right/front/back not applicable to cylinder
+  }
+  // sphere: no canonical faces in any direction
+  return null;
+}
+
+function canonicalBoxFaceEdges(base: OcctBackend, face: CanonicalFace): EdgeList {
+  // Match face by axis-aligned plane. We use the shape's bounding box to identify which
+  // OCCT face has the appropriate normal + offset, then collect that face's edges.
+  const shape = base.getReplicadShape();
+  const bb = shape.boundingBox;
+  // bb.bounds returns [SimplePoint, SimplePoint] where SimplePoint = [x, y, z]
+  const [minP, maxP] = bb.bounds;
+  const bbMinMax = { min: minP, max: maxP };
+  const target = pickFacePlane(bbMinMax, face);
+  // Iterate shape.faces; pick the one whose centroid aligns with the target plane.
+  // Face.center returns a Vector with .x, .y, .z properties.
+  const faces: Face[] = shape.faces;
+  const TOL = 0.1;
+  for (const f of faces) {
+    const c = f.center; // Vector with .x, .y, .z
+    const coord = target.axisIndex === 0 ? c.x : target.axisIndex === 1 ? c.y : c.z;
+    if (Math.abs(coord - target.value) < TOL) {
+      // Found the matching face. Return its edges.
+      return f.edges;
+    }
+  }
+  return [];
+}
+
+function canonicalCylinderEndCapEdges(base: OcctBackend, face: 'top'|'bottom'): EdgeList {
+  const shape = base.getReplicadShape();
+  const bb = shape.boundingBox;
+  const [minP, maxP] = bb.bounds;
+  const targetZ = face === 'top' ? maxP[2] : minP[2];
+  const TOL = 0.1;
+  const faces: Face[] = shape.faces;
+  for (const f of faces) {
+    if (Math.abs(f.center.z - targetZ) < TOL) {
+      return f.edges;
+    }
+  }
+  return [];
+}
+
+interface FacePlane { axisIndex: 0 | 1 | 2; value: number; }
+
+function pickFacePlane(
+  bb: { min: [number, number, number]; max: [number, number, number] },
+  face: CanonicalFace,
+): FacePlane {
+  switch (face) {
+    case 'top':    return { axisIndex: 2, value: bb.max[2] };
+    case 'bottom': return { axisIndex: 2, value: bb.min[2] };
+    case 'right':  return { axisIndex: 0, value: bb.max[0] };
+    case 'left':   return { axisIndex: 0, value: bb.min[0] };
+    case 'back':   return { axisIndex: 1, value: bb.max[1] };
+    case 'front':  return { axisIndex: 1, value: bb.min[1] };
+  }
+}

--- a/src/backends/occt/occtBackend.ts
+++ b/src/backends/occt/occtBackend.ts
@@ -4,6 +4,8 @@ import type { ShapeBackend, BackendTarget } from '../backend';
 import type { Vec3 } from '../../intent/types';
 import type { RuntimeMesh } from '../runtimeMesh';
 
+type ReplicadEdge = replicad.Edge;
+
 let initialized = false;
 
 /**
@@ -164,6 +166,46 @@ export class OcctBackend implements ShapeBackend {
     return new OcctBackend(
       this.shape.mirror(normal as [number, number, number], [0, 0, 0]) as ReplicadShape3D,
     );
+  }
+
+  /**
+   * Apply a fillet of the given `radius` to all edges in `edges`.
+   *
+   * The returned `OcctBackend` has **no** `kind` tag — the result is no
+   * longer a raw primitive. See `edgeSelection.pickEdges` for how to obtain
+   * the edge list.
+   *
+   * @throws {Error} If `edges` is empty.
+   * @throws {Error} If OCCT fails (e.g. radius too large for the geometry) —
+   *   the original exception is re-thrown so Task 3's lowerer can catch and
+   *   emit a `feature.fillet.failed` diagnostic.
+   */
+  fillet(edges: ReplicadEdge[], radius: number): OcctBackend {
+    if (edges.length === 0) {
+      throw new Error('OcctBackend.fillet: edge list must not be empty');
+    }
+    const result = this.shape.fillet(radius, (f) => f.inList(edges)) as ReplicadShape3D;
+    return new OcctBackend(result);
+  }
+
+  /**
+   * Apply a chamfer of the given `distance` to all edges in `edges`.
+   *
+   * The returned `OcctBackend` has **no** `kind` tag — the result is no
+   * longer a raw primitive. See `edgeSelection.pickEdges` for how to obtain
+   * the edge list.
+   *
+   * @throws {Error} If `edges` is empty.
+   * @throws {Error} If OCCT fails (e.g. distance too large for the geometry) —
+   *   the original exception is re-thrown so Task 3's lowerer can catch and
+   *   emit a `feature.chamfer.failed` diagnostic.
+   */
+  chamfer(edges: ReplicadEdge[], distance: number): OcctBackend {
+    if (edges.length === 0) {
+      throw new Error('OcctBackend.chamfer: edge list must not be empty');
+    }
+    const result = this.shape.chamfer(distance, (f) => f.inList(edges)) as ReplicadShape3D;
+    return new OcctBackend(result);
   }
 
   union(other: ShapeBackend): OcctBackend {

--- a/src/backends/occt/occtBackend.ts
+++ b/src/backends/occt/occtBackend.ts
@@ -53,9 +53,20 @@ export class OcctBackend implements ShapeBackend {
   readonly target: BackendTarget = 'export-occt';
   // erasableSyntaxOnly forbids constructor parameter properties — declare explicitly.
   private shape: ReplicadShape3D;
+  readonly kind?: 'box' | 'cylinder' | 'sphere';
 
-  constructor(shape: ReplicadShape3D) {
+  constructor(shape: ReplicadShape3D, kind?: 'box' | 'cylinder' | 'sphere') {
     this.shape = shape;
+    this.kind = kind;
+  }
+
+  /**
+   * Internal accessor for `edgeSelection.pickEdges` — returns the underlying replicad
+   * shape so the helper can iterate `shape.faces` / `shape.edges`. Treat as
+   * implementation detail; do not export from `index.ts`.
+   */
+  getReplicadShape(): ReplicadShape3D {
+    return this.shape;
   }
 
   static box(x: number, y: number, z: number, centered = false): OcctBackend {
@@ -68,17 +79,17 @@ export class OcctBackend implements ShapeBackend {
     const placed = centered
       ? (b.translate(0, 0, -z / 2) as ReplicadShape3D)
       : (b.translate(x / 2, y / 2, 0) as ReplicadShape3D);
-    return new OcctBackend(placed);
+    return new OcctBackend(placed, 'box');
   }
 
   static cylinder(h: number, r: number): OcctBackend {
     if (!initialized) throw new Error('OCCT not initialized — call initOcct() first');
-    return new OcctBackend(replicad.makeCylinder(r, h) as ReplicadShape3D);
+    return new OcctBackend(replicad.makeCylinder(r, h) as ReplicadShape3D, 'cylinder');
   }
 
   static sphere(r: number): OcctBackend {
     if (!initialized) throw new Error('OCCT not initialized — call initOcct() first');
-    return new OcctBackend(replicad.makeSphere(r) as ReplicadShape3D);
+    return new OcctBackend(replicad.makeSphere(r) as ReplicadShape3D, 'sphere');
   }
 
   /**

--- a/src/backends/occt/occtLowerer.ts
+++ b/src/backends/occt/occtLowerer.ts
@@ -9,6 +9,7 @@ import type { FeatureRecord } from '../../intent/featureRecord';
 import type { FeatureKind } from '../../intent/types';
 import type { CompilerDiagnostic } from '../../diagnostics/diagnostic';
 import { OcctBackend } from './occtBackend';
+import { pickEdges } from './edgeSelection';
 
 /**
  * Lowers `FeatureRecord`s to `OcctBackend` shapes.
@@ -31,6 +32,7 @@ export class OcctLowerer implements FeatureLowerer {
     'extrude',
     'revolve',
     'boolean',
+    'fillet',
   ]);
 
   async lower(r: FeatureRecord, inputs: ResolvedInputs): Promise<LowerResult> {
@@ -127,6 +129,49 @@ export class OcctLowerer implements FeatureLowerer {
           throw new Error(`Unknown boolean op: ${op}`);
         }
         shape = acc;
+        break;
+      }
+      case 'fillet': {
+        const base = inputs.byKey.base as OcctBackend | undefined;
+        if (!base) {
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.fillet.no-base',
+            featureId: r.id,
+            severity: 'error',
+            message: `fillet requires an input named 'base'.`,
+          });
+          throw new Error('fillet: no base shape');
+        }
+        const radius = r.params.radius?.evaluated;
+        if (radius === undefined) {
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.fillet.no-radius',
+            featureId: r.id,
+            severity: 'error',
+            message: `fillet requires a 'radius' parameter.`,
+          });
+          throw new Error('fillet: no radius');
+        }
+        const edgesResult = pickEdges(r, base);
+        if ('error' in edgesResult) {
+          diagnostics.push(edgesResult.error);
+          return { shape: base, diagnostics };
+        }
+        try {
+          shape = base.fillet(edgesResult, radius);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.fillet.failed',
+            featureId: r.id,
+            severity: 'error',
+            message: `OCCT fillet failed: ${msg}`,
+          });
+          return { shape: base, diagnostics };
+        }
         break;
       }
       default:

--- a/src/backends/occt/occtLowerer.ts
+++ b/src/backends/occt/occtLowerer.ts
@@ -33,6 +33,7 @@ export class OcctLowerer implements FeatureLowerer {
     'revolve',
     'boolean',
     'fillet',
+    'chamfer',
   ]);
 
   async lower(r: FeatureRecord, inputs: ResolvedInputs): Promise<LowerResult> {
@@ -169,6 +170,49 @@ export class OcctLowerer implements FeatureLowerer {
             featureId: r.id,
             severity: 'error',
             message: `OCCT fillet failed: ${msg}`,
+          });
+          return { shape: base, diagnostics };
+        }
+        break;
+      }
+      case 'chamfer': {
+        const base = inputs.byKey.base as OcctBackend | undefined;
+        if (!base) {
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.chamfer.no-base',
+            featureId: r.id,
+            severity: 'error',
+            message: `chamfer requires an input named 'base'.`,
+          });
+          throw new Error('chamfer: no base shape');
+        }
+        const distance = r.params.distance?.evaluated;
+        if (distance === undefined) {
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.chamfer.no-distance',
+            featureId: r.id,
+            severity: 'error',
+            message: `chamfer requires a 'distance' parameter.`,
+          });
+          throw new Error('chamfer: no distance');
+        }
+        const edgesResult = pickEdges(r, base);
+        if ('error' in edgesResult) {
+          diagnostics.push(edgesResult.error);
+          return { shape: base, diagnostics };
+        }
+        try {
+          shape = base.chamfer(edgesResult, distance);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.chamfer.failed',
+            featureId: r.id,
+            severity: 'error',
+            message: `OCCT chamfer failed: ${msg}`,
           });
           return { shape: base, diagnostics };
         }

--- a/src/capture/captureSession.ts
+++ b/src/capture/captureSession.ts
@@ -65,6 +65,36 @@ export class CaptureSession {
     });
   }
 
+  edgeFeature(
+    kind: 'fillet' | 'chamfer',
+    base: Shape,
+    valueParamName: 'radius' | 'distance',
+    value: number,
+    face?: 'top' | 'bottom' | 'left' | 'right' | 'front' | 'back',
+  ): Shape {
+    if (!this.records.some(r => r.id === base.id)) {
+      throw new Error(`${kind}: base shape '${base.id}' is not from this CaptureSession`);
+    }
+    const inputs: Record<string, FeatureRef> = {
+      base: { kind: 'feature', id: base.id },
+    };
+    if (face) {
+      inputs.face = {
+        kind: 'face',
+        featureId: base.id,
+        ref: { kind: 'canonical', face },
+      };
+    }
+    const valueParam: Param = {
+      expression: String(value), unit: 'mm', evaluated: value,
+    };
+    return this.createShape({
+      kind,
+      params: { [valueParamName]: valueParam },
+      inputs,
+    });
+  }
+
   getRecords(): readonly FeatureRecord[] {
     return this.records;
   }

--- a/src/capture/proxy.ts
+++ b/src/capture/proxy.ts
@@ -41,4 +41,12 @@ export class Shape {
   intersect(...others: Shape[]): Shape {
     return this.session.boolean('intersection', this, others);
   }
+
+  fillet(radius: number, opts?: { face?: 'top' | 'bottom' | 'left' | 'right' | 'front' | 'back' }): Shape {
+    return this.session.edgeFeature('fillet', this, 'radius', radius, opts?.face);
+  }
+
+  chamfer(distance: number, opts?: { face?: 'top' | 'bottom' | 'left' | 'right' | 'front' | 'back' }): Shape {
+    return this.session.edgeFeature('chamfer', this, 'distance', distance, opts?.face);
+  }
 }

--- a/tests/e2e/cli-acceptance.test.ts
+++ b/tests/e2e/cli-acceptance.test.ts
@@ -12,6 +12,7 @@ const DEMO = join(__dirname, 'fixtures/demo.kcad.ts');
 describe('v0.1 acceptance demo', () => {
   beforeAll(async () => { await initOcct(); });
 
+
   it('runs end-to-end and produces STL', async () => {
     const tmp = mkdtempSync(join(tmpdir(), 'kcad-acc-'));
     const out = join(tmp, 'plate.stl');
@@ -51,5 +52,47 @@ describe('v0.1 acceptance demo', () => {
     const shape = result.shapes.get(last.id)!;
     const expected = 100 * 50 * 30 - Math.PI * 100 * 30;
     expect(shape.volume()).toBeCloseTo(expected, -1);
+  });
+});
+
+describe('v0.2-alpha rounded-bracket fixture', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('runs end-to-end on the rounded-bracket fixture and produces STL', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'kcad-acc-'));
+    const out = join(tmp, 'rounded.stl');
+    const r = await exportScript({
+      file: join(__dirname, 'fixtures/rounded-bracket.kcad.ts'),
+      format: 'stl',
+      out,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(statSync(out).size).toBeGreaterThan(1000);
+  });
+
+  it('rounded-bracket has strictly less volume than the un-filleted equivalent', async () => {
+    const { runScript } = await import('../../src/script-runtime/runScript');
+    const { RecomputeEngine } = await import('../../src/compute/recomputeEngine');
+    const { OcctLowerer } = await import('../../src/backends/occt/occtLowerer');
+    const { readFile } = await import('node:fs/promises');
+
+    const fixturePath = join(__dirname, 'fixtures/rounded-bracket.kcad.ts');
+    const filletedCode = await readFile(fixturePath, 'utf8');
+    // Strip the trailing .fillet(r) call from the return statement to get the un-filleted equivalent.
+    const unfilletedCode = filletedCode.replace(/\.fillet\([^)]+\);?$/m, ';');
+
+    const engine = new RecomputeEngine(new OcctLowerer());
+    const filleted = await runScript({ code: filletedCode, fileName: fixturePath });
+    const unfilleted = await runScript({ code: unfilletedCode, fileName: fixturePath });
+
+    const fres = await engine.run(filleted.records);
+    const ures = await engine.run(unfilleted.records);
+
+    const flast = filleted.records[filleted.records.length - 1];
+    const ulast = unfilleted.records[unfilleted.records.length - 1];
+
+    const fv = fres.shapes.get(flast.id)!.volume();
+    const uv = ures.shapes.get(ulast.id)!.volume();
+    expect(fv).toBeLessThan(uv);
   });
 });

--- a/tests/e2e/fixtures/rounded-bracket.kcad.ts
+++ b/tests/e2e/fixtures/rounded-bracket.kcad.ts
@@ -1,0 +1,8 @@
+const w = param('Width', 60, { unit: 'mm', min: 30, max: 200 });
+const h = param('Height', 40, { unit: 'mm', min: 20, max: 120 });
+const t = param('Thickness', 5, { unit: 'mm', min: 2, max: 15 });
+const r = param('FilletRadius', 2, { unit: 'mm', min: 0.5, max: 4 });
+
+const base = box(w, h, t);
+const hole = cylinder(t + 2, 4).translate(w/2, h/2, -1);
+return base.subtract(hole).fillet(r);

--- a/tests/unit/backends/occt/edgeSelection.test.ts
+++ b/tests/unit/backends/occt/edgeSelection.test.ts
@@ -1,0 +1,71 @@
+// tests/unit/backends/occt/edgeSelection.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { pickEdges } from '../../../../src/backends/occt/edgeSelection';
+import { OcctBackend, initOcct } from '../../../../src/backends/occt/occtBackend';
+import type { FeatureRecord } from '../../../../src/intent/featureRecord';
+
+const filletNoFilter = (baseId: string): FeatureRecord => ({
+  id: 'fillet_1', kind: 'fillet',
+  inputs: { base: { kind: 'feature', id: baseId } },
+  params: { radius: { expression: '2', unit: 'mm', evaluated: 2 } },
+  transforms: [], suppressed: false,
+});
+
+const filletWithFace = (baseId: string, face: 'top'|'bottom'|'left'|'right'|'front'|'back'): FeatureRecord => ({
+  id: 'fillet_2', kind: 'fillet',
+  inputs: {
+    base: { kind: 'feature', id: baseId },
+    face: { kind: 'face', featureId: baseId, ref: { kind: 'canonical', face } },
+  },
+  params: { radius: { expression: '2', unit: 'mm', evaluated: 2 } },
+  transforms: [], suppressed: false,
+});
+
+describe('pickEdges', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('returns ALL edges when no face filter is set (un-transformed box)', () => {
+    const box = OcctBackend.box(20, 20, 20);
+    const result = pickEdges(filletNoFilter('box_1'), box);
+    if ('error' in result) throw new Error(`expected edges, got error: ${result.error.message}`);
+    expect(result.length).toBe(12); // a box has 12 edges
+  });
+
+  it('returns 4 edges for canonical "top" face on a box', () => {
+    const box = OcctBackend.box(20, 20, 20);
+    const result = pickEdges(filletWithFace('box_1', 'top'), box);
+    if ('error' in result) throw new Error(`expected edges, got error: ${result.error.message}`);
+    expect(result.length).toBe(4);
+  });
+
+  it('returns 1 edge for canonical "top" face on a cylinder', () => {
+    const cyl = OcctBackend.cylinder(20, 5);
+    const result = pickEdges(filletWithFace('cyl_1', 'top'), cyl);
+    if ('error' in result) throw new Error(`expected edges, got error: ${result.error.message}`);
+    expect(result.length).toBe(1); // cylinder top is one circular edge
+  });
+
+  it('returns error when face filter is on a non-primitive (boolean result)', () => {
+    const box = OcctBackend.box(20, 20, 20);
+    const cyl = OcctBackend.cylinder(20, 5).translate(10, 10, -1);
+    const bool = box.subtract(cyl); // result has no kind tag
+    const result = pickEdges(filletWithFace('bool_1', 'top'), bool);
+    if (!('error' in result)) throw new Error('expected error, got edges');
+    expect(result.error.code).toBe('feature.edge-feature.face-ref-not-resolvable');
+    expect(result.error.severity).toBe('error');
+  });
+
+  it('returns error when face filter is on a transformed primitive', () => {
+    const box = OcctBackend.box(20, 20, 20).translate(5, 0, 0); // transform drops kind tag
+    const result = pickEdges(filletWithFace('box_1', 'top'), box);
+    if (!('error' in result)) throw new Error('expected error, got edges');
+    expect(result.error.code).toBe('feature.edge-feature.face-ref-not-resolvable');
+  });
+
+  it('returns error when canonical face is not applicable to this primitive', () => {
+    const cyl = OcctBackend.cylinder(20, 5);
+    const result = pickEdges(filletWithFace('cyl_1', 'left'), cyl);
+    if (!('error' in result)) throw new Error('expected error, got edges');
+    expect(result.error.code).toBe('feature.edge-feature.face-ref-not-applicable');
+  });
+});

--- a/tests/unit/backends/occt/edgeSelection.test.ts
+++ b/tests/unit/backends/occt/edgeSelection.test.ts
@@ -68,4 +68,11 @@ describe('pickEdges', () => {
     if (!('error' in result)) throw new Error('expected error, got edges');
     expect(result.error.code).toBe('feature.edge-feature.face-ref-not-applicable');
   });
+
+  it('returns face-ref-not-applicable for sphere with any canonical face', () => {
+    const sphere = OcctBackend.sphere(10);
+    const result = pickEdges(filletWithFace('sphere_1', 'top'), sphere);
+    if (!('error' in result)) throw new Error('expected error, got edges');
+    expect(result.error.code).toBe('feature.edge-feature.face-ref-not-applicable');
+  });
 });

--- a/tests/unit/backends/occt/occtBackend.fillet.test.ts
+++ b/tests/unit/backends/occt/occtBackend.fillet.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { OcctBackend, initOcct } from '../../../../src/backends/occt/occtBackend';
+
+describe('OcctBackend.fillet / chamfer', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('fillet on all edges of a box reduces volume (radius < edge/2)', () => {
+    const box = OcctBackend.box(20, 20, 20);
+    const baseV = box.volume();
+    const all = box.getReplicadShape().edges;
+    const filleted = box.fillet(all, 2);
+    const v = filleted.volume();
+    expect(v).toBeLessThan(baseV);
+    expect(v).toBeGreaterThan(baseV - 12 * 20 * (4 - Math.PI)); // very loose lower bound
+  });
+
+  it('chamfer on all edges of a box reduces volume', () => {
+    const box = OcctBackend.box(20, 20, 20);
+    const baseV = box.volume();
+    const all = box.getReplicadShape().edges;
+    const chamfered = box.chamfer(all, 1.5);
+    expect(chamfered.volume()).toBeLessThan(baseV);
+  });
+
+  it('fillet returned shape has no kind tag (it is no longer a raw primitive)', () => {
+    const box = OcctBackend.box(20, 20, 20);
+    const all = box.getReplicadShape().edges;
+    expect(box.fillet(all, 2).kind).toBeUndefined();
+    expect(box.chamfer(all, 1).kind).toBeUndefined();
+  });
+
+  it('fillet with too-large radius throws (caught by lowerer in Task 3)', () => {
+    const box = OcctBackend.box(10, 10, 10);
+    const all = box.getReplicadShape().edges;
+    expect(() => box.fillet(all, 100)).toThrow();
+  });
+
+  it('fillet on empty edge list throws', () => {
+    const box = OcctBackend.box(20, 20, 20);
+    expect(() => box.fillet([], 2)).toThrow();
+  });
+});

--- a/tests/unit/backends/occt/occtBackend.kind.test.ts
+++ b/tests/unit/backends/occt/occtBackend.kind.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { OcctBackend, initOcct } from '../../../../src/backends/occt/occtBackend';
+
+describe('OcctBackend kind tag', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('static factories set kind', () => {
+    expect(OcctBackend.box(10, 10, 10).kind).toBe('box');
+    expect(OcctBackend.cylinder(10, 5).kind).toBe('cylinder');
+    expect(OcctBackend.sphere(5).kind).toBe('sphere');
+  });
+
+  it('translate drops kind tag', () => {
+    expect(OcctBackend.box(10, 10, 10).translate(5, 0, 0).kind).toBeUndefined();
+  });
+
+  it('rotate drops kind tag', () => {
+    expect(OcctBackend.box(10, 10, 10).rotate([0, 0, 1], 30).kind).toBeUndefined();
+  });
+
+  it('scale drops kind tag', () => {
+    expect(OcctBackend.box(10, 10, 10).scale([1.5, 1.5, 1.5]).kind).toBeUndefined();
+  });
+
+  it('mirror drops kind tag', () => {
+    expect(OcctBackend.box(10, 10, 10).mirror([1, 0, 0]).kind).toBeUndefined();
+  });
+
+  it('union drops kind tag', () => {
+    const a = OcctBackend.box(10, 10, 10);
+    const b = OcctBackend.box(5, 5, 5).translate(20, 0, 0);
+    expect(a.union(b).kind).toBeUndefined();
+  });
+
+  it('subtract drops kind tag', () => {
+    const a = OcctBackend.box(10, 10, 10);
+    const b = OcctBackend.box(5, 5, 5);
+    expect(a.subtract(b).kind).toBeUndefined();
+  });
+
+  it('intersect drops kind tag', () => {
+    const a = OcctBackend.box(10, 10, 10);
+    const b = OcctBackend.box(5, 5, 5);
+    expect(a.intersect(b).kind).toBeUndefined();
+  });
+});

--- a/tests/unit/backends/occt/occtLowerer.chamfer.test.ts
+++ b/tests/unit/backends/occt/occtLowerer.chamfer.test.ts
@@ -1,0 +1,55 @@
+// tests/unit/backends/occt/occtLowerer.chamfer.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { OcctLowerer } from '../../../../src/backends/occt/occtLowerer';
+import { OcctBackend, initOcct } from '../../../../src/backends/occt/occtBackend';
+import type { FeatureRecord } from '../../../../src/intent/featureRecord';
+import type { Param } from '../../../../src/intent/types';
+
+const mm = (n: number): Param => ({ expression: String(n), unit: 'mm', evaluated: n });
+
+describe('OcctLowerer chamfer', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('lowers an all-edges chamfer on a box', async () => {
+    const base = OcctBackend.box(20, 20, 20);
+    const r: FeatureRecord = {
+      id: 'chamfer_1', kind: 'chamfer',
+      inputs: { base: { kind: 'feature', id: 'box_1' } },
+      params: { distance: mm(1.5) },
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: { base } });
+    expect(result.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0);
+    expect(result.shape.volume()).toBeLessThan(8000);
+  });
+
+  it('lowers a top-face chamfer on a box', async () => {
+    const base = OcctBackend.box(20, 20, 20);
+    const r: FeatureRecord = {
+      id: 'chamfer_2', kind: 'chamfer',
+      inputs: {
+        base: { kind: 'feature', id: 'box_1' },
+        face: { kind: 'face', featureId: 'box_1', ref: { kind: 'canonical', face: 'top' } },
+      },
+      params: { distance: mm(1.5) },
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: { base } });
+    expect(result.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0);
+    expect(result.shape.volume()).toBeLessThan(8000);
+  });
+
+  it('emits feature.chamfer.failed when OCCT throws', async () => {
+    const base = OcctBackend.box(10, 10, 10);
+    const r: FeatureRecord = {
+      id: 'chamfer_3', kind: 'chamfer',
+      inputs: { base: { kind: 'feature', id: 'box_1' } },
+      params: { distance: mm(100) },
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: { base } });
+    const errs = result.diagnostics.filter(d => d.severity === 'error');
+    expect(errs).toHaveLength(1);
+    expect(errs[0].code).toBe('feature.chamfer.failed');
+  });
+});

--- a/tests/unit/backends/occt/occtLowerer.fillet.test.ts
+++ b/tests/unit/backends/occt/occtLowerer.fillet.test.ts
@@ -1,0 +1,74 @@
+// tests/unit/backends/occt/occtLowerer.fillet.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { OcctLowerer } from '../../../../src/backends/occt/occtLowerer';
+import { OcctBackend, initOcct } from '../../../../src/backends/occt/occtBackend';
+import type { FeatureRecord } from '../../../../src/intent/featureRecord';
+import type { Param } from '../../../../src/intent/types';
+
+const mm = (n: number): Param => ({ expression: String(n), unit: 'mm', evaluated: n });
+
+describe('OcctLowerer fillet', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('lowers an all-edges fillet on a box', async () => {
+    const base = OcctBackend.box(20, 20, 20);
+    const r: FeatureRecord = {
+      id: 'fillet_1', kind: 'fillet',
+      inputs: { base: { kind: 'feature', id: 'box_1' } },
+      params: { radius: mm(2) },
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: { base } });
+    expect(result.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0);
+    expect(result.shape.volume()).toBeLessThan(8000);
+  });
+
+  it('lowers a top-face fillet on a box (returns smaller volume than all-edges fillet)', async () => {
+    const base = OcctBackend.box(20, 20, 20);
+    const r: FeatureRecord = {
+      id: 'fillet_2', kind: 'fillet',
+      inputs: {
+        base: { kind: 'feature', id: 'box_1' },
+        face: { kind: 'face', featureId: 'box_1', ref: { kind: 'canonical', face: 'top' } },
+      },
+      params: { radius: mm(2) },
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: { base } });
+    expect(result.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0);
+    const v = result.shape.volume();
+    expect(v).toBeLessThan(8000);
+    expect(v).toBeGreaterThan(7900); // top-face fillet removes much less than all-edges
+  });
+
+  it('emits face-ref-not-resolvable for fillet on a transformed primitive', async () => {
+    const base = OcctBackend.box(20, 20, 20).translate(5, 0, 0);
+    const r: FeatureRecord = {
+      id: 'fillet_3', kind: 'fillet',
+      inputs: {
+        base: { kind: 'feature', id: 'box_1' },
+        face: { kind: 'face', featureId: 'box_1', ref: { kind: 'canonical', face: 'top' } },
+      },
+      params: { radius: mm(2) },
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: { base } });
+    const errs = result.diagnostics.filter(d => d.severity === 'error');
+    expect(errs).toHaveLength(1);
+    expect(errs[0].code).toBe('feature.edge-feature.face-ref-not-resolvable');
+  });
+
+  it('emits feature.fillet.failed when OCCT throws (radius too large)', async () => {
+    const base = OcctBackend.box(10, 10, 10);
+    const r: FeatureRecord = {
+      id: 'fillet_4', kind: 'fillet',
+      inputs: { base: { kind: 'feature', id: 'box_1' } },
+      params: { radius: mm(100) },
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: { base } });
+    const errs = result.diagnostics.filter(d => d.severity === 'error');
+    expect(errs).toHaveLength(1);
+    expect(errs[0].code).toBe('feature.fillet.failed');
+  });
+});

--- a/tests/unit/capture/proxy.fillet.test.ts
+++ b/tests/unit/capture/proxy.fillet.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOcct } from '../../../src/backends/occt/occtBackend';
+import { runScript } from '../../../src/script-runtime/runScript';
+
+describe('Shape.fillet / chamfer capture', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('registers a fillet record with base input and no face filter', async () => {
+    const code = `return box(10, 10, 10).fillet(2);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    expect(result.records).toHaveLength(2);
+    expect(result.records[1].kind).toBe('fillet');
+    expect(result.records[1].inputs.base).toEqual({ kind: 'feature', id: result.records[0].id });
+    expect(result.records[1].inputs.face).toBeUndefined();
+    expect(result.records[1].params.radius.evaluated).toBe(2);
+  });
+
+  it('registers a fillet record with a canonical face filter', async () => {
+    const code = `return box(10, 10, 10).fillet(2, { face: 'top' });`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    expect(result.records).toHaveLength(2);
+    const fillet = result.records[1];
+    expect(fillet.kind).toBe('fillet');
+    expect(fillet.inputs.face).toEqual({
+      kind: 'face',
+      featureId: result.records[0].id,
+      ref: { kind: 'canonical', face: 'top' },
+    });
+  });
+
+  it('registers a chamfer record with distance param', async () => {
+    const code = `return box(10, 10, 10).chamfer(1.5, { face: 'bottom' });`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const chamfer = result.records[1];
+    expect(chamfer.kind).toBe('chamfer');
+    expect(chamfer.params.distance.evaluated).toBe(1.5);
+    expect(chamfer.inputs.face).toEqual({
+      kind: 'face',
+      featureId: result.records[0].id,
+      ref: { kind: 'canonical', face: 'bottom' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

First edge feature surface for kernelCAD — `fillet` and `chamfer` on the v0.1 kernel.

\`\`\`typescript
box(20, 20, 5).fillet(2);                         // all 12 edges
box(20, 20, 5).fillet(2, { face: 'top' });        // 4 edges of the top face
box(20, 20, 5).chamfer(1.5, { face: 'bottom' });  // symmetric 45° chamfer
box.subtract(cylinder).fillet(1);                 // works on boolean results (all-edges)
\`\`\`

9 commits across 6 phases: edge-selection helper + kind tag, OcctBackend methods, lowerer cases, capture API, e2e + browser verification, release.

## Spec deviation
Ships ONE error code \`feature.edge-feature.face-ref-not-resolvable\` covering both "non-primitive base" and "transformed primitive" — splitting them cleanly would require refactoring \`FeatureLowerer.lower()\`. Documented in CHANGELOG.

## Test plan
- [x] \`npm run typecheck\` — 0 errors
- [x] \`npm run lint\` — 0 errors
- [x] \`npm test\` — 409 passing (was 378 in v0.1; +31 new)
- [x] \`npm run build:cli\` — produces working binary
- [x] CLI: \`kernelcad evaluate rounded-bracket.kcad.ts\` → \`Features: 4, OK\`
- [x] CLI: \`kernelcad export step rounded-bracket.kcad.ts -o /tmp/rounded.step\` → 74KB valid STEP
- [x] **Browser verification (HARD GATE)**: dev server loads, editor accepts \`.fillet(2)\`, viewport renders rounded geometry, Export STL downloads
- [x] Volume regression: filleted bracket = 11350.89 mm³, un-filleted = 11748.67 mm³ (Δ = 397.78 mm³, 3.4% reduction)

## Browser caveat
The deployed web demo's \`v01ApiShim\` proxies directly to Replicad rather than routing through the v0.2-alpha capture pipeline. Both produce visually equivalent rounded geometry (same OCCT underneath); v0.5 Studio UI rewrite will replace the shim with a true browser-side runtime.