### PR TITLE
fix(rc.11 hotfix): bundled CLI createRequire collision

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,5 +1,10 @@
 // src/mcp/server.ts
-import { createRequire } from 'node:module';
+// NOTE: alias `createRequire` to avoid a name collision with the
+// esbuild bundle's banner (which also injects `import { createRequire }
+// from 'module'` for build:cli). Without the alias, ESM rejects the
+// bundled output at load time with "Identifier 'createRequire' has
+// already been declared". (rc.11 hotfix.)
+import { createRequire as createRequireForServer } from 'node:module';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
@@ -17,7 +22,7 @@ import { listFacesTool } from './tools/listFaces';
 import { listFaceLabelsTool } from './tools/listFaceLabels';
 import { listApiTool } from './tools/listApi';
 
-const requireFromHere = createRequire(import.meta.url);
+const requireFromHere = createRequireForServer(import.meta.url);
 const pkg = requireFromHere('../../package.json') as { version: string };
 
 const TOOLS = [


### PR DESCRIPTION
**Critical regression introduced in rc.11 (PR #44).** The published `dist/cli/index.js` crashes at startup with `SyntaxError: Identifier 'createRequire' has already been declared`.

## Root cause
The I-C fix (`src/mcp/server.ts`) added \`import { createRequire } from 'node:module'\` to derive serverInfo.version from package.json. The esbuild bundle's \`build:cli\` banner ALSO injects \`import { createRequire } from 'module'\`. ESM treats \`'module'\` and \`'node:module'\` as distinct, so both top-level imports survive into the bundle → duplicate identifier → SyntaxError at module-load time.

Tests didn't catch this because vitest runs source via tsx, not the bundled dist/cli/index.js. The Task 6 implementer caught it during live-verify (\"actually use what you ship\" memory rule firing correctly).

## Fix
Alias the server.ts import: \`createRequire as createRequireForServer\`. Banner-injected \`createRequire\` and the renamed import no longer collide.

## Verification
- \`npm run build:cli\` succeeds and produces a working bundle.
- \`node dist/cli/index.js --version\` returns \`0.1.0\` (commander version — unrelated).
- \`node dist/cli/index.js mcp\` MCP \`initialize\` response shows \`serverInfo.version: "0.13.0-rc.11"\` (I-C fix lives through the bundle).
- \`npm test\` 712 passed / 0 failures.
- typecheck + lint clean.

## Test plan
- [x] build:cli succeeds (was failing before)
- [x] Bundled CLI startup no longer throws
- [x] MCP initialize returns rc.11 version (I-C still works)
- [x] All existing tests pass (712 / 0 fail)