### PR TITLE
feat(v0.13.0-rc.1): remove_feature MCP write tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## v0.13.0-rc.1 (NORTHSTAR roadmap: v0.12 final remove_feature) — 2026-04-30
+
+### Added
+- **Third MCP write tool: `remove_feature`** — removes a single line from a `.kcad.ts` script by substring match. Side-effect-free; returns `new_code` + re-evaluated diagnostics.
+  - Input: `{ code, match }`
+  - Output: `{ ok, new_code?, diagnostics?, error? }`
+  - Refuses to remove the `return` line (state-machine detects top-level return at brace depth 0)
+  - Errors on 0 or >1 matches (agent must disambiguate)
+- 11 new tests (7 primitive + 4 tool) + 1 integration spawn test
+
+### Why string-match (not feature_id)
+`FeatureRecord.scriptLocation` is declared but never populated; adding source-position tracking is a separate architectural piece. String match mirrors `set_param_value`'s `param_name` — agents already have a reliable identifier (the line they wrote). Once scriptLocation lands later, `feature_id` could be added as an alternative.
+
+### Deferred to v0.14+
+- `suppress_feature` — wraps a line in `// @suppress` annotation
+- `feature_id` alternative for set/remove tools (requires scriptLocation)
+
+---
+
 ## v0.13.0-beta.1 (NORTHSTAR roadmap: v0.4-beta extrudeRoundedRect) — 2026-04-30
 
 ### Added

