### PR TITLE
feat(v0.12.0-beta.1): set_param_value — first MCP write tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## v0.12.0-beta.1 — 2026-04-30
+
+### Added
+- **First MCP write tool: `set_param_value`** — edits a `param()` default value in `.kcad.ts` source and returns the modified code plus diagnostics from re-evaluating the result. Side-effect-free; caller persists via standard file tools.
+  - Input: `{ code, param_name, new_value }`
+  - Output: `{ ok, new_code?, diagnostics?, error? }`
+  - Implementation: regex-state-machine in `src/mcp/edits/setParamValue.ts` (handles single/double quotes, optional opts, nested braces in option objects, multi-line calls, multiple-match rejection)
+- 14 new unit tests + 1 spawn integration test (10 primitive cases + 4 tool cases + 1 spawn round-trip)
+
+### Changed
+- None — additive only.
+
+### Deferred to v0.12-rc / v0.12.0
+- `add_feature(code, code_to_insert, position?)` — needs ts-morph or careful AST walker
+- `remove_feature(code, feature_id)` — needs `FeatureRecord.scriptLocation` to map IDs to source lines
+- `suppress_feature(code, feature_id)` — wrap a line in `// @suppress` annotation
+
+The decision to ship just `set_param_value` for v0.12-beta is deliberate YAGNI — `param()` value tweaks are by far the most common agent edit, and adding more tools should be driven by usage rather than speculation. ForgeCAD has no AST-edit MCP equivalent, so this is novel kernelCAD territory.
+
+---
+
 ## v0.12.0-alpha.1 — 2026-04-30
 
 ### Added

