### PR TITLE
feat(v0.13.0-alpha.1): extrudePolygon — first arbitrary 2D profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## v0.13.0-alpha.1 (NORTHSTAR roadmap: v0.4-alpha extrudePolygon) — 2026-04-30
+
+### Added
+- **`extrudePolygon(points, depth)`** — first arbitrary-2D-profile primitive. Takes an array of `[x, y]` points in millimetres and an extrude depth. Auto-normalizes winding (CW input silently reversed to CCW). Closed by default. Minimum 3 points.
+- New diagnostic codes: `feature.extrude.bad-points` (missing/invalid metadata.points), `feature.extrude.failed` (OCCT exception during extrusion).
+- e2e fixture `tests/e2e/fixtures/triangle-extrusion.kcad.ts` + acceptance test.
+- `FeatureSpec.metadata` propagated through `CaptureSession.register()` so feature-specific structured data (like polygon points) can be attached without widening the param shape.
+
+### Changed
+- `extrude` FeatureKind now accepts `profileKind: 'polygon'` in addition to existing `'rect'` and `'circle'`.
+- Lowerer's `'extrude'` case refactored to extract `height` per-profile-arm rather than unconditionally — fixed a latent bug where polygon records (which have no `height` param) would have crashed before reaching the polygon arm.
+
+### Deferred to v0.4-beta+
+- Sketch builder pattern (`sketch.polygon().extrude()`, `sketch.path().lineTo().close()`)
+- `roundedRect` and `circle2d` as Sketch primitives
+- Open polylines (`.stroke(width)`)
+- Sketch revolve / sweep
+- Self-intersection validation
+
+---
+
 ## v0.12.0-rc.1 — 2026-04-30
 
 ### Added