--- a/docs/superpowers/plans/2026-04-30-v0.13-rc-remove-feature.md
+++ b/docs/superpowers/plans/2026-04-30-v0.13-rc-remove-feature.md
@@ -1,0 +1,493 @@
+# v0.13.0-rc.1 — `remove_feature` MCP write tool
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the third MCP write tool — `remove_feature(code, match)` — completing the agent-edit trio (set / add / remove). Uses string-match-based deletion rather than scriptLocation tracking, so it ships in half a day instead of needing AST plumbing.
+
+**Architecture:** Pure text-in / text-out, mirroring `set_param_value` and `add_feature`. Find the single line that contains `match` (a substring); error if 0 or >1 matches. Returns `new_code` plus diagnostics from re-evaluating the modified script.
+
+**Tech Stack:** Same as v0.12-beta/rc — TypeScript, vitest, MCP SDK 1.29.
+
+**Predecessor:** v0.13.0-beta.1 (extrudeRoundedRect).
+
+**Why string-match (not feature_id):** `FeatureRecord.scriptLocation` is declared in the IR but never populated by `captureSession`. Adding source-position tracking is a separate architectural piece (vm-context stack-trace reliability is uncertain; transpile-time instrumentation is more robust but ~1 day's work). String match is honest about the simpler scope, mirrors `set_param_value`'s `param_name` (which also uses literal string match), and gives agents a reliable identifier (the feature line they wrote earlier).
+
+---
+
+## Decisions Locked
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Identifier | `match: string` — substring of the line to remove | Symmetric with `set_param_value`'s `param_name`. Agents always know the feature they want to remove (they just added it). |
+| Match policy | First and only match wins; 0 or >1 → error | Agents must disambiguate. Same policy as `set_param_value`. |
+| Side-effect | None — returns text | Same as set/add. |
+| Removed line | The full line containing the match (newline included) | Common case; trailing newline preserved. |
+| Cannot remove `return` line | Yes — error with `cannot-remove-return` if match resolves to the line containing `return` | Removing the return statement breaks the script in a non-obvious way. Agents should use `set_param_value` or rewrite the script entirely. |
+
+---
+
+## File Structure
+
+**Create:**
+- `src/mcp/edits/removeFeature.ts`
+- `src/mcp/tools/removeFeature.ts`
+- `tests/unit/mcp/edits/removeFeature.test.ts`
+- `tests/unit/mcp/tools/removeFeature.test.ts`
+
+**Modify:**
+- `src/mcp/index.ts` — re-export
+- `src/mcp/server.ts` — TOOLS + switch
+- `tests/integration/mcp/spawn.test.ts` — 1 spawn case
+- `package.json` — version bump
+- `CHANGELOG.md` — prepend
+
+---
+
+## Phase 1: Edit primitive
+
+### Task 1: `removeFeature` primitive
+
+**Files:**
+- Create: `src/mcp/edits/removeFeature.ts`
+- Create: `tests/unit/mcp/edits/removeFeature.test.ts`
+
+- [ ] **Step 1: Write 7 failing tests**
+
+```typescript
+// tests/unit/mcp/edits/removeFeature.test.ts
+import { describe, it, expect } from 'vitest';
+import { removeFeature } from '../../../../src/mcp/edits/removeFeature';
+
+describe('removeFeature primitive', () => {
+  it('removes a single matching line', () => {
+    const code = [
+      `const w = box(10, 10, 10);`,
+      `const h = cylinder(5, 2);`,
+      `return w.subtract(h);`,
+    ].join('\n');
+    const r = removeFeature(code, 'cylinder(5, 2)');
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe([
+      `const w = box(10, 10, 10);`,
+      `return w.subtract(h);`,
+    ].join('\n'));
+  });
+
+  it('preserves trailing newline if present', () => {
+    const code = `const a = box(1,1,1);\nconst b = box(2,2,2);\nreturn a;\n`;
+    const r = removeFeature(code, 'box(2,2,2)');
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`const a = box(1,1,1);\nreturn a;\n`);
+  });
+
+  it('errors when match is not found', () => {
+    const code = `const a = box(1,1,1);\nreturn a;`;
+    const r = removeFeature(code, 'cylinder');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/not found/i);
+  });
+
+  it('errors when match appears in multiple lines', () => {
+    const code = [
+      `const a = box(1,1,1);`,
+      `const b = box(2,2,2);`,
+      `return a;`,
+    ].join('\n');
+    const r = removeFeature(code, 'box');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/multiple/i);
+  });
+
+  it('errors when match resolves to the return line', () => {
+    const code = `const a = box(1,1,1);\nreturn a;`;
+    const r = removeFeature(code, 'return');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/return/i);
+  });
+
+  it('preserves indentation context (does not affect surrounding lines)', () => {
+    const code = `  const a = box(1, 1, 1);\n  const b = cylinder(2, 1);\n  return a;\n`;
+    const r = removeFeature(code, 'cylinder(2, 1)');
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`  const a = box(1, 1, 1);\n  return a;\n`);
+  });
+
+  it('removes a line that is the only line in the script (other than return)', () => {
+    const code = `const x = 5;\nreturn box(x, x, x);`;
+    const r = removeFeature(code, 'const x');
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`return box(x, x, x);`);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing — `npx vitest run tests/unit/mcp/edits/removeFeature.test.ts`**
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/mcp/edits/removeFeature.ts
+
+export interface RemoveFeatureResult {
+  ok: boolean;
+  new_code?: string;
+  error?: string;
+}
+
+/**
+ * Remove a line from `code` whose contents include `match`. Returns error if
+ * 0 lines or >1 lines match, or if the match resolves to the line containing
+ * `return` (removing return breaks the script). String match is literal —
+ * not a regex.
+ */
+export function removeFeature(code: string, match: string): RemoveFeatureResult {
+  if (match.length === 0) {
+    return { ok: false, error: 'match must not be empty.' };
+  }
+
+  const lines = code.split('\n');
+  const matchedIndices: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes(match)) matchedIndices.push(i);
+  }
+
+  if (matchedIndices.length === 0) {
+    return { ok: false, error: `match '${match}' not found in code.` };
+  }
+  if (matchedIndices.length > 1) {
+    return { ok: false, error: `match '${match}' has multiple matches (${matchedIndices.length} lines) — refusing to pick one. Disambiguate.` };
+  }
+
+  const idx = matchedIndices[0];
+  // Refuse to remove the line containing `return` at brace depth 0
+  if (lineContainsTopLevelReturn(lines, idx)) {
+    return { ok: false, error: `match resolves to the line containing the return statement. Cannot remove the return.` };
+  }
+
+  lines.splice(idx, 1);
+  return { ok: true, new_code: lines.join('\n') };
+}
+
+/**
+ * Check whether the line at `lineIndex` contains a `return` keyword at brace
+ * depth 0 (top-level). Mirrors the state-machine in addFeature.ts.
+ */
+function lineContainsTopLevelReturn(lines: string[], lineIndex: number): boolean {
+  let depth = 0;
+  let inStr: '"' | "'" | '`' | null = null;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let li = 0; li <= lineIndex; li++) {
+    const line = lines[li];
+    inLineComment = false;
+    let i = 0;
+    let lineHasTopLevelReturn = false;
+
+    while (i < line.length) {
+      const c = line[i];
+      const c2 = line[i + 1];
+
+      if (inLineComment) { i++; continue; }
+      if (inBlockComment) {
+        if (c === '*' && c2 === '/') { inBlockComment = false; i += 2; continue; }
+        i++; continue;
+      }
+      if (inStr) {
+        if (c === '\\') { i += 2; continue; }
+        if (c === inStr) { inStr = null; i++; continue; }
+        i++; continue;
+      }
+      if (c === '/' && c2 === '/') { inLineComment = true; i += 2; continue; }
+      if (c === '/' && c2 === '*') { inBlockComment = true; i += 2; continue; }
+      if (c === '"' || c === "'" || c === '`') { inStr = c as '"' | "'" | '`'; i++; continue; }
+      if (c === '{') { depth++; i++; continue; }
+      if (c === '}') { depth--; i++; continue; }
+      if (depth === 0 && line.slice(i, i + 6) === 'return') {
+        const before = i === 0 ? ' ' : line[i - 1];
+        const after = line[i + 6] ?? ' ';
+        if (!/[A-Za-z0-9_$]/.test(before) && !/[A-Za-z0-9_$]/.test(after)) {
+          lineHasTopLevelReturn = true;
+          i += 6; continue;
+        }
+      }
+      i++;
+    }
+
+    if (li === lineIndex && lineHasTopLevelReturn) return true;
+  }
+  return false;
+}
+```
+
+- [ ] **Step 4: Run passing — 7/7 PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mcp/edits/removeFeature.ts tests/unit/mcp/edits/removeFeature.test.ts
+git commit -m "feat(mcp/edits): removeFeature primitive — string-match line removal with return-line guard"
+```
+
+---
+
+## Phase 2: MCP tool
+
+### Task 2: `removeFeatureTool` wrapper
+
+**Files:**
+- Create: `src/mcp/tools/removeFeature.ts`
+- Create: `tests/unit/mcp/tools/removeFeature.test.ts`
+
+- [ ] **Step 1: Write 4 failing tests**
+
+```typescript
+// tests/unit/mcp/tools/removeFeature.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { removeFeatureTool } from '../../../../src/mcp/tools/removeFeature';
+import { initOcct } from '../../../../src/backends/occt/occtBackend';
+
+describe('removeFeatureTool', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('removes a feature line and re-evaluates successfully', async () => {
+    const code = [
+      `const a = box(20, 20, 5);`,
+      `const b = cylinder(5, 2);`,
+      `return a;`,
+    ].join('\n');
+    const r = await removeFeatureTool({ code, match: 'cylinder(5, 2)' });
+    expect(r.ok).toBe(true);
+    expect(r.new_code).not.toContain(`cylinder(5, 2)`);
+    expect(r.new_code).toContain(`return a`);
+    expect(r.diagnostics?.filter(d => d.severity === 'error')).toHaveLength(0);
+  });
+
+  it('returns error when match not found', async () => {
+    const code = `return box(10, 10, 10);`;
+    const r = await removeFeatureTool({ code, match: 'nonexistent' });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/not found/i);
+  });
+
+  it('returns error when match is the return line', async () => {
+    const code = `const a = box(10,10,10);\nreturn a;`;
+    const r = await removeFeatureTool({ code, match: 'return' });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/return/i);
+  });
+
+  it('surfaces re-evaluation errors when removing a line breaks the script', async () => {
+    // Remove the const declaration of a variable used later — re-eval will fail.
+    const code = [
+      `const w = box(10, 10, 10);`,
+      `return w.subtract(box(5, 5, 5));`,
+    ].join('\n');
+    // Removing the const w line makes 'w' undefined.
+    const r = await removeFeatureTool({ code, match: `const w = box` });
+    expect(r.ok).toBe(true); // edit succeeded
+    expect(r.new_code).not.toContain(`const w = box`);
+    // Re-eval should produce an error diagnostic
+    expect(r.diagnostics?.some(d => d.severity === 'error')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing**
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// src/mcp/tools/removeFeature.ts
+import { removeFeature } from '../edits/removeFeature';
+import { evaluateScriptTool } from './evaluateScript';
+import type { CompilerDiagnostic } from '../../diagnostics/diagnostic';
+
+export interface RemoveFeatureInput {
+  code: string;
+  match: string;
+}
+
+export interface RemoveFeatureOutput {
+  ok: boolean;
+  new_code?: string;
+  diagnostics?: CompilerDiagnostic[];
+  error?: string;
+}
+
+export async function removeFeatureTool(
+  input: RemoveFeatureInput,
+): Promise<RemoveFeatureOutput> {
+  const edit = removeFeature(input.code, input.match);
+  if (!edit.ok || !edit.new_code) {
+    return { ok: false, error: edit.error };
+  }
+  const evalResult = await evaluateScriptTool({ code: edit.new_code });
+  return {
+    ok: true,
+    new_code: edit.new_code,
+    diagnostics: evalResult.diagnostics,
+  };
+}
+```
+
+- [ ] **Step 4: Run passing — 4/4 PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mcp/tools/removeFeature.ts tests/unit/mcp/tools/removeFeature.test.ts
+git commit -m "feat(mcp): remove_feature tool — remove + re-evaluate round-trip"
+```
+
+---
+
+## Phase 3: Server reg + integration test + tag
+
+### Task 3: Wire + spawn test + release
+
+**Files:**
+- Modify: `src/mcp/index.ts`
+- Modify: `src/mcp/server.ts`
+- Modify: `tests/integration/mcp/spawn.test.ts`
+- Modify: `package.json`, `CHANGELOG.md`
+
+- [ ] **Step 1: Re-export in `src/mcp/index.ts`**
+
+```typescript
+export { removeFeatureTool, type RemoveFeatureInput, type RemoveFeatureOutput } from './tools/removeFeature';
+```
+
+- [ ] **Step 2: TOOLS + switch + import in `src/mcp/server.ts`**
+
+Add import:
+```typescript
+import { removeFeatureTool } from './tools/removeFeature';
+```
+
+TOOLS entry:
+```typescript
+{
+  name: 'remove_feature',
+  description: 'Remove a single line from a kernelCAD script identified by a substring match. Returns the modified code plus diagnostics from re-evaluating. Refuses to remove the line containing the return statement. Side-effect-free.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      code: { type: 'string', description: 'The .kcad.ts source code.' },
+      match: { type: 'string', description: 'A substring that uniquely identifies the line to remove (e.g. `const hole = cylinder(5,`).' },
+    },
+    required: ['code', 'match'],
+  },
+},
+```
+
+Switch case:
+```typescript
+case 'remove_feature':
+  result = await removeFeatureTool(input as Parameters<typeof removeFeatureTool>[0]);
+  break;
+```
+
+- [ ] **Step 3: Spawn test in `tests/integration/mcp/spawn.test.ts`**
+
+```typescript
+  it('responds to remove_feature with edited code + diagnostics', async () => {
+    const result = await callTool('remove_feature', {
+      code: `const base = box(20, 20, 5);\nconst hole = cylinder(5, 2);\nreturn base;`,
+      match: `cylinder(5, 2)`,
+    });
+    const text = (result as { content: { text: string }[] }).content[0].text;
+    const payload = JSON.parse(text);
+    expect(payload.ok).toBe(true);
+    expect(payload.new_code).not.toContain(`cylinder(5, 2)`);
+  }, 90000);
+```
+
+- [ ] **Step 4: Build CLI + run integration**
+
+```bash
+npm run build:cli
+npx vitest run tests/integration/mcp/spawn.test.ts
+```
+
+Expected: 8/8 PASS (7 prior + 1 new).
+
+- [ ] **Step 5: Bump version + CHANGELOG**
+
+`package.json`: `0.13.0-beta.1` → `0.13.0-rc.1`
+
+Prepend:
+
+```markdown
+## v0.13.0-rc.1 (NORTHSTAR roadmap: v0.12 final remove_feature) — 2026-04-30
+
+### Added
+- **Third MCP write tool: `remove_feature`** — removes a single line from a `.kcad.ts` script by substring match. Side-effect-free; returns `new_code` + re-evaluated diagnostics.
+  - Input: `{ code, match }`
+  - Output: `{ ok, new_code?, diagnostics?, error? }`
+  - Refuses to remove the `return` line (state-machine detects top-level return at brace depth 0 — same machinery as add_feature)
+  - Errors on 0 or >1 matches (agent must disambiguate)
+- 11 new tests (7 primitive + 4 tool) + 1 integration spawn test
+
+### Why string-match instead of feature_id
+`FeatureRecord.scriptLocation` is declared but never populated — adding source-position tracking to capture is a separate architectural piece (vm-context stack-trace reliability is uncertain; transpile-time instrumentation is ~1 day's work). String match mirrors `set_param_value`'s `param_name` and gives agents a reliable identifier (the feature line they just added). Once scriptLocation tracking lands (v0.4 final / v0.14+), `remove_feature` could be augmented with `feature_id` as an alternative.
+
+### Deferred to v0.14+
+- `suppress_feature` — wraps a line in `// @suppress` annotation (or sets `Shape.suppress()` modifier). Needs capture-time annotation parsing.
+- `feature_id` alternative for remove/set tools (requires scriptLocation)
+```
+
+- [ ] **Step 6: PR + qc + merge + tag**
+
+```bash
+git add src/mcp/index.ts src/mcp/server.ts tests/integration/mcp/spawn.test.ts package.json CHANGELOG.md
+git commit -m "release: v0.13.0-rc.1 — remove_feature MCP write tool"
+git push -u origin feat/v0.13-rc-remove-feature
+gh pr create --base develop --head feat/v0.13-rc-remove-feature \
+  --title "feat(v0.13.0-rc.1): remove_feature MCP write tool" \
+  --body "Third MCP write tool. String-match identifier (mirrors set_param_value). Refuses to remove return line."
+# wait qc, merge --squash, tag v0.13.0-rc.1, push tag
+```
+
+- [ ] **Step 7: Live verify (per actually-use-what-you-ship rule)**
+
+```bash
+npm run build:cli
+
+# Send via echo pipe (proven pattern)
+( printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"claude","version":"1"}}}\n'
+  printf '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"remove_feature","arguments":{"code":"const a = box(20,20,5);\\nconst b = cylinder(5,2);\\nreturn a;","match":"cylinder(5,2)"}}}\n'
+  sleep 6
+) | node dist/cli/index.js mcp 2>/dev/null | tail -1 | python3 -c '
+import json, sys
+resp = json.loads(sys.stdin.read())
+payload = json.loads(resp["result"]["content"][0]["text"])
+print("ok:", payload["ok"])
+print("new_code:")
+for line in payload["new_code"].splitlines():
+    print(" ", line)
+print("diagnostics:", len(payload.get("diagnostics", [])))
+'
+```
+
+Expected: `ok: True`, two-line script remaining, 0 diagnostics.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Primitive (Task 1) + tool (Task 2) + server reg + spawn + release (Task 3). Standard pattern.
+
+**Placeholder scan:** No "TBD" / "implement later".
+
+**Type consistency:** `RemoveFeatureResult` (primitive) vs `RemoveFeatureOutput` (tool). Same shape pattern as set_param_value / add_feature.
+
+**Open issues:**
+- The `lineContainsTopLevelReturn` state machine is duplicated from `addFeature.ts` — eligible for extraction to a shared `scriptParse.ts` utility in v0.14+. For v0.13-rc, copy is fine (small + well-tested).
+- String match is literal substring — escape-aware (e.g. `'cylinder('` matches both `cylinder(5,2)` and `someCylinder(...)`). Agents need to use unique-enough strings; the >1-match error provides the safety net.
+
+---
+
+## Execution Handoff
+
+3 tasks, ~3-4 hours. Subagent-driven recommended.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kernelcad",
   "private": true,
-  "version": "0.13.0-beta.1",
+  "version": "0.13.0-rc.1",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/src/mcp/edits/removeFeature.ts
+++ b/src/mcp/edits/removeFeature.ts
@@ -1,0 +1,92 @@
+// src/mcp/edits/removeFeature.ts
+
+export interface RemoveFeatureResult {
+  ok: boolean;
+  new_code?: string;
+  error?: string;
+}
+
+/**
+ * Remove a line from `code` whose contents include `match`. Returns error if
+ * 0 lines or >1 lines match, or if the match resolves to the line containing
+ * `return` (removing return breaks the script). String match is literal —
+ * not a regex.
+ */
+export function removeFeature(code: string, match: string): RemoveFeatureResult {
+  if (match.length === 0) {
+    return { ok: false, error: 'match must not be empty.' };
+  }
+
+  const lines = code.split('\n');
+  const matchedIndices: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes(match)) matchedIndices.push(i);
+  }
+
+  if (matchedIndices.length === 0) {
+    return { ok: false, error: `match '${match}' not found in code.` };
+  }
+  if (matchedIndices.length > 1) {
+    return { ok: false, error: `match '${match}' has multiple matches (${matchedIndices.length} lines) — refusing to pick one. Disambiguate.` };
+  }
+
+  const idx = matchedIndices[0];
+  // Refuse to remove the line containing `return` at brace depth 0
+  if (lineContainsTopLevelReturn(lines, idx)) {
+    return { ok: false, error: `match resolves to the line containing the return statement. Cannot remove the return.` };
+  }
+
+  lines.splice(idx, 1);
+  return { ok: true, new_code: lines.join('\n') };
+}
+
+/**
+ * Check whether the line at `lineIndex` contains a `return` keyword at brace
+ * depth 0 (top-level). Mirrors the state-machine in addFeature.ts.
+ */
+function lineContainsTopLevelReturn(lines: string[], lineIndex: number): boolean {
+  let depth = 0;
+  let inStr: '"' | "'" | '`' | null = null;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let li = 0; li <= lineIndex; li++) {
+    const line = lines[li];
+    inLineComment = false;
+    let i = 0;
+    let lineHasTopLevelReturn = false;
+
+    while (i < line.length) {
+      const c = line[i];
+      const c2 = line[i + 1];
+
+      if (inLineComment) { i++; continue; }
+      if (inBlockComment) {
+        if (c === '*' && c2 === '/') { inBlockComment = false; i += 2; continue; }
+        i++; continue;
+      }
+      if (inStr) {
+        if (c === '\\') { i += 2; continue; }
+        if (c === inStr) { inStr = null; i++; continue; }
+        i++; continue;
+      }
+      if (c === '/' && c2 === '/') { inLineComment = true; i += 2; continue; }
+      if (c === '/' && c2 === '*') { inBlockComment = true; i += 2; continue; }
+      if (c === '"' || c === "'" || c === '`') { inStr = c as '"' | "'" | '`'; i++; continue; }
+      if (c === '{') { depth++; i++; continue; }
+      if (c === '}') { depth--; i++; continue; }
+      if (depth === 0 && line.slice(i, i + 6) === 'return') {
+        const before = i === 0 ? ' ' : line[i - 1];
+        const after = line[i + 6] ?? ' ';
+        if (!/[A-Za-z0-9_$]/.test(before) && !/[A-Za-z0-9_$]/.test(after)) {
+          lineHasTopLevelReturn = true;
+          i += 6; continue;
+        }
+      }
+      i++;
+    }
+
+    if (li === lineIndex && lineHasTopLevelReturn) return true;
+  }
+  return false;
+}

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -8,3 +8,4 @@ export { getEdgesOfTool, type GetEdgesOfInput, type GetEdgesOfOutput } from './t
 export { whyDidThisFailTool, type WhyDidThisFailInput, type WhyDidThisFailOutput } from './tools/whyDidThisFail';
 export { setParamValueTool, type SetParamValueInput, type SetParamValueOutput } from './tools/setParamValue';
 export { addFeatureTool, type AddFeatureInput, type AddFeatureOutput } from './tools/addFeature';