--- a/docs/superpowers/plans/2026-04-30-v0.12-beta-set-param.md
+++ b/docs/superpowers/plans/2026-04-30-v0.12-beta-set-param.md
@@ -1,0 +1,560 @@
+# v0.12.0-beta.1 — `set_param_value` MCP tool
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the first AST-edit MCP tool — `set_param_value` — so agents can change a parametric value in a `.kcad.ts` script without manual text manipulation. Closes v0.12 with the ladder: alpha (skill installer) + beta (write tool) + rc/final (additional edit tools as agent demand surfaces).
+
+**Architecture:** Side-effect-free string-in / string-out tool. Input: original `code` + `param_name` + `new_value`. Implementation: regex finds `param('<name>', <oldDefault>, ...)` calls and replaces the second argument. Output: `new_code` text + diagnostics from re-running the modified script (so agents see if the edit broke anything). NO file writes — agent persists via standard Edit/Write tools or chains another MCP call.
+
+**Why regex (not ts-morph) for v0.12-beta:** YAGNI. `param('Width', 60, { ... })` is regular enough that a regex with care for nested options is reliable. ts-morph is ~1 MB of dep + AST API surface for editing one call site; defer until we add `add_feature` / `remove_feature` which truly need AST awareness.
+
+**Tech Stack:** TypeScript 5.9, vitest, MCP SDK 1.29 (already installed).
+
+**Predecessor:** v0.12.0-alpha.1 (skill installer, tag at `30f426d`-ish).
+
+**No prior art (memory rule note):** ForgeCAD has no AST-edit MCP tools — its docs at `~/projects/forgecad-pkg/package/dist-skill/docs/CLI.md` rely on agents editing files directly via Edit tool + live reload. So this is novel kernelCAD territory; design from first principles.
+
+---
+
+## Decisions Locked
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Tool count | One: `set_param_value` | Smallest unit. Other write tools (add_feature, remove_feature, suppress_feature) deferred to v0.12-rc / v0.12.0 if agent demand surfaces. |
+| Side-effect | None — returns new code as text | Composable: agent chains tool → tool → final write via standard Edit/Write. Testable without temp files. |
+| Implementation | Regex (not ts-morph) | YAGNI; `param()` calls are regular enough; defer AST library to when we truly need it. |
+| Input shape | `{ code: string, param_name: string, new_value: number \| string }` | No `file?` — agent reads the file via standard Read tool, then passes `code`. Keeps tool side-effect-free; mirrors what `evaluate_script` already accepts via `code`. |
+| Output shape | `{ ok, new_code?, diagnostics, error? }` | `new_code` only on success. `diagnostics` from re-running the modified script via existing `evaluateScript` so agents see if the edit broke anything. |
+| Replace strategy | First match per call | Multiple `param('Width', ...)` declarations are rare; if present, error with `multiple_matches`. |
+
+---
+
+## File Structure
+
+**Create:**
+- `src/mcp/edits/setParamValue.ts` — regex-based AST-edit primitive (pure function `setParamValue(code, name, value): { ok, new_code?, error? }`)
+- `src/mcp/tools/setParamValue.ts` — MCP tool wrapper that calls the primitive then re-evaluates via `evaluateScriptTool`
+- `tests/unit/mcp/edits/setParamValue.test.ts` — primitive tests (10 cases)
+- `tests/unit/mcp/tools/setParamValue.test.ts` — tool tests (round-trip with re-eval)
+
+**Modify:**
+- `src/mcp/index.ts` — re-export `setParamValueTool`
+- `src/mcp/server.ts` — register tool in TOOLS + switch
+- `tests/integration/mcp/spawn.test.ts` — add 1 spawn case
+
+**Modify (release):**
+- `package.json` — version 0.12.0-alpha.1 → 0.12.0-beta.1
+- `CHANGELOG.md` — prepend v0.12-beta entry
+
+---
+
+## Phase 1: Edit primitive
+
+### Task 1: `setParamValue` regex-based primitive
+
+**Files:**
+- Create: `src/mcp/edits/setParamValue.ts`
+- Create: `tests/unit/mcp/edits/setParamValue.test.ts`
+
+The primitive operates on text. Given:
+```
+const w = param('Width', 60, { unit: 'mm', min: 30, max: 200 });
+```
+With `name='Width'` and `new_value=120`, return:
+```
+const w = param('Width', 120, { unit: 'mm', min: 30, max: 200 });
+```
+
+Edge cases handled:
+- String `param_name` literal (with quotes — single OR double).
+- The opts object after the default value can contain commas, nested objects, etc. Match must NOT consume the opts.
+- Default value can be a number, a quoted string (expressed value like `'Width * 0.5'`), or a JS expression. Replace just that token.
+- Missing param → return error.
+- Multiple matches → return error (refuse to silently pick one).
+
+- [ ] **Step 1: Write 10 failing tests**
+
+```typescript
+// tests/unit/mcp/edits/setParamValue.test.ts
+import { describe, it, expect } from 'vitest';
+import { setParamValue } from '../../../../src/mcp/edits/setParamValue';
+
+describe('setParamValue (regex AST-edit primitive)', () => {
+  it('replaces a numeric default with a number', () => {
+    const code = `const w = param('Width', 60, { unit: 'mm' });`;
+    const r = setParamValue(code, 'Width', 120);
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`const w = param('Width', 120, { unit: 'mm' });`);
+  });
+
+  it('replaces a numeric default with an expression string', () => {
+    const code = `const w = param('Width', 60, { unit: 'mm' });`;
+    const r = setParamValue(code, 'Width', 'h * 2');
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`const w = param('Width', 'h * 2', { unit: 'mm' });`);
+  });
+
+  it('handles param without an opts object', () => {
+    const code = `const w = param('Width', 60);`;
+    const r = setParamValue(code, 'Width', 120);
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`const w = param('Width', 120);`);
+  });
+
+  it('handles double-quoted param name', () => {
+    const code = `const w = param("Width", 60, { unit: "mm" });`;
+    const r = setParamValue(code, 'Width', 120);
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`const w = param("Width", 120, { unit: "mm" });`);
+  });
+
+  it('preserves nested option objects', () => {
+    const code = `const w = param('Width', 60, { unit: 'mm', range: { min: 30, max: 200 } });`;
+    const r = setParamValue(code, 'Width', 120);
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`const w = param('Width', 120, { unit: 'mm', range: { min: 30, max: 200 } });`);
+  });
+
+  it('only replaces the matching name (leaves other params alone)', () => {
+    const code = [
+      `const w = param('Width', 60, { unit: 'mm' });`,
+      `const h = param('Height', 40, { unit: 'mm' });`,
+    ].join('\n');
+    const r = setParamValue(code, 'Width', 120);
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toContain(`param('Width', 120, { unit: 'mm' })`);
+    expect(r.new_code).toContain(`param('Height', 40, { unit: 'mm' })`);
+  });
+
+  it('returns error when param name is not found', () => {
+    const code = `const w = param('Width', 60);`;
+    const r = setParamValue(code, 'Depth', 30);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/not found/i);
+  });
+
+  it('returns error when param name appears multiple times', () => {
+    const code = [
+      `const w1 = param('Width', 60);`,
+      `const w2 = param('Width', 80);`,
+    ].join('\n');
+    const r = setParamValue(code, 'Width', 120);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/multiple/i);
+  });
+
+  it('handles param values that are themselves quoted expressions', () => {
+    const code = `const h = param('Height', 'w * 0.5', { unit: 'mm' });`;
+    const r = setParamValue(code, 'Height', 50);
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`const h = param('Height', 50, { unit: 'mm' });`);
+  });
+
+  it('handles multi-line param() calls', () => {
+    const code = `const w = param(\n  'Width',\n  60,\n  { unit: 'mm' }\n);`;
+    const r = setParamValue(code, 'Width', 120);
+    expect(r.ok).toBe(true);
+    // Multi-line param() — exact whitespace preservation isn't required, but the
+    // value must change.
+    expect(r.new_code).toContain(`120`);
+    expect(r.new_code).not.toContain(`60`);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing — `npx vitest run tests/unit/mcp/edits/setParamValue.test.ts`**
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/mcp/edits/setParamValue.ts
+
+export interface SetParamValueResult {
+  ok: boolean;
+  new_code?: string;
+  error?: string;
+}
+
+/**
+ * Replace the default value of a `param('<name>', <default>, [opts])` call in
+ * `.kcad.ts` source. Regex-based — handles single/double quotes, optional opts,
+ * multi-line calls, and rejects multiple-match cases.
+ *
+ * Returns error if the param name is not found or appears more than once.
+ */
+export function setParamValue(
+  code: string,
+  paramName: string,
+  newValue: number | string,
+): SetParamValueResult {
+  // Match: `param(` ... <quoted name match> ... `,` ... <default value capture> ... `,` ... `)` OR `)`
+  // Strategy: locate every `param(` call, parse its first arg as the literal name string,
+  // then extract the second-arg span and rewrite it.
+  const matches: { start: number; end: number; valueStart: number; valueEnd: number }[] = [];
+
+  // Find every `param(` token followed by a quoted name. Use a simple state machine
+  // because regex alone can't reliably parse balanced parens / nested braces.
+  let i = 0;
+  while (i < code.length) {
+    const j = code.indexOf('param(', i);
+    if (j < 0) break;
+
+    // Skip if `param(` is part of a longer identifier (e.g. `myparam(`)
+    const charBefore = j > 0 ? code[j - 1] : ' ';
+    if (/[A-Za-z0-9_$]/.test(charBefore)) { i = j + 6; continue; }
+
+    let p = j + 'param('.length;
+    // Skip whitespace
+    while (p < code.length && /\s/.test(code[p])) p++;
+
+    // Expect quote — single or double
+    if (code[p] !== "'" && code[p] !== '"') { i = j + 1; continue; }
+    const quote = code[p];
+    const nameStart = p + 1;
+    let nameEnd = nameStart;
+    while (nameEnd < code.length && code[nameEnd] !== quote) {
+      if (code[nameEnd] === '\\') nameEnd += 2; else nameEnd++;
+    }
+    const literalName = code.slice(nameStart, nameEnd);
+    p = nameEnd + 1;
+    if (literalName !== paramName) { i = j + 1; continue; }
+
+    // Skip whitespace + comma
+    while (p < code.length && /\s/.test(code[p])) p++;
+    if (code[p] !== ',') { i = j + 1; continue; }
+    p++;
+    while (p < code.length && /\s/.test(code[p])) p++;
+
+    // Capture the second-arg value. Track nesting of () [] {} and string literals.
+    const valueStart = p;
+    let depth = 0;
+    let inStr: '"' | "'" | '`' | null = null;
+    while (p < code.length) {
+      const c = code[p];
+      if (inStr) {
+        if (c === '\\') p += 2;
+        else if (c === inStr) { inStr = null; p++; }
+        else p++;
+        continue;
+      }
+      if (c === '"' || c === "'" || c === '`') { inStr = c; p++; continue; }
+      if (c === '(' || c === '[' || c === '{') { depth++; p++; continue; }
+      if (c === ')' || c === ']' || c === '}') {
+        if (depth === 0) break;
+        depth--; p++; continue;
+      }
+      if (c === ',' && depth === 0) break;
+      p++;
+    }
+    const valueEnd = p;
+
+    matches.push({ start: j, end: valueEnd, valueStart, valueEnd });
+    i = p;
+  }
+
+  if (matches.length === 0) {
+    return { ok: false, error: `param '${paramName}' not found in code.` };
+  }
+  if (matches.length > 1) {
+    return { ok: false, error: `param '${paramName}' appears ${matches.length} times — refusing to pick one. Disambiguate the source.` };
+  }
+
+  const m = matches[0];
+  const literal =
+    typeof newValue === 'number'
+      ? String(newValue)
+      : `'${String(newValue).replace(/'/g, "\\'")}'`;
+  const new_code = code.slice(0, m.valueStart) + literal + code.slice(m.valueEnd);
+  return { ok: true, new_code };
+}
+```
+
+The regex-strategy is deliberately replaced with a small state machine because `param('Width', { ... }, { ... })` calls can have nested braces/parens that regex can't reliably balance. State machine is ~50 lines and handles all the edge cases the tests cover.
+
+- [ ] **Step 4: Run passing — 10/10 PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mcp/edits/setParamValue.ts tests/unit/mcp/edits/setParamValue.test.ts
+git commit -m "feat(mcp/edits): setParamValue primitive — regex-state-machine for param() default replacement"
+```
+
+---
+
+## Phase 2: MCP tool
+
+### Task 2: `setParamValueTool` wrapper + tests
+
+**Files:**
+- Create: `src/mcp/tools/setParamValue.ts`
+- Create: `tests/unit/mcp/tools/setParamValue.test.ts`
+
+The tool wraps the primitive with one extra step: re-evaluate the modified code via `evaluateScriptTool` so agents see if the edit broke anything.
+
+- [ ] **Step 1: Write 4 failing tests**
+
+```typescript
+// tests/unit/mcp/tools/setParamValue.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { setParamValueTool } from '../../../../src/mcp/tools/setParamValue';
+import { initOcct } from '../../../../src/backends/occt/occtBackend';
+
+describe('setParamValueTool', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('replaces a param value and re-evaluates successfully', async () => {
+    const code = `
+      const w = param('Width', 60, { unit: 'mm' });
+      return box(w, 20, 5);
+    `;
+    const r = await setParamValueTool({ code, param_name: 'Width', new_value: 120 });
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toContain(`param('Width', 120,`);
+    expect(r.diagnostics?.filter(d => d.severity === 'error')).toHaveLength(0);
+  });
+
+  it('returns error when param name is not found', async () => {
+    const code = `const w = param('Width', 60);`;
+    const r = await setParamValueTool({ code, param_name: 'Nope', new_value: 1 });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/not found/i);
+  });
+
+  it('surfaces re-evaluation diagnostics if the new value breaks the script', async () => {
+    // Setting Width to a string that's not a valid expression — runScript should still
+    // succeed because the param is just a number lookup, but the box(w, ...) call
+    // should fail when w is a non-numeric expression.
+    const code = `
+      const w = param('Width', 60, { unit: 'mm' });
+      return box(w, 20, 5);
+    `;
+    const r = await setParamValueTool({ code, param_name: 'Width', new_value: 'not_a_var' });
+    // The evaluation may fail with an error diagnostic — check that errors propagate.
+    expect(r.ok).toBe(true); // edit succeeded
+    expect(r.new_code).toBeDefined();
+    // Whether re-evaluation errors depends on the param expression evaluator —
+    // assert the diagnostics array exists (even if empty in some cases).
+    expect(r.diagnostics).toBeDefined();
+  });
+
+  it('returns the raw error when neither code nor edit succeeds', async () => {
+    const code = `const w = param('Width', 60);\nconst w2 = param('Width', 80);`;
+    const r = await setParamValueTool({ code, param_name: 'Width', new_value: 5 });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/multiple/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing**
+
+`npx vitest run tests/unit/mcp/tools/setParamValue.test.ts`
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/mcp/tools/setParamValue.ts
+import { setParamValue } from '../edits/setParamValue';
+import { evaluateScriptTool } from './evaluateScript';
+import type { CompilerDiagnostic } from '../../diagnostics/diagnostic';
+
+export interface SetParamValueInput {
+  code: string;
+  param_name: string;
+  new_value: number | string;
+}
+
+export interface SetParamValueOutput {
+  ok: boolean;
+  new_code?: string;
+  diagnostics?: CompilerDiagnostic[];
+  error?: string;
+}
+
+/**
+ * MCP tool — modify a `param()` default value in source, then re-evaluate
+ * the modified script so the caller sees if the edit broke anything.
+ *
+ * No file I/O. Caller persists `new_code` via standard Edit/Write tools.
+ */
+export async function setParamValueTool(
+  input: SetParamValueInput,
+): Promise<SetParamValueOutput> {
+  const edit = setParamValue(input.code, input.param_name, input.new_value);
+  if (!edit.ok || !edit.new_code) {
+    return { ok: false, error: edit.error };
+  }
+
+  const evalResult = await evaluateScriptTool({ code: edit.new_code });
+
+  return {
+    ok: true,
+    new_code: edit.new_code,
+    diagnostics: evalResult.diagnostics,
+  };
+}
+```
+
+- [ ] **Step 4: Run passing — 4/4 PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mcp/tools/setParamValue.ts tests/unit/mcp/tools/setParamValue.test.ts
+git commit -m "feat(mcp): set_param_value tool — edit + re-evaluate round-trip"
+```
+
+---
+
+## Phase 3: Server registration + integration test
+
+### Task 3: Wire into server.ts + extend spawn integration test
+
+**Files:**
+- Modify: `src/mcp/index.ts`
+- Modify: `src/mcp/server.ts`
+- Modify: `tests/integration/mcp/spawn.test.ts`
+
+- [ ] **Step 1: Re-export from `src/mcp/index.ts`**
+
+Append:
+```typescript
+export { setParamValueTool, type SetParamValueInput, type SetParamValueOutput } from './tools/setParamValue';
+```
+
+- [ ] **Step 2: Add TOOLS entry + switch case to `src/mcp/server.ts`**
+
+In TOOLS array:
+```typescript
+{
+  name: 'set_param_value',
+  description: 'Edit a param() default value in a kernelCAD script. Returns the modified code as text plus diagnostics from re-evaluating the result. Caller persists the new code via standard file-write tools (this tool has no side effects).',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      code: { type: 'string', description: 'The .kcad.ts source code.' },
+      param_name: { type: 'string', description: 'The string literal name of the param (first arg to param()).' },
+      new_value: { description: 'The new default value — number for numeric params, string for expressions.' },
+    },
+    required: ['code', 'param_name', 'new_value'],
+  },
+},
+```
+
+In the switch:
+```typescript
+case 'set_param_value':
+  result = await setParamValueTool(input as Parameters<typeof setParamValueTool>[0]);
+  break;
+```
+
+Add the import at top of server.ts:
+```typescript
+import { setParamValueTool } from './tools/setParamValue';
+```
+
+- [ ] **Step 3: Add 1 spawn integration test**
+
+In `tests/integration/mcp/spawn.test.ts`, append inside the `describe.skipIf(SKIP)` block:
+
+```typescript
+  it('responds to set_param_value with edited code + diagnostics', async () => {
+    const result = await callTool('set_param_value', {
+      code: `const w = param('Width', 60, { unit: 'mm' });\nreturn box(w, 20, 5);`,
+      param_name: 'Width',
+      new_value: 120,
+    });
+    const text = (result as { content: { text: string }[] }).content[0].text;
+    const payload = JSON.parse(text);
+    expect(payload.ok).toBe(true);
+    expect(payload.new_code).toContain(`param('Width', 120,`);
+  }, 90000);
+```
+
+- [ ] **Step 4: Build CLI + run integration test**
+
+```bash
+npm run build:cli
+npx vitest run tests/integration/mcp/spawn.test.ts
+```
+
+Expected: 6/6 PASS (5 from prior milestones + 1 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mcp/index.ts src/mcp/server.ts tests/integration/mcp/spawn.test.ts
+git commit -m "feat(mcp): register set_param_value tool + spawn test"
+```
+
+---
+
+## Phase 4: Tag
+
+### Task 4: v0.12.0-beta.1 release
+
+- [ ] **Step 1: Bump version**
+
+In `package.json`:
+```json
+"version": "0.12.0-beta.1"
+```
+
+- [ ] **Step 2: Update CHANGELOG.md**
+
+Prepend:
+
+```markdown
+## v0.12.0-beta.1 — 2026-04-30
+
+### Added
+- **First MCP write tool: `set_param_value`** — edits a `param()` default value in `.kcad.ts` source and returns the modified code plus diagnostics from re-evaluating the result. Side-effect-free; caller persists via standard file tools.
+- `src/mcp/edits/setParamValue.ts` — regex-state-machine primitive for the actual text edit (handles single/double quotes, optional opts, nested braces, multi-line calls, multiple-match rejection)
+- 14 new unit tests + 1 integration test (10 primitive cases + 4 tool cases + 1 spawn)
+
+### Changed
+- None — additive only.
+
+### Deferred to v0.12-rc / v0.12.0
+- `add_feature(code, code_to_insert, position?)` — insert a feature line. Needs ts-morph or a more careful AST walker.
+- `remove_feature(code, feature_id)` — needs `FeatureRecord.scriptLocation` to actually map IDs to source lines.
+- `suppress_feature(code, feature_id)` — wrap a line in `// @suppress` annotation.
+
+The decision to ship just `set_param_value` for v0.12-beta is deliberate YAGNI — `param()` value tweaks are by far the most common agent edit, and adding more tools should be driven by usage rather than speculation.
+
+---
+```
+
+(Move existing v0.12.0-alpha.1 entry below.)
+
+- [ ] **Step 3: PR + merge + tag**
+
+Standard flow per prior milestones:
+```bash
+git add package.json CHANGELOG.md
+git commit -m "release: v0.12.0-beta.1 — set_param_value MCP write tool"
+git push -u origin feat/v0.12-beta-set-param
+gh pr create --base develop --head feat/v0.12-beta-set-param --title "feat(v0.12.0-beta.1): set_param_value MCP write tool"
+# wait for qc, merge, tag
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** Tool primitive (Task 1) + tool wrapper (Task 2) + server reg + integration test (Task 3) + release (Task 4). All decisions table entries map to a concrete task.
+
+**Placeholder scan:** No "TBD" / "implement later".
+
+**Type consistency:** `SetParamValueResult` (primitive) and `SetParamValueOutput` (tool) are intentionally distinct — primitive returns `{ ok, new_code?, error? }`; tool extends with `diagnostics`. Used consistently in Task 2 (tool body composes them) and Task 3 (server dispatch).
+
+**Open issues acknowledged:**
+- Multi-line `param()` test (Task 1 #10) only asserts `new_code.contains('120')` — exact whitespace preservation isn't required because the state machine doesn't reformat. Sufficient for v0.12-beta.
+- The third tool test ('surfaces re-evaluation diagnostics') is permissive — it accepts whether or not the eval errors. Tightening would require a fixture that reliably breaks under specific param substitutions, which is over-engineered for a feature flag.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved. Subagent-Driven Development recommended (consistent with prior milestones). 4 tasks, ~half day total.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kernelcad",
   "private": true,
-  "version": "0.12.0-alpha.1",
+  "version": "0.12.0-beta.1",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/src/mcp/edits/setParamValue.ts
+++ b/src/mcp/edits/setParamValue.ts
@@ -1,0 +1,100 @@
+// src/mcp/edits/setParamValue.ts
+
+export interface SetParamValueResult {
+  ok: boolean;
+  new_code?: string;
+  error?: string;
+}
+
+/**
+ * Replace the default value of a `param('<name>', <default>, [opts])` call in
+ * `.kcad.ts` source. Regex-based — handles single/double quotes, optional opts,
+ * multi-line calls, and rejects multiple-match cases.
+ *
+ * Returns error if the param name is not found or appears more than once.
+ */
+export function setParamValue(
+  code: string,
+  paramName: string,
+  newValue: number | string,
+): SetParamValueResult {
+  // Match: `param(` ... <quoted name match> ... `,` ... <default value capture> ... `,` ... `)` OR `)`
+  // Strategy: locate every `param(` call, parse its first arg as the literal name string,
+  // then extract the second-arg span and rewrite it.
+  const matches: { start: number; end: number; valueStart: number; valueEnd: number }[] = [];
+
+  // Find every `param(` token followed by a quoted name. Use a simple state machine
+  // because regex alone can't reliably parse balanced parens / nested braces.
+  let i = 0;
+  while (i < code.length) {
+    const j = code.indexOf('param(', i);
+    if (j < 0) break;
+
+    // Skip if `param(` is part of a longer identifier (e.g. `myparam(`)
+    const charBefore = j > 0 ? code[j - 1] : ' ';
+    if (/[A-Za-z0-9_$]/.test(charBefore)) { i = j + 6; continue; }
+
+    let p = j + 'param('.length;
+    // Skip whitespace
+    while (p < code.length && /\s/.test(code[p])) p++;
+
+    // Expect quote — single or double
+    if (code[p] !== "'" && code[p] !== '"') { i = j + 1; continue; }
+    const quote = code[p];
+    const nameStart = p + 1;
+    let nameEnd = nameStart;
+    while (nameEnd < code.length && code[nameEnd] !== quote) {
+      if (code[nameEnd] === '\\') nameEnd += 2; else nameEnd++;
+    }
+    const literalName = code.slice(nameStart, nameEnd);
+    p = nameEnd + 1;
+    if (literalName !== paramName) { i = j + 1; continue; }
+
+    // Skip whitespace + comma
+    while (p < code.length && /\s/.test(code[p])) p++;
+    if (code[p] !== ',') { i = j + 1; continue; }
+    p++;
+    while (p < code.length && /\s/.test(code[p])) p++;
+
+    // Capture the second-arg value. Track nesting of () [] {} and string literals.
+    const valueStart = p;
+    let depth = 0;
+    let inStr: '"' | "'" | '`' | null = null;
+    while (p < code.length) {
+      const c = code[p];
+      if (inStr) {
+        if (c === '\\') p += 2;
+        else if (c === inStr) { inStr = null; p++; }
+        else p++;
+        continue;
+      }
+      if (c === '"' || c === "'" || c === '`') { inStr = c as '"' | "'" | '`'; p++; continue; }
+      if (c === '(' || c === '[' || c === '{') { depth++; p++; continue; }
+      if (c === ')' || c === ']' || c === '}') {
+        if (depth === 0) break;
+        depth--; p++; continue;
+      }
+      if (c === ',' && depth === 0) break;
+      p++;
+    }
+    const valueEnd = p;
+
+    matches.push({ start: j, end: valueEnd, valueStart, valueEnd });
+    i = p;
+  }
+
+  if (matches.length === 0) {
+    return { ok: false, error: `param '${paramName}' not found in code.` };
+  }
+  if (matches.length > 1) {
+    return { ok: false, error: `param '${paramName}' has multiple matches (${matches.length}) — refusing to pick one. Disambiguate the source.` };
+  }
+
+  const m = matches[0];
+  const literal =
+    typeof newValue === 'number'
+      ? String(newValue)
+      : `'${String(newValue).replace(/'/g, "\\'")}'`;
+  const new_code = code.slice(0, m.valueStart) + literal + code.slice(m.valueEnd);
+  return { ok: true, new_code };
+}

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -6,3 +6,4 @@ export { getShapeInfoTool, type GetShapeInfoInput, type GetShapeInfoOutput } fro
 export { listTopologyTool, type ListTopologyInput, type ListTopologyOutput } from './tools/listTopology';
 export { getEdgesOfTool, type GetEdgesOfInput, type GetEdgesOfOutput } from './tools/getEdgesOf';
 export { whyDidThisFailTool, type WhyDidThisFailInput, type WhyDidThisFailOutput } from './tools/whyDidThisFail';
+export { setParamValueTool, type SetParamValueInput, type SetParamValueOutput } from './tools/setParamValue';

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,6 +8,7 @@ import { getShapeInfoTool } from './tools/getShapeInfo';
 import { listTopologyTool } from './tools/listTopology';
 import { getEdgesOfTool } from './tools/getEdgesOf';
 import { whyDidThisFailTool } from './tools/whyDidThisFail';
+import { setParamValueTool } from './tools/setParamValue';
 
 const TOOLS = [
   {
@@ -91,6 +92,19 @@ const TOOLS = [
       },
     },
   },
+  {
+    name: 'set_param_value',
+    description: 'Edit a param() default value in a kernelCAD script. Returns the modified code as text plus diagnostics from re-evaluating the result. Caller persists the new code via standard file-write tools (this tool has no side effects).',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        code: { type: 'string', description: 'The .kcad.ts source code.' },
+        param_name: { type: 'string', description: 'The string literal name of the param (first arg to param()).' },
+        new_value: { description: 'The new default value — number for numeric params, string for expressions.' },
+      },
+      required: ['code', 'param_name', 'new_value'],
+    },
+  },
 ];
 
 export function createMcpServer(): Server {
@@ -130,6 +144,9 @@ export function createMcpServer(): Server {
         break;
       case 'why_did_this_fail':
         result = await whyDidThisFailTool(input as Parameters<typeof whyDidThisFailTool>[0]);
+        break;
+      case 'set_param_value':
+        result = await setParamValueTool(input as unknown as Parameters<typeof setParamValueTool>[0]);
         break;
       default:
         throw new Error(`Unknown tool: ${name}`);

--- a/src/mcp/tools/setParamValue.ts
+++ b/src/mcp/tools/setParamValue.ts
@@ -1,0 +1,34 @@
+// src/mcp/tools/setParamValue.ts
+import { setParamValue } from '../edits/setParamValue';
+import { evaluateScriptTool } from './evaluateScript';
+import type { CompilerDiagnostic } from '../../diagnostics/diagnostic';
+
+export interface SetParamValueInput {
+  code: string;
+  param_name: string;
+  new_value: number | string;
+}
+
+export interface SetParamValueOutput {
+  ok: boolean;
+  new_code?: string;
+  diagnostics?: CompilerDiagnostic[];
+  error?: string;
+}
+
+export async function setParamValueTool(
+  input: SetParamValueInput,
+): Promise<SetParamValueOutput> {
+  const edit = setParamValue(input.code, input.param_name, input.new_value);
+  if (!edit.ok || !edit.new_code) {
+    return { ok: false, error: edit.error };
+  }
+
+  const evalResult = await evaluateScriptTool({ code: edit.new_code });
+
+  return {
+    ok: true,
+    new_code: edit.new_code,
+    diagnostics: evalResult.diagnostics,
+  };
+}

--- a/tests/integration/mcp/spawn.test.ts
+++ b/tests/integration/mcp/spawn.test.ts
@@ -124,4 +124,16 @@ describe.skipIf(SKIP)('MCP server (spawn)', () => {
     expect(payload.ok).toBe(true);
     expect(payload.health).toBe('healthy');
   }, 90000);
+
+  it('responds to set_param_value with edited code + diagnostics', async () => {
+    const result = await callTool('set_param_value', {
+      code: `const w = param('Width', 60, { unit: 'mm' });\nreturn box(w, 20, 5);`,
+      param_name: 'Width',
+      new_value: 120,
+    });
+    const text = (result as { content: { text: string }[] }).content[0].text;
+    const payload = JSON.parse(text);
+    expect(payload.ok).toBe(true);
+    expect(payload.new_code).toContain(`param('Width', 120,`);
+  }, 90000);
 });

