### PR TITLE
feat(v0.12.0-rc.1): add_feature MCP write tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## v0.12.0-rc.1 — 2026-04-30
+
+### Added
+- **Second MCP write tool: `add_feature`** — inserts a single-statement line into a `.kcad.ts` script before the last top-level `return`. Side-effect-free; caller persists via standard file tools.
+  - Input: `{ code, feature_code }`
+  - Output: `{ ok, new_code?, diagnostics?, error? }`
+  - Implementation: state-machine that finds the last brace-depth-0 `return` line (skips inner returns in helper functions / arrow bodies), preserves indentation, respects strings/comments
+- 11 new tests (7 primitive + 3 tool + 1 integration spawn)
+- Live verification: spawned `kernelcad mcp`, sent JSON-RPC `tools/call` for `set_param_value`, confirmed the round-trip works end-to-end as Claude would consume it
+
+### Deferred to v0.12.0 (final) / v0.13+
+- `remove_feature(code, feature_id)` — needs `FeatureRecord.scriptLocation` to be populated by the capture session (currently declared but never set)
+- `suppress_feature(code, feature_id)` — same scriptLocation requirement, plus capture-time `// @suppress` annotation parsing or `.suppress()` modifier method on the Shape proxy
+
+The decision to ship just `add_feature` (without remove/suppress) is driven by the scriptLocation gap — adding source-position tracking to capture is its own architectural change worth a separate plan. v0.12.0 final would land after that work or after additional agent feedback.
+
+---
+
 ## v0.12.0-beta.1 — 2026-04-30
 
 ### Added

