### PR TITLE
feat(v0.13.0-rc.5): arc vocabulary — threePointsArc, sagittaArc, bulgeArc, radiusArc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## v0.13.0-rc.5 (NORTHSTAR roadmap: v0.4-rc arc vocabulary) — 2026-05-01
+
+### Added
+- **`PathBuilder.threePointsArc(x, y, midX, midY)`** — arc through 3 points (start = current position, mid = via, end = (x,y)). No prior tangent required.
+- **`PathBuilder.sagittaArc(x, y, sagitta)`** — arc by chord + perpendicular bulge height. Sign chooses bulge side (positive = ccw).
+- **`PathBuilder.bulgeArc(x, y, bulge)`** — arc by chord + DXF bulge factor (`tan(includedAngle/4)`). Sign chooses bulge side.
+- **`PathBuilder.radiusArc(x, y, radius)`** — arc by chord + explicit radius. Always minor arc. Sign chooses bulge side. Validates `|radius| >= chord/2` and `chord > 0`.
+- New `SketchCommand` variants: `threePointsArc`, `sagittaArc`, `bulgeArc`, `radiusArc`. Stored in sketch metadata.
+- New diagnostic code: `feature.sketch.degenerate-arc` — fires when `radiusArc` has `|radius| < chord/2` or degenerate chord. Hint entry in `whyDidThisFail`.
+- E2E fixtures: `tests/e2e/fixtures/gear-blank.kcad.ts` (4-arc circle via threePointsArc), `tests/e2e/fixtures/cam-profile.kcad.ts` (mixed lineTo + sagittaArc + radiusArc).
+
+### Changed
+- `OcctBackend.fromSketchCommands` now tracks `currentX`/`currentY` in its replay loop so `radiusArc` can compute chord length. Replicad's `BaseSketcher2d.pointer` is protected; this is the cleanest workaround.
+- `OcctLowerer` `'sketch'` arm narrows caught errors starting with `radiusArc:` to the new `feature.sketch.degenerate-arc` code (was `feature.sketch.failed`).
+
+### Deferred to subsequent rcs
+- Beziers (`quadraticBezierTo`, `cubicBezierTo`, `bezierTo`) — rc.6
+- `centerArc(center, end)` — center+end form
+- Major-arc opt-in for `radiusArc` (use `threePointsArc` for now)
+- Convenience variants (`vSagittaArc`, `hBulgeArc`, etc.)
+- Elliptical arcs
+
+---
+
 ## v0.13.0-rc.4 (NORTHSTAR roadmap: v0.4-rc sketch revolve) — 2026-04-30
 
 ### Added