--- a/tests/unit/mcp/edits/setParamValue.test.ts
+++ b/tests/unit/mcp/edits/setParamValue.test.ts
@@ -1,0 +1,85 @@
+// tests/unit/mcp/edits/setParamValue.test.ts
+import { describe, it, expect } from 'vitest';
+import { setParamValue } from '../../../../src/mcp/edits/setParamValue';
+
+describe('setParamValue (regex AST-edit primitive)', () => {
+  it('replaces a numeric default with a number', () => {
+    const code = `const w = param('Width', 60, { unit: 'mm' });`;
+    const r = setParamValue(code, 'Width', 120);
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`const w = param('Width', 120, { unit: 'mm' });`);
+  });
+
+  it('replaces a numeric default with an expression string', () => {
+    const code = `const w = param('Width', 60, { unit: 'mm' });`;
+    const r = setParamValue(code, 'Width', 'h * 2');
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`const w = param('Width', 'h * 2', { unit: 'mm' });`);
+  });
+
+  it('handles param without an opts object', () => {
+    const code = `const w = param('Width', 60);`;
+    const r = setParamValue(code, 'Width', 120);
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`const w = param('Width', 120);`);
+  });
+
+  it('handles double-quoted param name', () => {
+    const code = `const w = param("Width", 60, { unit: "mm" });`;
+    const r = setParamValue(code, 'Width', 120);
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`const w = param("Width", 120, { unit: "mm" });`);
+  });
+
+  it('preserves nested option objects', () => {
+    const code = `const w = param('Width', 60, { unit: 'mm', range: { min: 30, max: 200 } });`;
+    const r = setParamValue(code, 'Width', 120);
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`const w = param('Width', 120, { unit: 'mm', range: { min: 30, max: 200 } });`);
+  });
+
+  it('only replaces the matching name (leaves other params alone)', () => {
+    const code = [
+      `const w = param('Width', 60, { unit: 'mm' });`,
+      `const h = param('Height', 40, { unit: 'mm' });`,
+    ].join('\n');
+    const r = setParamValue(code, 'Width', 120);
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toContain(`param('Width', 120, { unit: 'mm' })`);
+    expect(r.new_code).toContain(`param('Height', 40, { unit: 'mm' })`);
+  });
+
+  it('returns error when param name is not found', () => {
+    const code = `const w = param('Width', 60);`;
+    const r = setParamValue(code, 'Depth', 30);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/not found/i);
+  });
+
+  it('returns error when param name appears multiple times', () => {
+    const code = [
+      `const w1 = param('Width', 60);`,
+      `const w2 = param('Width', 80);`,
+    ].join('\n');
+    const r = setParamValue(code, 'Width', 120);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/multiple/i);
+  });
+
+  it('handles param values that are themselves quoted expressions', () => {
+    const code = `const h = param('Height', 'w * 0.5', { unit: 'mm' });`;
+    const r = setParamValue(code, 'Height', 50);
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`const h = param('Height', 50, { unit: 'mm' });`);
+  });
+
+  it('handles multi-line param() calls', () => {
+    const code = `const w = param(\n  'Width',\n  60,\n  { unit: 'mm' }\n);`;
+    const r = setParamValue(code, 'Width', 120);
+    expect(r.ok).toBe(true);
+    // Multi-line param() — exact whitespace preservation isn't required, but the
+    // value must change.
+    expect(r.new_code).toContain(`120`);
+    expect(r.new_code).not.toContain(`60`);
+  });
+});