--- a/docs/superpowers/plans/2026-04-30-v0.12-rc-add-feature.md
+++ b/docs/superpowers/plans/2026-04-30-v0.12-rc-add-feature.md
@@ -1,0 +1,491 @@
+# v0.12.0-rc.1 — `add_feature` MCP tool
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the second AST-edit MCP tool — `add_feature` — so agents can splice a new feature line into a `.kcad.ts` script before the `return` statement. Companion to v0.12-beta's `set_param_value`.
+
+**Architecture:** Pure text-in / text-out, mirroring v0.12-beta. Find the script's last top-level `return ...;` statement; insert the new feature line immediately before it. Returns `new_code` text + diagnostics from re-running.
+
+**Tech Stack:** TypeScript 5.9, vitest (no new deps).
+
+**Predecessor:** v0.12.0-beta.1 (set_param_value).
+
+**Why no `remove_feature` / `suppress_feature` in this RC:** Both require `FeatureRecord.scriptLocation` to map IDs to source lines. The field is declared in `src/intent/featureRecord.ts:18` but never populated by `captureSession`. Adding scriptLocation tracking is its own architectural change — defer to v0.12.0 final or v0.13.
+
+---
+
+## Decisions Locked
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Tool name | `add_feature` | Mirrors `set_param_value` shape. |
+| Insertion point | Last `return ...;` in the source | Common kernelCAD pattern is `return <expression>;` at the end. Inserting before that keeps captured-feature ordering correct. |
+| Insertion fallback | Append to end + add `return <last-var>;` | If no return is found AND the inserted code defines a `const`, we don't add a return — caller handles. If no return is found AND the inserted code is an expression statement, error. |
+| Input shape | `{ code: string, feature_code: string }` | `feature_code` is a single statement (e.g. `const hole = cylinder(t+2, 4);`). Multi-statement insertions require multiple calls. |
+| Output shape | `{ ok, new_code?, diagnostics?, error? }` | Mirrors `set_param_value`. |
+| File side-effect | None | Same as v0.12-beta — caller persists. |
+
+---
+
+## File Structure
+
+**Create:**
+- `src/mcp/edits/addFeature.ts` — primitive
+- `src/mcp/tools/addFeature.ts` — MCP tool wrapper
+- `tests/unit/mcp/edits/addFeature.test.ts`
+- `tests/unit/mcp/tools/addFeature.test.ts`
+
+**Modify:**
+- `src/mcp/index.ts` — re-export
+- `src/mcp/server.ts` — register
+- `tests/integration/mcp/spawn.test.ts` — add 1 spawn case
+- `package.json` — version bump
+- `CHANGELOG.md` — prepend v0.12-rc entry
+
+---
+
+## Phase 1: Edit primitive
+
+### Task 1: `addFeature(code, feature_code)` primitive
+
+**Files:**
+- Create: `src/mcp/edits/addFeature.ts`
+- Create: `tests/unit/mcp/edits/addFeature.test.ts`
+
+- [ ] **Step 1: Write 7 failing tests**
+
+```typescript
+// tests/unit/mcp/edits/addFeature.test.ts
+import { describe, it, expect } from 'vitest';
+import { addFeature } from '../../../../src/mcp/edits/addFeature';
+
+describe('addFeature primitive', () => {
+  it('inserts a feature before the last return statement', () => {
+    const code = [
+      `const w = param('Width', 60);`,
+      `const base = box(w, 20, 5);`,
+      `return base;`,
+    ].join('\n');
+    const r = addFeature(code, `const hole = cylinder(5, 2);`);
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe([
+      `const w = param('Width', 60);`,
+      `const base = box(w, 20, 5);`,
+      `const hole = cylinder(5, 2);`,
+      `return base;`,
+    ].join('\n'));
+  });
+
+  it('preserves indentation of the surrounding lines', () => {
+    const code = [
+      `const w = param('Width', 60);`,
+      `  return box(w, 20, 5);`, // indented
+    ].join('\n');
+    const r = addFeature(code, `const h = param('Height', 30);`);
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toContain(`  const h = param('Height', 30);\n  return box(w, 20, 5);`);
+  });
+
+  it('inserts before the LAST return when multiple returns exist (e.g., in helpers)', () => {
+    const code = [
+      `function helper() { return 5; }`,
+      `const w = helper();`,
+      `return box(w, 20, 5);`,
+    ].join('\n');
+    const r = addFeature(code, `const t = 3;`);
+    expect(r.ok).toBe(true);
+    // The helper's return is preserved; insertion is before the top-level return.
+    expect(r.new_code).toContain(`function helper() { return 5; }`);
+    expect(r.new_code).toContain(`const t = 3;\nreturn box(w, 20, 5);`);
+  });
+
+  it('handles return with multi-line expression', () => {
+    const code = [
+      `const a = box(10, 10, 10);`,
+      `return a`,
+      `  .translate(5, 0, 0)`,
+      `  .fillet(2);`,
+    ].join('\n');
+    const r = addFeature(code, `const b = cylinder(3, 1);`);
+    expect(r.ok).toBe(true);
+    // Insert before the line containing 'return' — multi-line return is preserved.
+    expect(r.new_code).toContain(`const b = cylinder(3, 1);\nreturn a`);
+  });
+
+  it('errors when no return statement is found', () => {
+    const code = `const w = param('Width', 60);\nconst base = box(w, 20, 5);`;
+    const r = addFeature(code, `const h = param('Height', 30);`);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/no return/i);
+  });
+
+  it('handles single-line script with just a return', () => {
+    const code = `return box(10, 10, 10);`;
+    const r = addFeature(code, `const w = param('Width', 60);`);
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`const w = param('Width', 60);\nreturn box(10, 10, 10);`);
+  });
+
+  it('preserves trailing newline in source', () => {
+    const code = `const w = box(1, 1, 1);\nreturn w;\n`;
+    const r = addFeature(code, `const h = box(2, 2, 2);`);
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`const w = box(1, 1, 1);\nconst h = box(2, 2, 2);\nreturn w;\n`);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing**
+
+`npx vitest run tests/unit/mcp/edits/addFeature.test.ts`
+
+- [ ] **Step 3: Implement**
+
+Find the last top-level `return` statement using a state machine that respects nesting (functions can have inner `return`s). Track `{}` depth — top-level means `depth === 0`.
+
+```typescript
+// src/mcp/edits/addFeature.ts
+
+export interface AddFeatureResult {
+  ok: boolean;
+  new_code?: string;
+  error?: string;
+}
+
+/**
+ * Insert `feature_code` as a new line in `code` immediately before the LAST
+ * top-level `return` statement.
+ *
+ * "Top-level" means at brace depth 0 — `return` statements inside helper
+ * functions / arrow bodies are skipped. The script must contain at least
+ * one top-level `return` or this returns an error.
+ *
+ * Indentation of the inserted line matches the indentation of the `return`
+ * line it precedes.
+ */
+export function addFeature(code: string, feature_code: string): AddFeatureResult {
+  const returnIndex = findLastTopLevelReturnLine(code);
+  if (returnIndex < 0) {
+    return { ok: false, error: 'no return statement found at top level — cannot place new feature.' };
+  }
+
+  // Preserve source line endings.
+  const lines = code.split('\n');
+  const returnLine = lines[returnIndex];
+  // Indentation = leading whitespace of the return line.
+  const indentMatch = returnLine.match(/^(\s*)/);
+  const indent = indentMatch ? indentMatch[1] : '';
+
+  const insertLine = `${indent}${feature_code}`;
+  lines.splice(returnIndex, 0, insertLine);
+  return { ok: true, new_code: lines.join('\n') };
+}
+
+/**
+ * Find the line index (0-based) of the last `return` statement at brace
+ * depth 0. Tracks string literals, template strings, and `{}` nesting.
+ * Returns -1 if no top-level return is present.
+ */
+function findLastTopLevelReturnLine(code: string): number {
+  const lines = code.split('\n');
+  let depth = 0;
+  let inStr: '"' | "'" | '`' | null = null;
+  let inLineComment = false;
+  let inBlockComment = false;
+  let lastReturnLine = -1;
+
+  for (let li = 0; li < lines.length; li++) {
+    const line = lines[li];
+    inLineComment = false;
+    let i = 0;
+    let lineHasTopLevelReturn = false;
+
+    while (i < line.length) {
+      const c = line[i];
+      const c2 = line[i + 1];
+
+      if (inLineComment) { i++; continue; }
+      if (inBlockComment) {
+        if (c === '*' && c2 === '/') { inBlockComment = false; i += 2; continue; }
+        i++; continue;
+      }
+      if (inStr) {
+        if (c === '\\') { i += 2; continue; }
+        if (c === inStr) { inStr = null; i++; continue; }
+        i++; continue;
+      }
+      if (c === '/' && c2 === '/') { inLineComment = true; i += 2; continue; }
+      if (c === '/' && c2 === '*') { inBlockComment = true; i += 2; continue; }
+      if (c === '"' || c === "'" || c === '`') { inStr = c as '"' | "'" | '`'; i++; continue; }
+      if (c === '{') { depth++; i++; continue; }
+      if (c === '}') { depth--; i++; continue; }
+
+      // Check for `return` at depth 0 — it must be a word boundary.
+      if (depth === 0 && line.slice(i, i + 6) === 'return') {
+        const before = i === 0 ? ' ' : line[i - 1];
+        const after = line[i + 6] ?? ' ';
+        if (!/[A-Za-z0-9_$]/.test(before) && !/[A-Za-z0-9_$]/.test(after)) {
+          lineHasTopLevelReturn = true;
+          i += 6;
+          continue;
+        }
+      }
+      i++;
+    }
+
+    if (lineHasTopLevelReturn) lastReturnLine = li;
+  }
+
+  return lastReturnLine;
+}
+```
+
+- [ ] **Step 4: Run passing — 7/7 PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mcp/edits/addFeature.ts tests/unit/mcp/edits/addFeature.test.ts
+git commit -m "feat(mcp/edits): addFeature primitive — insert feature line before last top-level return"
+```
+
+---
+
+## Phase 2: MCP tool
+
+### Task 2: `addFeatureTool` wrapper
+
+**Files:**
+- Create: `src/mcp/tools/addFeature.ts`
+- Create: `tests/unit/mcp/tools/addFeature.test.ts`
+
+- [ ] **Step 1: Write 3 failing tests**
+
+```typescript
+// tests/unit/mcp/tools/addFeature.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { addFeatureTool } from '../../../../src/mcp/tools/addFeature';
+import { initOcct } from '../../../../src/backends/occt/occtBackend';
+
+describe('addFeatureTool', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('inserts a feature line and re-evaluates successfully', async () => {
+    const code = [
+      `const base = box(20, 20, 5);`,
+      `return base;`,
+    ].join('\n');
+    const r = await addFeatureTool({ code, feature_code: `const hole = cylinder(5, 2).translate(10, 10, -1);` });
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toContain(`const hole = cylinder(5, 2)`);
+    expect(r.diagnostics?.filter(d => d.severity === 'error')).toHaveLength(0);
+  });
+
+  it('returns error when no return statement', async () => {
+    const code = `const base = box(20, 20, 5);`; // no return
+    const r = await addFeatureTool({ code, feature_code: `const x = 1;` });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/no return/i);
+  });
+
+  it('surfaces re-evaluation errors when inserted code is invalid', async () => {
+    const code = [
+      `const base = box(10, 10, 10);`,
+      `return base;`,
+    ].join('\n');
+    // `nonexistent` is not in scope — runScript will throw a ReferenceError.
+    const r = await addFeatureTool({ code, feature_code: `const x = nonexistent();` });
+    expect(r.ok).toBe(true); // edit succeeded
+    expect(r.diagnostics?.some(d => d.severity === 'error')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing**
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/mcp/tools/addFeature.ts
+import { addFeature } from '../edits/addFeature';
+import { evaluateScriptTool } from './evaluateScript';
+import type { CompilerDiagnostic } from '../../diagnostics/diagnostic';
+
+export interface AddFeatureInput {
+  code: string;
+  feature_code: string;
+}
+
+export interface AddFeatureOutput {
+  ok: boolean;
+  new_code?: string;
+  diagnostics?: CompilerDiagnostic[];
+  error?: string;
+}
+
+export async function addFeatureTool(input: AddFeatureInput): Promise<AddFeatureOutput> {
+  const edit = addFeature(input.code, input.feature_code);
+  if (!edit.ok || !edit.new_code) {
+    return { ok: false, error: edit.error };
+  }
+  const evalResult = await evaluateScriptTool({ code: edit.new_code });
+  return {
+    ok: true,
+    new_code: edit.new_code,
+    diagnostics: evalResult.diagnostics,
+  };
+}
+```
+
+- [ ] **Step 4: Run passing — 3/3 PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mcp/tools/addFeature.ts tests/unit/mcp/tools/addFeature.test.ts
+git commit -m "feat(mcp): add_feature tool — insert + re-evaluate round-trip"
+```
+
+---
+
+## Phase 3: Server registration + integration test
+
+### Task 3: Wire into server.ts + 1 spawn test
+
+**Files:**
+- Modify: `src/mcp/index.ts` (re-export)
+- Modify: `src/mcp/server.ts` (TOOLS + switch + import)
+- Modify: `tests/integration/mcp/spawn.test.ts` (1 spawn case)
+
+- [ ] **Step 1: Re-export**
+
+```typescript
+// src/mcp/index.ts (append)
+export { addFeatureTool, type AddFeatureInput, type AddFeatureOutput } from './tools/addFeature';
+```
+
+- [ ] **Step 2: Server TOOLS entry**
+
+```typescript
+{
+  name: 'add_feature',
+  description: 'Insert a new feature line into a kernelCAD script before the last top-level return statement. Returns the modified code as text plus diagnostics from re-evaluating the result. Side-effect-free.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      code: { type: 'string', description: 'The .kcad.ts source code.' },
+      feature_code: { type: 'string', description: 'Single-statement source line to insert (e.g. `const hole = cylinder(5, 2).translate(10, 10, -1);`).' },
+    },
+    required: ['code', 'feature_code'],
+  },
+},
+```
+
+- [ ] **Step 3: Server import + switch case**
+
+```typescript
+import { addFeatureTool } from './tools/addFeature';
+// ...
+case 'add_feature':
+  result = await addFeatureTool(input as Parameters<typeof addFeatureTool>[0]);
+  break;
+```
+
+- [ ] **Step 4: Spawn test**
+
+Inside `describe.skipIf(SKIP)` in `tests/integration/mcp/spawn.test.ts`:
+
+```typescript
+  it('responds to add_feature with edited code + diagnostics', async () => {
+    const result = await callTool('add_feature', {
+      code: `const base = box(20, 20, 5);\nreturn base;`,
+      feature_code: `const hole = cylinder(5, 2).translate(10, 10, -1);`,
+    });
+    const text = (result as { content: { text: string }[] }).content[0].text;
+    const payload = JSON.parse(text);
+    expect(payload.ok).toBe(true);
+    expect(payload.new_code).toContain(`const hole = cylinder(5, 2)`);
+  }, 90000);
+```
+
+- [ ] **Step 5: Build CLI + run**
+
+```bash
+npm run build:cli
+npx vitest run tests/integration/mcp/spawn.test.ts
+```
+
+Expected: 7/7 PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/mcp/index.ts src/mcp/server.ts tests/integration/mcp/spawn.test.ts
+git commit -m "feat(mcp): register add_feature tool + spawn test"
+```
+
+---
+
+## Phase 4: Tag
+
+### Task 4: v0.12.0-rc.1 release
+
+- [ ] **Step 1: Bump `package.json`**
+
+```json
+"version": "0.12.0-rc.1"
+```
+
+- [ ] **Step 2: CHANGELOG**
+
+Prepend:
+
+```markdown
+## v0.12.0-rc.1 — 2026-04-30
+
+### Added
+- **Second MCP write tool: `add_feature`** — inserts a single-statement line into a `.kcad.ts` script before the last top-level `return`. Side-effect-free; caller persists via standard file tools.
+  - Input: `{ code, feature_code }`
+  - Output: `{ ok, new_code?, diagnostics?, error? }`
+  - Implementation: state-machine that finds the last brace-depth-0 `return` line (skips inner returns in helper functions / arrow bodies), preserves indentation
+- 10 new unit tests (7 primitive + 3 tool) + 1 integration spawn test
+
+### Deferred to v0.12.0 final / v0.13+
+- `remove_feature(code, feature_id)` — needs `FeatureRecord.scriptLocation` to be populated by the capture session (currently declared but never set)
+- `suppress_feature(code, feature_id)` — same scriptLocation requirement, plus capture-time `// @suppress` annotation parsing or `.suppress()` modifier method on the Shape proxy
+
+The decision to ship just `add_feature` (without remove/suppress) is driven by the scriptLocation gap — adding source-position tracking to capture is its own architectural change worth a separate plan.
+
+---
+```
+
+- [ ] **Step 3: Standard PR + merge + tag flow**
+
+```bash
+git add package.json CHANGELOG.md
+git commit -m "release: v0.12.0-rc.1 — add_feature MCP write tool"
+git push -u origin feat/v0.12-rc-add-feature
+gh pr create --base develop --head feat/v0.12-rc-add-feature \
+  --title "feat(v0.12.0-rc.1): add_feature MCP write tool"
+# wait for qc; merge; tag
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** Primitive (Task 1) + tool (Task 2) + server reg + integration test (Task 3) + release (Task 4). Standard pattern from prior milestones.
+
+**Placeholder scan:** No "TBD" / "implement later".
+
+**Type consistency:** `AddFeatureResult` (primitive) vs `AddFeatureOutput` (tool). Same shape pattern as v0.12-beta `set_param_value`.
+
+**Open issues:**
+- The state machine in `findLastTopLevelReturnLine` doesn't model regex literals — `const r = /return/;` would be misclassified as a return statement in pathological cases. Negligible for v0.12-rc; revisit in v0.12.0 final if anyone complains.
+- Multi-line return tests (Task 1 #4) only check substring presence, not exact whitespace. Acceptable looseness.
+
+---
+
+## Execution Handoff
+
+Plan complete. 4 tasks, ~3-4 hours total. Subagent-driven recommended.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kernelcad",
   "private": true,
-  "version": "0.12.0-beta.1",
+  "version": "0.12.0-rc.1",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/src/mcp/edits/addFeature.ts
+++ b/src/mcp/edits/addFeature.ts
@@ -1,0 +1,94 @@
+// src/mcp/edits/addFeature.ts
+
+export interface AddFeatureResult {
+  ok: boolean;
+  new_code?: string;
+  error?: string;
+}
+
+/**
+ * Insert `feature_code` as a new line in `code` immediately before the LAST
+ * top-level `return` statement.
+ *
+ * "Top-level" means at brace depth 0 — `return` statements inside helper
+ * functions / arrow bodies are skipped. The script must contain at least
+ * one top-level `return` or this returns an error.
+ *
+ * Indentation of the inserted line matches the indentation of the `return`
+ * line it precedes.
+ */
+export function addFeature(code: string, feature_code: string): AddFeatureResult {
+  const returnIndex = findLastTopLevelReturnLine(code);
+  if (returnIndex < 0) {
+    return { ok: false, error: 'no return statement found at top level — cannot place new feature.' };
+  }
+
+  // Preserve source line endings.
+  const lines = code.split('\n');
+  const returnLine = lines[returnIndex];
+  // Indentation = leading whitespace of the return line.
+  const indentMatch = returnLine.match(/^(\s*)/);
+  const indent = indentMatch ? indentMatch[1] : '';
+
+  const insertLine = `${indent}${feature_code}`;
+  lines.splice(returnIndex, 0, insertLine);
+  return { ok: true, new_code: lines.join('\n') };
+}
+
+/**
+ * Find the line index (0-based) of the last `return` statement at brace
+ * depth 0. Tracks string literals, template strings, and `{}` nesting.
+ * Returns -1 if no top-level return is present.
+ */
+function findLastTopLevelReturnLine(code: string): number {
+  const lines = code.split('\n');
+  let depth = 0;
+  let inStr: '"' | "'" | '`' | null = null;
+  let inLineComment = false;
+  let inBlockComment = false;
+  let lastReturnLine = -1;
+
+  for (let li = 0; li < lines.length; li++) {
+    const line = lines[li];
+    inLineComment = false;
+    let i = 0;
+    let lineHasTopLevelReturn = false;
+
+    while (i < line.length) {
+      const c = line[i];
+      const c2 = line[i + 1];
+
+      if (inLineComment) { i++; continue; }
+      if (inBlockComment) {
+        if (c === '*' && c2 === '/') { inBlockComment = false; i += 2; continue; }
+        i++; continue;
+      }
+      if (inStr) {
+        if (c === '\\') { i += 2; continue; }
+        if (c === inStr) { inStr = null; i++; continue; }
+        i++; continue;
+      }
+      if (c === '/' && c2 === '/') { inLineComment = true; i += 2; continue; }
+      if (c === '/' && c2 === '*') { inBlockComment = true; i += 2; continue; }
+      if (c === '"' || c === "'" || c === '`') { inStr = c as '"' | "'" | '`'; i++; continue; }
+      if (c === '{') { depth++; i++; continue; }
+      if (c === '}') { depth--; i++; continue; }
+
+      // Check for `return` at depth 0 — it must be a word boundary.
+      if (depth === 0 && line.slice(i, i + 6) === 'return') {
+        const before = i === 0 ? ' ' : line[i - 1];
+        const after = line[i + 6] ?? ' ';
+        if (!/[A-Za-z0-9_$]/.test(before) && !/[A-Za-z0-9_$]/.test(after)) {
+          lineHasTopLevelReturn = true;
+          i += 6;
+          continue;
+        }
+      }
+      i++;
+    }
+
+    if (lineHasTopLevelReturn) lastReturnLine = li;
+  }
+
+  return lastReturnLine;
+}

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -7,3 +7,4 @@ export { listTopologyTool, type ListTopologyInput, type ListTopologyOutput } fro
 export { getEdgesOfTool, type GetEdgesOfInput, type GetEdgesOfOutput } from './tools/getEdgesOf';
 export { whyDidThisFailTool, type WhyDidThisFailInput, type WhyDidThisFailOutput } from './tools/whyDidThisFail';
 export { setParamValueTool, type SetParamValueInput, type SetParamValueOutput } from './tools/setParamValue';
+export { addFeatureTool, type AddFeatureInput, type AddFeatureOutput } from './tools/addFeature';

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -9,6 +9,7 @@ import { listTopologyTool } from './tools/listTopology';
 import { getEdgesOfTool } from './tools/getEdgesOf';
 import { whyDidThisFailTool } from './tools/whyDidThisFail';
 import { setParamValueTool } from './tools/setParamValue';
+import { addFeatureTool } from './tools/addFeature';
 
 const TOOLS = [
   {
@@ -105,6 +106,18 @@ const TOOLS = [
       required: ['code', 'param_name', 'new_value'],
     },
   },
+  {
+    name: 'add_feature',
+    description: 'Insert a new feature line into a kernelCAD script before the last top-level return statement. Returns the modified code as text plus diagnostics from re-evaluating the result. Side-effect-free.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        code: { type: 'string', description: 'The .kcad.ts source code.' },
+        feature_code: { type: 'string', description: 'Single-statement source line to insert (e.g. `const hole = cylinder(5, 2).translate(10, 10, -1);`).' },
+      },
+      required: ['code', 'feature_code'],
+    },
+  },
 ];
 
 export function createMcpServer(): Server {
@@ -147,6 +160,9 @@ export function createMcpServer(): Server {
         break;
       case 'set_param_value':
         result = await setParamValueTool(input as unknown as Parameters<typeof setParamValueTool>[0]);
+        break;
+      case 'add_feature':
+        result = await addFeatureTool(input as unknown as Parameters<typeof addFeatureTool>[0]);
         break;
       default:
         throw new Error(`Unknown tool: ${name}`);

--- a/src/mcp/tools/addFeature.ts
+++ b/src/mcp/tools/addFeature.ts
@@ -1,0 +1,29 @@
+// src/mcp/tools/addFeature.ts
+import { addFeature } from '../edits/addFeature';
+import { evaluateScriptTool } from './evaluateScript';
+import type { CompilerDiagnostic } from '../../diagnostics/diagnostic';
+
+export interface AddFeatureInput {
+  code: string;
+  feature_code: string;
+}
+
+export interface AddFeatureOutput {
+  ok: boolean;
+  new_code?: string;
+  diagnostics?: CompilerDiagnostic[];
+  error?: string;
+}
+
+export async function addFeatureTool(input: AddFeatureInput): Promise<AddFeatureOutput> {
+  const edit = addFeature(input.code, input.feature_code);
+  if (!edit.ok || !edit.new_code) {
+    return { ok: false, error: edit.error };
+  }
+  const evalResult = await evaluateScriptTool({ code: edit.new_code });
+  return {
+    ok: true,
+    new_code: edit.new_code,
+    diagnostics: evalResult.diagnostics,
+  };
+}

--- a/tests/integration/mcp/spawn.test.ts
+++ b/tests/integration/mcp/spawn.test.ts
@@ -136,4 +136,15 @@ describe.skipIf(SKIP)('MCP server (spawn)', () => {
     expect(payload.ok).toBe(true);
     expect(payload.new_code).toContain(`param('Width', 120,`);
   }, 90000);
+
+  it('responds to add_feature with edited code + diagnostics', async () => {
+    const result = await callTool('add_feature', {
+      code: `const base = box(20, 20, 5);\nreturn base;`,
+      feature_code: `const hole = cylinder(5, 2).translate(10, 10, -1);`,
+    });
+    const text = (result as { content: { text: string }[] }).content[0].text;
+    const payload = JSON.parse(text);
+    expect(payload.ok).toBe(true);
+    expect(payload.new_code).toContain(`const hole = cylinder(5, 2)`);
+  }, 90000);
 });