+export { removeFeatureTool, type RemoveFeatureInput, type RemoveFeatureOutput } from './tools/removeFeature';

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -10,6 +10,7 @@ import { getEdgesOfTool } from './tools/getEdgesOf';
 import { whyDidThisFailTool } from './tools/whyDidThisFail';
 import { setParamValueTool } from './tools/setParamValue';
 import { addFeatureTool } from './tools/addFeature';
+import { removeFeatureTool } from './tools/removeFeature';
 
 const TOOLS = [
   {
@@ -118,6 +119,18 @@ const TOOLS = [
       required: ['code', 'feature_code'],
     },
   },
+  {
+    name: 'remove_feature',
+    description: 'Remove a single line from a kernelCAD script identified by a substring match. Returns the modified code plus diagnostics from re-evaluating. Refuses to remove the line containing the return statement. Side-effect-free.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        code: { type: 'string', description: 'The .kcad.ts source code.' },
+        match: { type: 'string', description: 'A substring that uniquely identifies the line to remove (e.g. `const hole = cylinder(5,`).' },
+      },
+      required: ['code', 'match'],
+    },
+  },
 ];
 
 export function createMcpServer(): Server {
@@ -163,6 +176,9 @@ export function createMcpServer(): Server {
         break;
       case 'add_feature':
         result = await addFeatureTool(input as unknown as Parameters<typeof addFeatureTool>[0]);
+        break;
+      case 'remove_feature':
+        result = await removeFeatureTool(input as unknown as Parameters<typeof removeFeatureTool>[0]);
         break;
       default:
         throw new Error(`Unknown tool: ${name}`);

--- a/src/mcp/tools/removeFeature.ts
+++ b/src/mcp/tools/removeFeature.ts
@@ -1,0 +1,31 @@
+// src/mcp/tools/removeFeature.ts
+import { removeFeature } from '../edits/removeFeature';
+import { evaluateScriptTool } from './evaluateScript';
+import type { CompilerDiagnostic } from '../../diagnostics/diagnostic';
+
+export interface RemoveFeatureInput {
+  code: string;
+  match: string;
+}
+
+export interface RemoveFeatureOutput {
+  ok: boolean;
+  new_code?: string;
+  diagnostics?: CompilerDiagnostic[];
+  error?: string;
+}
+
+export async function removeFeatureTool(
+  input: RemoveFeatureInput,
+): Promise<RemoveFeatureOutput> {
+  const edit = removeFeature(input.code, input.match);
+  if (!edit.ok || !edit.new_code) {
+    return { ok: false, error: edit.error };
+  }
+  const evalResult = await evaluateScriptTool({ code: edit.new_code });
+  return {
+    ok: true,
+    new_code: edit.new_code,
+    diagnostics: evalResult.diagnostics,
+  };
+}

--- a/tests/integration/mcp/spawn.test.ts
+++ b/tests/integration/mcp/spawn.test.ts
@@ -147,4 +147,15 @@ describe.skipIf(SKIP)('MCP server (spawn)', () => {
     expect(payload.ok).toBe(true);
     expect(payload.new_code).toContain(`const hole = cylinder(5, 2)`);
   }, 90000);
+
+  it('responds to remove_feature with edited code + diagnostics', async () => {
+    const result = await callTool('remove_feature', {
+      code: `const base = box(20, 20, 5);\nconst hole = cylinder(5, 2);\nreturn base;`,
+      match: `cylinder(5, 2)`,
+    });
+    const text = (result as { content: { text: string }[] }).content[0].text;
+    const payload = JSON.parse(text);
+    expect(payload.ok).toBe(true);
+    expect(payload.new_code).not.toContain(`cylinder(5, 2)`);
+  }, 90000);
 });