--- a/docs/superpowers/plans/2026-05-01-v0.4-rc5-arc-vocabulary.md
+++ b/docs/superpowers/plans/2026-05-01-v0.4-rc5-arc-vocabulary.md
@@ -1,0 +1,826 @@
+# v0.4-rc5 Arc Vocabulary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `threePointsArc`, `sagittaArc`, `bulgeArc`, and `radiusArc` to the path builder so agents have a complete arc vocabulary (DXF-native + ergonomic) for sketches.
+
+**Architecture:** Four new `SketchCommand` variants and four matching `PathBuilder` methods. Three (threePointsArc, sagittaArc, bulgeArc) pass through to Replicad pen methods of the same name. The fourth (`radiusArc`) computes a signed sagitta from chord+radius and delegates to `sagittaArcTo`. Position tracking added to the replay loop in `fromSketchCommands` because Replicad's `BaseSketcher2d.pointer` is protected. Lowerer narrows `feature.sketch.failed` to `feature.sketch.degenerate-arc` when the thrown message starts with `radiusArc:`.
+
+**Tech Stack:** TypeScript, Replicad (OpenCascade WASM), Vitest, Node 20 ESM.
+
+---
+
+## File Structure
+
+**Modified:**
+- `src/capture/sketch.ts` — extend `SketchCommand` union with 4 variants; add 4 PathBuilder methods
+- `src/backends/occt/occtBackend.ts` — extend `fromSketchCommands` switch with 4 arms; track `currentX/currentY` in replay loop
+- `src/backends/occt/occtLowerer.ts` — narrow caught-error code to `feature.sketch.degenerate-arc` when message starts with `radiusArc:`
+- `src/mcp/tools/whyDidThisFail.ts` — hint entry for `feature.sketch.degenerate-arc`
+- `tests/unit/capture/sketch.test.ts` — 4 capture tests + 1 diagnostic test
+- `tests/unit/backends/occt/occtBackend.sketchExtrude.test.ts` — 7 backend tests
+- `tests/e2e/cli-acceptance.test.ts` — 2 new describe blocks
+- `package.json` — version `0.13.0-rc.4` → `0.13.0-rc.5`
+- `CHANGELOG.md` — new top entry
+
+**Created:**
+- `tests/e2e/fixtures/gear-blank.kcad.ts`
+- `tests/e2e/fixtures/cam-profile.kcad.ts`
+
+---
+
+## Phase 1: Capture
+
+### Task 1: SketchCommand union + 4 PathBuilder methods
+
+**Files:**
+- Modify: `src/capture/sketch.ts`
+- Test: `tests/unit/capture/sketch.test.ts`
+
+- [ ] **Step 1: Write 4 failing capture tests**
+
+Append to `tests/unit/capture/sketch.test.ts` BEFORE the closing `});` of the outer `describe('path() builder + Sketch capture', ...)` block:
+
+```typescript
+  it('captures threePointsArc with end and midpoint', async () => {
+    const code = `
+      const s = path().moveTo(0, 0).threePointsArc(20, 0, 10, 5).close();
+      return s.extrude(1);
+    `;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const sketchRec = result.records.find(r => r.kind === 'sketch')!;
+    const commands = (sketchRec.metadata as { commands: unknown[] }).commands;
+    expect(commands).toContainEqual({ kind: 'threePointsArc', x: 20, y: 0, midX: 10, midY: 5 });
+  });
+
+  it('captures sagittaArc with chord endpoint and bulge', async () => {
+    const code = `return path().moveTo(0, 0).sagittaArc(20, 0, 5).close().extrude(1);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const sketchRec = result.records.find(r => r.kind === 'sketch')!;
+    const commands = (sketchRec.metadata as { commands: unknown[] }).commands;
+    expect(commands).toContainEqual({ kind: 'sagittaArc', x: 20, y: 0, sagitta: 5 });
+  });
+
+  it('captures bulgeArc with chord endpoint and DXF bulge factor', async () => {
+    const code = `return path().moveTo(0, 0).bulgeArc(20, 0, 0.5).close().extrude(1);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const sketchRec = result.records.find(r => r.kind === 'sketch')!;
+    const commands = (sketchRec.metadata as { commands: unknown[] }).commands;
+    expect(commands).toContainEqual({ kind: 'bulgeArc', x: 20, y: 0, bulge: 0.5 });
+  });
+
+  it('captures radiusArc with chord endpoint and radius', async () => {
+    const code = `return path().moveTo(0, 0).radiusArc(20, 0, 15).close().extrude(1);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const sketchRec = result.records.find(r => r.kind === 'sketch')!;
+    const commands = (sketchRec.metadata as { commands: unknown[] }).commands;
+    expect(commands).toContainEqual({ kind: 'radiusArc', x: 20, y: 0, radius: 15 });
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/unit/capture/sketch.test.ts`
+
+Expected: FAIL — `threePointsArc is not a function` (and the same for sagittaArc, bulgeArc, radiusArc).
+
+- [ ] **Step 3: Extend SketchCommand union**
+
+In `src/capture/sketch.ts`, find the existing union (lines 6-10):
+
+```typescript
+export type SketchCommand =
+  | { kind: 'moveTo'; x: number; y: number }
+  | { kind: 'lineTo'; x: number; y: number }
+  | { kind: 'tangentArc'; x: number; y: number }
+  | { kind: 'close' };
+```
+
+Replace with:
+
+```typescript
+export type SketchCommand =
+  | { kind: 'moveTo'; x: number; y: number }
+  | { kind: 'lineTo'; x: number; y: number }
+  | { kind: 'tangentArc'; x: number; y: number }
+  | { kind: 'threePointsArc'; x: number; y: number; midX: number; midY: number }
+  | { kind: 'sagittaArc'; x: number; y: number; sagitta: number }
+  | { kind: 'bulgeArc'; x: number; y: number; bulge: number }
+  | { kind: 'radiusArc'; x: number; y: number; radius: number }
+  | { kind: 'close' };
+```
+
+- [ ] **Step 4: Add 4 PathBuilder methods**
+
+In `src/capture/sketch.ts`, add these four methods to the `PathBuilder` class right after the existing `tangentArc` method (around line 99, before `close()`):
+
+```typescript
+  /**
+   * Arc through three points (start = current pen position, mid = via, end = (x, y)).
+   * No prior tangent required — can be the first segment of a path.
+   *
+   * Pick this when you know an interior point on the curve (e.g. reverse-engineering
+   * from a CAD reference) or when you need a major arc (>180°) — set the midpoint
+   * on the far side of the chord. No sign convention; midpoint position fully
+   * determines the arc.
+   *
+   * @param x endpoint X
+   * @param y endpoint Y
+   * @param midX midpoint X (any point the arc passes through, not on the chord)
+   * @param midY midpoint Y
+   */
+  threePointsArc(x: number, y: number, midX: number, midY: number): PathBuilder {
+    this.commands.push({ kind: 'threePointsArc', x, y, midX, midY });
+    return this;
+  }
+
+  /**
+   * Arc by chord + perpendicular bulge height (sagitta).
+   * No prior tangent required — can be the first segment of a path.
+   *
+   * Pick this when you know how far the arc bulges from the chord. Replicad-native
+   * (`sagittaArcTo`).
+   *
+   * Sign convention: positive sagitta → arc bulges LEFT of chord direction
+   * (counterclockwise from start to end). Negative → bulges RIGHT (clockwise).
+   *
+   * @param x endpoint X
+   * @param y endpoint Y
+   * @param sagitta perpendicular bulge height (signed)
+   */
+  sagittaArc(x: number, y: number, sagitta: number): PathBuilder {
+    this.commands.push({ kind: 'sagittaArc', x, y, sagitta });
+    return this;
+  }
+
+  /**
+   * Arc by chord + DXF bulge factor (bulge = tan(includedAngle / 4)).
+   * No prior tangent required — can be the first segment of a path.
+   *
+   * Pick this when round-tripping DXF (DXF stores arcs as bulge factors).
+   * Replicad-native (`bulgeArcTo`).
+   *
+   * Sign convention: positive bulge → counterclockwise (left of chord direction).
+   * Negative → clockwise. Magnitude > 1 means included angle > 180°.
+   *
+   * @param x endpoint X
+   * @param y endpoint Y
+   * @param bulge DXF bulge factor (signed)
+   */
+  bulgeArc(x: number, y: number, bulge: number): PathBuilder {
+    this.commands.push({ kind: 'bulgeArc', x, y, bulge });
+    return this;
+  }
+
+  /**
+   * Arc by chord + explicit radius. Always the MINOR arc (<180°). For a major
+   * arc, use threePointsArc with the midpoint on the far side of the chord.
+   * No prior tangent required — can be the first segment of a path.
+   *
+   * Pick this for parametric work where radius is the natural mental model.
+   * Computed via signed sagitta and lowered through `sagittaArcTo`.
+   *
+   * Sign convention: positive radius → arc bulges LEFT of chord direction
+   * (counterclockwise from start to end). Negative → bulges RIGHT.
+   *
+   * Validation (at lowering time):
+   * - `|radius| >= chord/2` — else `feature.sketch.degenerate-arc` diagnostic
+   * - `chord > 0` (start ≠ end) — else `feature.sketch.degenerate-arc`
+   *
+   * @param x endpoint X
+   * @param y endpoint Y
+   * @param radius arc radius (signed)
+   */
+  radiusArc(x: number, y: number, radius: number): PathBuilder {
+    this.commands.push({ kind: 'radiusArc', x, y, radius });
+    return this;
+  }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/capture/sketch.test.ts`
+
+Expected: PASS — 13 prior tests + 4 new = 17/17.
+
+- [ ] **Step 6: Run typecheck (the SketchCommand union widened — check no consumer breaks)**
+
+Run: `npm run typecheck`
+
+Expected: clean. If anything fails, the most likely cause is an exhaustive switch on `c.kind` somewhere outside `fromSketchCommands` that needs the new variants. Search with `grep -rn "c\.kind" src/` to find any.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/capture/sketch.ts tests/unit/capture/sketch.test.ts
+git commit --author="w1ne <14119286+w1ne@users.noreply.github.com>" -m "feat(capture): four new arc commands — threePointsArc, sagittaArc, bulgeArc, radiusArc"
+```
+
+---
+
+## Phase 2: Backend
+
+### Task 2: fromSketchCommands arms + radiusArc math + position tracking
+
+**Files:**
+- Modify: `src/backends/occt/occtBackend.ts`
+- Test: `tests/unit/backends/occt/occtBackend.sketchExtrude.test.ts`
+
+- [ ] **Step 1: Write 7 failing backend tests**
+
+Append to `tests/unit/backends/occt/occtBackend.sketchExtrude.test.ts` BEFORE the closing `});` of the outermost `describe('OcctBackend sketch + extrudeSketch', ...)` block:
+
+```typescript
+  it('threePointsArc produces a non-zero-area extrusion', () => {
+    const commands: SketchCommand[] = [
+      { kind: 'moveTo', x: 0, y: 0 },
+      { kind: 'threePointsArc', x: 20, y: 0, midX: 10, midY: 5 },
+      { kind: 'close' },
+    ];
+    const sketch = OcctBackend.fromSketchCommands(commands);
+    const extruded = OcctBackend.extrudeFromSketch(sketch, 1);
+    const v = extruded.volume();
+    expect(v).toBeGreaterThan(50);
+    expect(v).toBeLessThan(80);
+  });
+
+  it('sagittaArc with positive vs negative sagitta produces equal-magnitude volumes (sign = bulge side)', () => {
+    const cmdsPos: SketchCommand[] = [
+      { kind: 'moveTo', x: 0, y: 0 },
+      { kind: 'sagittaArc', x: 20, y: 0, sagitta: 5 },
+      { kind: 'close' },
+    ];
+    const cmdsNeg: SketchCommand[] = [
+      { kind: 'moveTo', x: 0, y: 0 },
+      { kind: 'sagittaArc', x: 20, y: 0, sagitta: -5 },
+      { kind: 'close' },
+    ];
+    const vPos = OcctBackend.extrudeFromSketch(OcctBackend.fromSketchCommands(cmdsPos), 1).volume();
+    const vNeg = OcctBackend.extrudeFromSketch(OcctBackend.fromSketchCommands(cmdsNeg), 1).volume();
+    expect(vPos).toBeGreaterThan(50);
+    expect(vNeg).toBeCloseTo(vPos, 1);
+  });
+
+  it('bulgeArc and sagittaArc produce equivalent shapes when sagitta = bulge × halfChord (within 5%)', () => {
+    // Replicad bulge = tan(theta/4); for shallow arcs this approximates sagitta/halfChord.
+    // For chord 20, sagitta 5 → halfChord 10 → bulge ≈ 0.5 (DXF convention). 5% tolerance.
+    const cmdsSag: SketchCommand[] = [
+      { kind: 'moveTo', x: 0, y: 0 },
+      { kind: 'sagittaArc', x: 20, y: 0, sagitta: 5 },
+      { kind: 'close' },
+    ];
+    const cmdsBulge: SketchCommand[] = [
+      { kind: 'moveTo', x: 0, y: 0 },
+      { kind: 'bulgeArc', x: 20, y: 0, bulge: 0.5 },
+      { kind: 'close' },
+    ];
+    const vSag = OcctBackend.extrudeFromSketch(OcctBackend.fromSketchCommands(cmdsSag), 1).volume();
+    const vBulge = OcctBackend.extrudeFromSketch(OcctBackend.fromSketchCommands(cmdsBulge), 1).volume();
+    const ratio = vBulge / vSag;
+    expect(ratio).toBeGreaterThan(0.95);
+    expect(ratio).toBeLessThan(1.05);
+  });
+
+  it('radiusArc produces correct volume — analytic circular segment area', () => {
+    // chord 20, radius 15 → theta = 2·asin(2/3) ≈ 1.4595 rad
+    // segment area = R²(theta − sin theta)/2 ≈ 225 × (1.4595 − 0.9938)/2 ≈ 52.4
+    const commands: SketchCommand[] = [
+      { kind: 'moveTo', x: 0, y: 0 },
+      { kind: 'radiusArc', x: 20, y: 0, radius: 15 },
+      { kind: 'close' },
+    ];
+    const sketch = OcctBackend.fromSketchCommands(commands);
+    const v = OcctBackend.extrudeFromSketch(sketch, 1).volume();
+    expect(v).toBeGreaterThan(40);
+    expect(v).toBeLessThan(70);
+  });
+
+  it('radiusArc throws when |radius| < chord/2', () => {
+    const commands: SketchCommand[] = [
+      { kind: 'moveTo', x: 0, y: 0 },
+      { kind: 'radiusArc', x: 20, y: 0, radius: 9 },
+      { kind: 'close' },
+    ];
+    expect(() => OcctBackend.fromSketchCommands(commands))
+      .toThrow(/radiusArc:.*radius.*9.*too small.*chord/);
+  });
+
+  it('radiusArc throws when chord is degenerate (start ≈ end)', () => {
+    const commands: SketchCommand[] = [
+      { kind: 'moveTo', x: 5, y: 5 },
+      { kind: 'radiusArc', x: 5, y: 5, radius: 10 },
+      { kind: 'close' },
+    ];
+    expect(() => OcctBackend.fromSketchCommands(commands))
+      .toThrow(/radiusArc:.*degenerate chord/);
+  });
+
+  it('radiusArc with positive vs negative radius produces equal-magnitude volumes (sign = bulge side)', () => {
+    const cmdsPos: SketchCommand[] = [
+      { kind: 'moveTo', x: 0, y: 0 },
+      { kind: 'radiusArc', x: 20, y: 0, radius: 15 },
+      { kind: 'close' },
+    ];
+    const cmdsNeg: SketchCommand[] = [
+      { kind: 'moveTo', x: 0, y: 0 },
+      { kind: 'radiusArc', x: 20, y: 0, radius: -15 },
+      { kind: 'close' },
+    ];
+    const vPos = OcctBackend.extrudeFromSketch(OcctBackend.fromSketchCommands(cmdsPos), 1).volume();
+    const vNeg = OcctBackend.extrudeFromSketch(OcctBackend.fromSketchCommands(cmdsNeg), 1).volume();
+    expect(vPos).toBeGreaterThan(40);
+    expect(vNeg).toBeCloseTo(vPos, 1);
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/unit/backends/occt/occtBackend.sketchExtrude.test.ts`
+
+Expected: FAIL — the new arc commands fall through the existing switch which only handles `lineTo` and `tangentArc`. The pen has no segments for them, so close+extrude either produces a degenerate volume or Replicad throws.
+
+- [ ] **Step 3: Extend `fromSketchCommands` with 4 arc arms + position tracking**
+
+In `src/backends/occt/occtBackend.ts`, find the existing replay loop in `fromSketchCommands` (around lines 243-251):
+
+```typescript
+    let pen = replicad.draw([first.x, first.y]);
+    for (let i = 1; i < closeIdx; i++) {
+      const c = commands[i];
+      if (c.kind === 'lineTo') {
+        pen = pen.lineTo([c.x, c.y]) as typeof pen;
+      } else if (c.kind === 'tangentArc') {
+        pen = pen.tangentArcTo([c.x, c.y]) as typeof pen;
+      }
+    }
+```
+
+Replace with:
+
+```typescript
+    let pen = replicad.draw([first.x, first.y]);
+    let currentX = first.x;
+    let currentY = first.y;
+    for (let i = 1; i < closeIdx; i++) {
+      const c = commands[i];
+      if (c.kind === 'lineTo') {
+        pen = pen.lineTo([c.x, c.y]) as typeof pen;
+      } else if (c.kind === 'tangentArc') {
+        pen = pen.tangentArcTo([c.x, c.y]) as typeof pen;
+      } else if (c.kind === 'threePointsArc') {
+        pen = pen.threePointsArcTo([c.x, c.y], [c.midX, c.midY]) as typeof pen;
+      } else if (c.kind === 'sagittaArc') {
+        pen = pen.sagittaArcTo([c.x, c.y], c.sagitta) as typeof pen;
+      } else if (c.kind === 'bulgeArc') {
+        pen = pen.bulgeArcTo([c.x, c.y], c.bulge) as typeof pen;
+      } else if (c.kind === 'radiusArc') {
+        const chord = Math.hypot(c.x - currentX, c.y - currentY);
+        if (chord < 1e-9) {
+          throw new Error(`radiusArc: degenerate chord (start ≈ end) at point (${c.x}, ${c.y})`);
+        }
+        if (Math.abs(c.radius) < chord / 2) {
+          throw new Error(`radiusArc: radius (${c.radius}) too small for chord length ${chord.toFixed(3)} — needs |radius| >= chord/2`);
+        }
+        const halfChord = chord / 2;
+        const sagittaMagnitude = Math.abs(c.radius) - Math.sqrt(c.radius * c.radius - halfChord * halfChord);
+        const signedSagitta = Math.sign(c.radius) * sagittaMagnitude;
+        pen = pen.sagittaArcTo([c.x, c.y], signedSagitta) as typeof pen;
+      }
+      // Update position after every non-close command (all have explicit x/y endpoint)
+      if ('x' in c && 'y' in c) {
+        currentX = c.x;
+        currentY = c.y;
+      }
+    }
+```
+
+- [ ] **Step 4: Run new backend tests**
+
+Run: `npx vitest run tests/unit/backends/occt/occtBackend.sketchExtrude.test.ts`
+
+Expected: PASS — 5 prior tests + 7 new = 12/12.
+
+If the threePointsArc test fails with "function not on pen" — Replicad's pen exposes `threePointsArcTo`. Verify spelling against `node_modules/replicad/dist/replicad.d.ts:186` (`threePointsArcTo(end, midPoint)`).
+
+If the bulgeArc/sagittaArc equivalence test fails because volumes differ by >5% — Replicad bulge is `tan(theta/4)`, not `sagitta/halfChord`. Adjust the test's expected bulge value: for chord 20 / sagitta 5, the included angle θ satisfies `sin(θ/2) = halfChord/R`. With R ≈ 12.5 (computed from sagitta 5 and chord 20), `θ/2 ≈ asin(0.8) ≈ 0.927` so `θ ≈ 1.855` and `tan(θ/4) ≈ tan(0.464) ≈ 0.500`. The 0.5 bulge value should hold; if it doesn't, switch the test to compare each arc against its own analytic area.
+
+- [ ] **Step 5: Run full unit suite for regressions**
+
+Run: `npx vitest run tests/unit/`
+
+Expected: All previously passing tests + 7 new = 220+, 0 failures.
+
+- [ ] **Step 6: Run typecheck + lint**
+
+Run: `npm run typecheck && npm run lint`
+
+Both clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/backends/occt/occtBackend.ts tests/unit/backends/occt/occtBackend.sketchExtrude.test.ts
+git commit --author="w1ne <14119286+w1ne@users.noreply.github.com>" -m "feat(backends/occt): four arc lowering arms + radiusArc sagitta math"
+```
+
+---
+
+## Phase 3: Diagnostic narrowing
+
+### Task 3: feature.sketch.degenerate-arc code + hint
+
+**Files:**
+- Modify: `src/backends/occt/occtLowerer.ts`
+- Modify: `src/mcp/tools/whyDidThisFail.ts`
+- Test: `tests/unit/capture/sketch.test.ts`
+
+- [ ] **Step 1: Write failing diagnostic test**
+
+Append to `tests/unit/capture/sketch.test.ts` BEFORE the closing `});` of the outer describe block:
+
+```typescript
+  it('emits feature.sketch.degenerate-arc when radiusArc has invalid radius', async () => {
+    const { RecomputeEngine } = await import('../../../src/compute/recomputeEngine');
+    const { OcctLowerer } = await import('../../../src/backends/occt/occtLowerer');
+    // chord 20, radius 5 → 5 < 10 → degenerate
+    const code = `return path().moveTo(0, 0).radiusArc(20, 0, 5).close().extrude(1);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const engine = new RecomputeEngine(new OcctLowerer());
+    const r = await engine.run(result.records);
+    expect(r.diagnostics.some(d =>
+      d.code === 'feature.sketch.degenerate-arc' && d.severity === 'error'
+    )).toBe(true);
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/capture/sketch.test.ts -t "degenerate-arc"`
+
+Expected: FAIL — current lowerer emits `feature.sketch.failed`, not the new code.
+
+- [ ] **Step 3: Narrow the lowerer's caught-error code**
+
+In `src/backends/occt/occtLowerer.ts`, find the existing `'sketch'` arm catch block (around lines 76-86):
+
+```typescript
+        try {
+          shape = OcctBackend.fromSketchCommands(commands as import('../../capture/sketch').SketchCommand[]);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.sketch.failed',
+            featureId: r.id,
+            severity: 'error',
+            message: `sketch construction failed: ${msg}`,
+          });
+          return { shape: undefined as unknown as ShapeBackend, diagnostics };
+        }
+```
+
+Replace with:
+
+```typescript
+        try {
+          shape = OcctBackend.fromSketchCommands(commands as import('../../capture/sketch').SketchCommand[]);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          // Narrow degenerate-arc cases (radiusArc-only for now) to a specific code
+          // so whyDidThisFail can give a more actionable hint.
+          const code = msg.startsWith('radiusArc:') ? 'feature.sketch.degenerate-arc' : 'feature.sketch.failed';
+          diagnostics.push({
+            target: 'export-occt',
+            code,
+            featureId: r.id,
+            severity: 'error',
+            message: `sketch construction failed: ${msg}`,
+          });
+          return { shape: undefined as unknown as ShapeBackend, diagnostics };
+        }
+```
+
+- [ ] **Step 4: Add hint entry**
+
+In `src/mcp/tools/whyDidThisFail.ts`, find the existing `feature.sketch.failed` entry (or any nearby `feature.sketch.*` entry) in the HINTS table. If `feature.sketch.failed` doesn't have an entry, add it; either way, add the new degenerate-arc entry next to other `feature.sketch.*` entries:
+
+```typescript
+  'feature.sketch.degenerate-arc': "An arc segment has degenerate geometry. For radiusArc: |radius| must be >= chord/2 (where chord is the straight-line distance start→end), and start must not coincide with end. Either pick a larger radius, change the endpoints, or use threePointsArc / sagittaArc.",
+```
+
+If `feature.sketch.failed` is missing, also add (defensive — useful for future agent debugging):
+
+```typescript
+  'feature.sketch.failed': "Sketch construction failed during lowering. Check the diagnostic message for the underlying error from Replicad or our validation.",
+```
+
+(If `feature.sketch.failed` already has an entry, skip adding it again.)
+
+- [ ] **Step 5: Run the diagnostic test**
+
+Run: `npx vitest run tests/unit/capture/sketch.test.ts -t "degenerate-arc"`
+
+Expected: PASS.
+
+- [ ] **Step 6: Run full capture suite for regressions**
+
+Run: `npx vitest run tests/unit/capture/sketch.test.ts`
+
+Expected: 17 prior + 1 new = 18/18 PASS.
+
+- [ ] **Step 7: Run typecheck**
+
+Run: `npm run typecheck`
+
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/backends/occt/occtLowerer.ts src/mcp/tools/whyDidThisFail.ts tests/unit/capture/sketch.test.ts
+git commit --author="w1ne <14119286+w1ne@users.noreply.github.com>" -m "feat(diagnostics): feature.sketch.degenerate-arc — narrowed code for radiusArc validation failures"
+```
+
+---
+
+## Phase 4: E2E + release
+
+### Task 4: Fixtures + version bump + tag v0.13.0-rc.5
+
+**Files:**
+- Create: `tests/e2e/fixtures/gear-blank.kcad.ts`
+- Create: `tests/e2e/fixtures/cam-profile.kcad.ts`
+- Modify: `tests/e2e/cli-acceptance.test.ts`
+- Modify: `package.json`, `CHANGELOG.md`
+
+- [ ] **Step 1: Create gear-blank fixture**
+
+Create `tests/e2e/fixtures/gear-blank.kcad.ts`:
+
+```typescript
+const radius = param('Radius', 20, { unit: 'mm', min: 5, max: 100 });
+const thickness = param('Thickness', 5, { unit: 'mm', min: 1, max: 20 });
+
+// Circular blank built from 4 quarter-arcs via threePointsArc.
+// Each quarter-arc spans 90°. Midpoint is at 45° angle on the circle.
+// For a quarter from (R, 0) to (0, R): midpoint at (R/√2, R/√2) ≈ (R·0.7071, R·0.7071).
+const m = radius * 0.7071067811865475; // cos(45°) = sin(45°)
+
+return path()
+  .moveTo(radius, 0)
+  .threePointsArc(0, radius, m, m)         // Q1: (R,0) → (0,R) via (m,m)
+  .threePointsArc(-radius, 0, -m, m)       // Q2: (0,R) → (-R,0) via (-m,m)
+  .threePointsArc(0, -radius, -m, -m)      // Q3: (-R,0) → (0,-R) via (-m,-m)
+  .threePointsArc(radius, 0, m, -m)        // Q4: (0,-R) → (R,0) via (m,-m)
+  .close()
+  .extrude(thickness);
+```
+
+- [ ] **Step 2: Create cam-profile fixture**
+
+Create `tests/e2e/fixtures/cam-profile.kcad.ts`:
+
+```typescript
+const baseRadius = param('BaseRadius', 15, { unit: 'mm', min: 5, max: 50 });
+const liftHeight = param('LiftHeight', 8, { unit: 'mm', min: 1, max: 20 });
+const thickness = param('Thickness', 5, { unit: 'mm', min: 1, max: 15 });
+
+// Cam profile mixing line + sagittaArc (lift) + radiusArc (return) + line.
+// Forms a teardrop-ish closed curve. Coordinates verified to keep |radius| >= chord/2.
+return path()
+  .moveTo(baseRadius, 0)
+  .lineTo(baseRadius, liftHeight)
+  .sagittaArc(-baseRadius, liftHeight, 4)           // bulge up
+  .lineTo(-baseRadius, 0)
+  .radiusArc(baseRadius, 0, baseRadius * 1.5)       // return arc, radius > chord/2 = baseRadius
+  .close()
+  .extrude(thickness);
+```
+
+- [ ] **Step 3: Add 2 e2e describe blocks**
+
+Append to `tests/e2e/cli-acceptance.test.ts` (after the closing `});` of the last existing describe block, currently `'v0.4-rc4 mug-body revolve fixture'`):
+
+```typescript
+describe('v0.4-rc5 gear-blank threePointsArc fixture', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('runs end-to-end on the gear-blank fixture and produces STL', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'kcad-acc-'));
+    const out = join(tmp, 'gear-blank.stl');
+    const r = await exportScript({
+      file: join(__dirname, 'fixtures/gear-blank.kcad.ts'),
+      format: 'stl',
+      out,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(statSync(out).size).toBeGreaterThan(500);
+  });
+});
+
+describe('v0.4-rc5 cam-profile mixed-arc fixture', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('runs end-to-end on the cam-profile fixture and produces STL', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'kcad-acc-'));
+    const out = join(tmp, 'cam-profile.stl');
+    const r = await exportScript({
+      file: join(__dirname, 'fixtures/cam-profile.kcad.ts'),
+      format: 'stl',
+      out,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(statSync(out).size).toBeGreaterThan(500);
+  });
+});
+```
+
+- [ ] **Step 4: Run e2e tests**
+
+Run: `npx vitest run tests/e2e/cli-acceptance.test.ts`
+
+Expected: All existing tests + 2 new = PASS.
+
+If the cam-profile test fails because Replicad rejects the `radiusArc(baseRadius, 0, baseRadius * 1.5)` math:
+- Verify chord = √((baseRadius−(−baseRadius))² + 0²) = 2·baseRadius = 30. Half-chord = 15.
+- `|radius| = baseRadius * 1.5 = 22.5`. Check `22.5 >= 15` ✓. Math is fine.
+- If Replicad still rejects, check the sagitta sign — change radius to `-baseRadius * 1.5` to flip the bulge side.
+
+If the gear-blank test fails because the four quarter-arcs don't connect properly:
+- Verify each `threePointsArc` endpoint matches the next arc's start.
+- Q1 ends at (0, radius). Q2 starts there. ✓
+- Q2 ends at (-radius, 0). Q3 starts there. ✓
+- Q3 ends at (0, -radius). Q4 starts there. ✓
+- Q4 ends at (radius, 0). Closes back to start. ✓
+
+- [ ] **Step 5: Bump version**
+
+In `package.json`, change `"version": "0.13.0-rc.4"` → `"version": "0.13.0-rc.5"`.
+
+- [ ] **Step 6: Prepend CHANGELOG entry**
+
+In `CHANGELOG.md`, prepend this entry above the existing `## v0.13.0-rc.4` entry (after the file header / intro):
+
+```markdown
+## v0.13.0-rc.5 (NORTHSTAR roadmap: v0.4-rc arc vocabulary) — 2026-05-01
+
+### Added
+- **`PathBuilder.threePointsArc(x, y, midX, midY)`** — arc through 3 points (start = current position, mid = via, end = (x,y)). No prior tangent required.
+- **`PathBuilder.sagittaArc(x, y, sagitta)`** — arc by chord + perpendicular bulge height. Sign chooses bulge side (positive = ccw).
+- **`PathBuilder.bulgeArc(x, y, bulge)`** — arc by chord + DXF bulge factor (`tan(includedAngle/4)`). Sign chooses bulge side.
+- **`PathBuilder.radiusArc(x, y, radius)`** — arc by chord + explicit radius. Always minor arc. Sign chooses bulge side. Validates `|radius| >= chord/2` and `chord > 0`.
+- New `SketchCommand` variants: `threePointsArc`, `sagittaArc`, `bulgeArc`, `radiusArc`. Stored in sketch metadata.
+- New diagnostic code: `feature.sketch.degenerate-arc` — fires when `radiusArc` has `|radius| < chord/2` or degenerate chord. Hint entry in `whyDidThisFail`.
+- E2E fixtures: `tests/e2e/fixtures/gear-blank.kcad.ts` (4-arc circle via threePointsArc), `tests/e2e/fixtures/cam-profile.kcad.ts` (mixed lineTo + sagittaArc + radiusArc).
+
+### Changed
+- `OcctBackend.fromSketchCommands` now tracks `currentX`/`currentY` in its replay loop so `radiusArc` can compute chord length. Replicad's `BaseSketcher2d.pointer` is protected; this is the cleanest workaround.
+- `OcctLowerer` `'sketch'` arm narrows caught errors starting with `radiusArc:` to the new `feature.sketch.degenerate-arc` code (was `feature.sketch.failed`).
+
+### Deferred to subsequent rcs
+- Beziers (`quadraticBezierTo`, `cubicBezierTo`, `bezierTo`) — rc.6
+- `centerArc(center, end)` — center+end form
+- Major-arc opt-in for `radiusArc` (use `threePointsArc` for now)
+- Convenience variants (`vSagittaArc`, `hBulgeArc`, etc.)
+- Elliptical arcs
+
+---
+```
+
+- [ ] **Step 7: Run full qc locally**
+
+```bash
+npm run typecheck
+npm run lint
+npm test
+npm run build
+```
+
+All must pass. Do NOT skip any. If anything fails, fix before continuing.
+
+- [ ] **Step 8: Commit + push**
+
+```bash
+git add tests/e2e/fixtures/gear-blank.kcad.ts tests/e2e/fixtures/cam-profile.kcad.ts tests/e2e/cli-acceptance.test.ts package.json CHANGELOG.md
+git commit --author="w1ne <14119286+w1ne@users.noreply.github.com>" -m "release: v0.13.0-rc.5 — arc vocabulary"
+git push -u origin feat/v0.4-rc5-arc-vocabulary
+```
+
+- [ ] **Step 9: Open PR**
+
+```bash
+gh pr create --base develop --head feat/v0.4-rc5-arc-vocabulary \
+  --title "feat(v0.13.0-rc.5): arc vocabulary — threePointsArc, sagittaArc, bulgeArc, radiusArc" \
+  --body "$(cat <<'EOF'
+Phase 1 step 5 of the agent-first geometry-parity roadmap. Adds explicit arc vocabulary to the path builder — all four can serve as the first segment (unlike tangentArc).
+
+## Summary
+- threePointsArc(end, mid) — Replicad-native, no sign convention
+- sagittaArc(end, sagitta) — Replicad-native, sign = bulge side
+- bulgeArc(end, bulge) — Replicad-native, DXF round-trip
+- radiusArc(end, radius) — custom math (signed sagitta), minor arc only, validates degenerate cases
+- New diagnostic: feature.sketch.degenerate-arc
+- E2E fixtures: gear-blank, cam-profile
+
+## Test plan
+- [x] capture tests — 18/18 (4 arc capture + 1 diagnostic + 13 prior)
+- [x] backend tests — 12/12 (7 new + 5 prior)
+- [x] e2e — all + 2 new pass
+- [x] typecheck + lint + build clean
+EOF
+)"
+```
+
+Report the PR URL and number.
+
+- [ ] **Step 10: Wait for qc, merge**
+
+```bash
+gh pr checks <PR_NUMBER> --watch
+```
+
+When `qc` is green:
+
+```bash
+gh pr merge <PR_NUMBER> --squash --delete-branch
+```
+
+- [ ] **Step 11: Tag and push tag**
+
+```bash
+git checkout develop
+git pull --ff-only origin develop
+git tag v0.13.0-rc.5
+git push origin v0.13.0-rc.5
+```
+
+- [ ] **Step 12: Live verify the shipped CLI**
+
+```bash
+npm run build:cli
+node dist/cli/index.js evaluate --json tests/e2e/fixtures/gear-blank.kcad.ts 2>&1 | grep -v -i 'wasm\|loading' | tail -10
+node dist/cli/index.js export step tests/e2e/fixtures/cam-profile.kcad.ts -o /tmp/cam.step
+ls -la /tmp/cam.step
+head -1 /tmp/cam.step
+```
+
+Expected:
+- `evaluate --json` shows `"featureCount": 2` (sketch + extrude), `"diagnostics": []`
+- `cam.step` exists, size > 5 KB
+- First line is `ISO-10303-21;`
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| `threePointsArc` capture | Task 1 |
+| `sagittaArc` capture | Task 1 |
+| `bulgeArc` capture | Task 1 |
+| `radiusArc` capture | Task 1 |
+| `threePointsArc` lowering | Task 2 |
+| `sagittaArc` lowering | Task 2 |
+| `bulgeArc` lowering | Task 2 |
+| `radiusArc` math + validation | Task 2 |
+| Position tracking in replay loop | Task 2 |
+| `feature.sketch.degenerate-arc` diagnostic | Task 3 |
+| `whyDidThisFail` hint entry | Task 3 |
+| Sign-symmetry tests (sagitta + radius) | Task 2 |
+| Analytic radiusArc volume test | Task 2 |
+| Degenerate-radius + degenerate-chord rejection | Task 2 |
+| Diagnostic code (not message) test | Task 3 |
+| gear-blank e2e fixture | Task 4 |
+| cam-profile e2e fixture | Task 4 |
+| Version bump | Task 4 |
+| CHANGELOG entry | Task 4 |
+| Tag v0.13.0-rc.5 | Task 4 |
+| Live CLI verify | Task 4 |
+
+All 20 spec items covered.
+
+**Placeholder scan:** No "TBD", "TODO", "implement later", or "similar to Task N". Every step has actual code or exact commands. Diagnostic message and JSDoc text written verbatim.
+
+**Type consistency:**
+- `SketchCommand` union extended consistently across capture (Task 1) and backend (Task 2)
+- All four PathBuilder methods return `PathBuilder` (chainable, matches `lineTo`/`tangentArc`)
+- `threePointsArc` field names: `x, y, midX, midY` — same in capture, command type, lowering, test
+- `sagittaArc` field name: `sagitta` — consistent
+- `bulgeArc` field name: `bulge` — consistent
+- `radiusArc` field name: `radius` — consistent
+- Diagnostic code `feature.sketch.degenerate-arc` consistent across lowerer (Task 3 step 3), hint table (Task 3 step 4), test assertion (Task 3 step 1)
+- `currentX`/`currentY` introduced in Task 2 step 3, no other task references them (correctly localized)
+
+**Open notes:**
+- Task 1 step 6 includes a defensive typecheck — the `SketchCommand` union widening may break exhaustive switches elsewhere. The `tests/unit/` regression run in Task 2 step 5 catches any logic regressions; the typecheck catches structural ones.
+- Task 2 step 4 includes a debugging note for the bulge-vs-sagitta tolerance test — Replicad bulge is `tan(theta/4)`, not `sagitta/halfChord`. Math worked through: for chord 20 / sagitta 5, expected bulge ≈ 0.5. If the test fails empirically, fall back to per-arc analytic comparison.
+- Task 4 step 4 includes specific debugging steps for the e2e fixtures (chord lengths, endpoint matching). These are forensic notes, not placeholders.
+- Phase 4 includes 12 release-mechanics steps but they're individually trivial (each is one shell command or one file edit). Bundled into a single task because they belong together.
+
+---
+
+## Execution Handoff
+
+Plan complete. The implementation follows the same TDD pattern proven in v0.13.0-rc.2, rc.3, rc.4 — test first, verify failure mode, implement, verify pass, commit. Each task produces a working tested unit before the next builds on it. radiusArc's custom math is the only non-mechanical piece; the analytic test (Task 2 step 4) catches sign or formula bugs.