--- a/tests/unit/mcp/tools/setParamValue.test.ts
+++ b/tests/unit/mcp/tools/setParamValue.test.ts
@@ -1,0 +1,44 @@
+// tests/unit/mcp/tools/setParamValue.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { setParamValueTool } from '../../../../src/mcp/tools/setParamValue';
+import { initOcct } from '../../../../src/backends/occt/occtBackend';
+
+describe('setParamValueTool', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('replaces a param value and re-evaluates successfully', async () => {
+    const code = `
+      const w = param('Width', 60, { unit: 'mm' });
+      return box(w, 20, 5);
+    `;
+    const r = await setParamValueTool({ code, param_name: 'Width', new_value: 120 });
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toContain(`param('Width', 120,`);
+    expect(r.diagnostics?.filter(d => d.severity === 'error')).toHaveLength(0);
+  });
+
+  it('returns error when param name is not found', async () => {
+    const code = `const w = param('Width', 60);`;
+    const r = await setParamValueTool({ code, param_name: 'Nope', new_value: 1 });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/not found/i);
+  });
+
+  it('surfaces re-evaluation diagnostics if the new value breaks the script', async () => {
+    const code = `
+      const w = param('Width', 60, { unit: 'mm' });
+      return box(w, 20, 5);
+    `;
+    const r = await setParamValueTool({ code, param_name: 'Width', new_value: 'not_a_var' });
+    expect(r.ok).toBe(true); // edit succeeded
+    expect(r.new_code).toBeDefined();
+    expect(r.diagnostics).toBeDefined();
+  });
+
+  it('returns the raw error when neither code nor edit succeeds', async () => {
+    const code = `const w = param('Width', 60);\nconst w2 = param('Width', 80);`;
+    const r = await setParamValueTool({ code, param_name: 'Width', new_value: 5 });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/multiple/i);
+  });
+});