--- a/tests/unit/mcp/edits/addFeature.test.ts
+++ b/tests/unit/mcp/edits/addFeature.test.ts
@@ -1,0 +1,78 @@
+// tests/unit/mcp/edits/addFeature.test.ts
+import { describe, it, expect } from 'vitest';
+import { addFeature } from '../../../../src/mcp/edits/addFeature';
+
+describe('addFeature primitive', () => {
+  it('inserts a feature before the last return statement', () => {
+    const code = [
+      `const w = param('Width', 60);`,
+      `const base = box(w, 20, 5);`,
+      `return base;`,
+    ].join('\n');
+    const r = addFeature(code, `const hole = cylinder(5, 2);`);
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe([
+      `const w = param('Width', 60);`,
+      `const base = box(w, 20, 5);`,
+      `const hole = cylinder(5, 2);`,
+      `return base;`,
+    ].join('\n'));
+  });
+
+  it('preserves indentation of the surrounding lines', () => {
+    const code = [
+      `const w = param('Width', 60);`,
+      `  return box(w, 20, 5);`, // indented
+    ].join('\n');
+    const r = addFeature(code, `const h = param('Height', 30);`);
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toContain(`  const h = param('Height', 30);\n  return box(w, 20, 5);`);
+  });
+
+  it('inserts before the LAST return when multiple returns exist (e.g., in helpers)', () => {
+    const code = [
+      `function helper() { return 5; }`,
+      `const w = helper();`,
+      `return box(w, 20, 5);`,
+    ].join('\n');
+    const r = addFeature(code, `const t = 3;`);
+    expect(r.ok).toBe(true);
+    // The helper's return is preserved; insertion is before the top-level return.
+    expect(r.new_code).toContain(`function helper() { return 5; }`);
+    expect(r.new_code).toContain(`const t = 3;\nreturn box(w, 20, 5);`);
+  });
+
+  it('handles return with multi-line expression', () => {
+    const code = [
+      `const a = box(10, 10, 10);`,
+      `return a`,
+      `  .translate(5, 0, 0)`,
+      `  .fillet(2);`,
+    ].join('\n');
+    const r = addFeature(code, `const b = cylinder(3, 1);`);
+    expect(r.ok).toBe(true);
+    // Insert before the line containing 'return' — multi-line return is preserved.
+    expect(r.new_code).toContain(`const b = cylinder(3, 1);\nreturn a`);
+  });
+
+  it('errors when no return statement is found', () => {
+    const code = `const w = param('Width', 60);\nconst base = box(w, 20, 5);`;
+    const r = addFeature(code, `const h = param('Height', 30);`);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/no return/i);
+  });
+
+  it('handles single-line script with just a return', () => {
+    const code = `return box(10, 10, 10);`;
+    const r = addFeature(code, `const w = param('Width', 60);`);
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`const w = param('Width', 60);\nreturn box(10, 10, 10);`);
+  });
+
+  it('preserves trailing newline in source', () => {
+    const code = `const w = box(1, 1, 1);\nreturn w;\n`;
+    const r = addFeature(code, `const h = box(2, 2, 2);`);
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`const w = box(1, 1, 1);\nconst h = box(2, 2, 2);\nreturn w;\n`);
+  });
+});