--- a/docs/superpowers/specs/2026-05-01-v0.4-rc5-arc-vocabulary-design.md
+++ b/docs/superpowers/specs/2026-05-01-v0.4-rc5-arc-vocabulary-design.md
@@ -1,0 +1,236 @@
+# v0.4-rc5 Arc Vocabulary — Design
+
+**Date:** 2026-05-01
+**Milestone:** v0.13.0-rc.5 (NORTHSTAR roadmap step in v0.4-rc trajectory: arc curve vocabulary)
+**Status:** approved, ready for implementation plan
+
+## Context
+
+Following the v0.4-rc trajectory:
+- **rc.1** — `remove_feature` MCP write tool
+- **rc.2** — sketch builder (line-only `path()`)
+- **rc.3** — `tangentArc` (curved 2D segment, requires prior tangent)
+- **rc.4** — sketch revolve (terminal `.revolve()`)
+- **rc.5 (this spec)** — explicit arc vocabulary: `threePointsArc`, `sagittaArc`, `bulgeArc`, `radiusArc`
+
+`tangentArc` (rc.3) requires a prior segment to derive tangent direction — it cannot be the first segment of a path. The arc vocabulary in rc.5 fills this gap with arcs that take explicit geometry. All four can serve as the first segment of a path. Combined, they cover the DXF-native arc forms (threePointsArc, sagittaArc, bulgeArc) plus an agent-ergonomic explicit-radius form (radiusArc).
+
+## Why these four arcs (when to use which)
+
+Future me (agent or human) reading this spec to write a sketch — pick the arc that matches the input you have:
+
+| Arc method | Input you have | Best for |
+|---|---|---|
+| `threePointsArc(end, mid)` | Three points the arc must pass through | Reverse-engineering from a CAD reference; cases where you know an interior point on the curve |
+| `sagittaArc(end, sagitta)` | Chord + perpendicular bulge height | DXF imports (some forms); rounded corners where you know the bulge depth |
+| `bulgeArc(end, bulge)` | DXF bulge factor | Round-tripping DXF directly (DXF stores arcs as bulge factors) |
+| `radiusArc(end, radius)` | Explicit radius | Most parametric work — radius is the natural mental model |
+
+When in doubt: use `radiusArc`. When importing a DXF: use `bulgeArc`. When ergonomics demand 3 known points: use `threePointsArc`.
+
+## Goals
+
+1. Agents can build any 2D arc by specifying any of: three points, chord+sagitta, chord+bulge, or chord+radius.
+2. All arcs work as the first segment of a path (unlike `tangentArc`).
+3. All arcs compose seamlessly with existing `lineTo`, `tangentArc`, `close` — and downstream `.extrude(d)` / `.revolve()` work without modification.
+4. `radiusArc` validates degenerate input (`|radius| < chord/2`, `chord ≈ 0`) upfront and surfaces a clear, specific diagnostic.
+5. DXF-importing agents can use `bulgeArc` directly.
+
+## Non-goals (deferred to later rcs)
+
+- Bezier curves (`quadraticBezierTo`, `cubicBezierTo`) — rc.6
+- `centerArc(center, end)` — center-and-end form; uncommon in DXF or parametric workflow
+- Elliptical arcs — different primitive; not in Replicad pen
+- Major-arc opt-in for `radiusArc` (e.g. `{ major: true }`) — see "Sign conventions" below; major arcs reachable via `threePointsArc`
+- Convenience variants (`vSagittaArc`, `hBulgeArc`) — Replicad has these; defer until evidence agents need them
+- Arc-fillet on existing line corners — different feature class
+
+## API
+
+```typescript
+// Three-point arc — agent specifies any three points the arc passes through
+// (start = current pen position, mid = via point, end = endpoint)
+path()
+  .moveTo(0, 0)
+  .threePointsArc(20, 0, 10, 5)   // (endX, endY, midX, midY)
+  .close();
+
+// Sagitta arc — chord direction + perpendicular bulge height
+path()
+  .moveTo(0, 0)
+  .sagittaArc(20, 0, 5)           // (endX, endY, sagitta)
+  .close();
+
+// Bulge arc — DXF-native (bulge = tan(includedAngle/4); positive = ccw, negative = cw)
+path()
+  .moveTo(0, 0)
+  .bulgeArc(20, 0, 0.5)           // (endX, endY, bulge factor)
+  .close();
+
+// Radius arc — explicit radius, minor arc only. Sign chooses bulge side
+path()
+  .moveTo(0, 0)
+  .radiusArc(20, 0, 15)           // (endX, endY, radius) — positive = left of chord = ccw
+  .close();
+```
+
+## Sign conventions (consistent across all four)
+
+There are TWO independent properties of any arc:
+
+**(A) Bulge side** — left vs right of the chord direction (start → end):
+- Positive `sagitta`, `bulge`, or `radius` → arc bulges to the **left** of chord direction (counterclockwise from start to end).
+- Negative → bulges **right** (clockwise from start to end).
+- `threePointsArc` has no sign — fully determined by midpoint position.
+
+**(B) Minor vs major arc** — angle subtended <180° vs >180°:
+- `sagittaArc` / `bulgeArc`: implicit — magnitude of sagitta or bulge controls arc depth (sagitta >= radius means major arc; bulge > 1 means included angle > 180°).
+- `radiusArc`: **always minor arc** (rc.5 limitation). To get a major arc, use `threePointsArc` with a midpoint on the far side of the chord.
+
+This split keeps `radiusArc` simple — a single `radius` parameter — without needing a `{ major: boolean }` flag. The escape hatch (`threePointsArc`) covers the rare major-arc case.
+
+**Returns:** `PathBuilder` (chainable, like all existing path methods)
+
+## Architecture
+
+### Capture layer (`src/capture/sketch.ts`)
+
+Add 4 new variants to the `SketchCommand` discriminated union:
+
+```typescript
+export type SketchCommand =
+  | { kind: 'moveTo'; x: number; y: number }
+  | { kind: 'lineTo'; x: number; y: number }
+  | { kind: 'tangentArc'; x: number; y: number }
+  | { kind: 'threePointsArc'; x: number; y: number; midX: number; midY: number }
+  | { kind: 'sagittaArc'; x: number; y: number; sagitta: number }
+  | { kind: 'bulgeArc'; x: number; y: number; bulge: number }
+  | { kind: 'radiusArc'; x: number; y: number; radius: number }
+  | { kind: 'close' };
+```
+
+Add 4 new methods on `PathBuilder`. Each pushes the corresponding command and returns `this`. No validation at capture (consistent with `tangentArc` rc.3 pattern).
+
+JSDoc on each method should state: (a) what input it takes, (b) sign convention, (c) error mode. Future-me reading IntelliSense / MCP `getShapeInfo` should immediately know which arc to pick.
+
+### Backend (`src/backends/occt/occtBackend.ts`)
+
+Extend `fromSketchCommands` switch with four new arms. Three are direct passthroughs to Replicad:
+
+```typescript
+} else if (c.kind === 'threePointsArc') {
+  pen = pen.threePointsArcTo([c.x, c.y], [c.midX, c.midY]) as typeof pen;
+} else if (c.kind === 'sagittaArc') {
+  pen = pen.sagittaArcTo([c.x, c.y], c.sagitta) as typeof pen;
+} else if (c.kind === 'bulgeArc') {
+  pen = pen.bulgeArcTo([c.x, c.y], c.bulge) as typeof pen;
+}
+```
+
+`radiusArc` requires custom math — Replicad has no `radiusArcTo`. Compute the equivalent signed sagitta. Use Replicad's `pen.lastPoint` getter to obtain the start position (rather than tracking it ourselves):
+
+```typescript
+} else if (c.kind === 'radiusArc') {
+  const [startX, startY] = pen.lastPoint;
+  const chord = Math.hypot(c.x - startX, c.y - startY);
+  if (chord < 1e-9) {
+    throw new Error(`radiusArc: degenerate chord (start ≈ end) at point (${c.x}, ${c.y})`);
+  }
+  if (Math.abs(c.radius) < chord / 2) {
+    throw new Error(`radiusArc: radius (${c.radius}) too small for chord length ${chord.toFixed(3)} — needs |radius| >= chord/2`);
+  }
+  // Minor arc: sagitta_magnitude = |r| − √(r² − (chord/2)²)
+  const halfChord = chord / 2;
+  const sagittaMagnitude = Math.abs(c.radius) - Math.sqrt(c.radius * c.radius - halfChord * halfChord);
+  // Sign of sagitta follows sign of radius (positive radius → left bulge)
+  const signedSagitta = Math.sign(c.radius) * sagittaMagnitude;
+  pen = pen.sagittaArcTo([c.x, c.y], signedSagitta) as typeof pen;
+}
+```
+
+No `currentX`/`currentY` tracking needed — `pen.lastPoint` is authoritative.
+
+### Lowerer (`src/backends/occt/occtLowerer.ts`)
+
+Existing `'sketch'` arm catches Replicad/throw errors and surfaces `feature.sketch.failed`. Add narrow mapping: when caught error message starts with `radiusArc:`, emit `feature.sketch.degenerate-arc` instead. This gives `whyDidThisFail` a more specific hint:
+
+```typescript
+} catch (e) {
+  const msg = e instanceof Error ? e.message : String(e);
+  const code = msg.startsWith('radiusArc:') ? 'feature.sketch.degenerate-arc' : 'feature.sketch.failed';
+  diagnostics.push({
+    target: 'export-occt',
+    code,
+    featureId: r.id,
+    severity: 'error',
+    message: `sketch construction failed: ${msg}`,
+  });
+  return { shape: undefined as unknown as ShapeBackend, diagnostics };
+}
+```
+
+### Hint table (`src/mcp/tools/whyDidThisFail.ts`)
+
+Add one entry:
+
+```typescript
+'feature.sketch.degenerate-arc': "An arc segment has degenerate geometry. For radiusArc: |radius| must be >= chord/2 (where chord is the straight-line distance start→end), and start must not coincide with end. Either pick a larger radius, change the endpoints, or use threePointsArc / sagittaArc.",
+```
+
+## Test plan
+
+### Unit — capture (`tests/unit/capture/sketch.test.ts`)
+
+1. `path().threePointsArc(20, 0, 10, 5).close()` registers a sketch with command `{ kind: 'threePointsArc', x: 20, y: 0, midX: 10, midY: 5 }`
+2. `path().sagittaArc(20, 0, 5).close()` registers `{ kind: 'sagittaArc', x: 20, y: 0, sagitta: 5 }`
+3. `path().bulgeArc(20, 0, 0.5).close()` registers `{ kind: 'bulgeArc', x: 20, y: 0, bulge: 0.5 }`
+4. `path().radiusArc(20, 0, 15).close()` registers `{ kind: 'radiusArc', x: 20, y: 0, radius: 15 }`
+
+### Unit — backend (`tests/unit/backends/occt/occtBackend.sketchExtrude.test.ts`)
+
+5. **threePointsArc extrudes:** moveTo(0,0) → threePointsArc(20,0,10,5) → close. Extrude depth 1. Volume between 50 and 80 (closed circular segment with 20 chord and ~5 high midpoint, area ≈ 66).
+6. **sagittaArc symmetry:** moveTo(0,0) → sagittaArc(20,0,5) → close. Extrude 1. Volume V_pos. Repeat with sagitta=-5 → V_neg. `expect(V_neg).toBeCloseTo(V_pos, 1)`.
+7. **bulgeArc ↔ sagittaArc equivalence:** bulge × halfChord = sagitta (when bulge = sagitta / halfChord). bulgeArc(20,0,0.5) and sagittaArc(20,0,5) should produce volumes within 5% of each other. (`bulge` exact formula may differ — Replicad's `bulgeArcTo` is DXF-bulge `tan(theta/4)`. Test tolerance accounts for this.)
+8. **radiusArc analytic check:** moveTo(0,0) → radiusArc(20,0,15) → close. Extrude 1. Analytic segment area: R²×(θ−sinθ)/2, where θ = 2·arcsin(chord/2R) = 2·arcsin(2/3) ≈ 1.459 rad → area ≈ 52.4 → volume in [40, 70].
+9. **radiusArc rejects radius < chord/2:** moveTo(0,0) → radiusArc(20,0,9) → close. fromSketchCommands throws with message containing `radius (9) too small for chord`.
+10. **radiusArc rejects degenerate chord:** moveTo(5,5) → radiusArc(5,5,10) → close. fromSketchCommands throws with message containing `degenerate chord`.
+11. **radiusArc sign symmetry:** radiusArc(20,0,15) vs radiusArc(20,0,-15). Volumes equal in magnitude (mirror image profiles have same area).
+
+### Unit — lowerer / diagnostic (`tests/unit/capture/sketch.test.ts`)
+
+12. Script `path().moveTo(0,0).radiusArc(20,0,5).close().extrude(1)` → recompute emits diagnostic with code `feature.sketch.degenerate-arc` (asserted by code, not message text).
+
+### E2E (`tests/e2e/cli-acceptance.test.ts` + 2 fixtures)
+
+13. **Gear-blank fixture** (`tests/e2e/fixtures/gear-blank.kcad.ts`) — circular blank built from 4 quarter-arcs via `threePointsArc`, extruded → STL > 500 bytes.
+14. **Cam-profile fixture** (`tests/e2e/fixtures/cam-profile.kcad.ts`) — cam shape mixing `lineTo`, `sagittaArc`, and `radiusArc` → STL > 500 bytes.
+
+### Regression
+
+Existing 562 tests must keep passing. Focus areas: existing `tangentArc` paths (rc.3 fixtures), existing `extrude`+`sketch` paths, existing `revolve`+`sketch` paths.
+
+## Files
+
+**Modified:**
+- `src/capture/sketch.ts` — `SketchCommand` union + 4 new PathBuilder methods (with agent-friendly JSDoc)
+- `src/backends/occt/occtBackend.ts` — 4 new arms in `fromSketchCommands`; use `pen.lastPoint` for radiusArc start position
+- `src/backends/occt/occtLowerer.ts` — narrow `feature.sketch.degenerate-arc` mapping when error message starts with `radiusArc:`
+- `src/mcp/tools/whyDidThisFail.ts` — hint entry for `feature.sketch.degenerate-arc`
+- `tests/unit/capture/sketch.test.ts` — 4 capture tests + 1 diagnostic test (5 new)
+- `tests/unit/backends/occt/occtBackend.sketchExtrude.test.ts` — 7 backend tests (5–11)
+- `tests/e2e/cli-acceptance.test.ts` — 2 new describe blocks
+- `package.json` — version `0.13.0-rc.4` → `0.13.0-rc.5`
+- `CHANGELOG.md` — new top entry
+
+**Created:**
+- `tests/e2e/fixtures/gear-blank.kcad.ts`
+- `tests/e2e/fixtures/cam-profile.kcad.ts`
+
+## Acceptance criteria
+
+- All 14 new tests pass.
+- Existing 562 tests continue to pass.
+- `kcad evaluate --json tests/e2e/fixtures/gear-blank.kcad.ts` reports `featureCount: 2`, `diagnostics: []`.
+- `kcad export step tests/e2e/fixtures/cam-profile.kcad.ts -o /tmp/cam.step` produces a valid STEP (first line `ISO-10303-21;`).
+- PR merges to `develop` via `qc`.
+- Tag `v0.13.0-rc.5` pushed.

--- a/docs/superpowers/specs/2026-05-01-v0.4-rc5-arc-vocabulary-design.md
+++ b/docs/superpowers/specs/2026-05-01-v0.4-rc5-arc-vocabulary-design.md
@@ -127,12 +127,11 @@ Extend `fromSketchCommands` switch with four new arms. Three are direct passthro
 }
 ```
 
-`radiusArc` requires custom math — Replicad has no `radiusArcTo`. Compute the equivalent signed sagitta. Use Replicad's `pen.lastPoint` getter to obtain the start position (rather than tracking it ourselves):
+`radiusArc` requires custom math — Replicad has no `radiusArcTo`. Compute the equivalent signed sagitta. Track `currentX`/`currentY` in our replay loop (Replicad's `BaseSketcher2d.pointer` is `protected` so not directly accessible). Update after every non-close command:
 
 ```typescript
 } else if (c.kind === 'radiusArc') {
-  const [startX, startY] = pen.lastPoint;
-  const chord = Math.hypot(c.x - startX, c.y - startY);
+  const chord = Math.hypot(c.x - currentX, c.y - currentY);
   if (chord < 1e-9) {
     throw new Error(`radiusArc: degenerate chord (start ≈ end) at point (${c.x}, ${c.y})`);
   }
@@ -148,7 +147,7 @@ Extend `fromSketchCommands` switch with four new arms. Three are direct passthro
 }
 ```
 
-No `currentX`/`currentY` tracking needed — `pen.lastPoint` is authoritative.
+Position is tracked alongside the pen: every non-close command has an explicit `(x, y)` endpoint, so `currentX = c.x; currentY = c.y` after the call. `radiusArc` reads `currentX/currentY` BEFORE updating (for chord math), then updates.
 
 ### Lowerer (`src/backends/occt/occtLowerer.ts`)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kernelcad",
   "private": true,
-  "version": "0.13.0-rc.4",
+  "version": "0.13.0-rc.5",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/src/backends/occt/occtBackend.ts
+++ b/src/backends/occt/occtBackend.ts
@@ -241,12 +241,37 @@ export class OcctBackend implements ShapeBackend {
       throw new Error('OcctBackend.fromSketchCommands: first command must be moveTo.');
     }
     let pen = replicad.draw([first.x, first.y]);
+    let currentX = first.x;
+    let currentY = first.y;
     for (let i = 1; i < closeIdx; i++) {
       const c = commands[i];
       if (c.kind === 'lineTo') {
         pen = pen.lineTo([c.x, c.y]) as typeof pen;
       } else if (c.kind === 'tangentArc') {
         pen = pen.tangentArcTo([c.x, c.y]) as typeof pen;
+      } else if (c.kind === 'threePointsArc') {
+        pen = pen.threePointsArcTo([c.x, c.y], [c.midX, c.midY]) as typeof pen;
+      } else if (c.kind === 'sagittaArc') {
+        pen = pen.sagittaArcTo([c.x, c.y], c.sagitta) as typeof pen;
+      } else if (c.kind === 'bulgeArc') {
+        pen = pen.bulgeArcTo([c.x, c.y], c.bulge) as typeof pen;
+      } else if (c.kind === 'radiusArc') {
+        const chord = Math.hypot(c.x - currentX, c.y - currentY);
+        if (chord < 1e-9) {
+          throw new Error(`radiusArc: degenerate chord (start ≈ end) at point (${c.x}, ${c.y})`);
+        }
+        if (Math.abs(c.radius) < chord / 2) {
+          throw new Error(`radiusArc: radius (${c.radius}) too small for chord length ${chord.toFixed(3)} — needs |radius| >= chord/2`);
+        }
+        const halfChord = chord / 2;
+        const sagittaMagnitude = Math.abs(c.radius) - Math.sqrt(c.radius * c.radius - halfChord * halfChord);
+        const signedSagitta = Math.sign(c.radius) * sagittaMagnitude;
+        pen = pen.sagittaArcTo([c.x, c.y], signedSagitta) as typeof pen;
+      }
+      // Update position after every non-close command (all have explicit x/y endpoint)
+      if ('x' in c && 'y' in c) {
+        currentX = c.x;
+        currentY = c.y;
       }
     }
     const drawing = pen.close();

--- a/src/backends/occt/occtLowerer.ts
+++ b/src/backends/occt/occtLowerer.ts
@@ -75,9 +75,12 @@ export class OcctLowerer implements FeatureLowerer {
           shape = OcctBackend.fromSketchCommands(commands as import('../../capture/sketch').SketchCommand[]);
         } catch (e) {
           const msg = e instanceof Error ? e.message : String(e);
+          // Narrow degenerate-arc cases (radiusArc-only for now) to a specific code
+          // so whyDidThisFail can give a more actionable hint.
+          const code = msg.startsWith('radiusArc:') ? 'feature.sketch.degenerate-arc' : 'feature.sketch.failed';
           diagnostics.push({
             target: 'export-occt',
-            code: 'feature.sketch.failed',
+            code,
             featureId: r.id,
             severity: 'error',
             message: `sketch construction failed: ${msg}`,

--- a/src/capture/sketch.ts
+++ b/src/capture/sketch.ts
@@ -7,6 +7,10 @@ export type SketchCommand =
   | { kind: 'moveTo'; x: number; y: number }
   | { kind: 'lineTo'; x: number; y: number }
   | { kind: 'tangentArc'; x: number; y: number }
+  | { kind: 'threePointsArc'; x: number; y: number; midX: number; midY: number }
+  | { kind: 'sagittaArc'; x: number; y: number; sagitta: number }
+  | { kind: 'bulgeArc'; x: number; y: number; bulge: number }
+  | { kind: 'radiusArc'; x: number; y: number; radius: number }
   | { kind: 'close' };
 
 /**
@@ -95,6 +99,87 @@ export class PathBuilder {
    */
   tangentArc(x: number, y: number): PathBuilder {
     this.commands.push({ kind: 'tangentArc', x, y });
+    return this;
+  }
+
+  /**
+   * Arc through three points (start = current pen position, mid = via, end = (x, y)).
+   * No prior tangent required — can be the first segment of a path.
+   *
+   * Pick this when you know an interior point on the curve (e.g. reverse-engineering
+   * from a CAD reference) or when you need a major arc (>180°) — set the midpoint
+   * on the far side of the chord. No sign convention; midpoint position fully
+   * determines the arc.
+   *
+   * @param x endpoint X
+   * @param y endpoint Y
+   * @param midX midpoint X (any point the arc passes through, not on the chord)
+   * @param midY midpoint Y
+   */
+  threePointsArc(x: number, y: number, midX: number, midY: number): PathBuilder {
+    this.commands.push({ kind: 'threePointsArc', x, y, midX, midY });
+    return this;
+  }
+
+  /**
+   * Arc by chord + perpendicular bulge height (sagitta).
+   * No prior tangent required — can be the first segment of a path.
+   *
+   * Pick this when you know how far the arc bulges from the chord. Replicad-native
+   * (`sagittaArcTo`).
+   *
+   * Sign convention: positive sagitta → arc bulges LEFT of chord direction
+   * (counterclockwise from start to end). Negative → bulges RIGHT (clockwise).
+   *
+   * @param x endpoint X
+   * @param y endpoint Y
+   * @param sagitta perpendicular bulge height (signed)
+   */
+  sagittaArc(x: number, y: number, sagitta: number): PathBuilder {
+    this.commands.push({ kind: 'sagittaArc', x, y, sagitta });
+    return this;
+  }
+
+  /**
+   * Arc by chord + DXF bulge factor (bulge = tan(includedAngle / 4)).
+   * No prior tangent required — can be the first segment of a path.
+   *
+   * Pick this when round-tripping DXF (DXF stores arcs as bulge factors).
+   * Replicad-native (`bulgeArcTo`).
+   *
+   * Sign convention: positive bulge → counterclockwise (left of chord direction).
+   * Negative → clockwise. Magnitude > 1 means included angle > 180°.
+   *
+   * @param x endpoint X
+   * @param y endpoint Y
+   * @param bulge DXF bulge factor (signed)
+   */
+  bulgeArc(x: number, y: number, bulge: number): PathBuilder {
+    this.commands.push({ kind: 'bulgeArc', x, y, bulge });
+    return this;
+  }
+
+  /**
+   * Arc by chord + explicit radius. Always the MINOR arc (<180°). For a major
+   * arc, use threePointsArc with the midpoint on the far side of the chord.
+   * No prior tangent required — can be the first segment of a path.
+   *
+   * Pick this for parametric work where radius is the natural mental model.
+   * Computed via signed sagitta and lowered through `sagittaArcTo`.
+   *
+   * Sign convention: positive radius → arc bulges LEFT of chord direction
+   * (counterclockwise from start to end). Negative → bulges RIGHT.
+   *
+   * Validation (at lowering time):
+   * - `|radius| >= chord/2` — else `feature.sketch.degenerate-arc` diagnostic
+   * - `chord > 0` (start ≠ end) — else `feature.sketch.degenerate-arc`
+   *
+   * @param x endpoint X
+   * @param y endpoint Y
+   * @param radius arc radius (signed)
+   */
+  radiusArc(x: number, y: number, radius: number): PathBuilder {
+    this.commands.push({ kind: 'radiusArc', x, y, radius });
     return this;
   }
 

--- a/src/mcp/tools/whyDidThisFail.ts
+++ b/src/mcp/tools/whyDidThisFail.ts
@@ -72,6 +72,8 @@ const HINTS: Record<string, string> = {
   'feature.face-feature.face-ref-not-resolvable': "Same constraint as edge features: canonical face refs only work on un-transformed primitives. Apply shell before transforms.",
   'feature.face-feature.face-ref-not-applicable': "That canonical face is not valid for this primitive. Cylinders accept only top/bottom for shell; spheres have no canonical faces.",
   'feature.face-feature.face-ref-not-supported': "Only canonical face refs are supported in v0.2-alpha. Tracked / created / propagated face refs land in v0.2 full.",
+  'feature.sketch.degenerate-arc': "An arc segment has degenerate geometry. For radiusArc: |radius| must be >= chord/2 (where chord is the straight-line distance start→end), and start must not coincide with end. Either pick a larger radius, change the endpoints, or use threePointsArc / sagittaArc.",
+  'feature.sketch.failed': "Sketch construction failed during lowering. Check the diagnostic message for the underlying error from Replicad or our validation.",
   'recompute.input.missing': "An upstream feature failed or was suppressed. Use `why_did_this_fail` on the upstream feature ID to find the root cause.",
   'recompute.lowering.exception': "An exception was raised during lowering. Check the diagnostic message for the OCCT error.",
   'cli.script.exception': "Your script raised an exception during execution. Check the diagnostic message for the JS error.",

--- a/tests/e2e/cli-acceptance.test.ts
+++ b/tests/e2e/cli-acceptance.test.ts
@@ -236,3 +236,35 @@ describe('v0.4-rc4 mug-body revolve fixture', () => {
     expect(statSync(out).size).toBeGreaterThan(500);
   }, 30000);
 });
+
+describe('v0.4-rc5 gear-blank threePointsArc fixture', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('runs end-to-end on the gear-blank fixture and produces STL', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'kcad-acc-'));
+    const out = join(tmp, 'gear-blank.stl');
+    const r = await exportScript({
+      file: join(__dirname, 'fixtures/gear-blank.kcad.ts'),
+      format: 'stl',
+      out,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(statSync(out).size).toBeGreaterThan(500);
+  });
+});
+
+describe('v0.4-rc5 cam-profile mixed-arc fixture', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('runs end-to-end on the cam-profile fixture and produces STL', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'kcad-acc-'));
+    const out = join(tmp, 'cam-profile.stl');
+    const r = await exportScript({
+      file: join(__dirname, 'fixtures/cam-profile.kcad.ts'),
+      format: 'stl',
+      out,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(statSync(out).size).toBeGreaterThan(500);
+  });
+});

--- a/tests/e2e/fixtures/cam-profile.kcad.ts
+++ b/tests/e2e/fixtures/cam-profile.kcad.ts
@@ -1,0 +1,14 @@
+const baseRadius = param('BaseRadius', 15, { unit: 'mm', min: 5, max: 50 });
+const liftHeight = param('LiftHeight', 8, { unit: 'mm', min: 1, max: 20 });
+const thickness = param('Thickness', 5, { unit: 'mm', min: 1, max: 15 });
+
+// Cam profile mixing line + sagittaArc (lift) + radiusArc (return) + line.
+// Forms a teardrop-ish closed curve. Coordinates verified to keep |radius| >= chord/2.
+return path()
+  .moveTo(baseRadius, 0)
+  .lineTo(baseRadius, liftHeight)
+  .sagittaArc(-baseRadius, liftHeight, 4)           // bulge up
+  .lineTo(-baseRadius, 0)
+  .radiusArc(baseRadius, 0, baseRadius * 1.5)       // return arc, radius > chord/2 = baseRadius
+  .close()
+  .extrude(thickness);

--- a/tests/e2e/fixtures/gear-blank.kcad.ts
+++ b/tests/e2e/fixtures/gear-blank.kcad.ts
@@ -1,0 +1,16 @@
+const radius = param('Radius', 20, { unit: 'mm', min: 5, max: 100 });
+const thickness = param('Thickness', 5, { unit: 'mm', min: 1, max: 20 });
+
+// Circular blank built from 4 quarter-arcs via threePointsArc.
+// Each quarter-arc spans 90°. Midpoint is at 45° angle on the circle.
+// For a quarter from (R, 0) to (0, R): midpoint at (R/√2, R/√2) ≈ (R·0.7071, R·0.7071).
+const m = radius * 0.7071067811865475; // cos(45°) = sin(45°)
+
+return path()
+  .moveTo(radius, 0)
+  .threePointsArc(0, radius, m, m)         // Q1: (R,0) → (0,R) via (m,m)
+  .threePointsArc(-radius, 0, -m, m)       // Q2: (0,R) → (-R,0) via (-m,m)
+  .threePointsArc(0, -radius, -m, -m)      // Q3: (-R,0) → (0,-R) via (-m,-m)
+  .threePointsArc(radius, 0, m, -m)        // Q4: (0,-R) → (R,0) via (m,-m)
+  .close()
+  .extrude(thickness);

--- a/tests/unit/backends/occt/occtBackend.sketchExtrude.test.ts
+++ b/tests/unit/backends/occt/occtBackend.sketchExtrude.test.ts
@@ -62,4 +62,104 @@ describe('OcctBackend sketch + extrudeSketch', () => {
     expect(extruded.volume()).toBeGreaterThan(1687.5);
     expect(extruded.volume()).toBeLessThan(1800);
   });
+
+  it('threePointsArc produces a non-zero-area extrusion', () => {
+    const commands: SketchCommand[] = [
+      { kind: 'moveTo', x: 0, y: 0 },
+      { kind: 'threePointsArc', x: 20, y: 0, midX: 10, midY: 5 },
+      { kind: 'close' },
+    ];
+    const sketch = OcctBackend.fromSketchCommands(commands);
+    const extruded = OcctBackend.extrudeFromSketch(sketch, 1);
+    const v = extruded.volume();
+    expect(v).toBeGreaterThan(50);
+    expect(v).toBeLessThan(80);
+  });
+
+  it('sagittaArc with positive vs negative sagitta produces equal-magnitude volumes (sign = bulge side)', () => {
+    const cmdsPos: SketchCommand[] = [
+      { kind: 'moveTo', x: 0, y: 0 },
+      { kind: 'sagittaArc', x: 20, y: 0, sagitta: 5 },
+      { kind: 'close' },
+    ];
+    const cmdsNeg: SketchCommand[] = [
+      { kind: 'moveTo', x: 0, y: 0 },
+      { kind: 'sagittaArc', x: 20, y: 0, sagitta: -5 },
+      { kind: 'close' },
+    ];
+    const vPos = OcctBackend.extrudeFromSketch(OcctBackend.fromSketchCommands(cmdsPos), 1).volume();
+    const vNeg = OcctBackend.extrudeFromSketch(OcctBackend.fromSketchCommands(cmdsNeg), 1).volume();
+    expect(vPos).toBeGreaterThan(50);
+    expect(vNeg).toBeCloseTo(vPos, 1);
+  });
+
+  it('bulgeArc and sagittaArc produce equivalent shapes when sagitta = bulge × halfChord (within 5%)', () => {
+    // Replicad bulge = tan(theta/4); for chord 20 / sagitta 5, expected bulge ≈ 0.5.
+    const cmdsSag: SketchCommand[] = [
+      { kind: 'moveTo', x: 0, y: 0 },
+      { kind: 'sagittaArc', x: 20, y: 0, sagitta: 5 },
+      { kind: 'close' },
+    ];
+    const cmdsBulge: SketchCommand[] = [
+      { kind: 'moveTo', x: 0, y: 0 },
+      { kind: 'bulgeArc', x: 20, y: 0, bulge: 0.5 },
+      { kind: 'close' },
+    ];
+    const vSag = OcctBackend.extrudeFromSketch(OcctBackend.fromSketchCommands(cmdsSag), 1).volume();
+    const vBulge = OcctBackend.extrudeFromSketch(OcctBackend.fromSketchCommands(cmdsBulge), 1).volume();
+    const ratio = vBulge / vSag;
+    expect(ratio).toBeGreaterThan(0.95);
+    expect(ratio).toBeLessThan(1.05);
+  });
+
+  it('radiusArc produces correct volume — analytic circular segment area', () => {
+    // chord 20, radius 15 → theta = 2·asin(2/3) ≈ 1.4595 rad
+    // segment area = R²(theta − sin theta)/2 ≈ 225 × (1.4595 − 0.9938)/2 ≈ 52.4
+    const commands: SketchCommand[] = [
+      { kind: 'moveTo', x: 0, y: 0 },
+      { kind: 'radiusArc', x: 20, y: 0, radius: 15 },
+      { kind: 'close' },
+    ];
+    const sketch = OcctBackend.fromSketchCommands(commands);
+    const v = OcctBackend.extrudeFromSketch(sketch, 1).volume();
+    expect(v).toBeGreaterThan(40);
+    expect(v).toBeLessThan(70);
+  });
+
+  it('radiusArc throws when |radius| < chord/2', () => {
+    const commands: SketchCommand[] = [
+      { kind: 'moveTo', x: 0, y: 0 },
+      { kind: 'radiusArc', x: 20, y: 0, radius: 9 },
+      { kind: 'close' },
+    ];
+    expect(() => OcctBackend.fromSketchCommands(commands))
+      .toThrow(/radiusArc:.*radius.*9.*too small.*chord/);
+  });
+
+  it('radiusArc throws when chord is degenerate (start ≈ end)', () => {
+    const commands: SketchCommand[] = [
+      { kind: 'moveTo', x: 5, y: 5 },
+      { kind: 'radiusArc', x: 5, y: 5, radius: 10 },
+      { kind: 'close' },
+    ];
+    expect(() => OcctBackend.fromSketchCommands(commands))
+      .toThrow(/radiusArc:.*degenerate chord/);
+  });
+
+  it('radiusArc with positive vs negative radius produces equal-magnitude volumes (sign = bulge side)', () => {
+    const cmdsPos: SketchCommand[] = [
+      { kind: 'moveTo', x: 0, y: 0 },
+      { kind: 'radiusArc', x: 20, y: 0, radius: 15 },
+      { kind: 'close' },
+    ];
+    const cmdsNeg: SketchCommand[] = [
+      { kind: 'moveTo', x: 0, y: 0 },
+      { kind: 'radiusArc', x: 20, y: 0, radius: -15 },
+      { kind: 'close' },
+    ];
+    const vPos = OcctBackend.extrudeFromSketch(OcctBackend.fromSketchCommands(cmdsPos), 1).volume();
+    const vNeg = OcctBackend.extrudeFromSketch(OcctBackend.fromSketchCommands(cmdsNeg), 1).volume();
+    expect(vPos).toBeGreaterThan(40);
+    expect(vNeg).toBeCloseTo(vPos, 1);
+  });
 });

--- a/tests/unit/capture/sketch.test.ts
+++ b/tests/unit/capture/sketch.test.ts
@@ -232,4 +232,17 @@ describe('path() builder + Sketch capture', () => {
     const commands = (sketchRec.metadata as { commands: unknown[] }).commands;
     expect(commands).toContainEqual({ kind: 'radiusArc', x: 20, y: 0, radius: 15 });
   });
+
+  it('emits feature.sketch.degenerate-arc when radiusArc has invalid radius', async () => {
+    const { RecomputeEngine } = await import('../../../src/compute/recomputeEngine');
+    const { OcctLowerer } = await import('../../../src/backends/occt/occtLowerer');
+    // chord 20, radius 5 → 5 < 10 → degenerate
+    const code = `return path().moveTo(0, 0).radiusArc(20, 0, 5).close().extrude(1);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const engine = new RecomputeEngine(new OcctLowerer());
+    const r = await engine.run(result.records);
+    expect(r.diagnostics.some(d =>
+      d.code === 'feature.sketch.degenerate-arc' && d.severity === 'error'
+    )).toBe(true);
+  });
 });