--- a/tests/unit/mcp/edits/removeFeature.test.ts
+++ b/tests/unit/mcp/edits/removeFeature.test.ts
@@ -1,0 +1,65 @@
+// tests/unit/mcp/edits/removeFeature.test.ts
+import { describe, it, expect } from 'vitest';
+import { removeFeature } from '../../../../src/mcp/edits/removeFeature';
+
+describe('removeFeature primitive', () => {
+  it('removes a single matching line', () => {
+    const code = [
+      `const w = box(10, 10, 10);`,
+      `const h = cylinder(5, 2);`,
+      `return w.subtract(h);`,
+    ].join('\n');
+    const r = removeFeature(code, 'cylinder(5, 2)');
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe([
+      `const w = box(10, 10, 10);`,
+      `return w.subtract(h);`,
+    ].join('\n'));
+  });
+
+  it('preserves trailing newline if present', () => {
+    const code = `const a = box(1,1,1);\nconst b = box(2,2,2);\nreturn a;\n`;
+    const r = removeFeature(code, 'box(2,2,2)');
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`const a = box(1,1,1);\nreturn a;\n`);
+  });
+
+  it('errors when match is not found', () => {
+    const code = `const a = box(1,1,1);\nreturn a;`;
+    const r = removeFeature(code, 'cylinder');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/not found/i);
+  });
+
+  it('errors when match appears in multiple lines', () => {
+    const code = [
+      `const a = box(1,1,1);`,
+      `const b = box(2,2,2);`,
+      `return a;`,
+    ].join('\n');
+    const r = removeFeature(code, 'box');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/multiple/i);
+  });
+
+  it('errors when match resolves to the return line', () => {
+    const code = `const a = box(1,1,1);\nreturn a;`;
+    const r = removeFeature(code, 'return');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/return/i);
+  });
+
+  it('preserves indentation context (does not affect surrounding lines)', () => {
+    const code = `  const a = box(1, 1, 1);\n  const b = cylinder(2, 1);\n  return a;\n`;
+    const r = removeFeature(code, 'cylinder(2, 1)');
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`  const a = box(1, 1, 1);\n  return a;\n`);
+  });
+
+  it('removes a line that is the only line in the script (other than return)', () => {
+    const code = `const x = 5;\nreturn box(x, x, x);`;
+    const r = removeFeature(code, 'const x');
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toBe(`return box(x, x, x);`);
+  });
+});