--- a/tests/unit/mcp/tools/addFeature.test.ts
+++ b/tests/unit/mcp/tools/addFeature.test.ts
@@ -1,0 +1,36 @@
+// tests/unit/mcp/tools/addFeature.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { addFeatureTool } from '../../../../src/mcp/tools/addFeature';
+import { initOcct } from '../../../../src/backends/occt/occtBackend';
+
+describe('addFeatureTool', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('inserts a feature line and re-evaluates successfully', async () => {
+    const code = [
+      `const base = box(20, 20, 5);`,
+      `return base;`,
+    ].join('\n');
+    const r = await addFeatureTool({ code, feature_code: `const hole = cylinder(5, 2).translate(10, 10, -1);` });
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toContain(`const hole = cylinder(5, 2)`);
+    expect(r.diagnostics?.filter(d => d.severity === 'error')).toHaveLength(0);
+  });
+
+  it('returns error when no return statement', async () => {
+    const code = `const base = box(20, 20, 5);`; // no return
+    const r = await addFeatureTool({ code, feature_code: `const x = 1;` });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/no return/i);
+  });
+
+  it('surfaces re-evaluation errors when inserted code is invalid', async () => {
+    const code = [
+      `const base = box(10, 10, 10);`,
+      `return base;`,
+    ].join('\n');
+    const r = await addFeatureTool({ code, feature_code: `const x = nonexistent();` });
+    expect(r.ok).toBe(true); // edit succeeded
+    expect(r.diagnostics?.some(d => d.severity === 'error')).toBe(true);
+  });
+});


### PR DESCRIPTION
Companion to v0.12-beta's set_param_value. State-machine finds the last top-level return; inserts a feature line before it. 11 tests + live verification using the shipped MCP server end-to-end (set_param_value round-trip, evaluate_script + export step + skill one-file all confirmed working as a real agent flow).

Deferred: remove_feature / suppress_feature (need FeatureRecord.scriptLocation populated by captureSession — currently declared but never set; bigger architectural change).