--- a/docs/superpowers/plans/2026-04-30-v0.4-alpha-extrude-polygon.md
+++ b/docs/superpowers/plans/2026-04-30-v0.4-alpha-extrude-polygon.md
@@ -1,0 +1,498 @@
+# v0.4.0-alpha.1 — `extrudePolygon` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the first arbitrary-2D-profile primitive — `extrudePolygon(points, depth)` — so users can extrude any closed polygon, not just the hardcoded `rect` / `circle` profiles. Smallest useful addition; full sketch builders (`sketch.polygon().extrude()`, `path()` chains, `roundedRect`) deferred to v0.4-beta+.
+
+**Architecture:** Mirrors the existing `extrudeRect` / `extrudeCircle` pattern — new top-level function, new OcctBackend factory, new lowerer case. The `extrude` FeatureKind already exists with a `profileKind` param ('rect' | 'circle'); v0.4-alpha extends to `'polygon'`. Points are stored in `FeatureRecord.metadata.points` (existing optional field; no schema change).
+
+**Tech Stack:** TypeScript 5.9, vitest, Replicad WASM (`drawPolysides` / `drawPolygon` API).
+
+**Predecessor:** v0.12.0-rc.1 (last MCP write tool).
+
+**Why minimal scope:** ForgeCAD has `polygon(points).extrude(t)` as a sketch-builder chain — more flexible for future revolve/sweep. kernelCAD currently uses `extrudeRect`/`extrudeCircle` separate-function pattern. Adding `extrudePolygon` continues the existing pattern (lowest-friction addition). v0.4-beta can introduce the unified `Sketch` builder once we have ≥3 operations needing a common 2D base.
+
+---
+
+## Decisions Locked
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| API name | `extrudePolygon(points, depth)` | Continues `extrudeRect` / `extrudeCircle` naming pattern. v0.4-beta can add `polygon(points): Sketch` builder alongside. |
+| Points format | `[number, number][]` — array of `[x, y]` tuples in mm | Simple, no new types. |
+| Closed by default | Yes — last point auto-connects to first | Matches user intuition; explicit closed = trailing point equal to first is also accepted. |
+| Winding | Auto-normalized (CW input silently reversed to CCW) | Mirrors ForgeCAD's behavior; saves agents from a footgun. |
+| Min points | 3 | Triangle minimum; reject 0/1/2 with diagnostic. |
+| Self-intersection | Not validated | YAGNI; OCCT throws on bad geometry; lowerer translates throw → diagnostic. |
+| Points storage | `FeatureRecord.metadata.points: [number, number][]` | Avoids new IR field; metadata is already declared as `Record<string, unknown>`. |
+
+---
+
+## File Structure
+
+**Create:**
+- `tests/unit/backends/occt/occtBackend.extrudePolygon.test.ts`
+- `tests/unit/backends/occt/occtLowerer.extrudePolygon.test.ts`
+- `tests/unit/capture/proxy.extrudePolygon.test.ts` — actually `tests/unit/modules/api.extrudePolygon.test.ts` since this is a top-level function (no Shape proxy method). Use the latter.
+- `tests/e2e/fixtures/triangle-extrusion.kcad.ts`
+
+**Modify:**
+- `src/backends/occt/occtBackend.ts` — add static `extrudePolygon(points, depth)` factory
+- `src/backends/occt/occtLowerer.ts` — extend `'extrude'` case to handle `profileKind === 'polygon'`
+- `src/modules/api.ts` — expose `extrudePolygon(points, depth)` top-level function that calls `session.createShape({ kind: 'extrude', params: { profileKind: 'polygon', depth }, inputs: {}, metadata: { points } })`
+- `tests/e2e/cli-acceptance.test.ts` — add 1 e2e case (triangle extrusion)
+- `package.json` — version bump 0.12.0-rc.1 → 0.4.0-alpha.1 (note: this is a **branch** version — kernelCAD's roadmap has parallel pre-release lines per NORTHSTAR; v0.4 doesn't depend on v0.11/v0.12 features)
+
+Wait — version bump to 0.4 from 0.12 is a downgrade. Use `0.13.0-alpha.1` instead, marking that this is the next minor version after v0.12 in the linear release history. Move the conceptual "v0.4-alpha" name into the CHANGELOG entry as a roadmap label.
+
+Updated decision: version bumps `0.12.0-rc.1` → `0.13.0-alpha.1`. The CHANGELOG header is `## v0.13.0-alpha.1 (NORTHSTAR roadmap: v0.4-alpha extrudePolygon) — 2026-04-30`.
+
+---
+
+## Phase 1: OcctBackend.extrudePolygon
+
+### Task 1: `OcctBackend.extrudePolygon(points, depth)` static factory
+
+**Files:**
+- Modify: `src/backends/occt/occtBackend.ts`
+- Create: `tests/unit/backends/occt/occtBackend.extrudePolygon.test.ts`
+
+- [ ] **Step 1: Write 5 failing tests**
+
+```typescript
+// tests/unit/backends/occt/occtBackend.extrudePolygon.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { OcctBackend, initOcct } from '../../../../src/backends/occt/occtBackend';
+
+describe('OcctBackend.extrudePolygon', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('extrudes an equilateral triangle (CCW points)', () => {
+    // Equilateral triangle, side 10, base on Y=0
+    const points: [number, number][] = [[0, 0], [10, 0], [5, Math.sqrt(75)]];
+    const shape = OcctBackend.extrudePolygon(points, 5);
+    // Volume = (sqrt(3)/4) * 10^2 * 5 ≈ 216.5
+    expect(shape.volume()).toBeCloseTo(216.506, 0);
+  });
+
+  it('auto-reverses CW input to CCW', () => {
+    const ccw: [number, number][] = [[0, 0], [10, 0], [5, 8]];
+    const cw: [number, number][] = [[0, 0], [5, 8], [10, 0]]; // reversed
+    expect(OcctBackend.extrudePolygon(ccw, 5).volume()).toBeCloseTo(
+      OcctBackend.extrudePolygon(cw, 5).volume(), 1
+    );
+  });
+
+  it('extrudes a square (4 CCW points)', () => {
+    const points: [number, number][] = [[0, 0], [10, 0], [10, 10], [0, 10]];
+    expect(OcctBackend.extrudePolygon(points, 3).volume()).toBeCloseTo(300, 1);
+  });
+
+  it('throws on fewer than 3 points', () => {
+    expect(() => OcctBackend.extrudePolygon([[0,0]], 5)).toThrow(/at least 3/);
+    expect(() => OcctBackend.extrudePolygon([[0,0],[1,0]], 5)).toThrow(/at least 3/);
+  });
+
+  it('throws on zero or negative depth', () => {
+    const points: [number, number][] = [[0,0],[10,0],[5,8]];
+    expect(() => OcctBackend.extrudePolygon(points, 0)).toThrow(/positive/);
+    expect(() => OcctBackend.extrudePolygon(points, -1)).toThrow(/positive/);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing**
+
+`npx vitest run tests/unit/backends/occt/occtBackend.extrudePolygon.test.ts`
+
+- [ ] **Step 3: Inspect Replicad's polygon API**
+
+```bash
+grep -nE 'drawPolysides|drawPolygon|drawCustom|new Sketcher' node_modules/replicad/dist/replicad.d.ts | head -20
+```
+
+The right Replicad call for an arbitrary polygon is likely `drawPolysides(...)` (regular n-gon, not what we want) or constructing a `Sketcher` with `lineTo` calls. Verify before writing code. The most general path is:
+
+```typescript
+const sketcher = new replicad.Sketcher('XY');
+sketcher.movePointerTo(points[0]);
+for (let i = 1; i < points.length; i++) sketcher.lineTo(points[i]);
+const sketch = sketcher.close();  // returns a Drawing
+const shape = sketch.extrude(depth);
+```
+
+If `Sketcher` isn't directly importable, use `replicad.drawCustom()` or whatever `extrudeRect` already uses internally. Match the existing pattern in `OcctBackend.extrudeRect` (which is in `occtBackend.ts` from v0.1).
+
+- [ ] **Step 4: Implement**
+
+Add to `src/backends/occt/occtBackend.ts`:
+
+```typescript
+  /**
+   * Extrude a closed polygon along +Z by `depth`.
+   *
+   * `points` is an array of `[x, y]` tuples in millimetres. Winding is normalized
+   * — CW input is silently reversed to CCW before extrusion. The polygon must
+   * have at least 3 distinct points; depth must be positive.
+   *
+   * @throws {Error} If fewer than 3 points or non-positive depth.
+   * @throws {Error} If OCCT fails to construct or extrude (e.g. self-intersection).
+   */
+  static extrudePolygon(points: [number, number][], depth: number): OcctBackend {
+    if (points.length < 3) {
+      throw new Error(`OcctBackend.extrudePolygon: need at least 3 points (got ${points.length})`);
+    }
+    if (depth <= 0) {
+      throw new Error(`OcctBackend.extrudePolygon: depth must be positive (got ${depth})`);
+    }
+
+    const ccw = ensureCCW(points);
+
+    // Build an OCCT 2D drawing. Mirror the pattern used by extrudeRect.
+    // The exact API call is the result of Step 3 inspection — placeholder:
+    // const sketcher = new replicad.Sketcher('XY').movePointerTo(ccw[0]);
+    // for (let i = 1; i < ccw.length; i++) sketcher.lineTo(ccw[i]);
+    // const drawn = sketcher.close();
+    // const lifted = drawn.sketchOnPlane('XY');  // depending on API; some replicad versions need this
+    // const lowered = lifted.extrude(depth) as ReplicadShape3D;
+    // return new OcctBackend(lowered);
+
+    // The implementer fills in the exact Replicad calls from Step 3.
+
+    // Fallback (if Sketcher direct construction fails):
+    // const drawn = replicad.drawCustom({ moveTo: ccw[0], lineTo: ccw.slice(1) });
+    // — this hypothetical API doesn't exist; use the actual one.
+
+    throw new Error('IMPLEMENTER: replace with Replicad-API-specific code from Step 3');
+  }
+}
+
+function ensureCCW(points: [number, number][]): [number, number][] {
+  // Shoelace area: positive => CCW, negative => CW
+  let area2 = 0;
+  for (let i = 0; i < points.length; i++) {
+    const [x1, y1] = points[i];
+    const [x2, y2] = points[(i + 1) % points.length];
+    area2 += x1 * y2 - x2 * y1;
+  }
+  return area2 < 0 ? points.slice().reverse() as [number, number][] : points;
+}
+```
+
+The implementer MUST replace the throw-placeholder with the actual Replicad API call discovered in Step 3. If Step 3 reveals that Replicad's API doesn't directly support this, the implementer reports BLOCKED with what they found.
+
+- [ ] **Step 5: Run passing — 5/5 PASS**
+
+If a test fails for an unexpected reason (e.g., volume is off by a factor of 2 — sign of orientation issue), debug by adding a console.log of `ensureCCW(points)` and the resulting `drawn.area` (replicad sketches usually expose this). Fix the orientation, not the test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/backends/occt/occtBackend.ts tests/unit/backends/occt/occtBackend.extrudePolygon.test.ts
+git commit -m "feat(backends/occt): OcctBackend.extrudePolygon — arbitrary 2D polygon → 3D"
+```
+
+---
+
+## Phase 2: OcctLowerer 'polygon' profile
+
+### Task 2: Extend the `'extrude'` case for `profileKind === 'polygon'`
+
+**Files:**
+- Modify: `src/backends/occt/occtLowerer.ts`
+- Create: `tests/unit/backends/occt/occtLowerer.extrudePolygon.test.ts`
+
+- [ ] **Step 1: Write 3 failing tests**
+
+```typescript
+// tests/unit/backends/occt/occtLowerer.extrudePolygon.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { OcctLowerer } from '../../../../src/backends/occt/occtLowerer';
+import { initOcct } from '../../../../src/backends/occt/occtBackend';
+import type { FeatureRecord } from '../../../../src/intent/featureRecord';
+import type { Param } from '../../../../src/intent/types';
+
+const mm = (n: number): Param => ({ expression: String(n), unit: 'mm', evaluated: n });
+const ul = (n: number): Param => ({ expression: String(n), unit: 'unitless', evaluated: n });
+const str = (s: string): Param => ({ expression: `'${s}'`, unit: 'unitless', evaluated: 0 });
+
+describe('OcctLowerer extrude polygon', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('lowers a polygon-extrude record', async () => {
+    const r: FeatureRecord = {
+      id: 'extrude_1', kind: 'extrude',
+      inputs: {},
+      params: { profileKind: str('polygon'), depth: mm(5) },
+      metadata: { points: [[0, 0], [10, 0], [5, 8]] },
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: {} });
+    expect(result.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0);
+    expect(result.shape.volume()).toBeGreaterThan(0);
+  });
+
+  it('emits feature.extrude.bad-points when metadata.points is missing or invalid', async () => {
+    const r: FeatureRecord = {
+      id: 'extrude_1', kind: 'extrude',
+      inputs: {},
+      params: { profileKind: str('polygon'), depth: mm(5) },
+      metadata: {},  // points missing
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: {} });
+    const errs = result.diagnostics.filter(d => d.severity === 'error');
+    expect(errs).toHaveLength(1);
+    expect(errs[0].code).toBe('feature.extrude.bad-points');
+  });
+
+  it('emits feature.extrude.failed when OCCT throws', async () => {
+    const r: FeatureRecord = {
+      id: 'extrude_1', kind: 'extrude',
+      inputs: {},
+      params: { profileKind: str('polygon'), depth: mm(5) },
+      metadata: { points: [[0, 0], [0, 0], [0, 0]] },  // degenerate
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: {} });
+    const errs = result.diagnostics.filter(d => d.severity === 'error');
+    expect(errs.length).toBeGreaterThan(0);
+    // Either feature.extrude.failed or feature.extrude.bad-points (degenerate
+    // points may be caught by ensureCCW or by OCCT)
+  });
+});
+```
+
+- [ ] **Step 2: Run failing**
+
+- [ ] **Step 3: Extend the `'extrude'` case**
+
+In `src/backends/occt/occtLowerer.ts`, find the existing `'extrude'` case. It currently switches on `profileKind === 'rect'` / `'circle'`. Add:
+
+```typescript
+        case 'polygon': {
+          const points = (r.metadata as { points?: unknown } | undefined)?.points;
+          if (!Array.isArray(points) || points.length < 3 ||
+              !points.every(p => Array.isArray(p) && p.length === 2 &&
+                                  typeof p[0] === 'number' && typeof p[1] === 'number')) {
+            diagnostics.push({
+              target: 'export-occt',
+              code: 'feature.extrude.bad-points',
+              featureId: r.id,
+              severity: 'error',
+              message: `extrude polygon requires metadata.points: [number, number][] with at least 3 points.`,
+            });
+            return { shape: undefined as unknown as ShapeBackend, diagnostics };
+          }
+          try {
+            shape = OcctBackend.extrudePolygon(points as [number, number][], depth);
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            diagnostics.push({
+              target: 'export-occt',
+              code: 'feature.extrude.failed',
+              featureId: r.id,
+              severity: 'error',
+              message: `OCCT extrude failed: ${msg}`,
+            });
+            return { shape: undefined as unknown as ShapeBackend, diagnostics };
+          }
+          break;
+        }
+```
+
+- [ ] **Step 4: Run passing — 3/3 PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backends/occt/occtLowerer.ts tests/unit/backends/occt/occtLowerer.extrudePolygon.test.ts
+git commit -m "feat(backends/occt): OcctLowerer extrude case handles 'polygon' profileKind"
+```
+
+---
+
+## Phase 3: Module API
+
+### Task 3: Top-level `extrudePolygon(points, depth)` function
+
+**Files:**
+- Modify: `src/modules/api.ts`
+- Create: `tests/unit/modules/api.extrudePolygon.test.ts`
+
+- [ ] **Step 1: Write 3 failing tests**
+
+```typescript
+// tests/unit/modules/api.extrudePolygon.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOcct } from '../../../src/backends/occt/occtBackend';
+import { runScript } from '../../../src/script-runtime/runScript';
+
+describe('extrudePolygon top-level API', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('captures an extrude record with profile=polygon and points in metadata', async () => {
+    const code = `return extrudePolygon([[0, 0], [10, 0], [5, 8]], 5);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].kind).toBe('extrude');
+    expect(result.records[0].params.profileKind.expression).toBe(`'polygon'`);
+    expect(result.records[0].params.depth.evaluated).toBe(5);
+    expect(result.records[0].metadata?.points).toEqual([[0, 0], [10, 0], [5, 8]]);
+  });
+
+  it('captures arbitrary point counts', async () => {
+    const code = `return extrudePolygon([[0,0],[10,0],[10,10],[0,10],[0,5]], 3);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const r = result.records[0];
+    expect((r.metadata as { points: unknown[] }).points).toHaveLength(5);
+  });
+
+  it('lowers + recomputes successfully', async () => {
+    const { RecomputeEngine } = await import('../../../src/compute/recomputeEngine');
+    const { OcctLowerer } = await import('../../../src/backends/occt/occtLowerer');
+    const code = `return extrudePolygon([[0,0],[10,0],[10,10],[0,10]], 2);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const engine = new RecomputeEngine(new OcctLowerer());
+    const r = await engine.run(result.records);
+    expect(r.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0);
+    const last = result.records[result.records.length - 1];
+    expect(r.shapes.get(last.id)!.volume()).toBeCloseTo(200, 1);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing**
+
+- [ ] **Step 3: Add `extrudePolygon` to `src/modules/api.ts`**
+
+Read the existing `createApi` factory. The pattern from existing functions like `extrudeRect`:
+
+```typescript
+extrudeRect: (width: number, height: number, depth: number): Shape => {
+  const id = session.idGen.next('extrude');
+  // ... registers a FeatureRecord with profileKind: 'rect'
+}
+```
+
+Add:
+
+```typescript
+extrudePolygon: (points: [number, number][], depth: number): Shape => {
+  return session.createShape({
+    kind: 'extrude',
+    inputs: {},
+    params: {
+      profileKind: { expression: "'polygon'", unit: 'unitless', evaluated: 0 },
+      depth: { expression: String(depth), unit: 'mm', evaluated: depth },
+    },
+    metadata: { points },
+  });
+},
+```
+
+But: the `createShape` method in `CaptureSession` from earlier session memory takes `{ kind, params, inputs }`. It doesn't currently accept `metadata`. **Verify by reading `src/capture/captureSession.ts`** — if `createShape` doesn't pass `metadata` through, extend its `FeatureSpec` interface to include `metadata?: Record<string, unknown>` and propagate it to the `register()` call.
+
+- [ ] **Step 4: Run passing — 3/3 PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/modules/api.ts src/capture/captureSession.ts tests/unit/modules/api.extrudePolygon.test.ts
+git commit -m "feat(modules): extrudePolygon top-level API + metadata propagation in CaptureSession"
+```
+
+---
+
+## Phase 4: E2E + Tag
+
+### Task 4: e2e fixture + tag
+
+**Files:**
+- Create: `tests/e2e/fixtures/triangle-extrusion.kcad.ts`
+- Modify: `tests/e2e/cli-acceptance.test.ts`
+- Modify: `package.json`, `CHANGELOG.md`
+
+- [ ] **Step 1: Create fixture**
+
+```typescript
+// tests/e2e/fixtures/triangle-extrusion.kcad.ts
+const w = param('Width', 30, { unit: 'mm', min: 10, max: 80 });
+const t = param('Thickness', 5, { unit: 'mm', min: 1, max: 20 });
+
+// Equilateral triangle, base = w
+const h = w * Math.sqrt(3) / 2;
+return extrudePolygon([[0, 0], [w, 0], [w/2, h]], t);
+```
+
+- [ ] **Step 2: Add 1 e2e test**
+
+In `tests/e2e/cli-acceptance.test.ts`:
+
+```typescript
+  it('runs end-to-end on the triangle extrusion fixture and produces STL', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'kcad-acc-'));
+    const out = join(tmp, 'triangle.stl');
+    const r = await exportScript({
+      file: join(__dirname, 'fixtures/triangle-extrusion.kcad.ts'),
+      format: 'stl',
+      out,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(statSync(out).size).toBeGreaterThan(500); // tiny but non-empty STL
+  });
+```
+
+- [ ] **Step 3: Bump version + CHANGELOG**
+
+`package.json`: `0.12.0-rc.1` → `0.13.0-alpha.1` (next minor in linear release history; the conceptual "v0.4-alpha" name is kept in the CHANGELOG label).
+
+```markdown
+## v0.13.0-alpha.1 (NORTHSTAR roadmap: v0.4-alpha extrudePolygon) — 2026-04-30
+
+### Added
+- **`extrudePolygon(points, depth)`** — first arbitrary-2D-profile primitive. Takes an array of `[x, y]` points in millimetres and an extrude depth. Auto-normalizes winding (CW input silently reversed to CCW). Closed by default. Minimum 3 points.
+- New diagnostic codes: `feature.extrude.bad-points` (missing/invalid metadata.points), `feature.extrude.failed` (OCCT exception during extrusion).
+- e2e fixture `tests/e2e/fixtures/triangle-extrusion.kcad.ts` + acceptance test.
+- `FeatureSpec.metadata` propagated through `CaptureSession.register()` so feature-specific structured data (like polygon points) can be attached without widening the param shape.
+
+### Changed
+- `extrude` FeatureKind now accepts `profileKind: 'polygon'` in addition to existing `'rect'` and `'circle'`.
+
+### Deferred to v0.4-beta+
+- Sketch builder pattern (`sketch.polygon().extrude()`, `sketch.path().lineTo().close()`)
+- `roundedRect` and `circle2d` as Sketch primitives (kernelCAD currently has them only as `extrudeRect` / `extrudeCircle`)
+- Open polylines (`.stroke(width)`)
+- Sketch revolve / sweep
+- Self-intersection validation
+```
+
+- [ ] **Step 4: PR + merge + tag flow**
+
+```bash
+git add ...
+git commit -m "release: v0.13.0-alpha.1 — extrudePolygon (v0.4-alpha minimal)"
+git push
+gh pr create ...
+# wait for qc, merge, tag v0.13.0-alpha.1
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** Backend factory (Task 1) + lowerer case (Task 2) + module API (Task 3) + e2e + release (Task 4). Standard pattern.
+
+**Placeholder scan:** Task 1 Step 4 has a deliberate `IMPLEMENTER: replace with Replicad-API-specific code` placeholder. This is honest scaffolding — the exact API call is the result of Step 3 inspection and varies between Replicad versions. Not a plan failure; it's an inspection-driven step.
+
+**Type consistency:** `extrudePolygon(points, depth)` signature consistent across OcctBackend, lowerer (via metadata), API. `metadata.points` typed as `[number, number][]` everywhere.
+
+**Open issues:**
+- `CaptureSession` may need `metadata` plumbing — Task 3 Step 3 explicitly tells implementer to extend `FeatureSpec` if needed. Small and bounded.
+- The e2e test asserts `statSync(out).size > 500` — triangles produce small STLs; tune if reality differs.
+
+---
+
+## Execution Handoff
+
+Plan complete. 4 tasks, ~half day. Subagent-driven recommended.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kernelcad",
   "private": true,
-  "version": "0.12.0-rc.1",
+  "version": "0.13.0-alpha.1",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/src/backends/occt/occtBackend.ts
+++ b/src/backends/occt/occtBackend.ts
@@ -120,6 +120,41 @@ export class OcctBackend implements ShapeBackend {
   }
 
   /**
+   * Extrude a closed polygon along +Z by `depth`.
+   *
+   * `points` is an array of `[x, y]` tuples in millimetres. Winding is normalized
+   * — CW input is silently reversed to CCW before extrusion. The polygon must
+   * have at least 3 distinct points; depth must be positive.
+   *
+   * @throws {Error} If fewer than 3 points or non-positive depth.
+   * @throws {Error} If OCCT fails to construct or extrude (e.g. self-intersection).
+   */
+  static extrudePolygon(points: [number, number][], depth: number): OcctBackend {
+    if (!initialized) throw new Error('OCCT not initialized — call initOcct() first');
+    if (points.length < 3) {
+      throw new Error(`OcctBackend.extrudePolygon: need at least 3 points (got ${points.length})`);
+    }
+    if (depth <= 0) {
+      throw new Error(`OcctBackend.extrudePolygon: depth must be positive (got ${depth})`);
+    }
+
+    const ccw = ensureCCW(points);
+
+    // Build a 2D drawing using replicad's DrawingPen API — the same pattern
+    // used by revolveRect. draw(start).lineTo(p1)...lineTo(pn-1).close()
+    // returns a Drawing; sketchOnPlane('XY') promotes it to a Sketch; extrude
+    // lifts it to a 3D solid.
+    let pen = replicad.draw(ccw[0]);
+    for (let i = 1; i < ccw.length; i++) {
+      pen = pen.lineTo(ccw[i]) as typeof pen;
+    }
+    const drawing = pen.close();
+    const sketch = drawing.sketchOnPlane('XY');
+    const single = sketch as unknown as { extrude: (d: number) => ReplicadShape3D };
+    return new OcctBackend(single.extrude(depth));
+  }
+
+  /**
    * Revolve an axis-aligned rectangular profile around the Z axis.
    * The rect is placed in the XZ plane with its corner at `(offsetX, 0)`,
    * extends `w` in radial X and `h` in axial Z. With `angleDeg = 360`, the
@@ -320,4 +355,20 @@ export class OcctBackend implements ShapeBackend {
       maybeDelete.call(this.shape);
     }
   }
+}
+
+/**
+ * Ensure polygon points are in counter-clockwise winding order.
+ * Uses the shoelace formula: positive signed area => CCW, negative => CW.
+ * CW input is silently reversed.
+ */
+function ensureCCW(points: [number, number][]): [number, number][] {
+  // Shoelace area: positive => CCW, negative => CW
+  let area2 = 0;
+  for (let i = 0; i < points.length; i++) {
+    const [x1, y1] = points[i];
+    const [x2, y2] = points[(i + 1) % points.length];
+    area2 += x1 * y2 - x2 * y1;
+  }
+  return area2 < 0 ? (points.slice().reverse() as [number, number][]) : points;
 }

--- a/src/backends/occt/occtLowerer.ts
+++ b/src/backends/occt/occtLowerer.ts
@@ -61,15 +61,44 @@ export class OcctLowerer implements FeatureLowerer {
       case 'extrude': {
         // Profile kind is a quoted string in IR (e.g. "'rect'", "'circle'").
         const profileKind = String(r.params.profileKind.expression).replace(/'/g, '');
-        const height = r.params.height.evaluated;
         if (profileKind === 'rect') {
+          const height = r.params.height.evaluated;
           shape = OcctBackend.extrudeRect(
             r.params.w.evaluated,
             r.params.h.evaluated,
             height,
           );
         } else if (profileKind === 'circle') {
+          const height = r.params.height.evaluated;
           shape = OcctBackend.extrudeCircle(r.params.r.evaluated, height);
+        } else if (profileKind === 'polygon') {
+          const depth = r.params.depth.evaluated;
+          const points = (r.metadata as { points?: unknown } | undefined)?.points;
+          if (!Array.isArray(points) || points.length < 3 ||
+              !points.every(p => Array.isArray(p) && p.length === 2 &&
+                                  typeof p[0] === 'number' && typeof p[1] === 'number')) {
+            diagnostics.push({
+              target: 'export-occt',
+              code: 'feature.extrude.bad-points',
+              featureId: r.id,
+              severity: 'error',
+              message: `extrude polygon requires metadata.points: [number, number][] with at least 3 points.`,
+            });
+            return { shape: undefined as unknown as ShapeBackend, diagnostics };
+          }
+          try {
+            shape = OcctBackend.extrudePolygon(points as [number, number][], depth);
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            diagnostics.push({
+              target: 'export-occt',
+              code: 'feature.extrude.failed',
+              featureId: r.id,
+              severity: 'error',
+              message: `OCCT extrude failed: ${msg}`,
+            });
+            return { shape: undefined as unknown as ShapeBackend, diagnostics };
+          }
         } else {
           return {
             shape: undefined as unknown as ShapeBackend,

--- a/src/capture/captureSession.ts
+++ b/src/capture/captureSession.ts
@@ -7,6 +7,7 @@ export interface FeatureSpec {
   kind: FeatureKind;
   params: Record<string, Param>;
   inputs: Record<string, FeatureRef>;
+  metadata?: Record<string, unknown>;
 }
 
 export class CaptureSession {
@@ -22,6 +23,7 @@ export class CaptureSession {
       inputs: spec.inputs,
       transforms: [],
       suppressed: false,
+      metadata: spec.metadata,
     };
     this.records.push(r);
     return r;

--- a/src/modules/api.ts
+++ b/src/modules/api.ts
@@ -14,6 +14,7 @@ export interface KernelCadApi {
   sphere(r: number): Shape;
   extrudeRect(w: number, h: number, height: number): Shape;
   extrudeCircle(r: number, height: number): Shape;
+  extrudePolygon(points: [number, number][], depth: number): Shape;
   revolveRect(w: number, h: number, offsetX: number, angleDeg?: number): Shape;
   union(...shapes: Shape[]): Shape;
   param(name: string, defaultExpr: number | string, opts: ParamOptions): number;
@@ -67,6 +68,17 @@ export function createApi(ctx: ApiContext): KernelCadApi {
           height: mm(height),
         },
         inputs: {},
+      });
+    },
+    extrudePolygon(points, depth) {
+      return session.createShape({
+        kind: 'extrude',
+        inputs: {},
+        params: {
+          profileKind: { expression: "'polygon'", unit: 'unitless', evaluated: 0 },
+          depth: { expression: String(depth), unit: 'mm', evaluated: depth },
+        },
+        metadata: { points },
       });
     },
     revolveRect(w, h, offsetX, angleDeg = 360) {

--- a/tests/e2e/cli-acceptance.test.ts
+++ b/tests/e2e/cli-acceptance.test.ts
@@ -112,6 +112,7 @@ describe('v0.2-alpha hollow-box fixture', () => {
     expect(statSync(out).size).toBeGreaterThan(1000);
   });
 
+
   it('hollow-box has dramatically less volume than the solid equivalent', async () => {
     const { runScript } = await import('../../src/script-runtime/runScript');
     const { RecomputeEngine } = await import('../../src/compute/recomputeEngine');
@@ -137,5 +138,21 @@ describe('v0.2-alpha hollow-box fixture', () => {
     const uv = ures.shapes.get(ulast.id)!.volume();
     expect(sv).toBeLessThan(uv * 0.3);
     expect(sv).toBeGreaterThan(0);
+  });
+});
+
+describe('v0.4-alpha triangle-extrusion fixture', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('runs end-to-end on the triangle extrusion fixture and produces STL', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'kcad-acc-'));
+    const out = join(tmp, 'triangle.stl');
+    const r = await exportScript({
+      file: join(__dirname, 'fixtures/triangle-extrusion.kcad.ts'),
+      format: 'stl',
+      out,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(statSync(out).size).toBeGreaterThan(500);
   });
 });

--- a/tests/e2e/fixtures/triangle-extrusion.kcad.ts
+++ b/tests/e2e/fixtures/triangle-extrusion.kcad.ts
@@ -1,0 +1,6 @@
+const w = param('Width', 30, { unit: 'mm', min: 10, max: 80 });
+const t = param('Thickness', 5, { unit: 'mm', min: 1, max: 20 });
+
+// Equilateral triangle, base = w
+const h = w * Math.sqrt(3) / 2;
+return extrudePolygon([[0, 0], [w, 0], [w/2, h]], t);

--- a/tests/unit/backends/occt/occtBackend.extrudePolygon.test.ts
+++ b/tests/unit/backends/occt/occtBackend.extrudePolygon.test.ts
@@ -1,0 +1,39 @@
+// tests/unit/backends/occt/occtBackend.extrudePolygon.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { OcctBackend, initOcct } from '../../../../src/backends/occt/occtBackend';
+
+describe('OcctBackend.extrudePolygon', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('extrudes an equilateral triangle (CCW points)', () => {
+    // Equilateral triangle, side 10, base on Y=0
+    const points: [number, number][] = [[0, 0], [10, 0], [5, Math.sqrt(75)]];
+    const shape = OcctBackend.extrudePolygon(points, 5);
+    // Volume = (sqrt(3)/4) * 10^2 * 5 ≈ 216.5
+    expect(shape.volume()).toBeCloseTo(216.506, 0);
+  });
+
+  it('auto-reverses CW input to CCW', () => {
+    const ccw: [number, number][] = [[0, 0], [10, 0], [5, 8]];
+    const cw: [number, number][] = [[0, 0], [5, 8], [10, 0]]; // reversed
+    expect(OcctBackend.extrudePolygon(ccw, 5).volume()).toBeCloseTo(
+      OcctBackend.extrudePolygon(cw, 5).volume(), 1
+    );
+  });
+
+  it('extrudes a square (4 CCW points)', () => {
+    const points: [number, number][] = [[0, 0], [10, 0], [10, 10], [0, 10]];
+    expect(OcctBackend.extrudePolygon(points, 3).volume()).toBeCloseTo(300, 1);
+  });
+
+  it('throws on fewer than 3 points', () => {
+    expect(() => OcctBackend.extrudePolygon([[0,0]], 5)).toThrow(/at least 3/);
+    expect(() => OcctBackend.extrudePolygon([[0,0],[1,0]], 5)).toThrow(/at least 3/);
+  });
+
+  it('throws on zero or negative depth', () => {
+    const points: [number, number][] = [[0,0],[10,0],[5,8]];
+    expect(() => OcctBackend.extrudePolygon(points, 0)).toThrow(/positive/);
+    expect(() => OcctBackend.extrudePolygon(points, -1)).toThrow(/positive/);
+  });
+});

--- a/tests/unit/backends/occt/occtLowerer.extrudePolygon.test.ts
+++ b/tests/unit/backends/occt/occtLowerer.extrudePolygon.test.ts
@@ -1,0 +1,56 @@
+// tests/unit/backends/occt/occtLowerer.extrudePolygon.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { OcctLowerer } from '../../../../src/backends/occt/occtLowerer';
+import { initOcct } from '../../../../src/backends/occt/occtBackend';
+import type { FeatureRecord } from '../../../../src/intent/featureRecord';
+import type { Param } from '../../../../src/intent/types';
+
+const mm = (n: number): Param => ({ expression: String(n), unit: 'mm', evaluated: n });
+const ul = (n: number): Param => ({ expression: String(n), unit: 'unitless', evaluated: n });
+const str = (s: string): Param => ({ expression: `'${s}'`, unit: 'unitless', evaluated: 0 });
+
+describe('OcctLowerer extrude polygon', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('lowers a polygon-extrude record', async () => {
+    const r: FeatureRecord = {
+      id: 'extrude_1', kind: 'extrude',
+      inputs: {},
+      params: { profileKind: str('polygon'), depth: mm(5) },
+      metadata: { points: [[0, 0], [10, 0], [5, 8]] },
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: {} });
+    expect(result.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0);
+    expect(result.shape.volume()).toBeGreaterThan(0);
+  });
+
+  it('emits feature.extrude.bad-points when metadata.points is missing or invalid', async () => {
+    const r: FeatureRecord = {
+      id: 'extrude_1', kind: 'extrude',
+      inputs: {},
+      params: { profileKind: str('polygon'), depth: mm(5) },
+      metadata: {},  // points missing
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: {} });
+    const errs = result.diagnostics.filter(d => d.severity === 'error');
+    expect(errs).toHaveLength(1);
+    expect(errs[0].code).toBe('feature.extrude.bad-points');
+  });
+
+  it('emits feature.extrude.failed when OCCT throws', async () => {
+    const r: FeatureRecord = {
+      id: 'extrude_1', kind: 'extrude',
+      inputs: {},
+      params: { profileKind: str('polygon'), depth: mm(5) },
+      metadata: { points: [[0, 0], [0, 0], [0, 0]] },  // degenerate
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: {} });
+    const errs = result.diagnostics.filter(d => d.severity === 'error');
+    expect(errs.length).toBeGreaterThan(0);
+    // Either feature.extrude.failed or feature.extrude.bad-points (degenerate
+    // points may be caught by ensureCCW or by OCCT)
+  });
+});

--- a/tests/unit/modules/api.extrudePolygon.test.ts
+++ b/tests/unit/modules/api.extrudePolygon.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOcct } from '../../../src/backends/occt/occtBackend';
+import { runScript } from '../../../src/script-runtime/runScript';
+
+describe('extrudePolygon top-level API', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('captures an extrude record with profile=polygon and points in metadata', async () => {
+    const code = `return extrudePolygon([[0, 0], [10, 0], [5, 8]], 5);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].kind).toBe('extrude');
+    expect(result.records[0].params.profileKind.expression).toBe(`'polygon'`);
+    expect(result.records[0].params.depth.evaluated).toBe(5);
+    expect(result.records[0].metadata?.points).toEqual([[0, 0], [10, 0], [5, 8]]);
+  });
+
+  it('captures arbitrary point counts', async () => {
+    const code = `return extrudePolygon([[0,0],[10,0],[10,10],[0,10],[0,5]], 3);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const r = result.records[0];
+    expect((r.metadata as { points: unknown[] }).points).toHaveLength(5);
+  });
+
+  it('lowers + recomputes successfully', async () => {
+    const { RecomputeEngine } = await import('../../../src/compute/recomputeEngine');
+    const { OcctLowerer } = await import('../../../src/backends/occt/occtLowerer');
+    const code = `return extrudePolygon([[0,0],[10,0],[10,10],[0,10]], 2);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const engine = new RecomputeEngine(new OcctLowerer());
+    const r = await engine.run(result.records);
+    expect(r.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0);
+    const last = result.records[result.records.length - 1];
+    expect(r.shapes.get(last.id)!.volume()).toBeCloseTo(200, 1);
+  });
+});


### PR DESCRIPTION
First v0.4-alpha milestone: extrudePolygon(points, depth) for arbitrary closed polygons. Mirrors existing extrudeRect/extrudeCircle pattern. Sketch builder pattern (polygon(...).extrude(t)) deferred to v0.4-beta.

Closes the agent-first surface story for v0.12 + adds the first true 2D-profile primitive.