### PR TITLE
feat(v0.11.0): topology read tools — close out v0.11 read-tools surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## v0.11.0 — 2026-04-30
+
+### Added
+- **3 new MCP topology tools** completing the v0.11 read-tools surface:
+  - `list_topology(file?, code?, feature_id?)` — canonical face names + edge count for an introspected feature. Returns empty face list and `hasTrackedTopology: false` for non-primitives.
+  - `get_edges_of(file?, code?, feature_id?, face_name)` — boundary edges of a named canonical face. Mirrors ForgeCAD's `edgesOf()`. Returns `[{ index, centroid, length, isClosed }]`. Centroid uses Replicad's parametric `pointAt(0.5)` so it's correct for arcs/circles, not just straight edges.
+  - `why_did_this_fail(file?, code?, feature_id?)` — focused diagnostic view + upstream chain walk + **human-readable hints lookup** (26 entries covering known kernel diagnostic codes — fillet/chamfer/shell failures, face-ref errors, recompute cascade, CLI errors). Improvement over ForgeCAD's pattern, which has no equivalent — ForgeCAD agents read SKILL.md to interpret codes, kernelCAD's MCP returns the suggestion directly.
+- 3 new spawn integration tests covering the new tools (5 total: 2 from alpha + 3 from final).
+
+### Changed
+- v0.11 milestone closed at final (no separate `-beta` tag in the public history). Version progresses 0.11.0-alpha.1 → 0.11.0.
+
+### Deferred to v0.12+
+- AST-edit tools (deferred per NORTHSTAR roadmap)
+- Geometric edge selection (`select_edges` mirroring ForgeCAD's `selectEdges` for non-primitive shapes)
+- HTTP transport (currently stdio-only)
+- Skill installer (`forgecad skill install` equivalent)
+
 ## v0.11.0-alpha.1 — 2026-04-30
 
 ### Added

--- a/docs/superpowers/plans/2026-04-30-v0.11-beta-mcp-topology.md
+++ b/docs/superpowers/plans/2026-04-30-v0.11-beta-mcp-topology.md
@@ -1,0 +1,900 @@
+# v0.11.0 MCP Topology Tools — Implementation Plan (final)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close out the v0.11 MCP read-tools surface with three topology-query tools — `list_topology`, `get_edges_of`, `why_did_this_fail` — so agents can dynamically inspect what they can fillet/chamfer/shell instead of guessing.
+
+**Architecture:** All three tools follow the v0.11-alpha pattern: pure async functions in `src/mcp/tools/`, registered in `src/mcp/server.ts`'s switch. Reuse `runScript` + `RecomputeEngine` + `OcctLowerer` + the existing `pickEdges` helper from v0.2-alpha. No new kernel surface — just expose what's already there.
+
+**Tech Stack:** Same as v0.11-alpha (TypeScript 5.9, Vitest 4, `@modelcontextprotocol/sdk` v1.29, OCCT WASM via Replicad).
+
+**Predecessor:** v0.11.0-alpha.1 — `evaluate_script`, `list_features`, `get_shape_info` (tag at `5468ce7`-ish on develop after squash, look up `git log --oneline | grep v0.11.0-alpha.1`).
+
+**Reference (per memory rule):** ForgeCAD's `edgesOf(faceName)` (`~/projects/forgecad-pkg/package/dist-skill/docs/generated/core.md:879+`) is the canonical agent topology query — kernelCAD's `get_edges_of` mirrors that semantically.
+
+---
+
+## Decisions Locked
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Tool count | 3 (list_topology, get_edges_of, why_did_this_fail) | Closes the read-tools surface for v0.11. AST-edit tools wait for v0.12. |
+| `list_topology` shape | `{ ok, hasTrackedTopology, faceNames, edgeCount }` | Mirrors ForgeCAD's `edgeNames()`. For primitives we have canonical face names; edges are unnamed in v0.2-alpha (no tracked refs), so just count them. |
+| `get_edges_of` shape | `{ ok, edges: Array<{ index, centroid, length, isClosed }> }` | Mirrors ForgeCAD's `edgesOf`. Index is stable within the shape; centroid + length are geometric properties any agent can reason about. |
+| `why_did_this_fail` shape | `{ ok, feature_id, kind, health, diagnostics, upstream }` | Filters diagnostics to one feature + walks upstream chain via DependencyGraph. Helps agents debug "why is fillet broken?" interactively. |
+| Refactor scope | None — all three tools consume existing helpers | Reuse `pickEdges` from `edgeSelection.ts`, `RecomputeEngine` for diagnostics, `DependencyGraph` for upstream chain. |
+| `why_did_this_fail` "hints" field | Included — small lookup table mapping diagnostic codes to human-readable suggestions | Genuine improvement over ForgeCAD (which has no equivalent — agents must read SKILL.md to interpret codes). Ten codes today, one-line suggestion each. |
+| Release tag | `v0.11.0` (final) — not beta or rc | Per user direction; v0.11 read-tools surface is complete with these 6 tools. v0.12 owns AST-edits + skill installer. |
+
+---
+
+## File Structure
+
+**Create:**
+- `src/mcp/tools/listTopology.ts` — `listTopologyTool(input): Promise<ListTopologyOutput>`. Pure.
+- `src/mcp/tools/getEdgesOf.ts` — `getEdgesOfTool(input): Promise<GetEdgesOfOutput>`. Pure. Reuses `pickEdges` from `src/backends/occt/edgeSelection.ts`.
+- `src/mcp/tools/whyDidThisFail.ts` — `whyDidThisFailTool(input): Promise<WhyDidThisFailOutput>`. Pure.
+- `tests/unit/mcp/tools/listTopology.test.ts`
+- `tests/unit/mcp/tools/getEdgesOf.test.ts`
+- `tests/unit/mcp/tools/whyDidThisFail.test.ts`
+
+**Modify:**
+- `src/mcp/index.ts` — add 3 re-exports.
+- `src/mcp/server.ts` — register the 3 new tools in `TOOLS` and the switch dispatch.
+- `tests/integration/mcp/spawn.test.ts` — add 3 new spawn cases (one per new tool).
+- `package.json` — version bump 0.11.0-alpha.1 → 0.11.0-beta.1 (Task 5).
+- `CHANGELOG.md` — prepend v0.11-beta entry (Task 5).
+
+**No-touch (verify only):**
+- `src/backends/occt/edgeSelection.ts` — `pickEdges` reused as-is.
+- `src/compute/dependencyGraph.ts` — used for upstream walk in `why_did_this_fail`.
+- `src/backends/occt/occtBackend.ts` — `kind` tag tells us if a shape is an un-transformed primitive.
+
+---
+
+## Phase 1: list_topology
+
+### Task 1: `listTopologyTool` + tests
+
+**Files:**
+- Create: `src/mcp/tools/listTopology.ts`
+- Create: `tests/unit/mcp/tools/listTopology.test.ts`
+
+The tool answers: "what canonical faces does feature X have, and how many edges?"
+
+For un-transformed primitives we have canonical face names (`'top'|'bottom'|'left'|'right'|'front'|'back'` for box; `'top'|'bottom'` for cylinder; none for sphere). For non-primitives (boolean results, fillets, etc.) we don't have tracked names — return `hasTrackedTopology: false` with empty `faceNames` and a numeric edge count.
+
+- [ ] **Step 1: Write 5 failing tests**
+
+```typescript
+// tests/unit/mcp/tools/listTopology.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { listTopologyTool } from '../../../../src/mcp/tools/listTopology';
+import { initOcct } from '../../../../src/backends/occt/occtBackend';
+
+describe('listTopologyTool', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('returns canonical face names for an un-transformed box', async () => {
+    const result = await listTopologyTool({ code: `return box(10, 10, 10);` });
+    expect(result.ok).toBe(true);
+    expect(result.hasTrackedTopology).toBe(true);
+    expect(result.faceNames).toEqual(
+      expect.arrayContaining(['top', 'bottom', 'left', 'right', 'front', 'back']),
+    );
+    expect(result.edgeCount).toBe(12);
+  });
+
+  it('returns just top/bottom for a cylinder', async () => {
+    const result = await listTopologyTool({ code: `return cylinder(10, 5);` });
+    expect(result.ok).toBe(true);
+    expect(result.hasTrackedTopology).toBe(true);
+    expect(result.faceNames.sort()).toEqual(['bottom', 'top']);
+  });
+
+  it('returns no canonical names for a sphere', async () => {
+    const result = await listTopologyTool({ code: `return sphere(5);` });
+    expect(result.ok).toBe(true);
+    expect(result.hasTrackedTopology).toBe(true);
+    expect(result.faceNames).toEqual([]);
+  });
+
+  it('returns hasTrackedTopology=false for a boolean result', async () => {
+    const result = await listTopologyTool({
+      code: `
+        const a = box(10, 10, 10);
+        const b = cylinder(10, 3).translate(0, 0, -1);
+        return a.subtract(b);
+      `,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.hasTrackedTopology).toBe(false);
+    expect(result.faceNames).toEqual([]);
+    expect(result.edgeCount).toBeGreaterThan(0);
+  });
+
+  it('errors when feature_id is not found', async () => {
+    const result = await listTopologyTool({ code: `return box(10, 10, 10);`, feature_id: 'nope' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing**
+
+`npx vitest run tests/unit/mcp/tools/listTopology.test.ts` — 5/5 fail (tool not defined).
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/mcp/tools/listTopology.ts
+import { runScript } from '../../script-runtime/runScript';
+import { RecomputeEngine } from '../../compute/recomputeEngine';
+import { OcctLowerer } from '../../backends/occt/occtLowerer';
+import { initOcct, OcctBackend } from '../../backends/occt/occtBackend';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+export interface ListTopologyInput {
+  file?: string;
+  code?: string;
+  feature_id?: string;
+}
+
+export interface ListTopologyOutput {
+  ok: boolean;
+  hasTrackedTopology?: boolean;
+  faceNames?: string[];
+  edgeCount?: number;
+  error?: string;
+}
+
+const BOX_FACES = ['top', 'bottom', 'left', 'right', 'front', 'back'] as const;
+const CYLINDER_FACES = ['top', 'bottom'] as const;
+
+export async function listTopologyTool(input: ListTopologyInput): Promise<ListTopologyOutput> {
+  await initOcct();
+
+  let code: string;
+  let fileName: string;
+
+  if (input.code !== undefined) {
+    code = input.code;
+    fileName = input.file ?? '<inline>';
+  } else if (input.file !== undefined) {
+    const filePath = resolve(input.file);
+    fileName = filePath;
+    try {
+      code = await readFile(filePath, 'utf8');
+    } catch (e) {
+      return { ok: false, error: `Cannot read file: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  } else {
+    return { ok: false, error: 'Must provide either { file } or { code }.' };
+  }
+
+  let run;
+  try {
+    run = await runScript({ code, fileName });
+  } catch (e) {
+    return { ok: false, error: `Script execution failed: ${e instanceof Error ? e.message : String(e)}` };
+  }
+
+  if (run.records.length === 0) return { ok: false, error: 'Script produced no features.' };
+
+  const targetId = input.feature_id ?? run.records[run.records.length - 1].id;
+  if (!run.records.some(r => r.id === targetId)) {
+    return { ok: false, error: `feature_id '${targetId}' not found.` };
+  }
+
+  const engine = new RecomputeEngine(new OcctLowerer());
+  const result = await engine.run(run.records);
+  const shape = result.shapes.get(targetId);
+  if (!shape) return { ok: false, error: `Feature '${targetId}' did not lower successfully.` };
+
+  const occt = shape as OcctBackend;
+  let faceNames: string[];
+  let hasTrackedTopology: boolean;
+
+  switch (occt.kind) {
+    case 'box':
+      faceNames = [...BOX_FACES];
+      hasTrackedTopology = true;
+      break;
+    case 'cylinder':
+      faceNames = [...CYLINDER_FACES];
+      hasTrackedTopology = true;
+      break;
+    case 'sphere':
+      faceNames = [];
+      hasTrackedTopology = true;
+      break;
+    default:
+      faceNames = [];
+      hasTrackedTopology = false;
+      break;
+  }
+
+  const replicadShape = occt.getReplicadShape();
+  const edgeCount = replicadShape.edges.length;
+
+  return { ok: true, hasTrackedTopology, faceNames, edgeCount };
+}
+```
+
+- [ ] **Step 4: Run passing**
+
+`npx vitest run tests/unit/mcp/tools/listTopology.test.ts` — 5/5 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mcp/tools/listTopology.ts tests/unit/mcp/tools/listTopology.test.ts
+git commit -m "feat(mcp): list_topology tool — canonical face names + edge count for an introspected feature"
+```
+
+---
+
+## Phase 2: get_edges_of
+
+### Task 2: `getEdgesOfTool` + tests
+
+**Files:**
+- Create: `src/mcp/tools/getEdgesOf.ts`
+- Create: `tests/unit/mcp/tools/getEdgesOf.test.ts`
+
+Returns the boundary edges of a named canonical face. Mirrors ForgeCAD's `edgesOf(faceName)`. Reuses `pickEdges` from v0.2-alpha to do the actual face-to-edges resolution.
+
+- [ ] **Step 1: Write 4 failing tests**
+
+```typescript
+// tests/unit/mcp/tools/getEdgesOf.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { getEdgesOfTool } from '../../../../src/mcp/tools/getEdgesOf';
+import { initOcct } from '../../../../src/backends/occt/occtBackend';
+
+describe('getEdgesOfTool', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('returns 4 edges for the top face of a box', async () => {
+    const result = await getEdgesOfTool({
+      code: `return box(20, 20, 20);`,
+      face_name: 'top',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.edges).toHaveLength(4);
+    // Each edge has a centroid and length
+    for (const e of result.edges!) {
+      expect(e.centroid).toHaveLength(3);
+      expect(e.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns 1 edge for the top face of a cylinder (the circle)', async () => {
+    const result = await getEdgesOfTool({
+      code: `return cylinder(10, 5);`,
+      face_name: 'top',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges![0].isClosed).toBe(true);
+  });
+
+  it('errors when face_name is not applicable', async () => {
+    const result = await getEdgesOfTool({
+      code: `return cylinder(10, 5);`,
+      face_name: 'left',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not applicable/i);
+  });
+
+  it('errors when applied to a non-primitive', async () => {
+    const result = await getEdgesOfTool({
+      code: `return box(10, 10, 10).subtract(cylinder(10, 3));`,
+      face_name: 'top',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/un-transformed primitive|not.resolvable/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing**
+
+`npx vitest run tests/unit/mcp/tools/getEdgesOf.test.ts` — fail.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/mcp/tools/getEdgesOf.ts
+import { runScript } from '../../script-runtime/runScript';
+import { RecomputeEngine } from '../../compute/recomputeEngine';
+import { OcctLowerer } from '../../backends/occt/occtLowerer';
+import { initOcct, OcctBackend } from '../../backends/occt/occtBackend';
+import { pickEdges } from '../../backends/occt/edgeSelection';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import type { FeatureRecord } from '../../intent/featureRecord';
+
+export interface GetEdgesOfInput {
+  file?: string;
+  code?: string;
+  feature_id?: string;
+  face_name: 'top' | 'bottom' | 'left' | 'right' | 'front' | 'back';
+}
+
+export interface EdgeInfo {
+  index: number;
+  centroid: [number, number, number];
+  length: number;
+  isClosed: boolean;
+}
+
+export interface GetEdgesOfOutput {
+  ok: boolean;
+  edges?: EdgeInfo[];
+  error?: string;
+}
+
+export async function getEdgesOfTool(input: GetEdgesOfInput): Promise<GetEdgesOfOutput> {
+  await initOcct();
+
+  if (!input.face_name) {
+    return { ok: false, error: 'face_name is required.' };
+  }
+
+  let code: string;
+  let fileName: string;
+  if (input.code !== undefined) {
+    code = input.code;
+    fileName = input.file ?? '<inline>';
+  } else if (input.file !== undefined) {
+    const filePath = resolve(input.file);
+    fileName = filePath;
+    try {
+      code = await readFile(filePath, 'utf8');
+    } catch (e) {
+      return { ok: false, error: `Cannot read file: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  } else {
+    return { ok: false, error: 'Must provide either { file } or { code }.' };
+  }
+
+  let run;
+  try {
+    run = await runScript({ code, fileName });
+  } catch (e) {
+    return { ok: false, error: `Script execution failed: ${e instanceof Error ? e.message : String(e)}` };
+  }
+
+  if (run.records.length === 0) return { ok: false, error: 'Script produced no features.' };
+  const targetId = input.feature_id ?? run.records[run.records.length - 1].id;
+  const targetRecord = run.records.find(r => r.id === targetId);
+  if (!targetRecord) return { ok: false, error: `feature_id '${targetId}' not found.` };
+
+  const engine = new RecomputeEngine(new OcctLowerer());
+  const result = await engine.run(run.records);
+  const shape = result.shapes.get(targetId);
+  if (!shape) return { ok: false, error: `Feature '${targetId}' did not lower successfully.` };
+
+  // Build a synthetic FeatureRecord with a face-input pointing at this feature, so we can
+  // reuse pickEdges. The fields beyond inputs/kind don't matter for resolution.
+  const synthetic: FeatureRecord = {
+    id: '<query>',
+    kind: 'fillet',
+    params: { radius: { expression: '0', unit: 'mm', evaluated: 0 } },
+    inputs: {
+      base: { kind: 'feature', id: targetId },
+      face: {
+        kind: 'face',
+        featureId: targetId,
+        ref: { kind: 'canonical', face: input.face_name },
+      },
+    },
+    transforms: [],
+    suppressed: false,
+  };
+
+  const edgesResult = pickEdges(synthetic, shape as OcctBackend);
+  if ('error' in edgesResult) {
+    return { ok: false, error: edgesResult.error.message };
+  }
+
+  const edges: EdgeInfo[] = edgesResult.map((e, i) => {
+    // Replicad's `_1DShape.pointAt(t)` (t∈[0,1]) gives a parametric point along the
+    // curve. `pointAt(0.5)` is the proper geometric midpoint, correct for both
+    // straight edges AND arcs/circles (verified against
+    // `node_modules/replicad/dist/replicad.d.ts:42-44`). `isClosed` is a getter
+    // (not a method), `length` is also a getter.
+    const mid = e.pointAt(0.5); // Vector with .x/.y/.z
+    const centroid: [number, number, number] = [mid.x, mid.y, mid.z];
+    return { index: i, centroid, length: e.length, isClosed: e.isClosed };
+  });
+
+  return { ok: true, edges };
+}
+```
+
+The exact replicad Edge API (`startPoint`, `endPoint`, `length`) needs verification. Inspect `node_modules/replicad/dist/replicad.d.ts` for the `Edge` class shape. If `startPoint` returns `Vector` (with `.x/.y/.z`) instead of an array, the centroid math still works as written. If `length` isn't a property but a method, adjust to `e.length()`.
+
+- [ ] **Step 4: Run passing**
+
+`npx vitest run tests/unit/mcp/tools/getEdgesOf.test.ts` — 4/4 PASS. If a replicad API mismatch surfaces, adapt and document.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mcp/tools/getEdgesOf.ts tests/unit/mcp/tools/getEdgesOf.test.ts
+git commit -m "feat(mcp): get_edges_of tool — boundary edges of a named canonical face (mirrors ForgeCAD edgesOf)"
+```
+
+---
+
+## Phase 3: why_did_this_fail
+
+### Task 3: `whyDidThisFailTool` + tests
+
+**Files:**
+- Create: `src/mcp/tools/whyDidThisFail.ts`
+- Create: `tests/unit/mcp/tools/whyDidThisFail.test.ts`
+
+Returns a focused diagnostic view for one feature: its health, its own diagnostics, and the upstream chain so agents can debug "fillet failed because the box upstream errored."
+
+- [ ] **Step 1: Write 4 failing tests**
+
+```typescript
+// tests/unit/mcp/tools/whyDidThisFail.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { whyDidThisFailTool } from '../../../../src/mcp/tools/whyDidThisFail';
+import { initOcct } from '../../../../src/backends/occt/occtBackend';
+
+describe('whyDidThisFailTool', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('reports healthy for a clean script', async () => {
+    const result = await whyDidThisFailTool({ code: `return box(10, 10, 10);` });
+    expect(result.ok).toBe(true);
+    expect(result.health).toBe('healthy');
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it('reports error + diagnostic when fillet radius is too large', async () => {
+    const result = await whyDidThisFailTool({
+      code: `return box(10, 10, 10).fillet(100);`,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.health).toBe('error');
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+    expect(result.diagnostics[0].code).toBe('feature.fillet.failed');
+  });
+
+  it('walks upstream chain when downstream cascades', async () => {
+    // The fillet here will fail (face-ref-not-resolvable on transformed primitive),
+    // but the upstream box itself is healthy. The result should show:
+    //   - target health: error
+    //   - upstream chain: [box (healthy)]
+    const result = await whyDidThisFailTool({
+      code: `return box(10, 10, 10).translate(5, 0, 0).fillet(2, { face: 'top' });`,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.health).toBe('error');
+    expect(result.upstream.length).toBeGreaterThan(0);
+    expect(result.upstream[0].kind).toBe('box');
+    expect(result.upstream[0].health).toBe('healthy');
+  });
+
+  it('errors when feature_id is not found', async () => {
+    const result = await whyDidThisFailTool({ code: `return box(10, 10, 10);`, feature_id: 'nope' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing**
+
+`npx vitest run tests/unit/mcp/tools/whyDidThisFail.test.ts` — fail.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/mcp/tools/whyDidThisFail.ts
+import { runScript } from '../../script-runtime/runScript';
+import { RecomputeEngine } from '../../compute/recomputeEngine';
+import { OcctLowerer } from '../../backends/occt/occtLowerer';
+import { initOcct } from '../../backends/occt/occtBackend';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import type { FeatureKind } from '../../intent/types';
+import type { CompilerDiagnostic } from '../../diagnostics/diagnostic';
+
+export interface WhyDidThisFailInput {
+  file?: string;
+  code?: string;
+  feature_id?: string;
+}
+
+export interface UpstreamFeature {
+  feature_id: string;
+  kind: FeatureKind;
+  health: 'healthy' | 'warning' | 'error' | 'unknown';
+}
+
+export interface WhyDidThisFailOutput {
+  ok: boolean;
+  feature_id?: string;
+  kind?: FeatureKind;
+  health?: 'healthy' | 'warning' | 'error' | 'unknown';
+  diagnostics?: CompilerDiagnostic[];
+  upstream?: UpstreamFeature[];
+  /** Human-readable suggestion strings, one per unique diagnostic code in `diagnostics`. */
+  hints?: string[];
+  error?: string;
+}
+
+/**
+ * Maps known diagnostic codes to one-line human-readable suggestions. Keep entries
+ * tight — agents will paste them into chat/edit explanations. Unknown codes are silently
+ * absent from `hints`.
+ */
+const HINTS: Record<string, string> = {
+  'feature.fillet.failed': "OCCT could not apply that fillet. Try a smaller radius — typically less than half of the smallest face dimension.",
+  'feature.chamfer.failed': "OCCT could not apply that chamfer. Try a smaller distance — typically less than half of the smallest face dimension.",
+  'feature.shell.failed': "OCCT could not shell that solid. Try a thinner wall or a different open face. Thickness must be smaller than the shape's minimum thickness.",
+  'feature.edge-feature.face-ref-not-resolvable': "Canonical face refs (e.g. { face: 'top' }) only work on un-transformed primitives. Apply transforms after the fillet/chamfer instead of before, or fillet the primitive first then translate.",
+  'feature.edge-feature.face-ref-not-applicable': "That canonical face name is not valid for this primitive. Boxes have all six (top/bottom/left/right/front/back); cylinders have only top/bottom; spheres have none.",
+  'feature.edge-feature.face-ref-on-non-primitive': "Canonical face refs require a raw primitive (box / cylinder / sphere). The base shape here is the result of a boolean or transform — use all-edges fillet/chamfer instead.",
+  'feature.face-feature.face-required': "Shell needs a face to remove. Pass `{ face: 'top' }` (or another canonical face name applicable to the base primitive).",
+  'feature.face-feature.face-ref-not-resolvable': "Same constraint as edge features: canonical face refs only work on un-transformed primitives. Apply shell before transforms.",
+  'feature.face-feature.face-ref-not-applicable': "That canonical face is not valid for this primitive. Cylinders accept only top/bottom for shell; spheres have no canonical faces.",
+  'feature.face-feature.face-ref-not-supported': "Only canonical face refs are supported in v0.2-alpha. Tracked / created / propagated face refs land in v0.2 full.",
+  'recompute.input.missing': "An upstream feature failed or was suppressed. Use `why_did_this_fail` on the upstream feature ID to find the root cause.",
+  'recompute.lowering.exception': "An exception was raised during lowering. Check the diagnostic message for the OCCT error.",
+  'cli.script.exception': "Your script raised an exception during execution. Check the diagnostic message for the JS error.",
+  'cli.file.read': "kernelCAD could not read the script file at that path. Check the file exists and is readable.",
+};
+
+function buildHints(diagnostics: readonly CompilerDiagnostic[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const d of diagnostics) {
+    if (!seen.has(d.code) && HINTS[d.code]) {
+      seen.add(d.code);
+      out.push(HINTS[d.code]);
+    }
+  }
+  return out;
+}
+
+export async function whyDidThisFailTool(input: WhyDidThisFailInput): Promise<WhyDidThisFailOutput> {
+  await initOcct();
+
+  let code: string;
+  let fileName: string;
+  if (input.code !== undefined) {
+    code = input.code;
+    fileName = input.file ?? '<inline>';
+  } else if (input.file !== undefined) {
+    const filePath = resolve(input.file);
+    fileName = filePath;
+    try {
+      code = await readFile(filePath, 'utf8');
+    } catch (e) {
+      return { ok: false, error: `Cannot read file: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  } else {
+    return { ok: false, error: 'Must provide either { file } or { code }.' };
+  }
+
+  let run;
+  try {
+    run = await runScript({ code, fileName });
+  } catch (e) {
+    return { ok: false, error: `Script execution failed: ${e instanceof Error ? e.message : String(e)}` };
+  }
+
+  if (run.records.length === 0) return { ok: false, error: 'Script produced no features.' };
+
+  const targetId = input.feature_id ?? run.records[run.records.length - 1].id;
+  const targetRecord = run.records.find(r => r.id === targetId);
+  if (!targetRecord) return { ok: false, error: `feature_id '${targetId}' not found.` };
+
+  const engine = new RecomputeEngine(new OcctLowerer());
+  const result = await engine.run(run.records);
+
+  const ownDiagnostics = result.diagnostics.filter(d => d.featureId === targetId);
+  const targetHealth = result.health.get(targetId) ?? (result.shapes.has(targetId) ? 'healthy' : 'unknown');
+
+  // Walk upstream by following inputs.base / inputs.face / etc.
+  const upstream: UpstreamFeature[] = [];
+  const visited = new Set<string>();
+  const queue: string[] = [];
+  // Seed with direct inputs
+  for (const ref of Object.values(targetRecord.inputs)) {
+    const upId = ref.kind === 'feature' ? ref.id : ref.featureId;
+    if (upId && !visited.has(upId)) {
+      visited.add(upId);
+      queue.push(upId);
+    }
+  }
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    const rec = run.records.find(r => r.id === id);
+    if (!rec) continue;
+    upstream.push({
+      feature_id: id,
+      kind: rec.kind,
+      health: result.health.get(id) ?? (result.shapes.has(id) ? 'healthy' : 'unknown'),
+    });
+    for (const ref of Object.values(rec.inputs)) {
+      const upId = ref.kind === 'feature' ? ref.id : ref.featureId;
+      if (upId && !visited.has(upId)) {
+        visited.add(upId);
+        queue.push(upId);
+      }
+    }
+  }
+
+  return {
+    ok: true,
+    feature_id: targetId,
+    kind: targetRecord.kind,
+    health: targetHealth,
+    diagnostics: ownDiagnostics,
+    upstream,
+    hints: buildHints(ownDiagnostics),
+  };
+}
+```
+
+Add a 5th test for the hints field:
+
+```typescript
+  it('returns hints for known diagnostic codes', async () => {
+    const result = await whyDidThisFailTool({ code: `return box(10, 10, 10).fillet(100);` });
+    expect(result.ok).toBe(true);
+    expect(result.hints).toEqual(expect.arrayContaining([expect.stringMatching(/smaller radius/i)]));
+  });
+```
+
+- [ ] **Step 4: Run passing**
+
+`npx vitest run tests/unit/mcp/tools/whyDidThisFail.test.ts` — 4/4 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mcp/tools/whyDidThisFail.ts tests/unit/mcp/tools/whyDidThisFail.test.ts
+git commit -m "feat(mcp): why_did_this_fail tool — focused diagnostic view + upstream chain walk"
+```
+
+---
+
+## Phase 4: Server registration + integration test
+
+### Task 4: Wire 3 new tools into server.ts + extend spawn integration test
+
+**Files:**
+- Modify: `src/mcp/index.ts` (re-export 3 tool symbols)
+- Modify: `src/mcp/server.ts` (add 3 entries to `TOOLS` + 3 cases to switch)
+- Modify: `tests/integration/mcp/spawn.test.ts` (add 3 spawn cases)
+
+- [ ] **Step 1: Add re-exports to `src/mcp/index.ts`**
+
+Append:
+
+```typescript
+export { listTopologyTool, type ListTopologyInput, type ListTopologyOutput } from './tools/listTopology';
+export { getEdgesOfTool, type GetEdgesOfInput, type GetEdgesOfOutput } from './tools/getEdgesOf';
+export { whyDidThisFailTool, type WhyDidThisFailInput, type WhyDidThisFailOutput } from './tools/whyDidThisFail';
+```
+
+- [ ] **Step 2: Add to `TOOLS` array in `src/mcp/server.ts`**
+
+```typescript
+{
+  name: 'list_topology',
+  description: 'List the canonical face names available on a feature (top/bottom/left/right/front/back for box; top/bottom for cylinder; none for sphere or non-primitives) plus the total edge count. Pass { file?, code?, feature_id? }.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      file: { type: 'string' },
+      code: { type: 'string' },
+      feature_id: { type: 'string' },
+    },
+  },
+},
+{
+  name: 'get_edges_of',
+  description: 'Return the boundary edges of a named canonical face on an un-transformed primitive — index, centroid, length, isClosed. Mirrors ForgeCAD\'s edgesOf(). Pass { file?, code?, feature_id?, face_name: "top" | ... }.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      file: { type: 'string' },
+      code: { type: 'string' },
+      feature_id: { type: 'string' },
+      face_name: { type: 'string', enum: ['top', 'bottom', 'left', 'right', 'front', 'back'] },
+    },
+    required: ['face_name'],
+  },
+},
+{
+  name: 'why_did_this_fail',
+  description: 'Return the focused diagnostic view of one feature — its health, its own diagnostics, and the upstream chain (each upstream feature\'s id/kind/health). Use when fillet/chamfer/shell errors and the agent needs the dependency context. Pass { file?, code?, feature_id? }.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      file: { type: 'string' },
+      code: { type: 'string' },
+      feature_id: { type: 'string' },
+    },
+  },
+},
+```
+
+Add 3 cases to the switch in `setRequestHandler(CallToolRequestSchema, ...)`:
+
+```typescript
+case 'list_topology':
+  result = await listTopologyTool(input as Parameters<typeof listTopologyTool>[0]);
+  break;
+case 'get_edges_of':
+  result = await getEdgesOfTool(input as Parameters<typeof getEdgesOfTool>[0]);
+  break;
+case 'why_did_this_fail':
+  result = await whyDidThisFailTool(input as Parameters<typeof whyDidThisFailTool>[0]);
+  break;
+```
+
+Don't forget to import the 3 tool functions at the top of `server.ts`.
+
+- [ ] **Step 3: Add 3 spawn integration tests**
+
+In `tests/integration/mcp/spawn.test.ts`, append inside the `describe.skipIf(SKIP)` block:
+
+```typescript
+  it('responds to list_topology with canonical box face names', async () => {
+    const result = await callTool('list_topology', { code: 'return box(10, 10, 10);' });
+    const text = (result as { content: { text: string }[] }).content[0].text;
+    const payload = JSON.parse(text);
+    expect(payload.ok).toBe(true);
+    expect(payload.faceNames).toEqual(expect.arrayContaining(['top', 'bottom']));
+  }, 90000);
+
+  it('responds to get_edges_of with 4 edges of the top face of a box', async () => {
+    const result = await callTool('get_edges_of', { code: 'return box(20, 20, 20);', face_name: 'top' });
+    const text = (result as { content: { text: string }[] }).content[0].text;
+    const payload = JSON.parse(text);
+    expect(payload.ok).toBe(true);
+    expect(payload.edges).toHaveLength(4);
+  }, 90000);
+
+  it('responds to why_did_this_fail with healthy on a clean script', async () => {
+    const result = await callTool('why_did_this_fail', { code: 'return box(10, 10, 10);' });
+    const text = (result as { content: { text: string }[] }).content[0].text;
+    const payload = JSON.parse(text);
+    expect(payload.ok).toBe(true);
+    expect(payload.health).toBe('healthy');
+  }, 90000);
+```
+
+- [ ] **Step 4: Build + run integration tests**
+
+```bash
+npm run build:cli
+npx vitest run tests/integration/mcp/spawn.test.ts
+```
+
+Expected: 5/5 PASS (2 from v0.11-alpha + 3 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mcp/index.ts src/mcp/server.ts tests/integration/mcp/spawn.test.ts
+git commit -m "feat(mcp): register list_topology / get_edges_of / why_did_this_fail tools + spawn tests"
+```
+
+---
+
+## Phase 5: Tag
+
+### Task 5: v0.11.0 release
+
+- [ ] **Step 1: Bump version**
+
+In `package.json`:
+```json
+"version": "0.11.0-beta.1"
+```
+
+- [ ] **Step 2: Update CHANGELOG.md**
+
+Prepend:
+
+```markdown
+## v0.11.0 — 2026-04-30
+
+### Added
+- **3 new MCP read tools**:
+  - `list_topology(file?, code?, feature_id?)` — canonical face names + edge count for an introspected feature. Returns empty face list for non-primitives (no tracked topology yet).
+  - `get_edges_of(file?, code?, feature_id?, face_name)` — boundary edges of a named canonical face. Mirrors ForgeCAD's `edgesOf()`. Returns `[{ index, centroid, length, isClosed }]`.
+  - `why_did_this_fail(file?, code?, feature_id?)` — focused diagnostic view + upstream chain walk via DependencyGraph traversal.
+- 3 new spawn integration tests covering the new tools.
+
+### Changed
+- None — additive only.
+
+### Deferred to v0.11-rc / v0.12+
+- Human-readable hints in `why_did_this_fail` (mapping diagnostic codes to suggestions)
+- Geometric edge selection (`select_edges` mirroring ForgeCAD's `selectEdges` for non-primitive shapes)
+- AST-edit tools (v0.12)
+- HTTP transport (v0.11-rc)
+- Skill installer (v0.12)
+```
+
+Move the existing `## v0.11.0-alpha.1` entry below this one, preserving the rest of the changelog.
+
+- [ ] **Step 3: PR + merge + tag**
+
+```bash
+git add package.json CHANGELOG.md
+git commit -m "release: v0.11.0 — topology read tools (list_topology / get_edges_of / why_did_this_fail)"
+git push
+gh pr create --base develop --head feat/v0.11-beta-mcp-topology \
+  --title "feat(v0.11-beta): MCP topology read tools" \
+  --body "..."
+```
+
+After qc passes, squash-merge, then:
+
+```bash
+git checkout develop
+git pull --ff-only origin develop
+git tag v0.11.0
+git push origin v0.11.0
+```
+
+The tag triggers Pages deploy (orthogonal to MCP changes — Pages still serves the web demo unchanged).
+
+- [ ] **Step 4: Optional smoke-test against a real MCP client**
+
+If you have a local MCP-aware client (Claude Code, etc.), point it at the new bundled `dist/cli/index.js mcp` and verify all 6 tools (3 from alpha + 3 from beta) appear and execute correctly. Capture any usability findings as v0.11-rc input.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- 3 tools defined and tested unit + integration — Tasks 1-4
+- Server registration + integration tests — Task 4
+- Release — Task 5
+
+**Placeholder scan:** No "TBD" / "TODO" / "implement later". Each step has actual code or commands.
+
+**Type consistency:**
+- `ListTopologyInput / Output`, `GetEdgesOfInput / Output`, `WhyDidThisFailInput / Output` — defined in their respective Task files; reused unchanged in Task 4 (server) and Task 5 (re-exports).
+- `EdgeInfo` and `UpstreamFeature` — local to their tools; not shared cross-module.
+- `OcctBackend.kind?` — read in `listTopologyTool` (Task 1); set in v0.2-alpha.
+
+**Replicad API risks:**
+- `EdgeInfo` math uses `e.startPoint`, `e.endPoint`, `e.length` properties on Replicad's `Edge` class. Task 2 Step 3 explicitly tells the implementer to verify in `node_modules/replicad/dist/replicad.d.ts` and adapt. Most likely shape: `startPoint: Vector` with `.x/.y/.z` accessors. If `length` is a getter not a method, the code as written works.
+
+**Scope check:** All 3 tools are read-only, share the existing recompute pipeline, and don't widen any kernel surface. This is the right size for a single PR / single subagent-driven session.
+
+**Open questions acknowledged:**
+- "Hints" in `why_did_this_fail` — explicit deferral, called out in CHANGELOG.
+- Edge centroid is midpoint approximation, not the true geometric centroid. For straight edges they match; for arcs/circles they diverge. Acceptable for v0.11-beta; if agent feedback says it's misleading, tighten in rc.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-30-v0.11-beta-mcp-topology.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — fresh subagent per task with two-stage review.
+
+**2. Inline Execution** — execute tasks in this session with checkpoints.
+
+Pick one to proceed.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kernelcad",
   "private": true,
-  "version": "0.11.0-alpha.1",
+  "version": "0.11.0",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -3,3 +3,6 @@ export { createMcpServer } from './server';
 export { evaluateScriptTool, type EvaluateScriptInput, type EvaluateScriptOutput } from './tools/evaluateScript';
 export { listFeaturesTool, type ListFeaturesInput, type ListFeaturesOutput } from './tools/listFeatures';
 export { getShapeInfoTool, type GetShapeInfoInput, type GetShapeInfoOutput } from './tools/getShapeInfo';
+export { listTopologyTool, type ListTopologyInput, type ListTopologyOutput } from './tools/listTopology';
+export { getEdgesOfTool, type GetEdgesOfInput, type GetEdgesOfOutput } from './tools/getEdgesOf';
+export { whyDidThisFailTool, type WhyDidThisFailInput, type WhyDidThisFailOutput } from './tools/whyDidThisFail';

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -5,6 +5,9 @@ import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprot
 import { evaluateScriptTool } from './tools/evaluateScript';
 import { listFeaturesTool } from './tools/listFeatures';
 import { getShapeInfoTool } from './tools/getShapeInfo';
+import { listTopologyTool } from './tools/listTopology';
+import { getEdgesOfTool } from './tools/getEdgesOf';
+import { whyDidThisFailTool } from './tools/whyDidThisFail';
 
 const TOOLS = [
   {
@@ -50,6 +53,44 @@ const TOOLS = [
       },
     },
   },
+  {
+    name: 'list_topology',
+    description: 'List the canonical face names available on a feature (top/bottom/left/right/front/back for box; top/bottom for cylinder; none for sphere or non-primitives) plus the total edge count. Pass { file?, code?, feature_id? }.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        file: { type: 'string' },
+        code: { type: 'string' },
+        feature_id: { type: 'string' },
+      },
+    },
+  },
+  {
+    name: 'get_edges_of',
+    description: "Return the boundary edges of a named canonical face on an un-transformed primitive — index, centroid, length, isClosed. Mirrors ForgeCAD's edgesOf(). Pass { file?, code?, feature_id?, face_name: 'top' | ... }.",
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        file: { type: 'string' },
+        code: { type: 'string' },
+        feature_id: { type: 'string' },
+        face_name: { type: 'string', enum: ['top', 'bottom', 'left', 'right', 'front', 'back'] },
+      },
+      required: ['face_name'],
+    },
+  },
+  {
+    name: 'why_did_this_fail',
+    description: "Return the focused diagnostic view of one feature — its health, its own diagnostics, the upstream chain (each upstream feature's id/kind/health), and human-readable hints for known diagnostic codes. Use when fillet/chamfer/shell errors and the agent needs the dependency context. Pass { file?, code?, feature_id? }.",
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        file: { type: 'string' },
+        code: { type: 'string' },
+        feature_id: { type: 'string' },
+      },
+    },
+  },
 ];
 
 export function createMcpServer(): Server {
@@ -80,6 +121,15 @@ export function createMcpServer(): Server {
         result = await getShapeInfoTool(
           input as Parameters<typeof getShapeInfoTool>[0],
         );
+        break;
+      case 'list_topology':
+        result = await listTopologyTool(input as Parameters<typeof listTopologyTool>[0]);
+        break;
+      case 'get_edges_of':
+        result = await getEdgesOfTool(input as unknown as Parameters<typeof getEdgesOfTool>[0]);
+        break;
+      case 'why_did_this_fail':
+        result = await whyDidThisFailTool(input as Parameters<typeof whyDidThisFailTool>[0]);
         break;
       default:
         throw new Error(`Unknown tool: ${name}`);

--- a/src/mcp/tools/getEdgesOf.ts
+++ b/src/mcp/tools/getEdgesOf.ts
@@ -1,0 +1,108 @@
+// src/mcp/tools/getEdgesOf.ts
+import { runScript } from '../../script-runtime/runScript';
+import { RecomputeEngine } from '../../compute/recomputeEngine';
+import { OcctLowerer } from '../../backends/occt/occtLowerer';
+import { initOcct, OcctBackend } from '../../backends/occt/occtBackend';
+import { pickEdges } from '../../backends/occt/edgeSelection';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import type { FeatureRecord } from '../../intent/featureRecord';
+
+export interface GetEdgesOfInput {
+  file?: string;
+  code?: string;
+  feature_id?: string;
+  face_name: 'top' | 'bottom' | 'left' | 'right' | 'front' | 'back';
+}
+
+export interface EdgeInfo {
+  index: number;
+  centroid: [number, number, number];
+  length: number;
+  isClosed: boolean;
+}
+
+export interface GetEdgesOfOutput {
+  ok: boolean;
+  edges?: EdgeInfo[];
+  error?: string;
+}
+
+export async function getEdgesOfTool(input: GetEdgesOfInput): Promise<GetEdgesOfOutput> {
+  await initOcct();
+
+  if (!input.face_name) {
+    return { ok: false, error: 'face_name is required.' };
+  }
+
+  let code: string;
+  let fileName: string;
+  if (input.code !== undefined) {
+    code = input.code;
+    fileName = input.file ?? '<inline>';
+  } else if (input.file !== undefined) {
+    const filePath = resolve(input.file);
+    fileName = filePath;
+    try {
+      code = await readFile(filePath, 'utf8');
+    } catch (e) {
+      return { ok: false, error: `Cannot read file: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  } else {
+    return { ok: false, error: 'Must provide either { file } or { code }.' };
+  }
+
+  let run;
+  try {
+    run = await runScript({ code, fileName });
+  } catch (e) {
+    return { ok: false, error: `Script execution failed: ${e instanceof Error ? e.message : String(e)}` };
+  }
+
+  if (run.records.length === 0) return { ok: false, error: 'Script produced no features.' };
+  const targetId = input.feature_id ?? run.records[run.records.length - 1].id;
+  const targetRecord = run.records.find(r => r.id === targetId);
+  if (!targetRecord) return { ok: false, error: `feature_id '${targetId}' not found.` };
+
+  const engine = new RecomputeEngine(new OcctLowerer());
+  const result = await engine.run(run.records);
+  const shape = result.shapes.get(targetId);
+  if (!shape) return { ok: false, error: `Feature '${targetId}' did not lower successfully.` };
+
+  // Build a synthetic FeatureRecord with a face-input pointing at this feature, so we can
+  // reuse pickEdges. The fields beyond inputs/kind don't matter for edge resolution.
+  const synthetic: FeatureRecord = {
+    id: '<query>',
+    kind: 'fillet',
+    params: { radius: { expression: '0', unit: 'mm', evaluated: 0 } },
+    inputs: {
+      base: { kind: 'feature', id: targetId },
+      face: {
+        kind: 'face',
+        featureId: targetId,
+        ref: { kind: 'canonical', face: input.face_name },
+      },
+    },
+    transforms: [],
+    suppressed: false,
+  };
+
+  const edgesResult = pickEdges(synthetic, shape as OcctBackend);
+  if ('error' in edgesResult) {
+    return { ok: false, error: edgesResult.error.message };
+  }
+
+  // Replicad's _1DShape.pointAt(t∈[0,1]) gives the proper parametric midpoint —
+  // correct for arcs/circles, not just straight edges.
+  const edges: EdgeInfo[] = edgesResult.map((e, i) => {
+    const mid = e.pointAt(0.5);
+    return {
+      index: i,
+      centroid: [mid.x, mid.y, mid.z] as [number, number, number],
+      length: e.length,
+      isClosed: e.isClosed,
+    };
+  });
+
+  return { ok: true, edges };
+}

--- a/src/mcp/tools/listTopology.ts
+++ b/src/mcp/tools/listTopology.ts
@@ -1,0 +1,93 @@
+// src/mcp/tools/listTopology.ts
+import { runScript } from '../../script-runtime/runScript';
+import { RecomputeEngine } from '../../compute/recomputeEngine';
+import { OcctLowerer } from '../../backends/occt/occtLowerer';
+import { initOcct, OcctBackend } from '../../backends/occt/occtBackend';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+export interface ListTopologyInput {
+  file?: string;
+  code?: string;
+  feature_id?: string;
+}
+
+export interface ListTopologyOutput {
+  ok: boolean;
+  hasTrackedTopology?: boolean;
+  faceNames?: string[];
+  edgeCount?: number;
+  error?: string;
+}
+
+const BOX_FACES = ['top', 'bottom', 'left', 'right', 'front', 'back'] as const;
+const CYLINDER_FACES = ['top', 'bottom'] as const;
+
+export async function listTopologyTool(input: ListTopologyInput): Promise<ListTopologyOutput> {
+  await initOcct();
+
+  let code: string;
+  let fileName: string;
+
+  if (input.code !== undefined) {
+    code = input.code;
+    fileName = input.file ?? '<inline>';
+  } else if (input.file !== undefined) {
+    const filePath = resolve(input.file);
+    fileName = filePath;
+    try {
+      code = await readFile(filePath, 'utf8');
+    } catch (e) {
+      return { ok: false, error: `Cannot read file: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  } else {
+    return { ok: false, error: 'Must provide either { file } or { code }.' };
+  }
+
+  let run;
+  try {
+    run = await runScript({ code, fileName });
+  } catch (e) {
+    return { ok: false, error: `Script execution failed: ${e instanceof Error ? e.message : String(e)}` };
+  }
+
+  if (run.records.length === 0) return { ok: false, error: 'Script produced no features.' };
+
+  const targetId = input.feature_id ?? run.records[run.records.length - 1].id;
+  if (!run.records.some(r => r.id === targetId)) {
+    return { ok: false, error: `feature_id '${targetId}' not found.` };
+  }
+
+  const engine = new RecomputeEngine(new OcctLowerer());
+  const result = await engine.run(run.records);
+  const shape = result.shapes.get(targetId);
+  if (!shape) return { ok: false, error: `Feature '${targetId}' did not lower successfully.` };
+
+  const occt = shape as OcctBackend;
+  let faceNames: string[];
+  let hasTrackedTopology: boolean;
+
+  switch (occt.kind) {
+    case 'box':
+      faceNames = [...BOX_FACES];
+      hasTrackedTopology = true;
+      break;
+    case 'cylinder':
+      faceNames = [...CYLINDER_FACES];
+      hasTrackedTopology = true;
+      break;
+    case 'sphere':
+      faceNames = [];
+      hasTrackedTopology = true;
+      break;
+    default:
+      faceNames = [];
+      hasTrackedTopology = false;
+      break;
+  }
+
+  const replicadShape = occt.getReplicadShape();
+  const edgeCount = replicadShape.edges.length;
+
+  return { ok: true, hasTrackedTopology, faceNames, edgeCount };
+}

--- a/src/mcp/tools/whyDidThisFail.ts
+++ b/src/mcp/tools/whyDidThisFail.ts
@@ -1,0 +1,170 @@
+// src/mcp/tools/whyDidThisFail.ts
+import { runScript } from '../../script-runtime/runScript';
+import { RecomputeEngine } from '../../compute/recomputeEngine';
+import { OcctLowerer } from '../../backends/occt/occtLowerer';
+import { initOcct } from '../../backends/occt/occtBackend';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import type { FeatureKind } from '../../intent/types';
+import type { CompilerDiagnostic } from '../../diagnostics/diagnostic';
+
+export interface WhyDidThisFailInput {
+  file?: string;
+  code?: string;
+  feature_id?: string;
+}
+
+export interface UpstreamFeature {
+  feature_id: string;
+  kind: FeatureKind;
+  health: 'healthy' | 'warning' | 'error' | 'unknown';
+}
+
+export interface WhyDidThisFailOutput {
+  ok: boolean;
+  feature_id?: string;
+  kind?: FeatureKind;
+  health?: 'healthy' | 'warning' | 'error' | 'unknown';
+  diagnostics?: CompilerDiagnostic[];
+  upstream?: UpstreamFeature[];
+  /** Human-readable suggestions, one per unique diagnostic code in `diagnostics`. */
+  hints?: string[];
+  error?: string;
+}
+
+/**
+ * Maps known diagnostic codes to one-line human-readable suggestions. Keep entries
+ * tight — agents will paste them into chat/edit explanations. Unknown codes are
+ * silently absent from `hints`.
+ *
+ * Codes verified by grepping: src/backends/occt/edgeSelection.ts,
+ * src/backends/occt/occtLowerer.ts, src/compute/recomputeEngine.ts,
+ * src/cli/commands/evaluate.ts, src/cli/commands/export.ts,
+ * src/script-runtime/export.ts.
+ *
+ * Dropped (never emitted): feature.edge-feature.face-ref-on-non-primitive
+ * Added (emitted but missing from original plan): feature.fillet.no-base,
+ * feature.fillet.no-radius, feature.chamfer.no-base, feature.chamfer.no-distance,
+ * feature.shell.no-base, feature.shell.no-thickness,
+ * feature.extrude.unsupported-profile, feature.revolve.unsupported-profile,
+ * cli.no-input, cli.export.exception, export.no-shape, export.shape-not-lowered.
+ */
+const HINTS: Record<string, string> = {
+  'feature.fillet.failed': "OCCT could not apply that fillet. Try a smaller radius — typically less than half of the smallest face dimension.",
+  'feature.fillet.no-base': "Fillet has no base shape. Ensure the fillet is chained onto a solid shape (e.g. box(10, 10, 10).fillet(1)).",
+  'feature.fillet.no-radius': "Fillet is missing a radius parameter. Pass a positive number as the first argument (e.g. .fillet(2)).",
+  'feature.chamfer.failed': "OCCT could not apply that chamfer. Try a smaller distance — typically less than half of the smallest face dimension.",
+  'feature.chamfer.no-base': "Chamfer has no base shape. Ensure the chamfer is chained onto a solid shape (e.g. box(10, 10, 10).chamfer(1)).",
+  'feature.chamfer.no-distance': "Chamfer is missing a distance parameter. Pass a positive number as the first argument (e.g. .chamfer(2)).",
+  'feature.shell.failed': "OCCT could not shell that solid. Try a thinner wall or a different open face. Thickness must be smaller than the shape's minimum thickness.",
+  'feature.shell.no-base': "Shell has no base shape. Ensure the shell is chained onto a solid shape.",
+  'feature.shell.no-thickness': "Shell is missing a thickness parameter. Pass a positive number as the first argument (e.g. .shell(1)).",
+  'feature.extrude.unsupported-profile': "The extrude profile is not a supported 2D sketch type. Ensure you pass a sketch or closed wire as the profile.",
+  'feature.revolve.unsupported-profile': "The revolve profile is not a supported 2D sketch type. Ensure you pass a sketch or closed wire as the profile.",
+  'feature.edge-feature.face-ref-not-resolvable': "Canonical face refs (e.g. { face: 'top' }) only work on un-transformed primitives. Apply transforms after the fillet/chamfer instead of before, or fillet the primitive first then translate.",
+  'feature.edge-feature.face-ref-not-applicable': "That canonical face name is not valid for this primitive. Boxes have all six (top/bottom/left/right/front/back); cylinders have only top/bottom; spheres have none.",
+  'feature.edge-feature.face-ref-not-supported': "Only canonical face refs are supported in v0.2-alpha. Apply fillet/chamfer without a face filter, or use a canonical face name like { face: 'top' }.",
+  'feature.face-feature.face-required': "Shell needs a face to remove. Pass `{ face: 'top' }` (or another canonical face name applicable to the base primitive).",
+  'feature.face-feature.face-ref-not-resolvable': "Same constraint as edge features: canonical face refs only work on un-transformed primitives. Apply shell before transforms.",
+  'feature.face-feature.face-ref-not-applicable': "That canonical face is not valid for this primitive. Cylinders accept only top/bottom for shell; spheres have no canonical faces.",
+  'feature.face-feature.face-ref-not-supported': "Only canonical face refs are supported in v0.2-alpha. Tracked / created / propagated face refs land in v0.2 full.",
+  'recompute.input.missing': "An upstream feature failed or was suppressed. Use `why_did_this_fail` on the upstream feature ID to find the root cause.",
+  'recompute.lowering.exception': "An exception was raised during lowering. Check the diagnostic message for the OCCT error.",
+  'cli.script.exception': "Your script raised an exception during execution. Check the diagnostic message for the JS error.",
+  'cli.file.read': "kernelCAD could not read the script file at that path. Check the file exists and is readable.",
+  'cli.no-input': "No input provided to the CLI command. Pass either a file path or inline code.",
+  'cli.export.exception': "An exception occurred during export. Check the diagnostic message for details.",
+  'export.no-shape': "The script did not return a shape. Ensure your script ends with `return <shape>`.",
+  'export.shape-not-lowered': "The returned shape could not be lowered to OCCT. Check for upstream errors in the feature tree.",
+};
+
+function buildHints(diagnostics: readonly CompilerDiagnostic[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const d of diagnostics) {
+    if (!seen.has(d.code) && HINTS[d.code]) {
+      seen.add(d.code);
+      out.push(HINTS[d.code]);
+    }
+  }
+  return out;
+}
+
+export async function whyDidThisFailTool(input: WhyDidThisFailInput): Promise<WhyDidThisFailOutput> {
+  await initOcct();
+
+  let code: string;
+  let fileName: string;
+  if (input.code !== undefined) {
+    code = input.code;
+    fileName = input.file ?? '<inline>';
+  } else if (input.file !== undefined) {
+    const filePath = resolve(input.file);
+    fileName = filePath;
+    try {
+      code = await readFile(filePath, 'utf8');
+    } catch (e) {
+      return { ok: false, error: `Cannot read file: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  } else {
+    return { ok: false, error: 'Must provide either { file } or { code }.' };
+  }
+
+  let run;
+  try {
+    run = await runScript({ code, fileName });
+  } catch (e) {
+    return { ok: false, error: `Script execution failed: ${e instanceof Error ? e.message : String(e)}` };
+  }
+
+  if (run.records.length === 0) return { ok: false, error: 'Script produced no features.' };
+
+  const targetId = input.feature_id ?? run.records[run.records.length - 1].id;
+  const targetRecord = run.records.find(r => r.id === targetId);
+  if (!targetRecord) return { ok: false, error: `feature_id '${targetId}' not found.` };
+
+  const engine = new RecomputeEngine(new OcctLowerer());
+  const result = await engine.run(run.records);
+
+  const ownDiagnostics = result.diagnostics.filter(d => d.featureId === targetId);
+  const targetHealth = result.health.get(targetId) ?? (result.shapes.has(targetId) ? 'healthy' : 'unknown');
+
+  // Walk upstream by following inputs (BFS through the feature graph)
+  const upstream: UpstreamFeature[] = [];
+  const visited = new Set<string>();
+  const queue: string[] = [];
+  for (const ref of Object.values(targetRecord.inputs)) {
+    const upId = ref.kind === 'feature' ? ref.id : ref.featureId;
+    if (upId && !visited.has(upId)) {
+      visited.add(upId);
+      queue.push(upId);
+    }
+  }
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    const rec = run.records.find(r => r.id === id);
+    if (!rec) continue;
+    upstream.push({
+      feature_id: id,
+      kind: rec.kind,
+      health: result.health.get(id) ?? (result.shapes.has(id) ? 'healthy' : 'unknown'),
+    });
+    for (const ref of Object.values(rec.inputs)) {
+      const upId = ref.kind === 'feature' ? ref.id : ref.featureId;
+      if (upId && !visited.has(upId)) {
+        visited.add(upId);
+        queue.push(upId);
+      }
+    }
+  }
+
+  return {
+    ok: true,
+    feature_id: targetId,
+    kind: targetRecord.kind,
+    health: targetHealth,
+    diagnostics: ownDiagnostics,
+    upstream,
+    hints: buildHints(ownDiagnostics),
+  };
+}

--- a/tests/integration/mcp/spawn.test.ts
+++ b/tests/integration/mcp/spawn.test.ts
@@ -100,4 +100,28 @@ describe.skipIf(SKIP)('MCP server (spawn)', () => {
     const payload = JSON.parse(text);
     expect(payload.features.map((f: { kind: string }) => f.kind)).toEqual(['box', 'fillet']);
   }, 90000);
+
+  it('responds to list_topology with canonical box face names', async () => {
+    const result = await callTool('list_topology', { code: 'return box(10, 10, 10);' });
+    const text = (result as { content: { text: string }[] }).content[0].text;
+    const payload = JSON.parse(text);
+    expect(payload.ok).toBe(true);
+    expect(payload.faceNames).toEqual(expect.arrayContaining(['top', 'bottom']));
+  }, 90000);
+
+  it('responds to get_edges_of with 4 edges of the top face of a box', async () => {
+    const result = await callTool('get_edges_of', { code: 'return box(20, 20, 20);', face_name: 'top' });
+    const text = (result as { content: { text: string }[] }).content[0].text;
+    const payload = JSON.parse(text);
+    expect(payload.ok).toBe(true);
+    expect(payload.edges).toHaveLength(4);
+  }, 90000);
+
+  it('responds to why_did_this_fail with healthy on a clean script', async () => {
+    const result = await callTool('why_did_this_fail', { code: 'return box(10, 10, 10);' });
+    const text = (result as { content: { text: string }[] }).content[0].text;
+    const payload = JSON.parse(text);
+    expect(payload.ok).toBe(true);
+    expect(payload.health).toBe('healthy');
+  }, 90000);
 });

--- a/tests/unit/mcp/tools/getEdgesOf.test.ts
+++ b/tests/unit/mcp/tools/getEdgesOf.test.ts
@@ -1,0 +1,49 @@
+// tests/unit/mcp/tools/getEdgesOf.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { getEdgesOfTool } from '../../../../src/mcp/tools/getEdgesOf';
+import { initOcct } from '../../../../src/backends/occt/occtBackend';
+
+describe('getEdgesOfTool', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('returns 4 edges for the top face of a box', async () => {
+    const result = await getEdgesOfTool({
+      code: `return box(20, 20, 20);`,
+      face_name: 'top',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.edges).toHaveLength(4);
+    for (const e of result.edges!) {
+      expect(e.centroid).toHaveLength(3);
+      expect(e.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns 1 edge for the top face of a cylinder (the circle)', async () => {
+    const result = await getEdgesOfTool({
+      code: `return cylinder(10, 5);`,
+      face_name: 'top',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges![0].isClosed).toBe(true);
+  });
+
+  it('errors when face_name is not applicable', async () => {
+    const result = await getEdgesOfTool({
+      code: `return cylinder(10, 5);`,
+      face_name: 'left',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not applicable/i);
+  });
+
+  it('errors when applied to a non-primitive', async () => {
+    const result = await getEdgesOfTool({
+      code: `return box(10, 10, 10).subtract(cylinder(10, 3));`,
+      face_name: 'top',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/un-transformed primitive|not.resolvable/i);
+  });
+});

--- a/tests/unit/mcp/tools/listTopology.test.ts
+++ b/tests/unit/mcp/tools/listTopology.test.ts
@@ -1,0 +1,52 @@
+// tests/unit/mcp/tools/listTopology.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { listTopologyTool } from '../../../../src/mcp/tools/listTopology';
+import { initOcct } from '../../../../src/backends/occt/occtBackend';
+
+describe('listTopologyTool', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('returns canonical face names for an un-transformed box', async () => {
+    const result = await listTopologyTool({ code: `return box(10, 10, 10);` });
+    expect(result.ok).toBe(true);
+    expect(result.hasTrackedTopology).toBe(true);
+    expect(result.faceNames).toEqual(
+      expect.arrayContaining(['top', 'bottom', 'left', 'right', 'front', 'back']),
+    );
+    expect(result.edgeCount).toBe(12);
+  });
+
+  it('returns just top/bottom for a cylinder', async () => {
+    const result = await listTopologyTool({ code: `return cylinder(10, 5);` });
+    expect(result.ok).toBe(true);
+    expect(result.hasTrackedTopology).toBe(true);
+    expect(result.faceNames!.sort()).toEqual(['bottom', 'top']);
+  });
+
+  it('returns no canonical names for a sphere', async () => {
+    const result = await listTopologyTool({ code: `return sphere(5);` });
+    expect(result.ok).toBe(true);
+    expect(result.hasTrackedTopology).toBe(true);
+    expect(result.faceNames).toEqual([]);
+  });
+
+  it('returns hasTrackedTopology=false for a boolean result', async () => {
+    const result = await listTopologyTool({
+      code: `
+        const a = box(10, 10, 10);
+        const b = cylinder(10, 3).translate(0, 0, -1);
+        return a.subtract(b);
+      `,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.hasTrackedTopology).toBe(false);
+    expect(result.faceNames).toEqual([]);
+    expect(result.edgeCount).toBeGreaterThan(0);
+  });
+
+  it('errors when feature_id is not found', async () => {
+    const result = await listTopologyTool({ code: `return box(10, 10, 10);`, feature_id: 'nope' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+  });
+});

--- a/tests/unit/mcp/tools/whyDidThisFail.test.ts
+++ b/tests/unit/mcp/tools/whyDidThisFail.test.ts
@@ -1,0 +1,48 @@
+// tests/unit/mcp/tools/whyDidThisFail.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { whyDidThisFailTool } from '../../../../src/mcp/tools/whyDidThisFail';
+import { initOcct } from '../../../../src/backends/occt/occtBackend';
+
+describe('whyDidThisFailTool', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('reports healthy for a clean script', async () => {
+    const result = await whyDidThisFailTool({ code: `return box(10, 10, 10);` });
+    expect(result.ok).toBe(true);
+    expect(result.health).toBe('healthy');
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it('reports error + diagnostic when fillet radius is too large', async () => {
+    const result = await whyDidThisFailTool({
+      code: `return box(10, 10, 10).fillet(100);`,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.health).toBe('error');
+    expect(result.diagnostics!.length).toBeGreaterThan(0);
+    expect(result.diagnostics![0].code).toBe('feature.fillet.failed');
+  });
+
+  it('walks upstream chain when downstream cascades', async () => {
+    const result = await whyDidThisFailTool({
+      code: `return box(10, 10, 10).translate(5, 0, 0).fillet(2, { face: 'top' });`,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.health).toBe('error');
+    expect(result.upstream!.length).toBeGreaterThan(0);
+    expect(result.upstream![0].kind).toBe('box');
+    expect(result.upstream![0].health).toBe('healthy');
+  });
+
+  it('errors when feature_id is not found', async () => {
+    const result = await whyDidThisFailTool({ code: `return box(10, 10, 10);`, feature_id: 'nope' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+  });
+
+  it('returns hints for known diagnostic codes', async () => {
+    const result = await whyDidThisFailTool({ code: `return box(10, 10, 10).fillet(100);` });
+    expect(result.ok).toBe(true);
+    expect(result.hints).toEqual(expect.arrayContaining([expect.stringMatching(/smaller radius/i)]));
+  });
+});


### PR DESCRIPTION
## Summary

Closes the v0.11 MCP read-tools milestone with 3 new topology tools, bringing the total to 6.

\`\`\`
list_topology      — canonical face names + edge count
get_edges_of       — boundary edges of a face (true parametric centroid)
why_did_this_fail  — focused diagnostics + upstream chain + 26-entry hints lookup
\`\`\`

5 commits across 5 phases (3 tools + server registration + release).

## Strategic context

Per the ForgeCAD-alignment review earlier in the session, this surface mirrors ForgeCAD's \`edgesOf(faceName)\` pattern but adds the **hints field** as a kernelCAD-specific improvement: the MCP server returns one-line human-readable suggestions for known diagnostic codes, eliminating the round-trip to docs that ForgeCAD's skill-based approach requires.

## Test plan
- [x] \`npm run typecheck\` — 0 errors
- [x] \`npm run lint\` — 0 errors
- [x] \`npm test\` — 465/490 passing (25 pre-existing skips)
- [x] \`npm run build:cli\` — bundle works with all 6 tools
- [x] **Integration test (spawn + JSON-RPC)** — 5/5 tools verified end-to-end through subprocess + JSON-RPC: \`evaluate_script\`, \`list_features\`, \`list_topology\`, \`get_edges_of\`, \`why_did_this_fail\`
- [x] Hints expansion: implementer grepped kernel for actually-emitted diagnostic codes, expanded the lookup from ~14 (planned) to 26 (real) entries
- [x] Centroid math verified: \`edge.pointAt(0.5)\` (parametric midpoint) used for both straight edges and arcs/circles

## Sample agent invocation (unchanged from alpha)

\`\`\`json
{
  "mcpServers": {
    "kernelcad": {
      "command": "node",
      "args": ["/path/to/dist/cli/index.js", "mcp"]
    }
  }
}
\`\`\`

## Deferred to v0.12

- AST-edit tools (NORTHSTAR roadmap)
- \`select_edges\` for non-primitive shapes (ForgeCAD's \`selectEdges\` mirror)
- HTTP transport
- Skill installer