### PR TITLE
chore: post-v0.2.0-alpha.1 cleanup (spec sync + deploy concurrency)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,11 @@ permissions:
 
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  # Cancel any in-progress run when a new tag pushes a deploy.
+  # The e2e job doesn't gate the deploy job, so cancelling its in-flight
+  # run is a clean trade — saves us from the queue-behind-stale-e2e
+  # blockage we hit on v0.1.0-arch.2 and v0.2.0-alpha.1.
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/docs/superpowers/specs/2026-04-29-v0.2-alpha-fillet-chamfer-design.md
+++ b/docs/superpowers/specs/2026-04-29-v0.2-alpha-fillet-chamfer-design.md
@@ -1,7 +1,9 @@
 # v0.2-alpha — Fillet + Chamfer (canonical-refs only)
 
 **Date:** 2026-04-29
-**Status:** Design approved (awaiting plan)
+**Status:** Implemented and shipped as `v0.2.0-alpha.1` on 2026-04-30.
+
+> **Post-implementation note (2026-04-30):** the spec originally specified two distinct error codes — `feature.edge-feature.face-ref-on-non-primitive` and `feature.edge-feature.face-ref-on-transformed-primitive`. Producing distinct codes would have required refactoring `FeatureLowerer.lower()` to receive the base `FeatureRecord` rather than just the resolved `ShapeBackend`. Bigger blast radius than v0.2-alpha warranted, so the implementation ships ONE combined code: `feature.edge-feature.face-ref-not-resolvable`, with a message that differentiates which condition tripped. Implementation plan at `docs/superpowers/plans/2026-04-30-v0.2-alpha-fillet-chamfer.md`.
 **Author:** Andrii (with Claude assistance)
 **Repo:** `kernelCAD-web` on branch `develop`
 **Predecessor:** v0.1 (`docs/superpowers/specs/2026-04-29-kernelcad-NORTHSTAR.md`, `docs/superpowers/plans/2026-04-29-kernelcad-v0.1.md`)
@@ -135,8 +137,8 @@ Three new pieces:
 3. **`pickEdges(record: FeatureRecord, base: OcctBackend): TopoDS_Edge[]`** — resolves the optional `inputs.face` filter:
     - No `inputs.face` → returns all edges of `base`'s shape (via OCCT's `TopExp_Explorer` with `TopAbs_EDGE`).
     - `inputs.face` present + `base` is a primitive of compatible shape kind + **no transforms applied** → returns the canonical face's edges per the table below.
-    - `inputs.face` present + `base` is a non-primitive (e.g., result of boolean) → error diagnostic `feature.edge-feature.face-ref-on-non-primitive`.
-    - `inputs.face` present + base primitive **has transforms applied** → error diagnostic `feature.edge-feature.face-ref-on-transformed-primitive`. (Translate-preserves-orientation could be made to work but rotate/mirror cannot without history walking; ship the conservative rule for v0.2-alpha and revisit in v0.2-beta.)
+    - `inputs.face` present + `base` is a non-primitive (e.g., result of boolean) → error diagnostic `feature.edge-feature.face-ref-not-resolvable`.
+    - `inputs.face` present + base primitive **has transforms applied** → error diagnostic `feature.edge-feature.face-ref-not-resolvable`. (Translate-preserves-orientation could be made to work but rotate/mirror cannot without history walking; ship the conservative rule for v0.2-alpha and revisit in v0.2-beta.)
     - `inputs.face` present + face name not applicable to this primitive (e.g. `'left'` on a cylinder) → diagnostic `feature.edge-feature.face-ref-not-applicable`.
 
 ### Canonical-face → edges resolution
@@ -183,8 +185,8 @@ The existing `createApi` factory in `src/modules/api.ts` does NOT need new top-l
 | All-edges fillet of a box | `box(20,20,20).fillet(2)` | shape produced; volume strictly less than `8000`; diagnostics empty. |
 | Top-face fillet | `box(20,20,20).fillet(2, { face: 'top' })` | volume between full-fillet and no-fillet; bottom face still sharp (manual eyeball OK; assertion on volume bracket). |
 | Fillet on boolean result | `box.subtract(cylinder).fillet(1)` (no face) | succeeds; produces a smoother bracket. |