--- a/tests/unit/capture/sketch.test.ts
+++ b/tests/unit/capture/sketch.test.ts
@@ -197,4 +197,39 @@ describe('path() builder + Sketch capture', () => {
     expect(v).toBeGreaterThan(4500);
     expect(v).toBeLessThan(4900);
   });
+
+  it('captures threePointsArc with end and midpoint', async () => {
+    const code = `
+      const s = path().moveTo(0, 0).threePointsArc(20, 0, 10, 5).close();
+      return s.extrude(1);
+    `;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const sketchRec = result.records.find(r => r.kind === 'sketch')!;
+    const commands = (sketchRec.metadata as { commands: unknown[] }).commands;
+    expect(commands).toContainEqual({ kind: 'threePointsArc', x: 20, y: 0, midX: 10, midY: 5 });
+  });
+
+  it('captures sagittaArc with chord endpoint and bulge', async () => {
+    const code = `return path().moveTo(0, 0).sagittaArc(20, 0, 5).close().extrude(1);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const sketchRec = result.records.find(r => r.kind === 'sketch')!;
+    const commands = (sketchRec.metadata as { commands: unknown[] }).commands;
+    expect(commands).toContainEqual({ kind: 'sagittaArc', x: 20, y: 0, sagitta: 5 });
+  });
+
+  it('captures bulgeArc with chord endpoint and DXF bulge factor', async () => {
+    const code = `return path().moveTo(0, 0).bulgeArc(20, 0, 0.5).close().extrude(1);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const sketchRec = result.records.find(r => r.kind === 'sketch')!;
+    const commands = (sketchRec.metadata as { commands: unknown[] }).commands;
+    expect(commands).toContainEqual({ kind: 'bulgeArc', x: 20, y: 0, bulge: 0.5 });
+  });
+
+  it('captures radiusArc with chord endpoint and radius', async () => {
+    const code = `return path().moveTo(0, 0).radiusArc(20, 0, 15).close().extrude(1);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const sketchRec = result.records.find(r => r.kind === 'sketch')!;
+    const commands = (sketchRec.metadata as { commands: unknown[] }).commands;
+    expect(commands).toContainEqual({ kind: 'radiusArc', x: 20, y: 0, radius: 15 });
+  });
 });


### PR DESCRIPTION
Phase 1 step 5 of the agent-first geometry-parity roadmap. Adds explicit arc vocabulary to the path builder — all four can serve as the first segment (unlike tangentArc).

## Summary
- threePointsArc(end, mid) — Replicad-native, no sign convention
- sagittaArc(end, sagitta) — Replicad-native, sign = bulge side
- bulgeArc(end, bulge) — Replicad-native, DXF round-trip
- radiusArc(end, radius) — custom math (signed sagitta), minor arc only, validates degenerate cases
- New diagnostic: feature.sketch.degenerate-arc
- E2E fixtures: gear-blank, cam-profile

## Test plan
- [x] capture tests — 18/18 (4 arc capture + 1 diagnostic + 13 prior)
- [x] backend tests — 12/12 (7 new + 5 prior)
- [x] e2e — all + 2 new pass
- [x] typecheck + lint + build clean