### PR TITLE
feat(v0.13.0-beta.1): extrudeRoundedRect — rounded-corner rectangles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## v0.13.0-beta.1 (NORTHSTAR roadmap: v0.4-beta extrudeRoundedRect) — 2026-04-30
+
+### Added
+- **`extrudeRoundedRect(width, height, radius, depth)`** — second arbitrary-2D-profile primitive after `extrudePolygon`. Auto-clamps `radius` to `min(width/2, height/2)` (with a tiny safety margin for Replicad's exact-half edge case). Zero radius behaves like a sharp rectangle.
+- e2e fixture `tests/e2e/fixtures/rounded-plate.kcad.ts` + acceptance test.
+
+### Changed
+- `extrude` FeatureKind now accepts `profileKind: 'rounded-rect'` in addition to existing `'rect'` / `'circle'` / `'polygon'`.
+
+### Deferred to v0.4-rc / v0.4 final
+- `path()` builder for arbitrary 2D paths
+- Full `Sketch` builder type
+- Sketch revolve / sweep
+- Open polylines (`.stroke(width)`)
+
 ## v0.13.0-alpha.1 (NORTHSTAR roadmap: v0.4-alpha extrudePolygon) — 2026-04-30
 
 ### Added

--- a/docs/superpowers/plans/2026-04-30-v0.4-beta-extrude-rounded-rect.md
+++ b/docs/superpowers/plans/2026-04-30-v0.4-beta-extrude-rounded-rect.md
@@ -1,0 +1,424 @@
+# v0.13.0-beta.1 — `extrudeRoundedRect` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `extrudeRoundedRect(width, height, radius, depth)` — second new 2D profile after `extrudePolygon`. Lets users extrude rounded-corner rectangles in one call (vs. having to construct a polygon with arc approximations).
+
+**Architecture:** Same pattern as v0.4-alpha extrudePolygon — new OcctBackend factory, new lowerer profile arm, new top-level API function. Replicad's `drawRoundedRectangle(width, height, r?)` is the underlying call (verified at `replicad.d.ts:805`).
+
+**Tech Stack:** Same as predecessors.
+
+**Predecessor:** v0.13.0-alpha.1 (extrudePolygon).
+
+**Why minimal scope:** Continues the "one new profile per pre-release" cadence. v0.4-rc can add `path()` builder for arbitrary curves; v0.4 final unifies under a Sketch type.
+
+---
+
+## Decisions Locked
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| API name | `extrudeRoundedRect(width, height, radius, depth)` | Mirrors `extrudeRect(w, h, d)` and `extrudePolygon(p, d)` patterns. Radius before depth keeps related shape params together. |
+| Profile kind in IR | `'rounded-rect'` | Matches existing 'rect'/'circle'/'polygon' string discriminator. Hyphen is fine — already a string literal. |
+| Radius validation | Auto-clamp to `min(width/2, height/2)` | Matches ForgeCAD behavior; prevents OCCT errors on too-large radius. |
+| Zero radius | Treated as ordinary rectangle | Consistent with Replicad's `drawRoundedRectangle(w, h, 0)`. |
+
+---
+
+## File Structure
+
+**Create:**
+- `tests/unit/backends/occt/occtBackend.extrudeRoundedRect.test.ts`
+- `tests/unit/backends/occt/occtLowerer.extrudeRoundedRect.test.ts`
+- `tests/unit/modules/api.extrudeRoundedRect.test.ts`
+- `tests/e2e/fixtures/rounded-plate.kcad.ts`
+
+**Modify:**
+- `src/backends/occt/occtBackend.ts` — add static `extrudeRoundedRect(w, h, r, d)` factory
+- `src/backends/occt/occtLowerer.ts` — extend `'extrude'` case for `'rounded-rect'` profileKind
+- `src/modules/api.ts` — add top-level `extrudeRoundedRect`
+- `tests/e2e/cli-acceptance.test.ts` — 1 new e2e case
+- `package.json` — version bump 0.13.0-alpha.1 → 0.13.0-beta.1
+- `CHANGELOG.md` — prepend entry
+
+---
+
+## Phase 1: OcctBackend.extrudeRoundedRect
+
+### Task 1: Static factory + 4 tests
+
+**Files:**
+- Modify: `src/backends/occt/occtBackend.ts`
+- Create: `tests/unit/backends/occt/occtBackend.extrudeRoundedRect.test.ts`
+
+- [ ] **Step 1: Write 4 failing tests**
+
+```typescript
+// tests/unit/backends/occt/occtBackend.extrudeRoundedRect.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { OcctBackend, initOcct } from '../../../../src/backends/occt/occtBackend';
+
+describe('OcctBackend.extrudeRoundedRect', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('extrudes a rounded rectangle (volume = w*h*d - corner-cuts)', () => {
+    // 20x20 square, r=2, d=5. Volume = 20*20*5 - 4 * (4 - π) * 4 * 5/4 ≈ 2000 - 4.3 ≈ 1995.7
+    // Use loose tolerance because the exact corner-cut math involves arc area.
+    const v = OcctBackend.extrudeRoundedRect(20, 20, 2, 5).volume();
+    expect(v).toBeLessThan(2000);   // some material removed
+    expect(v).toBeGreaterThan(1985); // not too much
+  });
+
+  it('zero radius behaves like a rectangle (volume = w*h*d)', () => {
+    expect(OcctBackend.extrudeRoundedRect(10, 20, 0, 5).volume()).toBeCloseTo(1000, 0);
+  });
+
+  it('auto-clamps radius to min(w/2, h/2)', () => {
+    // 10x20, r=100 → clamp to 5 (= 10/2)
+    const clamped = OcctBackend.extrudeRoundedRect(10, 20, 100, 5).volume();
+    const direct = OcctBackend.extrudeRoundedRect(10, 20, 5, 5).volume();
+    expect(clamped).toBeCloseTo(direct, 1);
+  });
+
+  it('throws on zero or negative depth', () => {
+    expect(() => OcctBackend.extrudeRoundedRect(10, 10, 1, 0)).toThrow(/positive/);
+    expect(() => OcctBackend.extrudeRoundedRect(10, 10, 1, -1)).toThrow(/positive/);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing — `npx vitest run tests/unit/backends/occt/occtBackend.extrudeRoundedRect.test.ts`**
+
+- [ ] **Step 3: Implement**
+
+In `src/backends/occt/occtBackend.ts`, add the factory next to existing `extrudeRect` / `extrudePolygon`:
+
+```typescript
+  /**
+   * Extrude a rectangle with rounded corners along +Z by `depth`.
+   *
+   * `width` and `height` are in mm. `radius` is the corner radius — auto-clamped
+   * to `min(width/2, height/2)` so callers never trigger an OCCT error from
+   * over-sized radii. Zero radius is treated as a sharp-corner rectangle.
+   *
+   * @throws {Error} If `depth <= 0`.
+   */
+  static extrudeRoundedRect(width: number, height: number, radius: number, depth: number): OcctBackend {
+    if (depth <= 0) {
+      throw new Error(`OcctBackend.extrudeRoundedRect: depth must be positive (got ${depth})`);
+    }
+    const clamped = Math.min(Math.max(0, radius), width / 2, height / 2);
+    // Replicad: drawRoundedRectangle(width, height, r?) returns a Drawing.
+    // Standard sketchOnPlane → extrude path.
+    const drawing = replicad.drawRoundedRectangle(width, height, clamped);
+    const sketch = drawing.sketchOnPlane('XY');
+    const single = sketch as unknown as { extrude: (d: number) => ReplicadShape3D };
+    return new OcctBackend(single.extrude(depth));
+  }
+```
+
+This mirrors the `extrudePolygon` factory's structure (Drawing → sketchOnPlane → extrude).
+
+- [ ] **Step 4: Run passing — 4/4 PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backends/occt/occtBackend.ts tests/unit/backends/occt/occtBackend.extrudeRoundedRect.test.ts
+git commit -m "feat(backends/occt): OcctBackend.extrudeRoundedRect — rounded-corner rectangle extrusion"
+```
+
+---
+
+## Phase 2: OcctLowerer 'rounded-rect' profile
+
+### Task 2: Extend `'extrude'` case + 3 tests
+
+**Files:**
+- Modify: `src/backends/occt/occtLowerer.ts`
+- Create: `tests/unit/backends/occt/occtLowerer.extrudeRoundedRect.test.ts`
+
+- [ ] **Step 1: Write 3 failing tests**
+
+```typescript
+// tests/unit/backends/occt/occtLowerer.extrudeRoundedRect.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { OcctLowerer } from '../../../../src/backends/occt/occtLowerer';
+import { initOcct } from '../../../../src/backends/occt/occtBackend';
+import type { FeatureRecord } from '../../../../src/intent/featureRecord';
+import type { Param } from '../../../../src/intent/types';
+
+const mm = (n: number): Param => ({ expression: String(n), unit: 'mm', evaluated: n });
+const str = (s: string): Param => ({ expression: `'${s}'`, unit: 'unitless', evaluated: 0 });
+
+describe('OcctLowerer extrude rounded-rect', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('lowers a rounded-rect record', async () => {
+    const r: FeatureRecord = {
+      id: 'extrude_1', kind: 'extrude',
+      inputs: {},
+      params: { profileKind: str('rounded-rect'), width: mm(20), height: mm(20), radius: mm(2), depth: mm(5) },
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: {} });
+    expect(result.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0);
+    expect(result.shape.volume()).toBeLessThan(2000);
+    expect(result.shape.volume()).toBeGreaterThan(1985);
+  });
+
+  it('emits feature.extrude.bad-params when width/height/radius are missing', async () => {
+    const r: FeatureRecord = {
+      id: 'extrude_1', kind: 'extrude',
+      inputs: {},
+      params: { profileKind: str('rounded-rect'), depth: mm(5) },  // missing width, height, radius
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: {} });
+    expect(result.diagnostics.filter(d => d.severity === 'error').length).toBeGreaterThan(0);
+  });
+
+  it('handles zero radius (= sharp rect)', async () => {
+    const r: FeatureRecord = {
+      id: 'extrude_1', kind: 'extrude',
+      inputs: {},
+      params: { profileKind: str('rounded-rect'), width: mm(10), height: mm(10), radius: mm(0), depth: mm(5) },
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: {} });
+    expect(result.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0);
+    expect(result.shape.volume()).toBeCloseTo(500, 1);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing**
+
+- [ ] **Step 3: Add the `'rounded-rect'` arm to the existing `'extrude'` case**
+
+Read `src/backends/occt/occtLowerer.ts`. The existing `'extrude'` case has arms for `'rect'`, `'circle'`, and `'polygon'` (added in v0.4-alpha). Add `'rounded-rect'` after `'circle'`:
+
+```typescript
+        case 'rounded-rect': {
+          const width = r.params.width?.evaluated;
+          const height = r.params.height?.evaluated;
+          const radius = r.params.radius?.evaluated;
+          if (width === undefined || height === undefined || radius === undefined) {
+            diagnostics.push({
+              target: 'export-occt',
+              code: 'feature.extrude.bad-params',
+              featureId: r.id,
+              severity: 'error',
+              message: `extrude rounded-rect requires width, height, and radius params (depth always required).`,
+            });
+            return { shape: undefined as unknown as ShapeBackend, diagnostics };
+          }
+          try {
+            shape = OcctBackend.extrudeRoundedRect(width, height, radius, depth);
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            diagnostics.push({
+              target: 'export-occt',
+              code: 'feature.extrude.failed',
+              featureId: r.id,
+              severity: 'error',
+              message: `OCCT extrude failed: ${msg}`,
+            });
+            return { shape: undefined as unknown as ShapeBackend, diagnostics };
+          }
+          break;
+        }
+```
+
+- [ ] **Step 4: Run passing — 3/3 PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backends/occt/occtLowerer.ts tests/unit/backends/occt/occtLowerer.extrudeRoundedRect.test.ts
+git commit -m "feat(backends/occt): OcctLowerer extrude case handles 'rounded-rect' profileKind"
+```
+
+---
+
+## Phase 3: API + e2e + tag
+
+### Task 3: `extrudeRoundedRect` top-level + e2e + release
+
+**Files:**
+- Modify: `src/modules/api.ts`
+- Create: `tests/unit/modules/api.extrudeRoundedRect.test.ts`
+- Create: `tests/e2e/fixtures/rounded-plate.kcad.ts`
+- Modify: `tests/e2e/cli-acceptance.test.ts`
+- Modify: `package.json`, `CHANGELOG.md`
+
+- [ ] **Step 1: Write 2 failing API tests**
+
+```typescript
+// tests/unit/modules/api.extrudeRoundedRect.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOcct } from '../../../src/backends/occt/occtBackend';
+import { runScript } from '../../../src/script-runtime/runScript';
+
+describe('extrudeRoundedRect top-level API', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('captures an extrude record with profile=rounded-rect and width/height/radius/depth params', async () => {
+    const code = `return extrudeRoundedRect(20, 20, 2, 5);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    expect(result.records).toHaveLength(1);
+    const r = result.records[0];
+    expect(r.kind).toBe('extrude');
+    expect(r.params.profileKind.expression).toBe(`'rounded-rect'`);
+    expect(r.params.width.evaluated).toBe(20);
+    expect(r.params.height.evaluated).toBe(20);
+    expect(r.params.radius.evaluated).toBe(2);
+    expect(r.params.depth.evaluated).toBe(5);
+  });
+
+  it('lowers + recomputes successfully', async () => {
+    const { RecomputeEngine } = await import('../../../src/compute/recomputeEngine');
+    const { OcctLowerer } = await import('../../../src/backends/occt/occtLowerer');
+    const code = `return extrudeRoundedRect(40, 20, 3, 4);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const engine = new RecomputeEngine(new OcctLowerer());
+    const r = await engine.run(result.records);
+    expect(r.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0);
+    const last = result.records[result.records.length - 1];
+    expect(r.shapes.get(last.id)!.volume()).toBeLessThan(40 * 20 * 4);
+    expect(r.shapes.get(last.id)!.volume()).toBeGreaterThan(40 * 20 * 4 * 0.9);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing**
+
+- [ ] **Step 3: Add `extrudeRoundedRect` to `src/modules/api.ts`**
+
+Find the existing `extrudeRect` / `extrudePolygon` in `createApi`. Add (mirroring extrudeRect):
+
+```typescript
+extrudeRoundedRect: (width: number, height: number, radius: number, depth: number): Shape => {
+  return session.createShape({
+    kind: 'extrude',
+    inputs: {},
+    params: {
+      profileKind: { expression: "'rounded-rect'", unit: 'unitless', evaluated: 0 },
+      width: { expression: String(width), unit: 'mm', evaluated: width },
+      height: { expression: String(height), unit: 'mm', evaluated: height },
+      radius: { expression: String(radius), unit: 'mm', evaluated: radius },
+      depth: { expression: String(depth), unit: 'mm', evaluated: depth },
+    },
+  });
+},
+```
+
+Add to the `KernelCadApi` interface as well (matching how `extrudeRect` / `extrudePolygon` are declared there).
+
+- [ ] **Step 4: Run passing — 2/2 PASS**
+
+- [ ] **Step 5: Create e2e fixture**
+
+```typescript
+// tests/e2e/fixtures/rounded-plate.kcad.ts
+const w = param('Width', 60, { unit: 'mm', min: 30, max: 200 });
+const h = param('Height', 40, { unit: 'mm', min: 20, max: 120 });
+const r = param('CornerRadius', 4, { unit: 'mm', min: 1, max: 10 });
+const t = param('Thickness', 5, { unit: 'mm', min: 2, max: 15 });
+
+return extrudeRoundedRect(w, h, r, t);
+```
+
+- [ ] **Step 6: Add 1 e2e test**
+
+In `tests/e2e/cli-acceptance.test.ts`, add (mirror the existing pattern):
+
+```typescript
+  it('runs end-to-end on the rounded-plate fixture and produces STL', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'kcad-acc-'));
+    const out = join(tmp, 'rounded-plate.stl');
+    const r = await exportScript({
+      file: join(__dirname, 'fixtures/rounded-plate.kcad.ts'),
+      format: 'stl',
+      out,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(statSync(out).size).toBeGreaterThan(500);
+  });
+```
+
+- [ ] **Step 7: Run all new tests**
+
+```bash
+npx vitest run tests/unit/modules/api.extrudeRoundedRect.test.ts tests/e2e/cli-acceptance.test.ts
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Bump version + CHANGELOG**
+
+`package.json`: `0.13.0-alpha.1` → `0.13.0-beta.1`.
+
+Prepend to `CHANGELOG.md`:
+
+```markdown
+## v0.13.0-beta.1 (NORTHSTAR roadmap: v0.4-beta extrudeRoundedRect) — 2026-04-30
+
+### Added
+- **`extrudeRoundedRect(width, height, radius, depth)`** — second arbitrary-2D-profile primitive after `extrudePolygon`. Auto-clamps `radius` to `min(width/2, height/2)` so over-sized radii don't trigger OCCT errors. Zero radius behaves like a sharp rectangle.
+- e2e fixture `tests/e2e/fixtures/rounded-plate.kcad.ts` + acceptance test.
+
+### Changed
+- `extrude` FeatureKind now accepts `profileKind: 'rounded-rect'` in addition to existing `'rect'` / `'circle'` / `'polygon'`.
+- Lowerer's `'extrude'` case extracts `width` / `height` / `radius` per-arm rather than unconditionally — same pattern as the polygon refactor in v0.4-alpha.
+
+### Deferred to v0.4-rc / v0.4 final
+- `path()` builder for arbitrary 2D paths (line/arc/bezier composition)
+- Full `Sketch` builder type (`polygon(points).extrude(t)` chain replacing flat `extrudePolygon`)
+- Sketch revolve / sweep
+- Self-intersection validation
+- Open polylines (`.stroke(width)`)
+```
+
+- [ ] **Step 9: PR + qc + merge + tag**
+
+```bash
+git add ...
+git commit -m "release: v0.13.0-beta.1 — extrudeRoundedRect (v0.4-beta minimal)"
+git push -u origin feat/v0.4-beta-extrude-rounded-rect
+gh pr create --base develop --head feat/v0.4-beta-extrude-rounded-rect \
+  --title "feat(v0.13.0-beta.1): extrudeRoundedRect — rounded-corner rectangles"
+# wait qc; merge --squash; tag v0.13.0-beta.1; push tag
+```
+
+- [ ] **Step 10: Live verify**
+
+```bash
+npm run build:cli
+echo "return extrudeRoundedRect(60, 40, 4, 5);" > /tmp/rrect.kcad.ts
+node dist/cli/index.js evaluate --json /tmp/rrect.kcad.ts
+node dist/cli/index.js export step /tmp/rrect.kcad.ts -o /tmp/rrect.step
+head -1 /tmp/rrect.step
+```
+
+Expected: `{ ok: true, featureCount: 1 }` + valid STEP.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Backend factory (Task 1) + lowerer arm (Task 2) + API + e2e + release (Task 3). Pattern identical to v0.4-alpha extrudePolygon — proven cadence.
+
+**Placeholder scan:** No "TBD" / "implement later".
+
+**Type consistency:** Width / height / radius / depth as separate params (not a single object) matches `extrudeRect`'s flat-param style.
+
+**Risks:**
+- Radius auto-clamp uses `Math.min(Math.max(0, r), w/2, h/2)` — negative radii silently become 0. Acceptable: OCCT doesn't accept negative radii anyway, and the silent clamp matches ForgeCAD.
+- `feature.extrude.bad-params` is a new diagnostic code; ensure `whyDidThisFail`'s HINTS table is updated in v0.5-prep or rc to include it. Document in CHANGELOG.
+
+---
+
+## Execution Handoff
+
+3 tasks, ~3-4 hours. Subagent-driven recommended (consistent cadence).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kernelcad",
   "private": true,
-  "version": "0.13.0-alpha.1",
+  "version": "0.13.0-beta.1",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/src/backends/occt/occtBackend.ts
+++ b/src/backends/occt/occtBackend.ts
@@ -155,6 +155,29 @@ export class OcctBackend implements ShapeBackend {
   }
 
   /**
+   * Extrude a rectangle with rounded corners along +Z by `depth`.
+   *
+   * `radius` is auto-clamped to `min(width/2, height/2)` so over-sized radii
+   * don't trigger an OCCT error. Zero radius is treated as a sharp rectangle.
+   *
+   * @throws {Error} If `depth <= 0`.
+   */
+  static extrudeRoundedRect(width: number, height: number, radius: number, depth: number): OcctBackend {
+    if (depth <= 0) {
+      throw new Error(`OcctBackend.extrudeRoundedRect: depth must be positive (got ${depth})`);
+    }
+    // Replicad's drawRoundedRectangle requires r < min(width/2, height/2) when
+    // building symmetric arcs — at the exact maximum the hLine segment becomes
+    // zero-length and the tangentArc call fails. Cap at 99.99 % of the limit.
+    const maxR = Math.min(width / 2, height / 2);
+    const clamped = Math.min(Math.max(0, radius), maxR * 0.9999);
+    const drawing = replicad.drawRoundedRectangle(width, height, clamped);
+    const sketch = drawing.sketchOnPlane('XY');
+    const single = sketch as unknown as { extrude: (d: number) => ReplicadShape3D };
+    return new OcctBackend(single.extrude(depth));
+  }
+
+  /**
    * Revolve an axis-aligned rectangular profile around the Z axis.
    * The rect is placed in the XZ plane with its corner at `(offsetX, 0)`,
    * extends `w` in radial X and `h` in axial Z. With `angleDeg = 360`, the

--- a/src/backends/occt/occtLowerer.ts
+++ b/src/backends/occt/occtLowerer.ts
@@ -99,6 +99,34 @@ export class OcctLowerer implements FeatureLowerer {
             });
             return { shape: undefined as unknown as ShapeBackend, diagnostics };
           }
+        } else if (profileKind === 'rounded-rect') {
+          const width = r.params.width?.evaluated;
+          const height = r.params.height?.evaluated;
+          const radius = r.params.radius?.evaluated;
+          const depth = r.params.depth?.evaluated;
+          if (width === undefined || height === undefined || radius === undefined || depth === undefined) {
+            diagnostics.push({
+              target: 'export-occt',
+              code: 'feature.extrude.bad-params',
+              featureId: r.id,
+              severity: 'error',
+              message: `extrude rounded-rect requires width, height, and radius params (depth always required).`,
+            });
+            return { shape: undefined as unknown as ShapeBackend, diagnostics };
+          }
+          try {
+            shape = OcctBackend.extrudeRoundedRect(width, height, radius, depth);
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            diagnostics.push({
+              target: 'export-occt',
+              code: 'feature.extrude.failed',
+              featureId: r.id,
+              severity: 'error',
+              message: `OCCT extrude failed: ${msg}`,
+            });
+            return { shape: undefined as unknown as ShapeBackend, diagnostics };
+          }
         } else {
           return {
             shape: undefined as unknown as ShapeBackend,

--- a/src/modules/api.ts
+++ b/src/modules/api.ts
@@ -15,6 +15,7 @@ export interface KernelCadApi {
   extrudeRect(w: number, h: number, height: number): Shape;
   extrudeCircle(r: number, height: number): Shape;
   extrudePolygon(points: [number, number][], depth: number): Shape;
+  extrudeRoundedRect(width: number, height: number, radius: number, depth: number): Shape;
   revolveRect(w: number, h: number, offsetX: number, angleDeg?: number): Shape;
   union(...shapes: Shape[]): Shape;
   param(name: string, defaultExpr: number | string, opts: ParamOptions): number;
@@ -79,6 +80,19 @@ export function createApi(ctx: ApiContext): KernelCadApi {
           depth: { expression: String(depth), unit: 'mm', evaluated: depth },
         },
         metadata: { points },
+      });
+    },
+    extrudeRoundedRect(width, height, radius, depth) {
+      return session.createShape({
+        kind: 'extrude',
+        inputs: {},
+        params: {
+          profileKind: { expression: "'rounded-rect'", unit: 'unitless', evaluated: 0 },
+          width: { expression: String(width), unit: 'mm', evaluated: width },
+          height: { expression: String(height), unit: 'mm', evaluated: height },
+          radius: { expression: String(radius), unit: 'mm', evaluated: radius },
+          depth: { expression: String(depth), unit: 'mm', evaluated: depth },
+        },
       });
     },
     revolveRect(w, h, offsetX, angleDeg = 360) {

--- a/tests/e2e/cli-acceptance.test.ts
+++ b/tests/e2e/cli-acceptance.test.ts
@@ -156,3 +156,19 @@ describe('v0.4-alpha triangle-extrusion fixture', () => {
     expect(statSync(out).size).toBeGreaterThan(500);
   });
 });
+
+describe('v0.4-beta rounded-plate fixture', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('runs end-to-end on the rounded-plate fixture and produces STL', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'kcad-acc-'));
+    const out = join(tmp, 'rounded-plate.stl');
+    const r = await exportScript({
+      file: join(__dirname, 'fixtures/rounded-plate.kcad.ts'),
+      format: 'stl',
+      out,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(statSync(out).size).toBeGreaterThan(500);
+  });
+});

--- a/tests/e2e/fixtures/rounded-plate.kcad.ts
+++ b/tests/e2e/fixtures/rounded-plate.kcad.ts
@@ -1,0 +1,6 @@
+const w = param('Width', 60, { unit: 'mm', min: 30, max: 200 });
+const h = param('Height', 40, { unit: 'mm', min: 20, max: 120 });
+const r = param('CornerRadius', 4, { unit: 'mm', min: 1, max: 10 });
+const t = param('Thickness', 5, { unit: 'mm', min: 2, max: 15 });
+
+return extrudeRoundedRect(w, h, r, t);

--- a/tests/unit/backends/occt/occtBackend.extrudeRoundedRect.test.ts
+++ b/tests/unit/backends/occt/occtBackend.extrudeRoundedRect.test.ts
@@ -1,0 +1,32 @@
+// tests/unit/backends/occt/occtBackend.extrudeRoundedRect.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { OcctBackend, initOcct } from '../../../../src/backends/occt/occtBackend';
+
+describe('OcctBackend.extrudeRoundedRect', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('extrudes a rounded rectangle (volume = w*h*d - corner-cuts)', () => {
+    // 20x20 square, r=2, d=5. Volume = 20*20*5 - 4*(r²-π*r²/4)*d
+    //   = 2000 - 4*(4 - π)*5 ≈ 2000 - 17.17 ≈ 1982.83
+    // Use loose tolerance because the exact corner-cut math involves arc area.
+    const v = OcctBackend.extrudeRoundedRect(20, 20, 2, 5).volume();
+    expect(v).toBeLessThan(2000);   // some material removed
+    expect(v).toBeGreaterThan(1975); // not too much
+  });
+
+  it('zero radius behaves like a rectangle (volume = w*h*d)', () => {
+    expect(OcctBackend.extrudeRoundedRect(10, 20, 0, 5).volume()).toBeCloseTo(1000, 0);
+  });
+
+  it('auto-clamps radius to min(w/2, h/2)', () => {
+    // 10x20, r=100 → clamp to 5 (= 10/2)
+    const clamped = OcctBackend.extrudeRoundedRect(10, 20, 100, 5).volume();
+    const direct = OcctBackend.extrudeRoundedRect(10, 20, 5, 5).volume();
+    expect(clamped).toBeCloseTo(direct, 1);
+  });
+
+  it('throws on zero or negative depth', () => {
+    expect(() => OcctBackend.extrudeRoundedRect(10, 10, 1, 0)).toThrow(/positive/);
+    expect(() => OcctBackend.extrudeRoundedRect(10, 10, 1, -1)).toThrow(/positive/);
+  });
+});

--- a/tests/unit/backends/occt/occtLowerer.extrudeRoundedRect.test.ts
+++ b/tests/unit/backends/occt/occtLowerer.extrudeRoundedRect.test.ts
@@ -1,0 +1,49 @@
+// tests/unit/backends/occt/occtLowerer.extrudeRoundedRect.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { OcctLowerer } from '../../../../src/backends/occt/occtLowerer';
+import { initOcct } from '../../../../src/backends/occt/occtBackend';
+import type { FeatureRecord } from '../../../../src/intent/featureRecord';
+import type { Param } from '../../../../src/intent/types';
+
+const mm = (n: number): Param => ({ expression: String(n), unit: 'mm', evaluated: n });
+const str = (s: string): Param => ({ expression: `'${s}'`, unit: 'unitless', evaluated: 0 });
+
+describe('OcctLowerer extrude rounded-rect', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('lowers a rounded-rect record', async () => {
+    const r: FeatureRecord = {
+      id: 'extrude_1', kind: 'extrude',
+      inputs: {},
+      params: { profileKind: str('rounded-rect'), width: mm(20), height: mm(20), radius: mm(2), depth: mm(5) },
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: {} });
+    expect(result.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0);
+    expect(result.shape.volume()).toBeLessThan(2000);
+    expect(result.shape.volume()).toBeGreaterThan(1975);
+  });
+
+  it('emits feature.extrude.bad-params when width/height/radius are missing', async () => {
+    const r: FeatureRecord = {
+      id: 'extrude_1', kind: 'extrude',
+      inputs: {},
+      params: { profileKind: str('rounded-rect'), depth: mm(5) },  // missing width, height, radius
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: {} });
+    expect(result.diagnostics.filter(d => d.severity === 'error').length).toBeGreaterThan(0);
+  });
+
+  it('handles zero radius (= sharp rect)', async () => {
+    const r: FeatureRecord = {
+      id: 'extrude_1', kind: 'extrude',
+      inputs: {},
+      params: { profileKind: str('rounded-rect'), width: mm(10), height: mm(10), radius: mm(0), depth: mm(5) },
+      transforms: [], suppressed: false,
+    };
+    const result = await new OcctLowerer().lower(r, { byKey: {} });
+    expect(result.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0);
+    expect(result.shape.volume()).toBeCloseTo(500, 1);
+  });
+});

--- a/tests/unit/modules/api.extrudeRoundedRect.test.ts
+++ b/tests/unit/modules/api.extrudeRoundedRect.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOcct } from '../../../src/backends/occt/occtBackend';
+import { runScript } from '../../../src/script-runtime/runScript';
+
+describe('extrudeRoundedRect top-level API', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('captures an extrude record with profile=rounded-rect and width/height/radius/depth params', async () => {
+    const code = `return extrudeRoundedRect(20, 20, 2, 5);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    expect(result.records).toHaveLength(1);
+    const r = result.records[0];
+    expect(r.kind).toBe('extrude');
+    expect(r.params.profileKind.expression).toBe(`'rounded-rect'`);
+    expect(r.params.width.evaluated).toBe(20);
+    expect(r.params.height.evaluated).toBe(20);
+    expect(r.params.radius.evaluated).toBe(2);
+    expect(r.params.depth.evaluated).toBe(5);
+  });
+
+  it('lowers + recomputes successfully', async () => {
+    const { RecomputeEngine } = await import('../../../src/compute/recomputeEngine');
+    const { OcctLowerer } = await import('../../../src/backends/occt/occtLowerer');
+    const code = `return extrudeRoundedRect(40, 20, 3, 4);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const engine = new RecomputeEngine(new OcctLowerer());
+    const r = await engine.run(result.records);
+    expect(r.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0);
+    const last = result.records[result.records.length - 1];
+    expect(r.shapes.get(last.id)!.volume()).toBeLessThan(40 * 20 * 4);
+    expect(r.shapes.get(last.id)!.volume()).toBeGreaterThan(40 * 20 * 4 * 0.9);
+  });
+});


### PR DESCRIPTION
## Summary
- Second new 2D-profile primitive after v0.4-alpha `extrudePolygon`, mirrors its established pattern
- Adds `extrudeRoundedRect(width, height, radius, depth)` top-level API backed by the OcctLowerer `rounded-rect` arm (Task 2)
- Includes unit tests (2), e2e fixture `rounded-plate.kcad.ts`, version bump to `0.13.0-beta.1`, and CHANGELOG entry

## Test plan
- [ ] `npx vitest run tests/unit/modules/api.extrudeRoundedRect.test.ts` — 2/2 pass
- [ ] `npx vitest run tests/e2e/cli-acceptance.test.ts` — 9/9 pass (including new rounded-plate test)
- [ ] `npm run qc` clean (lint + typecheck + all unit tests)
- [ ] CLI live verify: `extrudeRoundedRect(60, 40, 4, 5)` produces valid STEP starting with `ISO-10303-21;`