--- a/tests/unit/mcp/tools/removeFeature.test.ts
+++ b/tests/unit/mcp/tools/removeFeature.test.ts
@@ -1,0 +1,49 @@
+// tests/unit/mcp/tools/removeFeature.test.ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { removeFeatureTool } from '../../../../src/mcp/tools/removeFeature';
+import { initOcct } from '../../../../src/backends/occt/occtBackend';
+
+describe('removeFeatureTool', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('removes a feature line and re-evaluates successfully', async () => {
+    const code = [
+      `const a = box(20, 20, 5);`,
+      `const b = cylinder(5, 2);`,
+      `return a;`,
+    ].join('\n');
+    const r = await removeFeatureTool({ code, match: 'cylinder(5, 2)' });
+    expect(r.ok).toBe(true);
+    expect(r.new_code).not.toContain(`cylinder(5, 2)`);
+    expect(r.new_code).toContain(`return a`);
+    expect(r.diagnostics?.filter(d => d.severity === 'error')).toHaveLength(0);
+  });
+
+  it('returns error when match not found', async () => {
+    const code = `return box(10, 10, 10);`;
+    const r = await removeFeatureTool({ code, match: 'nonexistent' });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/not found/i);
+  });
+
+  it('returns error when match is the return line', async () => {
+    const code = `const a = box(10,10,10);\nreturn a;`;
+    const r = await removeFeatureTool({ code, match: 'return' });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/return/i);
+  });
+
+  it('surfaces re-evaluation errors when removing a line breaks the script', async () => {
+    // Remove the const declaration of a variable used later — re-eval will fail.
+    const code = [
+      `const w = box(10, 10, 10);`,
+      `return w.subtract(box(5, 5, 5));`,
+    ].join('\n');
+    // Removing the const w line makes 'w' undefined.
+    const r = await removeFeatureTool({ code, match: `const w = box` });
+    expect(r.ok).toBe(true); // edit succeeded
+    expect(r.new_code).not.toContain(`const w = box`);
+    // Re-eval should produce an error diagnostic
+    expect(r.diagnostics?.some(d => d.severity === 'error')).toBe(true);
+  });
+});


### PR DESCRIPTION
Third MCP write tool. String-match identifier (mirrors set_param_value). Refuses to remove return line.