-| Face-ref on non-primitive | `box.subtract(cylinder).fillet(1, { face: 'top' })` | error diagnostic `feature.edge-feature.face-ref-on-non-primitive`. |
-| Face-ref on transformed primitive | `box(20,20,20).translate(5,0,0).fillet(1, { face: 'top' })` | error diagnostic `feature.edge-feature.face-ref-on-transformed-primitive`. |
+| Face-ref on non-primitive | `box.subtract(cylinder).fillet(1, { face: 'top' })` | error diagnostic `feature.edge-feature.face-ref-not-resolvable`. |
+| Face-ref on transformed primitive | `box(20,20,20).translate(5,0,0).fillet(1, { face: 'top' })` | error diagnostic `feature.edge-feature.face-ref-not-resolvable`. |
 | Face-ref applied before transform | `box(20,20,20).fillet(2, { face: 'top' }).translate(5,0,0)` | succeeds; rounded box is translated. |
 | Face-ref not applicable | `cylinder(10, 5).fillet(1, { face: 'left' })` | error diagnostic `feature.edge-feature.face-ref-not-applicable`. |
 | Radius too large | `box(10,10,10).fillet(100)` | error diagnostic `feature.fillet.failed`. |
@@ -254,7 +256,7 @@ No changes to `src/intent/`, `src/compute/`, `src/script-runtime/`, `src/cli/`, 
 
 3. **Identifying a primitive at lowering time.** Plan needs to settle Option A (kind-tag on `OcctBackend`) vs Option B (look up `FeatureRecord` kind via the `inputs.base` id). A is recommended but final call belongs in the plan.
 
-4. **Canonical face semantics under transforms.** If the user does `box(10,10,10).translate(5,0,0).fillet(2, { face: 'top' })`, what's "top"? Decision for v0.2-alpha: **canonical face refs require zero transforms on the base primitive**. Any `.translate()`/`.rotate()`/`.scale()`/`.mirror()` makes the face filter invalid (`feature.edge-feature.face-ref-on-transformed-primitive` diagnostic). User-facing workaround: apply the fillet *before* transforms — `box(10,10,10).fillet(2, { face: 'top' }).translate(5,0,0)` is fine because translate happens on the fillet's output, not its input. v0.2-beta can relax this for translation-only (translate preserves orientation, so "top" survives) but rotate/mirror can't be relaxed without history walking (full v0.2 territory).
+4. **Canonical face semantics under transforms.** If the user does `box(10,10,10).translate(5,0,0).fillet(2, { face: 'top' })`, what's "top"? Decision for v0.2-alpha: **canonical face refs require zero transforms on the base primitive**. Any `.translate()`/`.rotate()`/`.scale()`/`.mirror()` makes the face filter invalid (`feature.edge-feature.face-ref-not-resolvable` diagnostic). User-facing workaround: apply the fillet *before* transforms — `box(10,10,10).fillet(2, { face: 'top' }).translate(5,0,0)` is fine because translate happens on the fillet's output, not its input. v0.2-beta can relax this for translation-only (translate preserves orientation, so "top" survives) but rotate/mirror can't be relaxed without history walking (full v0.2 territory).
 
 ## Acceptance
 


### PR DESCRIPTION
Two small follow-ups after v0.2.0-alpha.1 shipped:

1. Sync `docs/superpowers/specs/2026-04-29-v0.2-alpha-fillet-chamfer-design.md` with shipped reality — the implementation collapsed two error codes into one (`face-ref-not-resolvable`) per the plan's documented deviation.
2. `deploy.yml` concurrency: `cancel-in-progress: true` so a new tag push cancels any in-flight deploy run (including its non-blocking e2e job). Without this, two consecutive tag pushes during dev get queued and the second waits ~50min for e2e to finish before its build/deploy can run.

No code changes; just docs + CI config.