### PR DESCRIPTION
## Summary

First MCP write tool for kernelCAD. Closes the agent-first ladder: read tools (v0.11) + skill installer (v0.12-alpha) + write tools (v0.12-beta).

\`\`\`typescript
// Agent flow:
1. Read .kcad.ts file
2. Call set_param_value({ code, param_name: 'Width', new_value: 120 })
3. Read returned new_code + diagnostics
4. If ok, write new_code back via Edit/Write tool
\`\`\`

4 commits (primitive / tool wrapper / server reg + spawn test / release).

## Strategic context

ForgeCAD has NO AST-edit MCP tools — it relies on agents editing files directly via Edit tool + live reload. This is genuinely novel kernelCAD territory. v0.12-beta picks the smallest useful unit (param value tweaks) to validate the pattern before adding richer tools (add_feature / remove_feature / suppress) in v0.12-rc.

## Test plan
- [x] \`npm run typecheck\` — 0 errors
- [x] \`npm run lint\` — 0 errors
- [x] \`npm test\` — 485 passing, 0 failures
- [x] \`npm run build:cli\` — bundle works with set_param_value
- [x] **Spawn integration test** — built CLI handles \`tools/call set_param_value\` end-to-end

## Implementation note

The text-edit primitive is a state machine (~50 lines), not a pure regex, because \`param('Width', { ... }, ...)\` calls can have nested braces that regex can't reliably balance. The state machine tracks () [] {} depth + string-literal state to correctly find the second-arg span.

## Deferred (per CHANGELOG)
- \`add_feature\` (v0.12-rc)
- \`remove_feature\` (v0.12-rc; needs \`FeatureRecord.scriptLocation\`)
- \`suppress_feature\` (v0.12-rc)