### PR TITLE
feat(v0.13.0-rc.16): binary STL + rc.15 review closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ A bundled feature + quality milestone. New `export_stl` MCP tool closes the agen
 - Tool count goes from 13 to 14; SKILL.md updated; drift sentinels green.
 
 ### Capture-time validation
-- `Shape.translate`, `Shape.rotate`, `Shape.scale`, `Shape.reflect`, `Shape.mirror` now validate their arguments at capture time and throw `KernelError` with feature-namespaced codes if invalid. Five new diagnostic codes: `feature.transform.invalid-translate`, `feature.transform.invalid-rotate`, `feature.transform.invalid-scale`, `feature.transform.invalid-reflect` (mirror reuses the existing `feature.mirror.invalid-plane`).
+- `Shape.translate`, `Shape.rotate`, `Shape.scale`, `Shape.reflect`, `Shape.mirror` now validate their arguments at capture time and throw `KernelError` with feature-namespaced codes if invalid. Four new diagnostic codes: `feature.transform.invalid-translate`, `feature.transform.invalid-rotate`, `feature.transform.invalid-scale`, `feature.transform.invalid-reflect` (mirror reuses the existing `feature.mirror.invalid-plane`).
 - Agents now get script-line precision in stack traces for malformed transform arguments, matching the `Sketch.reflect` precedent.
 - The lowering-time `feature.transform.invalid-plane` gate from rc.14 stays as forward-looking infrastructure (reclassified to `'direct-lowerer-only'`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+## v0.13.0-rc.16 — binary STL + rc.15 review closure (2026-05-01)
+
+A bundled feature + quality milestone. Upgrades `export_stl` from ASCII to true binary STL output (the rc.15 contract was right; the implementation finally matches). Closes the rc.15 review punch list (2 Critical + 6 Important + 2 Nits) plus a new "deviation propagation" discipline memory entry.
+
+### Feature surface
+- **`export_stl` now emits true binary STL.** rc.15 shipped ASCII despite the contract claiming binary; this milestone implements direct binary encoding via Replicad's mesh primitives. Files are ~3-5× smaller (684 bytes for a 12-triangle box vs ~3052 ASCII bytes). Format: 80-byte header + uint32 LE triangle count + 50 bytes per triangle (3× float32 normal + 9× float32 vertices + uint16 attribute count). Encoder lives at `src/script-runtime/exportStlBinary.ts`; integrated into `runAndExport`.
+- All three agent-readable description surfaces (SKILL.md, MCP tool description, JSDoc) now match what ships.
+
+### Path validation
+- New `validateOutputPath` helper at `src/script-runtime/safeOutputPath.ts`. `export_stl` rejects: paths containing `..` segments, dangerous absolute paths (`/etc/`, `/proc/`, `/sys/`, `/dev/`, `/root/`), and user-config paths (`~/.bashrc`, `~/.zshrc`, `~/.ssh/`, `~/.gnupg/`, `~/.aws/`, `~/.gcp/`). Allowed: relative paths within cwd, `/tmp/`, paths within `$HOME` not matching the protected patterns. 19 unit tests + 2 integration tests cover the policy.
+- First MCP tool with file-write side-effects sets the precedent for future writers (thumbnail, STEP-export, etc.).
+
+### Diagnostic surface
+- `HintReachability` value `'cli-path'` renamed to `'tool-error-field'`. Describes the actual axis: where in the wire format the code appears (in tool result's `error`/`errorCode` field, not `diagnostics[]`). Four `cli.*` codes reclassified accordingly.
+- `formatScalarForError` helper added to `src/intent/types.ts`. Preserves `NaN` / `Infinity` / `-Infinity` in error messages instead of letting `JSON.stringify` drop them to `null`. Used in five transform validators (rotate, scale, reflect, mirror; translate's template-literal form already preserved).
+- `feature.mirror.invalid-plane` reachability classification noted accurately.
+
+### Test coverage
+- 3 new `feature_id`-path integration tests for `export_stl`: explicit-id success, intermediate-feature export, feature-not-found error path. Exercises `export.feature-not-found` diagnostic that was previously dead by tests.
+- 4 new NaN/Infinity preservation assertions for transform validators.
+- 19 new unit tests for `validateOutputPath`.
+
+### Documentation + tooling
+- `feature_count` semantics clarified across three surfaces (MCP description, JSDoc, SKILL.md): "total features in the script, not the count contributing to the exported shape."
+- 6 SKILL.md drift sentinels refactored to call shared `assertEveryNameInSKILL` from `tests/unit/skill/_helpers.ts` (the helper was created in rc.15 but had no callers).
+- rc.15 CHANGELOG entry corrected: "Five new diagnostic codes" → "Four" (the fifth — `feature.mirror.invalid-plane` — was reused, not new).
+- Five `OcctBackend` methods' JSDocs had ephemeral plan-task references already stripped in rc.15 Task 7.
+
+### Discipline
+- New memory entry `feedback_propagate_implementer_deviations.md` codifies the rule: when a subagent implementer reports a spec deviation, the controller MUST audit all agent-readable surfaces (SKILL.md, MCP descriptions, JSDoc, CHANGELOG, lineage memory) and verify they match what shipped, not the spec's original claim. The rc.15 ASCII-STL gap surfaced this rule's necessity.
+
+---
+
 ## v0.13.0-rc.15 — export_stl + rc.14 review closure (2026-05-01)
 
 A bundled feature + quality milestone. New `export_stl` MCP tool closes the agent output-workflow gap; closes the rc.14 review punch list (6 Important + 2 Nits).

--- a/docs/superpowers/plans/2026-05-01-v0.4-rc16-binary-stl-and-rc15-fixes.md
+++ b/docs/superpowers/plans/2026-05-01-v0.4-rc16-binary-stl-and-rc15-fixes.md
@@ -1,0 +1,112 @@
+# v0.4-rc.16 — Binary STL + rc.15 review fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. The spec at `docs/superpowers/specs/2026-05-01-v0.4-rc16-binary-stl-and-rc15-fixes-design.md` is the source of truth.
+
+**Goal:** Implement true binary STL output; close 2 Critical + 6 Important + 2 Nits from rc.15 review; add discipline memory entry.
+
+**Architecture:** 9 tasks. Task 1 is the binary STL encoder (replaces the ASCII output). Tasks 2-7 are review-fix block. Task 8 is the memory-entry discipline fix. Task 9 is finishing.
+
+**Tech Stack:** TypeScript 5.9, Replicad 0.20.5, vitest 4. No new dependencies.
+
+---
+
+## Task index — 9 tasks
+
+### Feature side (Task 1)
+
+- [ ] **Task 1 — Binary STL encoder + integration.** Implements spec Component 1 (closes F1, F2, F3, C1).
+  - Discovery: probe Replicad's mesh API. Look for `Shape3D.mesh()`, `mesh3d`, or similar that returns vertices + triangle indices. If accessible: encode directly. If not: parse Replicad's ASCII output and re-encode.
+  - Create: `src/script-runtime/exportStlBinary.ts` — encoder. Takes mesh primitives, returns Buffer with binary STL bytes (80-byte header + uint32 LE triangle count + 50 bytes per triangle).
+  - Modify: `src/script-runtime/export.ts` — replace `blobSTL()` call with the new binary encoder.
+  - Modify three description sites to say "binary STL":
+    - `src/mcp/tools/exportStl.ts` JSDoc
+    - `src/mcp/server.ts` TOOLS array entry's description
+    - `src/skill/SKILL.md` export_stl entry
+  - Modify: `tests/integration/mcp/exportStl.test.ts` — assert binary STL header (`Buffer.readUInt32LE(80)` returns 12 for a box; total bytes = 84 + 50*12 = 684).
+  - Verify with bundle live-verify: `export_stl` for a 10×10×10 box returns ~684 bytes (down from rc.15's 3052 ASCII bytes).
+  - Commit: `feat(export): switch export_stl to true binary STL output`.
+
+### Review-fix block (Tasks 2-7)
+
+- [ ] **Task 2 — Reachability classification rename.** Implements Component 2 (closes C2).
+  - `src/mcp/tools/whyDidThisFail.ts` — `HintReachability` value `'cli-path'` → `'tool-error-field'`. Reclassify the 4 cli.* codes.
+  - `tests/unit/mcp/whyDidThisFailReachability.test.ts` — `KNOWN_CLI_PATH` → `KNOWN_TOOL_ERROR_FIELD`; `ALLOWED_REACHABILITY` updates.
+  - `src/skill/SKILL.md` — reachability classification paragraph: rename + describe new framing ("appears in MCP tool results' `error` / `errorCode` field rather than the `diagnostics[]` array").
+  - Drift sentinel `skillDiagnosticCodesDrift` should still pass (codes unchanged; only their reachability metadata).
+  - Commit: `refactor(mcp): rename 'cli-path' reachability to 'tool-error-field' for accuracy`.
+
+- [ ] **Task 3 — Path validation gate.** Implements Component 3 (closes I3).
+  - Create: `src/script-runtime/safeOutputPath.ts` — `validateOutputPath(path: string): { ok: true; resolved: string } | { ok: false; error: string }`. Rules:
+    - Reject paths containing `..` segments (path traversal).
+    - Reject absolute paths matching: `/etc/`, `/proc/`, `/sys/`, `/dev/`, `/root/`.
+    - Reject paths matching: `~/.bashrc`, `~/.bash_profile`, `~/.zshrc`, `~/.ssh/`, `~/.gnupg/` (resolve `~` to home dir first).
+    - Allow: relative paths within cwd (resolve to absolute), absolute paths in `/tmp/`, paths within home not matching the above.
+  - Modify: `src/mcp/tools/exportStl.ts` — call `validateOutputPath` before any write. On failure, return its error verbatim.
+  - Create: `tests/unit/script-runtime/safeOutputPath.test.ts` — comprehensive path-validation tests.
+  - Modify: `tests/integration/mcp/exportStl.test.ts` — extend with one path-validation rejection test.
+  - Commit: `feat(export): conservative-by-default path validation on export_stl output_path`.
+
+- [ ] **Task 4 — feature_id integration tests.** Implements Component 4 (closes I1).
+  - Modify: `tests/integration/mcp/exportStl.test.ts` — add 3 tests:
+    1. Successful export with explicit `feature_id` (the last feature's id; assert byte_count > 0, file exists).
+    2. Export of an intermediate feature: script `return box(10,10,10).fillet(2)` (2 features); export the box's id; assert volume of exported STL ≈ box volume (1000 mm³ minus fillet's small reduction).
+    3. `feature_id` not in records → `{ ok: false, error: ".../not found.../" }`.
+  - The third test exercises `export.feature-not-found` — currently dead by tests.
+  - Commit: `test(integration): exercise feature_id paths in export_stl`.
+
+- [ ] **Task 5 — NaN/Infinity error message preservation.** Implements Component 5 (closes I4).
+  - Add: `formatScalarForError` helper in `src/intent/types.ts` (or new `src/intent/errorFormatting.ts` — match existing style). Handles NaN/Infinity/-Infinity → string; falls back to JSON.stringify for other types.
+  - Modify: `src/capture/proxy.ts` — replace `JSON.stringify` calls in rotate/scale/reflect/mirror error messages with the helper. Translate's template-literal form already preserves NaN; verify and standardize.
+  - Modify: `tests/unit/capture/proxy.transforms.test.ts` — add NaN-value-preservation assertions for rotate/scale/reflect (assert error message contains "NaN", not "null").
+  - Commit: `fix(capture): preserve NaN/Infinity in transform validator error messages`.
+
+- [ ] **Task 6 — feature_count clarification.** Implements Component 6 (closes I5).
+  - `src/mcp/server.ts` — `export_stl` tool description: append "feature_count: total features in the script, not the count contributing to the exported shape."
+  - `src/mcp/tools/exportStl.ts` — JSDoc on `ExportStlOutput.feature_count` adds the same clarification.
+  - `src/skill/SKILL.md` — same clarification on the `export_stl` entry.
+  - No code change. Drift sentinel unaffected.
+  - Commit: `docs(mcp): clarify export_stl feature_count semantics`.
+
+- [ ] **Task 7 — assertEveryNameInSKILL adoption + CHANGELOG fix.** Implements Component 7 (closes I2, I6).
+  - Refactor 6 SKILL.md drift sentinels to call `assertEveryNameInSKILL` from `tests/unit/skill/_helpers.ts` instead of inline regex+missing-array logic. Keep failure-message conventions consistent across all 6.
+  - `CHANGELOG.md` — fix rc.15's "Five new diagnostic codes" → "Four new diagnostic codes" (the listed 4 are correct; fifth was reused).
+  - Commit: `refactor(test) + docs(changelog): use shared assertEveryNameInSKILL; fix rc.15 count`.
+
+### Discipline + finishing (Tasks 8-9)
+
+- [ ] **Task 8 — Discipline memory entry.** Implements Component 8 (closes M1).
+  - Create: `~/.claude/projects/-home-andrii/memory/feedback_propagate_implementer_deviations.md`. Content per spec A7.
+  - Update: `~/.claude/projects/-home-andrii/memory/MEMORY.md` — add a one-line index entry for the new feedback memory.
+  - No commit (memory lives outside the repo).
+
+- [ ] **Task 9 — Lineage + version + CHANGELOG + tag.** Implements Component 9.
+  - Update lineage memory with rc.16 row(s): binary STL encoder pattern, conservative-by-default file-write path validation, assertEveryNameInSKILL adoption.
+  - `package.json` version → `0.13.0-rc.16`.
+  - `CHANGELOG.md` — add `## v0.13.0-rc.16` entry summarizing feature side (binary STL — note this is upgrading rc.15's contract from ASCII to true binary) and quality block.
+  - `npm run qc:full` (Playwright env failure acceptable).
+  - Manual bundle live-verify: `serverInfo.version: "0.13.0-rc.16"`. Verify export_stl produces binary output (~684 bytes for a box) — this is the load-bearing live-verify since the rc.15 review caught the ASCII gap that we missed.
+  - Commit: `chore(release): v0.13.0-rc.16 binary STL + rc.15 review closure`.
+  - Push branch, open PR, wait for qc CI, squash-merge, tag, final live-verify.
+
+---
+
+## Subagent dispatch protocol
+
+Per `superpowers:subagent-driven-development` + the new feedback memory `feedback_propagate_implementer_deviations.md`:
+
+1. Scene-setting context.
+2. Relevant spec component verbatim.
+3. Discipline rules: no competitor refs, no Claude/AI in commits, capture lineage in memory before stripping, **plus the new rule** — controller verifies all agent-readable surfaces match shipped behavior whenever the implementer reports a deviation.
+4. Status report format.
+
+After each task: quick diff verification (per the new discipline rule, includes auditing description surfaces if any deviation was reported).
+
+---
+
+## Open questions resolved at the top of this plan
+
+1. **Binary STL source.** Plan-time: Task 1 first probes Replicad's mesh API. If `Shape3D.mesh()` exists (or similar), encode directly. Otherwise fall back to ASCII parse → binary re-encode.
+
+2. **Path validation deny-list.** Stays as defined in spec A3. Rule: deny-list with safe-pattern allow. Iteratively extend if rc.16+ implementations surface obvious additions.
+
+3. **`tool-error-field` naming.** Locked. The "field" suffix indicates where in the wire format the code appears (in tool result's `error` / `errorCode` field, not in `diagnostics[]` array). Self-explanatory in SKILL.md context.

--- a/docs/superpowers/specs/2026-05-01-v0.4-rc16-binary-stl-and-rc15-fixes-design.md
+++ b/docs/superpowers/specs/2026-05-01-v0.4-rc16-binary-stl-and-rc15-fixes-design.md
@@ -1,0 +1,214 @@
+# v0.4-rc.16 — Binary STL output + bundled rc.15 review fixes — Design Spec
+
+**Goal:** Convert `export_stl` from ASCII (rc.15 reality) to binary (rc.15 promise) STL output; close the rc.15 review punch list (2 Critical + 6 Important + 5 Nits).
+
+**Architecture:** Bundled feature + quality milestone. The "feature" is unusual — it's a contract-fix promoted to a real capability win. rc.15 shipped `export_stl` claiming binary STL but Replicad's `blobSTL()` emits ASCII, and the agent-facing surfaces (SKILL.md, MCP tool description, JSDoc) were never updated to match. rc.16 chooses the better path: implement true binary STL output instead of retreating the contract to ASCII. Smaller files (3-5× reduction), broader downstream-tool compatibility, contract becomes honest. The review-fix block closes C2 + the 6 Importants.
+
+**Tech Stack:** TypeScript 5.9, Replicad 0.20.5 (mesh access), vitest 4. No new dependencies — binary STL encoder is ~80 lines of buffer-writing.
+
+---
+
+## Why this milestone
+
+**The feature side.** rc.15's `export_stl` MCP tool claimed binary STL output across three agent-readable surfaces (SKILL.md, server.ts tool description, exportStl.ts JSDoc). During Task 1 implementation, the implementer discovered Replicad's `blobSTL()` returns ASCII STL, adapted the integration test correctly, and shipped — but the description surfaces still claim binary. **Agents reading the contract get wrong information**: storage budgets are wrong (3-5× smaller assumed), header-parsing code fails, binary-only downstream consumers reject the file silently.
+
+The right fix is implementing true binary output, not retreating to ASCII. Binary STL is the universal default for slicers, simulators, and 3D viewers. The encoder is well-defined (80-byte header + 4-byte little-endian triangle count + 50 bytes per triangle: 12 floats + 2 attribute bytes). Replicad exposes mesh primitives (vertices + triangle indices) we can encode directly without going through the ASCII round-trip.
+
+**The quality side.** The rc.15 review surfaced 2 Critical + 6 Important + 5 Nits. C1 (binary STL contract) is the feature pivot above. C2 (cli-path reachability misclassification) is a rename + reclassification. The Importants are bounded: missing tests, unused helper, security gate, error-message formatting, ambiguous return-field semantics, and a CHANGELOG count miscount.
+
+**The discipline lesson.** rc.15's review meta-observation: "implementer found a deviation, accepted it, didn't propagate to docs" should fail review. The controller (me, in subagent-driven mode) accepted the implementer's status report at face value without verifying that all agent-readable surfaces matched the actually-shipped behavior. rc.16 adds a `feedback_propagate_implementer_deviations.md` memory entry codifying the rule: **when an implementer reports a spec deviation, the controller MUST audit all agent-readable surfaces (SKILL.md, MCP descriptions, JSDoc, CHANGELOG, lineage memory) and verify they match what shipped, not the spec's original claim.**
+
+---
+
+## Scope (closed-set list)
+
+| ID | Source | Closes |
+|----|--------|--------|
+| F1 | Feature | Binary STL output via direct mesh-primitive encoding |
+| F2 | Feature | All three agent-readable description surfaces (SKILL.md, MCP description, JSDoc) updated to match |
+| F3 | Feature | Integration test asserts binary STL header + triangle count |
+| C1 | rc.15 review Critical | Tool description claims "binary STL" but emits ASCII (SOLVED via F1) |
+| C2 | rc.15 review Critical | `'cli-path'` reachability misclassification — codes reachable through MCP, not just CLI |
+| I1 | rc.15 review Important | No `feature_id` integration tests; `export.feature-not-found` is dead by tests |
+| I2 | rc.15 review Important | `assertEveryNameInSKILL` exported but never called |
+| I3 | rc.15 review Important | `output_path` accepts arbitrary paths with no kernelCAD-level validation |
+| I4 | rc.15 review Important | NaN/Infinity values dropped by `JSON.stringify` in 5 of 6 transform error messages |
+| I5 | rc.15 review Important | `feature_count` semantics ambiguous (total script vs contributing-to-export) |
+| I6 | rc.15 review Important | CHANGELOG says "Five new diagnostic codes" — actually 4 |
+| M1 | rc.15 review meta-observation | Add memory entry codifying "deviation propagation" discipline |
+
+Out of scope: the remaining rc.15 nits (HintReachability rename to HintSurface; `as unknown as` dispatch helper centralization; rotate edge cases; `pivot: null` test). Low-stakes; can land opportunistically.
+
+Also out of scope: `get_thumbnail` MCP tool (visibility gap); `Shape.array.linear` (DSL sugar); STEP export (parallel to STL but bigger scope). Defer to rc.17+.
+
+---
+
+## Architecture decisions made before spec write-up
+
+### A1 — Implement binary STL via direct mesh-primitive encoding (closes C1)
+
+**Decision.** Don't go through the ASCII round-trip (parse ASCII → re-encode binary). Instead, access Replicad's mesh primitives directly (vertices + triangle indices via the underlying OpenCascade mesh) and write binary STL bytes ourselves. Encoder lives in `src/script-runtime/exportStlBinary.ts` (or extends `src/script-runtime/export.ts`).
+
+**Why.** The ASCII round-trip is wasteful and error-prone. Binary STL format is well-specified (80-byte header + uint32 triangle count + 50-byte triangle records). Replicad exposes mesh primitives via the OpenCascade backend — we already use these for `list_edges` / `list_faces` / face-centroid calculations. Writing the binary bytes is ~50 lines of buffer-arithmetic. The result: a smaller file, a faster export, and a contract that matches reality.
+
+If Replicad's mesh primitives aren't directly accessible (sealed by the wrapper), the fallback is parsing the ASCII output — slower but still produces correct binary. Plan-time decides based on what's available.
+
+### A2 — Rename `'cli-path'` → `'tool-error-field'` (closes C2)
+
+**Decision.** Add the value `'tool-error-field'` to `HintReachability` (replacing `'cli-path'`). Reclassify the four codes (`cli.script.exception`, `cli.file.read`, `cli.no-input`, `cli.export.exception`) to the new value. Update SKILL.md paragraph + the reachability sentinel.
+
+**Why.** The codes are reachable through MCP, not just the CLI surface. `kernelErrorToDiagnostic`'s default code is `cli.script.exception`, and 9 MCP tools call it on their script-execution catch path. The codes appear in tool results' `error` / `errorCode` fields rather than `diagnostics[]` arrays — that's the actual classification axis. `'tool-error-field'` describes what agents observe.
+
+Out of scope for rc.16: renaming the codes themselves (e.g. `cli.script.exception` → `runtime.script.exception`). The `cli.*` prefix is historical baggage but renaming would require breaking changes to whyDidThisFail consumers. Defer.
+
+### A3 — Conservative-by-default path validation on `output_path` (closes I3)
+
+**Decision.** `export_stl` rejects paths that:
+1. Contain `..` segments (path traversal)
+2. Match dangerous absolute paths: `/etc/*`, `/proc/*`, `/sys/*`, `/dev/*`, `/root/*`
+3. Match user-config paths: `~/.bashrc`, `~/.bash_profile`, `~/.zshrc`, `~/.ssh/*`, `~/.gnupg/*`
+
+Allowed: relative paths within cwd, absolute paths in `/tmp/*`, paths within the user's home directory NOT matching the above patterns.
+
+The validation produces `{ ok: false, error: "Refusing to write to <path>: <reason>. Use an explicit safe path." }`.
+
+**Why.** First file-write MCP tool sets a precedent for future file-writers (rc.17+ STEP export, rc.16+ `get_thumbnail`). Conservative-by-default with explicit error messages is the agent-first stance — agents should learn the rule the first time they trip it. The list catches the most common foot-guns without being draconian.
+
+The validation lives in a shared helper (`src/script-runtime/safeOutputPath.ts`) so future file-writers reuse it.
+
+### A4 — Capture-time error messages preserve NaN/Infinity values (closes I4)
+
+**Decision.** Replace `JSON.stringify` with explicit value formatting in the 5 transform validators that lost NaN/Infinity to `null` in error messages. Use a small `formatScalarForError(v)` helper:
+```typescript
+function formatScalarForError(v: unknown): string {
+  if (typeof v === 'number') {
+    if (Number.isNaN(v)) return 'NaN';
+    if (v === Infinity) return 'Infinity';
+    if (v === -Infinity) return '-Infinity';
+    return String(v);
+  }
+  return JSON.stringify(v);
+}
+```
+
+**Why.** Agent debugging the validators sees error messages with the offending value. `JSON.stringify(NaN)` → `null` is a long-standing JavaScript gotcha that loses information. The helper makes the value preservation explicit at the type-aware layer.
+
+### A5 — `feature_count` clarification (closes I5)
+
+**Decision.** Keep the field name `feature_count` (renaming would be a breaking change to MCP consumers). Add a one-line clarification to the MCP tool description: "feature_count: total features in the script, not the count contributing to the exported shape."
+
+**Why.** Renaming breaks backward compatibility for any agent that reads `feature_count` today. The clarification is a doc fix that doesn't change wire format. If usage demand surfaces for the contributing-feature-count, add it as a sibling field in rc.17+.
+
+### A6 — `assertEveryNameInSKILL` adoption across all 6 sentinels (closes I2 + N1)
+
+**Decision.** Refactor all 6 SKILL.md drift sentinels to call `assertEveryNameInSKILL` from `_helpers.ts`. The helper currently exists with a complete docstring + friendly failure message but zero call sites — the abstraction was created but never adopted.
+
+**Why.** Either drop the unused helper or use it. Using it standardizes the failure-message format across the 6 sentinels (each currently has slightly different wording). Centralization simplifies future sentinel additions.
+
+### A7 — Discipline memory entry for deviation propagation (closes M1)
+
+**Decision.** Add `~/.claude/projects/-home-andrii/memory/feedback_propagate_implementer_deviations.md`:
+
+> When a subagent implementer reports a spec deviation in their status update — even if the deviation is correct (e.g. an empirical discovery), even if the test is updated correctly — the controller MUST audit all agent-readable surfaces (SKILL.md, MCP tool descriptions, JSDoc, CHANGELOG, lineage memory) and verify they match the actually-shipped behavior, not the spec's original claim.
+>
+> The agent-first kernel goal demands honest contracts. A spec that claims X and code that delivers Y, with description surfaces still claiming X, is the worst combination — agents read the contract, build assumptions on it, and fail silently.
+
+This file gets indexed in `MEMORY.md`.
+
+**Why.** rc.15's "binary STL" / ASCII-shipped failure was caught only at review time. Codifying the rule prevents recurrence — the controller's checklist becomes "implementer reports deviation → audit description surfaces → fix or revert".
+
+---
+
+## Components (9 tasks)
+
+### Component 1 — Binary STL encoder + integration with `export_stl` (closes F1, F2, F3, C1)
+
+**Where.**
+- Create: `src/script-runtime/exportStlBinary.ts` — binary STL encoder. Takes mesh primitives (vertices: `Float32Array | number[]`; triangles: `Uint32Array | number[][]`); returns `Buffer` with binary STL bytes.
+- Modify: `src/script-runtime/export.ts` — `runAndExport` calls the binary encoder instead of Replicad's `blobSTL()`. (Keep ASCII output as a future optional parameter.)
+- Modify: `src/mcp/tools/exportStl.ts` — JSDoc updated to say "binary STL".
+- Modify: `src/mcp/server.ts` — TOOLS array entry's description says "binary STL".
+- Modify: `src/skill/SKILL.md` — `export_stl` description says "binary STL".
+- Modify: `tests/integration/mcp/exportStl.test.ts` — round-trip test asserts binary STL structure (80-byte header, uint32 triangle count, 12 triangles for a box, 684 byte total).
+
+**Binary STL format (encoder spec):**
+```
+Bytes 0..79      80-byte header (free-form text or zeros; conventionally "binary stl, kernelcad rcN" or similar)
+Bytes 80..83     uint32 LE — triangle count
+Bytes 84..      Per triangle (50 bytes each):
+                  Bytes 0..11   3× float32 LE — normal vector
+                  Bytes 12..47  9× float32 LE — vertex 1, 2, 3 (3 floats each)
+                  Bytes 48..49  uint16 LE — attribute byte count (typically 0)
+```
+
+Encoder reads triangle count from the mesh, allocates a `Buffer` of size `84 + 50 * count`, and writes vertices in order. Normal vectors can be computed per-triangle (cross product of edge vectors) or extracted from the mesh if Replicad provides them.
+
+### Component 2 — Reachability classification rename (closes C2)
+
+**Where.**
+- Modify: `src/mcp/tools/whyDidThisFail.ts` — `HintReachability` value `'cli-path'` becomes `'tool-error-field'`. Reclassify the 4 `cli.*` codes accordingly.
+- Modify: `tests/unit/mcp/whyDidThisFailReachability.test.ts` — `ALLOWED_REACHABILITY` set replaces `'cli-path'` with `'tool-error-field'`. `KNOWN_CLI_PATH` constant renamed to `KNOWN_TOOL_ERROR_FIELD`.
+- Modify: `src/skill/SKILL.md` — reachability classification paragraph updates the value name and description: "`'tool-error-field'` — the code appears in MCP tool results' `error` / `errorCode` field rather than the `diagnostics[]` array. Agents see these as top-level tool failures."
+
+### Component 3 — Path validation gate (closes I3)
+
+**Where.**
+- Create: `src/script-runtime/safeOutputPath.ts` — `validateOutputPath(path: string): { ok: true; resolved: string } | { ok: false; error: string }`. Implements A3's rules.
+- Modify: `src/mcp/tools/exportStl.ts` — call `validateOutputPath` before any write. Return its error if invalid.
+- Add: `tests/unit/script-runtime/safeOutputPath.test.ts` — tests for path-traversal rejection, dangerous-system-path rejection, allowed-path acceptance, edge cases (`/tmp/foo`, `./out.stl`, `~/projects/foo.stl`, `~/.ssh/config` rejection).
+- Modify: `tests/integration/mcp/exportStl.test.ts` — extend with one path-validation test.
+
+### Component 4 — `feature_id` integration tests (closes I1)
+
+**Where.** `tests/integration/mcp/exportStl.test.ts` — add 3 tests:
+1. Successful export with explicit `feature_id` (e.g. exporting the last feature by id).
+2. Export of an intermediate feature when the script's last feature differs (e.g. script returns `box.fillet(...)`; export the box's id and verify volume of exported STL ≈ box volume, not filleted-box volume).
+3. Error path: `feature_id` not in records → `{ ok: false, error: "feature_id '<id>' not found." }` (exercises the `export.feature-not-found` diagnostic that's currently dead by tests).
+
+### Component 5 — NaN/Infinity preservation in transform error messages (closes I4)
+
+**Where.**
+- Modify: `src/capture/proxy.ts` — replace `JSON.stringify` calls with `formatScalarForError` (or similar helper) in the 5 transform validators (`translate` already does it correctly; rotate/scale/reflect/mirror need updating).
+- Add: helper function (in `src/intent/types.ts` or a new `src/intent/errorFormatting.ts`).
+- Modify: `tests/unit/capture/proxy.transforms.test.ts` — extend with NaN-value-preservation assertions on rotate/scale/reflect.
+
+### Component 6 — `feature_count` clarification (closes I5)
+
+**Where.**
+- Modify: `src/mcp/server.ts` — `export_stl` tool description's mention of `feature_count` adds the clarification.
+- Modify: `src/mcp/tools/exportStl.ts` — JSDoc on `ExportStlOutput.feature_count` adds the clarification.
+- Modify: `src/skill/SKILL.md` — `export_stl` entry adds the clarification.
+
+No code changes; doc-only fix.
+
+### Component 7 — `assertEveryNameInSKILL` adoption + CHANGELOG fix (closes I2, I6)
+
+**Where.**
+- Modify: 6 SKILL.md drift sentinels (`tests/unit/skill/skill*Drift.test.ts`) — refactor each to call `assertEveryNameInSKILL` from `_helpers.ts` instead of inline regex+missing-array logic.
+- Modify: `CHANGELOG.md` — fix the rc.15 entry's "Five new diagnostic codes" → "Four new diagnostic codes".
+
+### Component 8 — Discipline memory entry (closes M1)
+
+**Where.**
+- Create: `~/.claude/projects/-home-andrii/memory/feedback_propagate_implementer_deviations.md` (per A7).
+- Update: `~/.claude/projects/-home-andrii/memory/MEMORY.md` index.
+
+### Component 9 — Lineage memory + version bump + CHANGELOG + tag
+
+- `~/.claude/projects/-home-andrii/memory/kernelcad_design_lineage.md` — add rc.16 row(s): binary STL encoding pattern; conservative-by-default file-write path validation; assertEveryNameInSKILL adoption.
+- `package.json` version `0.13.0-rc.15` → `0.13.0-rc.16`.
+- `CHANGELOG.md` — add `## v0.13.0-rc.16` entry.
+- `npm run qc:full`, manual bundle live-verify (rc.16 version + binary STL byte count).
+- Push to `feat/v0.4-rc16-binary-stl-and-rc15-fixes` branch. Open PR. Wait for qc CI. Squash-merge. Tag `v0.13.0-rc.16`.
+
+---
+
+## Open questions for the spec reviewer
+
+1. **Binary STL encoder source — Replicad mesh primitives vs ASCII parse.** First plan task discovers whether Replicad exposes the mesh data structure. If yes (via an internal API or extension), encode directly. If no, parse the ASCII output Replicad provides. The latter is slower but still produces correct binary. Plan-time chooses based on availability.
+
+2. **Path validation allowlist scope.** A3 says reject paths matching dangerous patterns. Is this list complete? Other paths to consider: `/var/log/*`, `/usr/*`, `~/.config/*`. Plan-time may extend if obvious additions surface. The shape is "deny-list with safe-pattern allow"; the deny-list is iterative.
+
+3. **`tool-error-field` enum value name.** A2 picks `'tool-error-field'`. Alternatives: `'tool-error'`, `'error-field'`, `'mcp-tool-error'`. The chosen name should be self-explanatory in the SKILL.md paragraph context. Defer naming bikeshed to plan; current pick is workable.
+
+These are flagged for plan-writing; none block.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kernelcad",
   "private": true,
-  "version": "0.13.0-rc.15",
+  "version": "0.13.0-rc.16",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/src/backends/occt/occtBackend.ts
+++ b/src/backends/occt/occtBackend.ts
@@ -5,6 +5,7 @@ import type { Vec3, PlaneSpec, CardinalPlane } from '../../intent/types';
 import type { RuntimeMesh } from '../runtimeMesh';
 import type { SketchCommand } from '../../capture/sketch';
 import { isSameEdge } from './edgeQueries';
+import { encodeBinaryStl } from '../../script-runtime/exportStlBinary';
 
 type ReplicadEdge = replicad.Edge;
 type ReplicadFace = replicad.Face;
@@ -715,9 +716,9 @@ export class OcctBackend implements ShapeBackend {
   }
 
   async exportSTLAsync(): Promise<Uint8Array> {
-    const blob = this.shape.blobSTL();
-    const buf = await blob.arrayBuffer();
-    return new Uint8Array(buf);
+    const mesh = this.shape.mesh({ tolerance: 0.05, angularTolerance: 0.3 });
+    const buf = encodeBinaryStl({ vertices: mesh.vertices, triangles: mesh.triangles });
+    return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
   }
 
   exportSTEP(): Uint8Array {

--- a/src/capture/proxy.ts
+++ b/src/capture/proxy.ts
@@ -1,5 +1,5 @@
 import type { FeatureId, PlaneSpec } from '../intent/types';
-import { isValidVec3, isValidScaleSpec, isValidPlaneSpec } from '../intent/types';
+import { isValidVec3, isValidScaleSpec, isValidPlaneSpec, formatScalarForError } from '../intent/types';
 import { KernelError } from '../intent/kernelError';
 import type { CaptureSession } from './captureSession';
 import type { EdgeQuery, FaceQuery, EdgeSegment } from '../backends/occt/edgeQueries';
@@ -60,14 +60,14 @@ export class Shape {
     if (!isValidVec3(axis) || typeof degrees !== 'number' || !Number.isFinite(degrees)) {
       throw new KernelError(
         'feature.transform.invalid-rotate',
-        `Rotate axis must be a finite Vec3 and degrees must be a finite number; got axis=${JSON.stringify(axis)}, degrees=${degrees}.`,
+        `Rotate axis must be a finite Vec3 and degrees must be a finite number; got axis=${formatScalarForError(axis)}, degrees=${formatScalarForError(degrees)}.`,
         this.id,
       );
     }
     if (pivot !== undefined && !isValidVec3(pivot)) {
       throw new KernelError(
         'feature.transform.invalid-rotate',
-        `Rotate pivot (when provided) must be a finite Vec3; got ${JSON.stringify(pivot)}.`,
+        `Rotate pivot (when provided) must be a finite Vec3; got ${formatScalarForError(pivot)}.`,
         this.id,
       );
     }
@@ -82,7 +82,7 @@ export class Shape {
     if (!isValidScaleSpec(scaleSpec)) {
       throw new KernelError(
         'feature.transform.invalid-scale',
-        `Scale factor must be a positive finite number, or a Vec3 of three positive finite numbers; got ${JSON.stringify(scaleSpec)}.`,
+        `Scale factor must be a positive finite number, or a Vec3 of three positive finite numbers; got ${formatScalarForError(scaleSpec)}.`,
         this.id,
       );
     }
@@ -99,7 +99,7 @@ export class Shape {
     if (!isValidPlaneSpec(plane)) {
       throw new KernelError(
         'feature.transform.invalid-reflect',
-        `Reflect plane must be 'xy' | 'xz' | 'yz' or { plane: '<cardinal>', offset?: number }; got ${JSON.stringify(plane)}.`,
+        `Reflect plane must be 'xy' | 'xz' | 'yz' or { plane: '<cardinal>', offset?: number }; got ${formatScalarForError(plane)}.`,
         this.id,
       );
     }
@@ -111,7 +111,7 @@ export class Shape {
     if (!isValidPlaneSpec(plane)) {
       throw new KernelError(
         'feature.mirror.invalid-plane',
-        `Mirror plane must be 'xy' | 'xz' | 'yz' or { plane: '<cardinal>', offset?: number }; got ${JSON.stringify(plane)}.`,
+        `Mirror plane must be 'xy' | 'xz' | 'yz' or { plane: '<cardinal>', offset?: number }; got ${formatScalarForError(plane)}.`,
         this.id,
       );
     }

--- a/src/intent/types.ts
+++ b/src/intent/types.ts
@@ -105,6 +105,32 @@ export function isValidScaleSpec(v: unknown): v is ScaleSpec {
   return false;
 }
 
+/**
+ * Format a scalar value for inclusion in an error message.
+ *
+ * JSON.stringify drops NaN/Infinity to "null" — the worst diagnostic
+ * outcome. This helper preserves them as readable strings; falls back
+ * to JSON.stringify for other types.
+ */
+export function formatScalarForError(v: unknown): string {
+  if (typeof v === 'number') {
+    if (Number.isNaN(v)) return 'NaN';
+    if (v === Infinity) return 'Infinity';
+    if (v === -Infinity) return '-Infinity';
+    return String(v);
+  }
+  if (Array.isArray(v)) {
+    return `[${v.map((x) => formatScalarForError(x)).join(', ')}]`;
+  }
+  if (typeof v === 'object' && v !== null) {
+    const entries = Object.entries(v).map(
+      ([k, val]) => `${JSON.stringify(k)}: ${formatScalarForError(val)}`,
+    );
+    return `{ ${entries.join(', ')} }`;
+  }
+  return JSON.stringify(v);
+}
+
 export function isValidPlaneSpec(value: unknown): value is PlaneSpec {
   if (typeof value === 'string') {
     return value === 'xy' || value === 'xz' || value === 'yz';

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -196,6 +196,7 @@ export const TOOLS = [
       'Export the script geometry to a binary STL file. Pass either { file } or { code } plus a required { output_path }. ' +
       'Optional { feature_id } selects which feature to export (default: last). ' +
       'Returns { ok, output_path, byte_count, feature_count, diagnostics }. ' +
+      'feature_count is the total features in the script, not the count contributing to the exported shape. ' +
       'The STL file is written server-side; suitable for passing directly to slicers, simulators, and viewers.',
     inputSchema: {
       type: 'object' as const,

--- a/src/mcp/tools/exportStl.ts
+++ b/src/mcp/tools/exportStl.ts
@@ -17,6 +17,7 @@ export interface ExportStlOutput {
   ok: boolean;
   output_path?: string;
   byte_count?: number;
+  /** Total features in the script, not the count contributing to the exported shape. */
   feature_count?: number;
   diagnostics?: CompilerDiagnostic[];
   error?: string;

--- a/src/mcp/tools/exportStl.ts
+++ b/src/mcp/tools/exportStl.ts
@@ -4,6 +4,7 @@ import { dirname, isAbsolute, resolve as resolvePath } from 'node:path';
 import { initOcct } from '../../backends/occt/occtBackend';
 import { runAndExport } from '../../script-runtime/export';
 import type { CompilerDiagnostic } from '../../diagnostics/diagnostic';
+import { validateOutputPath } from '../../script-runtime/safeOutputPath';
 
 export interface ExportStlInput {
   file?: string;
@@ -82,7 +83,13 @@ export async function exportStlTool(input: ExportStlInput): Promise<ExportStlOut
     };
   }
 
-  const finalPath = isAbsolute(output_path) ? output_path : resolvePath(output_path);
+  // Validate output_path before any write.
+  const pathCheck = validateOutputPath(output_path);
+  if (!pathCheck.ok) {
+    return { ok: false, error: pathCheck.error };
+  }
+  const finalPath = pathCheck.resolved!;
+
   try {
     await mkdir(dirname(finalPath), { recursive: true });
     await writeFile(finalPath, Buffer.from(result.bytes));

--- a/src/mcp/tools/whyDidThisFail.ts
+++ b/src/mcp/tools/whyDidThisFail.ts
@@ -58,7 +58,7 @@ export interface WhyDidThisFailOutput {
  * feature.extrude.unsupported-profile, feature.revolve.unsupported-profile,
  * cli.no-input, cli.export.exception, export.no-shape, export.shape-not-lowered.
  */
-export type HintReachability = 'engine-path' | 'direct-lowerer-only' | 'reserved' | 'cli-path';
+export type HintReachability = 'engine-path' | 'direct-lowerer-only' | 'reserved' | 'tool-error-field';
 
 interface HintEntry {
   /** One-line human-readable suggestion. Pasted into agent chat. */
@@ -73,9 +73,10 @@ interface HintEntry {
    *   `recompute.input.missing` before the lowerer's branch runs, so
    *   agents won't see this code through normal MCP usage. See
    *   docs/superpowers/specs/2026-05-01-error-attribution-policy.md.
-   * - 'cli-path': fires from the CLI command-handlers (file I/O, script
-   *   exceptions, export errors). Agents using the MCP server may see
-   *   these via tool result error fields rather than diagnostic chains.
+   * - 'tool-error-field': the code appears in MCP tool results' `error` /
+   *   `errorCode` field rather than the `diagnostics[]` array. Agents see
+   *   these as top-level tool failures (file I/O, script exceptions, export
+   *   errors).
    * - 'reserved': forward-looking infrastructure with no current trigger.
    */
   reachable: HintReachability;
@@ -145,10 +146,10 @@ export const HINTS: Record<string, HintEntry> = {
   'feature.path.duplicate-label': { reachable: 'engine-path', hint: "Each sketch label must be unique. Pick a different name or remove the duplicate label() call." },
   'recompute.input.missing': { reachable: 'engine-path', hint: "An upstream feature failed or was suppressed. Use why_did_this_fail on the upstream feature ID to find the root cause." },
   'recompute.lowering.exception': { reachable: 'engine-path', hint: "An exception was raised during lowering. Check the diagnostic message for the OCCT error." },
-  'cli.script.exception': { reachable: 'cli-path', hint: "Your script raised an exception during execution. Check the diagnostic message for the JS error." },
-  'cli.file.read': { reachable: 'cli-path', hint: "kernelCAD could not read the script file at that path. Check the file exists and is readable." },
-  'cli.no-input': { reachable: 'cli-path', hint: "No input provided to the CLI command. Pass either a file path or inline code." },
-  'cli.export.exception': { reachable: 'cli-path', hint: "An exception occurred during export. Check the diagnostic message for details." },
+  'cli.script.exception': { reachable: 'tool-error-field', hint: "Your script raised an exception during execution. Check the diagnostic message for the JS error." },
+  'cli.file.read': { reachable: 'tool-error-field', hint: "kernelCAD could not read the script file at that path. Check the file exists and is readable." },
+  'cli.no-input': { reachable: 'tool-error-field', hint: "No input provided to the CLI command. Pass either a file path or inline code." },
+  'cli.export.exception': { reachable: 'tool-error-field', hint: "An exception occurred during export. Check the diagnostic message for details." },
   'export.no-shape': { reachable: 'engine-path', hint: "The script did not return a shape. Ensure your script ends with return <shape>." },
   'export.shape-not-lowered': { reachable: 'engine-path', hint: "The returned shape could not be lowered to OCCT. Check for upstream errors in the feature tree." },
 };

--- a/src/script-runtime/exportStlBinary.ts
+++ b/src/script-runtime/exportStlBinary.ts
@@ -1,0 +1,113 @@
+// src/script-runtime/exportStlBinary.ts
+
+const HEADER_SIZE = 80;
+const TRIANGLE_COUNT_SIZE = 4;
+const TRIANGLE_RECORD_SIZE = 50; // 12 (normal) + 36 (3 vertices) + 2 (attribute)
+
+/**
+ * Raw mesh data as produced by Replicad's ShapeMesh or any equivalent source.
+ *
+ * - `vertices`: flat array of floats [x0,y0,z0, x1,y1,z1, ...] — one
+ *   coordinate triple per vertex.
+ * - `triangles`: flat array of integer indices into `vertices` — three
+ *   consecutive indices form one triangle face.
+ */
+export interface MeshData {
+  vertices: number[] | Float32Array;
+  triangles: number[] | Uint32Array;
+}
+
+/**
+ * Encode mesh data as a binary STL Buffer.
+ *
+ * Binary STL format:
+ *   Bytes 0..79    80-byte header (free-form text or zeros)
+ *   Bytes 80..83   uint32 LE — triangle count
+ *   Per triangle (50 bytes each):
+ *     Bytes 0..11   3× float32 LE  — normal vector (computed from vertices)
+ *     Bytes 12..47  9× float32 LE  — vertex 1, 2, 3 (xyz each)
+ *     Bytes 48..49  uint16 LE      — attribute byte count (0)
+ *
+ * Normal vectors are computed as the cross product of (v1-v0) × (v2-v0),
+ * normalized to unit length. Degenerate triangles (zero-area) emit a zero
+ * normal, which is spec-compliant.
+ *
+ * @param mesh    Vertex/index mesh data
+ * @param header  Up to 80 ASCII characters written to the header field.
+ *                Defaults to "kernelcad binary stl". The header MUST NOT
+ *                start with "solid" — some lenient parsers use the prefix
+ *                to detect ASCII vs binary format.
+ */
+export function encodeBinaryStl(
+  mesh: MeshData,
+  header = 'kernelcad binary stl',
+): Buffer {
+  const { vertices, triangles } = mesh;
+  const triangleCount = Math.floor(triangles.length / 3);
+  const totalSize =
+    HEADER_SIZE + TRIANGLE_COUNT_SIZE + triangleCount * TRIANGLE_RECORD_SIZE;
+  const buf = Buffer.alloc(totalSize, 0);
+
+  // Header — write ASCII text, padded with zeros already from alloc.
+  // Ensure it does not start with "solid" (would confuse format sniffers).
+  const safeHeader = header.startsWith('solid') ? 'binary-stl ' + header : header;
+  const headerBytes = Buffer.from(safeHeader.slice(0, HEADER_SIZE), 'ascii');
+  headerBytes.copy(buf, 0);
+
+  // Triangle count at byte 80 (LE uint32).
+  buf.writeUInt32LE(triangleCount, HEADER_SIZE);
+
+  // Per-triangle records starting at byte 84.
+  let offset = HEADER_SIZE + TRIANGLE_COUNT_SIZE;
+  for (let i = 0; i < triangleCount; i++) {
+    const i0 = triangles[i * 3];
+    const i1 = triangles[i * 3 + 1];
+    const i2 = triangles[i * 3 + 2];
+
+    const v0x = vertices[i0 * 3];
+    const v0y = vertices[i0 * 3 + 1];
+    const v0z = vertices[i0 * 3 + 2];
+    const v1x = vertices[i1 * 3];
+    const v1y = vertices[i1 * 3 + 1];
+    const v1z = vertices[i1 * 3 + 2];
+    const v2x = vertices[i2 * 3];
+    const v2y = vertices[i2 * 3 + 1];
+    const v2z = vertices[i2 * 3 + 2];
+
+    // Normal = (v1 - v0) × (v2 - v0), normalized.
+    const ax = v1x - v0x, ay = v1y - v0y, az = v1z - v0z;
+    const bx = v2x - v0x, by = v2y - v0y, bz = v2z - v0z;
+    const nx = ay * bz - az * by;
+    const ny = az * bx - ax * bz;
+    const nz = ax * by - ay * bx;
+    const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
+    const nxN = len > 0 ? nx / len : 0;
+    const nyN = len > 0 ? ny / len : 0;
+    const nzN = len > 0 ? nz / len : 0;
+
+    // Normal (12 bytes).
+    buf.writeFloatLE(nxN, offset); offset += 4;
+    buf.writeFloatLE(nyN, offset); offset += 4;
+    buf.writeFloatLE(nzN, offset); offset += 4;
+
+    // Vertex 0 (12 bytes).
+    buf.writeFloatLE(v0x, offset); offset += 4;
+    buf.writeFloatLE(v0y, offset); offset += 4;
+    buf.writeFloatLE(v0z, offset); offset += 4;
+
+    // Vertex 1 (12 bytes).
+    buf.writeFloatLE(v1x, offset); offset += 4;
+    buf.writeFloatLE(v1y, offset); offset += 4;
+    buf.writeFloatLE(v1z, offset); offset += 4;
+
+    // Vertex 2 (12 bytes).
+    buf.writeFloatLE(v2x, offset); offset += 4;
+    buf.writeFloatLE(v2y, offset); offset += 4;
+    buf.writeFloatLE(v2z, offset); offset += 4;
+
+    // Attribute byte count (2 bytes, always 0).
+    buf.writeUInt16LE(0, offset); offset += 2;
+  }
+
+  return buf;
+}

--- a/src/script-runtime/safeOutputPath.ts
+++ b/src/script-runtime/safeOutputPath.ts
@@ -1,0 +1,87 @@
+// src/script-runtime/safeOutputPath.ts
+//
+// Conservative-by-default validation for MCP tool output_path arguments.
+// First file-write MCP tool (export_stl, rc.15) sets the precedent for
+// future writers (thumbnail, STEP-export, etc).
+//
+// Rules:
+// 1. Reject paths containing `..` segments (path traversal).
+// 2. Reject absolute paths under /etc/, /proc/, /sys/, /dev/, /root/.
+// 3. Reject user-config paths: ~/.bashrc, ~/.zshrc, ~/.ssh/, ~/.gnupg/, etc.
+// 4. Allow: relative paths within cwd, /tmp/* paths, paths within $HOME
+//    not matching the above patterns.
+
+import { resolve as resolvePath, isAbsolute } from 'node:path';
+import { homedir } from 'node:os';
+
+export interface ValidateOutputPathResult {
+  ok: boolean;
+  resolved?: string;
+  error?: string;
+}
+
+const DANGEROUS_SYSTEM_PREFIXES = [
+  '/etc/',
+  '/proc/',
+  '/sys/',
+  '/dev/',
+  '/root/',
+];
+
+const DANGEROUS_USER_CONFIG_PATTERNS: RegExp[] = [
+  /\/\.bashrc$/,
+  /\/\.bash_profile$/,
+  /\/\.zshrc$/,
+  /\/\.profile$/,
+  /\/\.ssh\//,
+  /\/\.gnupg\//,
+  /\/\.aws\//,
+  /\/\.gcp\//,
+];
+
+export function validateOutputPath(rawPath: string): ValidateOutputPathResult {
+  if (typeof rawPath !== 'string' || rawPath.length === 0) {
+    return { ok: false, error: 'output_path must be a non-empty string.' };
+  }
+
+  // Reject path traversal (.. segments).
+  // Splitting on '/' or '\\' to handle both posix and Windows paths.
+  const segments = rawPath.split(/[/\\]/);
+  if (segments.some((seg) => seg === '..')) {
+    return {
+      ok: false,
+      error: `Refusing to write to ${rawPath}: contains path-traversal segments (..). Use an explicit safe path.`,
+    };
+  }
+
+  // Resolve tilde to homedir if present.
+  let expanded = rawPath;
+  if (rawPath.startsWith('~/') || rawPath === '~') {
+    expanded = rawPath === '~' ? homedir() : `${homedir()}/${rawPath.slice(2)}`;
+  }
+
+  // Resolve to absolute (relative paths get resolved against cwd).
+  const resolved = isAbsolute(expanded) ? expanded : resolvePath(expanded);
+
+  // Reject dangerous system prefixes.
+  for (const prefix of DANGEROUS_SYSTEM_PREFIXES) {
+    if (resolved === prefix.slice(0, -1) || resolved.startsWith(prefix)) {
+      return {
+        ok: false,
+        error: `Refusing to write to ${resolved}: matches dangerous system path (${prefix}). Use an explicit safe path (e.g. /tmp/<name>.stl or a path in the project directory).`,
+      };
+    }
+  }
+
+  // Reject user-config patterns.
+  for (const pattern of DANGEROUS_USER_CONFIG_PATTERNS) {
+    if (pattern.test(resolved)) {
+      return {
+        ok: false,
+        error: `Refusing to write to ${resolved}: matches a protected user-config path (${pattern.source}). Use an explicit safe path.`,
+      };
+    }
+  }
+
+  return { ok: true, resolved };
+}

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -404,7 +404,7 @@ When the kernel rejects a feature, it emits a `CompilerDiagnostic` with one of t
 Each hint in the `hints` array includes a `reachable` classification:
 - `'engine-path'` — fires during normal recompute; highest-signal for typical agent workflows.
 - `'direct-lowerer-only'` — only reachable if the lowerer is invoked directly; through the standard MCP path, agents will see `recompute.input.missing` from an upstream feature instead.
-- `'cli-path'` — fires from the CLI command-handlers (file I/O, script exceptions, export errors); agents using the MCP server may see these via tool result error fields rather than diagnostic chains.
+- `'tool-error-field'` — the code appears in MCP tool results' `error` / `errorCode` field rather than the `diagnostics[]` array. Agents see these as top-level tool failures (file I/O, script exceptions, export errors).
 - `'reserved'` — forward-looking infrastructure with no current trigger.
 
 ## CLI Commands

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -441,7 +441,7 @@ When you have `kernelcad mcp` available, use the MCP tools for dynamic introspec
 - `list_faces({ file? code?, feature_id? })` — enumerate all faces with area and centroid
 - `list_face_labels({ file? code?, feature_id? })` — canonical face names resolvable on a feature
 - `list_api({})` — full curated API surface (globals, Shape methods, Sketch methods)
-- `export_stl({ file? | code?, output_path, feature_id? })` — write a binary STL file server-side; returns `{ ok, output_path, byte_count, feature_count, diagnostics }`
+- `export_stl({ file? | code?, output_path, feature_id? })` — write a binary STL file server-side; returns `{ ok, output_path, byte_count, feature_count, diagnostics }`. `feature_count` is the total features in the script, not the count contributing to the exported shape.
 
 ## Out of Scope
 

--- a/tests/e2e/cli-acceptance.test.ts
+++ b/tests/e2e/cli-acceptance.test.ts
@@ -153,7 +153,9 @@ describe('v0.4-alpha triangle-extrusion fixture', () => {
       out,
     });
     expect(r.exitCode).toBe(0);
-    expect(statSync(out).size).toBeGreaterThan(500);
+    // Binary STL: 80-byte header + 4-byte count + 50 bytes per triangle.
+    // A triangular prism has 8 triangles → 484 bytes; > 84 confirms non-empty binary output.
+    expect(statSync(out).size).toBeGreaterThan(84);
   });
 });
 

--- a/tests/integration/mcp/exportStl.test.ts
+++ b/tests/integration/mcp/exportStl.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { exportStlTool } from '../../../src/mcp/tools/exportStl';
+import { runScript } from '../../../src/script-runtime/runScript';
 
 beforeAll(async () => {
   const { initOcct } = await import('../../../src/backends/occt/occtBackend');
@@ -119,4 +120,62 @@ describe('export_stl MCP tool', () => {
     expect(result.ok).toBe(false);
     expect(result.error).toMatch(/path-traversal/);
   });
+});
+
+describe('export_stl feature_id paths', () => {
+  it('successfully exports with explicit feature_id', async () => {
+    const code = 'return box(10, 10, 10);';
+    const run = await runScript({ code, fileName: '<test>' });
+    const lastId = run.records[run.records.length - 1].id;
+
+    const outputPath = join(tmpDir, 'box-by-id.stl');
+    const result = await exportStlTool({
+      code,
+      output_path: outputPath,
+      feature_id: lastId,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.byte_count).toBeGreaterThan(0);
+    expect(existsSync(outputPath)).toBe(true);
+  }, 60000);
+
+  it('exports an intermediate feature (box, not the filleted result)', async () => {
+    const code = 'return box(10, 10, 10).fillet(2);';
+    const run = await runScript({ code, fileName: '<test>' });
+    // The first record is the box; the fillet is the second (last) record.
+    const boxId = run.records[0].id;
+
+    const outputPath = join(tmpDir, 'box-only.stl');
+    const result = await exportStlTool({
+      code,
+      output_path: outputPath,
+      feature_id: boxId,
+    });
+
+    expect(result.ok).toBe(true);
+
+    // A plain box has exactly 12 triangles → 80 + 4 + 12*50 = 684 bytes.
+    // A filleted box has many more triangles.
+    const buf = readFileSync(outputPath);
+    const triangleCount = buf.readUInt32LE(80);
+    expect(triangleCount).toBe(12);
+    expect(buf.length).toBe(684);
+  }, 60000);
+
+  it('returns ok: false when feature_id is not found', async () => {
+    const code = 'return box(10, 10, 10);';
+    const outputPath = join(tmpDir, 'nope.stl');
+    const result = await exportStlTool({
+      code,
+      output_path: outputPath,
+      feature_id: 'feature-id-that-does-not-exist',
+    });
+
+    expect(result.ok).toBe(false);
+    // The export.feature-not-found diagnostic surfaces in result.diagnostics[].message.
+    const message = result.error ?? result.diagnostics?.[0]?.message ?? '';
+    expect(message).toMatch(/not found/i);
+    expect(existsSync(outputPath)).toBe(false);
+  }, 60000);
 });

--- a/tests/integration/mcp/exportStl.test.ts
+++ b/tests/integration/mcp/exportStl.test.ts
@@ -81,15 +81,15 @@ describe('export_stl MCP tool', () => {
     expect(existsSync(outputPath)).toBe(false);
   }, 60000);
 
-  it('returns ok: false on unwritable path', async () => {
-    // Use a path inside a non-existent root directory that cannot be created
-    // (/root is not writable by unprivileged users)
+  it('returns ok: false on dangerous path (/root/)', async () => {
+    // /root/ is a protected system path — rejected by path validation before
+    // any write is attempted.
     const result = await exportStlTool({
       code: 'return box(10, 10, 10);',
       output_path: '/root/kernelcad-test-unwritable/box.stl',
     });
     expect(result.ok).toBe(false);
-    expect(result.error).toMatch(/Cannot write/);
+    expect(result.error).toMatch(/Refusing to write|system path/);
   }, 60000);
 
   it('creates parent directories if they do not exist', async () => {
@@ -101,4 +101,22 @@ describe('export_stl MCP tool', () => {
     expect(result.ok).toBe(true);
     expect(existsSync(outputPath)).toBe(true);
   }, 60000);
+
+  it('rejects dangerous output_path with kernelCAD-level validation', async () => {
+    const result = await exportStlTool({
+      code: 'return box(10, 10, 10);',
+      output_path: '/etc/cannot-write-here.stl',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Refusing to write|system path/);
+  });
+
+  it('rejects path with traversal segments', async () => {
+    const result = await exportStlTool({
+      code: 'return box(10, 10, 10);',
+      output_path: '/tmp/../etc/escape.stl',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/path-traversal/);
+  });
 });

--- a/tests/integration/mcp/exportStl.test.ts
+++ b/tests/integration/mcp/exportStl.test.ts
@@ -5,9 +5,6 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { exportStlTool } from '../../../src/mcp/tools/exportStl';
 
-// NOTE: Replicad's blobSTL() returns ASCII STL (not binary). The round-trip
-// tests below validate ASCII STL structure accordingly.
-
 beforeAll(async () => {
   const { initOcct } = await import('../../../src/backends/occt/occtBackend');
   await initOcct();
@@ -36,15 +33,26 @@ describe('export_stl MCP tool', () => {
     expect(result.feature_count).toBe(1);
     expect(existsSync(outputPath)).toBe(true);
 
-    // Validate STL content — Replicad produces ASCII STL
+    // Validate binary STL structure.
+    // Format: 80-byte header + 4-byte uint32 triangle count + 50 bytes per triangle.
+    // A box has 12 triangles (2 per face × 6 faces) → 80 + 4 + 12 × 50 = 684 bytes.
     const buf = readFileSync(outputPath);
-    expect(buf.length).toBeGreaterThan(0);
-    const text = buf.toString('utf8');
-    // ASCII STL starts with "solid" keyword and contains "facet normal" entries
-    expect(text).toMatch(/^solid\b/i);
-    expect(text).toContain('facet normal');
-    expect(text).toContain('vertex');
-    // byte_count in receipt must match what's on disk
+    expect(buf.length).toBeGreaterThanOrEqual(84);
+
+    // Triangle count at byte 80 (uint32 LE).
+    const triangleCount = buf.readUInt32LE(80);
+    // A box has exactly 12 triangles.
+    expect(triangleCount).toBe(12);
+
+    // Total size must be exactly 80 + 4 + 12 × 50 = 684 bytes.
+    expect(buf.length).toBe(684);
+
+    // Header must NOT start with "solid" — that prefix signals ASCII format to
+    // lenient parsers.
+    const headerPrefix = buf.subarray(0, 5).toString('ascii');
+    expect(headerPrefix).not.toBe('solid');
+
+    // byte_count in receipt must match what's on disk.
     expect(result.byte_count).toBe(buf.length);
   }, 60000);
 

--- a/tests/unit/capture/proxy.transforms.test.ts
+++ b/tests/unit/capture/proxy.transforms.test.ts
@@ -65,6 +65,14 @@ describe('Shape transform validators (capture-time)', () => {
     expect(String(caught)).toMatch(/invalid-rotate|finite/i);
   });
 
+  it('rotate error message preserves NaN degrees value', async () => {
+    let caught: unknown;
+    try {
+      await runScript({ code: `return box(10, 10, 10).rotate([0, 0, 1], NaN);`, fileName: 'test.kcad.ts' });
+    } catch (e) { caught = e; }
+    expect(String(caught)).toMatch(/NaN/);
+  });
+
   it('rotate does not throw for valid axis and degrees', async () => {
     const result = await runScript({ code: `return box(5, 5, 5).rotate([0, 0, 1], 90);`, fileName: 'test.kcad.ts' });
     expect(result.records).toHaveLength(1);
@@ -101,6 +109,14 @@ describe('Shape transform validators (capture-time)', () => {
     expect(String(caught)).toMatch(/invalid-scale|positive/i);
   });
 
+  it('scale error message preserves NaN value', async () => {
+    let caught: unknown;
+    try {
+      await runScript({ code: `return box(10, 10, 10).scale(NaN);`, fileName: 'test.kcad.ts' });
+    } catch (e) { caught = e; }
+    expect(String(caught)).toMatch(/NaN/);
+  });
+
   it('scale does not throw for valid positive factor', async () => {
     const result = await runScript({ code: `return box(5, 5, 5).scale(2);`, fileName: 'test.kcad.ts' });
     expect(result.records).toHaveLength(1);
@@ -133,6 +149,14 @@ describe('Shape transform validators (capture-time)', () => {
     expect(diag.code).toBe('feature.transform.invalid-reflect');
   });
 
+  it('reflect error message preserves Infinity in offset', async () => {
+    let caught: unknown;
+    try {
+      await runScript({ code: `return box(10, 10, 10).reflect({ plane: 'yz', offset: Infinity });`, fileName: 'test.kcad.ts' });
+    } catch (e) { caught = e; }
+    expect(String(caught)).toMatch(/Infinity/);
+  });
+
   it('reflect does not throw for valid cardinal plane', async () => {
     const result = await runScript({ code: `return box(5, 5, 5).reflect('xy');`, fileName: 'test.kcad.ts' });
     expect(result.records).toHaveLength(1);
@@ -152,6 +176,14 @@ describe('Shape transform validators (capture-time)', () => {
     expect(diag.code).toBe('feature.mirror.invalid-plane');
     expect(diag.featureId).toBeDefined();
     expect(typeof diag.featureId).toBe('string');
+  });
+
+  it('mirror error message preserves NaN in offset', async () => {
+    let caught: unknown;
+    try {
+      await runScript({ code: `return box(10, 10, 10).mirror({ plane: 'yz', offset: NaN });`, fileName: 'test.kcad.ts' });
+    } catch (e) { caught = e; }
+    expect(String(caught)).toMatch(/NaN/);
   });
 
   it('mirror does not throw for valid cardinal plane', async () => {

--- a/tests/unit/mcp/whyDidThisFailReachability.test.ts
+++ b/tests/unit/mcp/whyDidThisFailReachability.test.ts
@@ -5,7 +5,7 @@ const ALLOWED_REACHABILITY: ReadonlySet<HintReachability> = new Set([
   'engine-path',
   'direct-lowerer-only',
   'reserved',
-  'cli-path',
+  'tool-error-field',
 ] as const);
 
 const KNOWN_DIRECT_LOWERER_ONLY = [
@@ -14,7 +14,7 @@ const KNOWN_DIRECT_LOWERER_ONLY = [
   'feature.transform.invalid-plane',
 ] as const;
 
-const KNOWN_CLI_PATH = [
+const KNOWN_TOOL_ERROR_FIELD = [
   'cli.script.exception',
   'cli.file.read',
   'cli.no-input',
@@ -63,15 +63,15 @@ describe('whyDidThisFail HINTS table reachability classification', () => {
     ).toEqual(expected);
   });
 
-  it('the cli-path set matches the documented CLI codes', () => {
-    const cliPath = Object.entries(HINTS)
-      .filter(([, entry]) => entry.reachable === 'cli-path')
+  it('the tool-error-field set matches the documented tool-error codes', () => {
+    const toolErrorField = Object.entries(HINTS)
+      .filter(([, entry]) => entry.reachable === 'tool-error-field')
       .map(([code]) => code)
       .sort();
-    const expected = [...KNOWN_CLI_PATH].sort();
+    const expected = [...KNOWN_TOOL_ERROR_FIELD].sort();
     expect(
-      cliPath,
-      `Adding a new cli-path code requires updating KNOWN_CLI_PATH in this test.`,
+      toolErrorField,
+      `Adding a new tool-error-field code requires updating KNOWN_TOOL_ERROR_FIELD in this test.`,
     ).toEqual(expected);
   });
 });

--- a/tests/unit/script-runtime/safeOutputPath.test.ts
+++ b/tests/unit/script-runtime/safeOutputPath.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { homedir } from 'node:os';
+import { validateOutputPath } from '../../../src/script-runtime/safeOutputPath';
+
+describe('validateOutputPath', () => {
+  describe('accepts safe paths', () => {
+    it('accepts relative paths within cwd', () => {
+      const r = validateOutputPath('./out.stl');
+      expect(r.ok).toBe(true);
+      expect(r.resolved).toMatch(/\/out\.stl$/);
+    });
+
+    it('accepts /tmp/ paths', () => {
+      const r = validateOutputPath('/tmp/test.stl');
+      expect(r.ok).toBe(true);
+      expect(r.resolved).toBe('/tmp/test.stl');
+    });
+
+    it('accepts ~/projects/foo.stl', () => {
+      const r = validateOutputPath('~/projects/foo.stl');
+      expect(r.ok).toBe(true);
+      expect(r.resolved).toBe(`${homedir()}/projects/foo.stl`);
+    });
+
+    it('accepts subdir of cwd', () => {
+      const r = validateOutputPath('out/parts/bracket.stl');
+      expect(r.ok).toBe(true);
+    });
+  });
+
+  describe('rejects path traversal', () => {
+    it('rejects path with .. segment', () => {
+      const r = validateOutputPath('../escape.stl');
+      expect(r.ok).toBe(false);
+      expect(r.error).toMatch(/path-traversal/);
+    });
+
+    it('rejects absolute path with .. segment', () => {
+      const r = validateOutputPath('/tmp/safe/../etc/escape.stl');
+      expect(r.ok).toBe(false);
+      expect(r.error).toMatch(/path-traversal/);
+    });
+  });
+
+  describe('rejects dangerous system paths', () => {
+    it('rejects /etc/passwd', () => {
+      const r = validateOutputPath('/etc/passwd');
+      expect(r.ok).toBe(false);
+      expect(r.error).toMatch(/system path/);
+    });
+
+    it('rejects /proc/self/environ', () => {
+      const r = validateOutputPath('/proc/self/environ');
+      expect(r.ok).toBe(false);
+    });
+
+    it('rejects /sys/fs/cgroup/memory.limit', () => {
+      const r = validateOutputPath('/sys/fs/cgroup/memory.limit');
+      expect(r.ok).toBe(false);
+    });
+
+    it('rejects /dev/null', () => {
+      const r = validateOutputPath('/dev/null');
+      expect(r.ok).toBe(false);
+    });
+
+    it('rejects /root/foo.stl', () => {
+      const r = validateOutputPath('/root/foo.stl');
+      expect(r.ok).toBe(false);
+    });
+  });
+
+  describe('rejects user-config paths', () => {
+    it('rejects ~/.bashrc', () => {
+      const r = validateOutputPath('~/.bashrc');
+      expect(r.ok).toBe(false);
+      expect(r.error).toMatch(/protected user-config/);
+    });
+
+    it('rejects ~/.zshrc', () => {
+      const r = validateOutputPath('~/.zshrc');
+      expect(r.ok).toBe(false);
+    });
+
+    it('rejects ~/.ssh/config', () => {
+      const r = validateOutputPath('~/.ssh/config');
+      expect(r.ok).toBe(false);
+    });
+
+    it('rejects ~/.ssh/id_ed25519', () => {
+      const r = validateOutputPath('~/.ssh/id_ed25519');
+      expect(r.ok).toBe(false);
+    });
+
+    it('rejects ~/.gnupg/secring.gpg', () => {
+      const r = validateOutputPath('~/.gnupg/secring.gpg');
+      expect(r.ok).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('rejects empty string', () => {
+      const r = validateOutputPath('');
+      expect(r.ok).toBe(false);
+    });
+
+    it('rejects non-string input', () => {
+      // @ts-expect-error testing runtime guard
+      const r = validateOutputPath(null);
+      expect(r.ok).toBe(false);
+    });
+
+    it('error messages mention an alternative', () => {
+      const r = validateOutputPath('/etc/foo.stl');
+      expect(r.error).toMatch(/safe path|\/tmp\/|project/i);
+    });
+  });
+});

--- a/tests/unit/skill/skillDiagnosticCodesDrift.test.ts
+++ b/tests/unit/skill/skillDiagnosticCodesDrift.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve as resolvePath, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { HINTS } from '../../../src/mcp/tools/whyDidThisFail';
-import { escapeRegExp } from './_helpers';
+import { assertEveryNameInSKILL } from './_helpers';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SKILL_MD = readFileSync(
@@ -14,16 +14,6 @@ const SKILL_MD = readFileSync(
 describe('SKILL.md diagnostic codes drift sentinel', () => {
   it('every HINTS code appears in SKILL.md (word-boundary match)', () => {
     const codes = Object.keys(HINTS);
-    const missing: string[] = [];
-    for (const code of codes) {
-      const regex = new RegExp(`\\b${escapeRegExp(code)}\\b`);
-      if (!regex.test(SKILL_MD)) {
-        missing.push(code);
-      }
-    }
-    expect(
-      missing,
-      `SKILL.md does not mention these diagnostic codes. Add to the diagnostic-codes table: ${missing.join(', ')}`,
-    ).toEqual([]);
+    assertEveryNameInSKILL(SKILL_MD, codes, 'diagnostic codes');
   });
 });

--- a/tests/unit/skill/skillGlobalsDrift.test.ts
+++ b/tests/unit/skill/skillGlobalsDrift.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve as resolvePath, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { GLOBALS } from '../../../src/mcp/tools/listApi';
-import { escapeRegExp } from './_helpers';
+import { assertEveryNameInSKILL } from './_helpers';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SKILL_MD = readFileSync(
@@ -13,16 +13,7 @@ const SKILL_MD = readFileSync(
 
 describe('SKILL.md GLOBALS drift sentinel', () => {
   it('every GLOBALS entry name appears in SKILL.md (word-boundary match)', () => {
-    const missing: string[] = [];
-    for (const entry of GLOBALS) {
-      const regex = new RegExp(`\\b${escapeRegExp(entry.name)}\\b`);
-      if (!regex.test(SKILL_MD)) {
-        missing.push(entry.name);
-      }
-    }
-    expect(
-      missing,
-      `SKILL.md does not mention these top-level globals. Add an entry to the Top-level functions section: ${missing.join(', ')}`,
-    ).toEqual([]);
+    const names = GLOBALS.map((e) => e.name);
+    assertEveryNameInSKILL(SKILL_MD, names, 'top-level globals');
   });
 });

--- a/tests/unit/skill/skillPathBuilderMethodsDrift.test.ts
+++ b/tests/unit/skill/skillPathBuilderMethodsDrift.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve as resolvePath, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { PATH_BUILDER_METHODS } from '../../../src/mcp/tools/listApi';
-import { escapeRegExp } from './_helpers';
+import { assertEveryNameInSKILL } from './_helpers';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SKILL_MD = readFileSync(
@@ -13,16 +13,7 @@ const SKILL_MD = readFileSync(
 
 describe('SKILL.md PathBuilder methods drift sentinel', () => {
   it('every PATH_BUILDER_METHODS entry name appears in SKILL.md (word-boundary match)', () => {
-    const missing: string[] = [];
-    for (const entry of PATH_BUILDER_METHODS) {
-      const regex = new RegExp(`\\b${escapeRegExp(entry.name)}\\b`);
-      if (!regex.test(SKILL_MD)) {
-        missing.push(entry.name);
-      }
-    }
-    expect(
-      missing,
-      `SKILL.md does not mention these PathBuilder methods. Add an entry to the PathBuilder methods section: ${missing.join(', ')}`,
-    ).toEqual([]);
+    const names = PATH_BUILDER_METHODS.map((e) => e.name);
+    assertEveryNameInSKILL(SKILL_MD, names, 'PathBuilder methods');
   });
 });

--- a/tests/unit/skill/skillShapeMethodsDrift.test.ts
+++ b/tests/unit/skill/skillShapeMethodsDrift.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve as resolvePath, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { SHAPE_METHODS } from '../../../src/mcp/tools/listApi';
-import { escapeRegExp } from './_helpers';
+import { assertEveryNameInSKILL } from './_helpers';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SKILL_MD = readFileSync(
@@ -13,16 +13,7 @@ const SKILL_MD = readFileSync(
 
 describe('SKILL.md Shape methods drift sentinel', () => {
   it('every SHAPE_METHODS entry name appears in SKILL.md (word-boundary match)', () => {
-    const missing: string[] = [];
-    for (const method of SHAPE_METHODS) {
-      const regex = new RegExp(`\\b${escapeRegExp(method.name)}\\b`);
-      if (!regex.test(SKILL_MD)) {
-        missing.push(method.name);
-      }
-    }
-    expect(
-      missing,
-      `SKILL.md does not mention these Shape methods. Add an entry to the corresponding section: ${missing.join(', ')}`,
-    ).toEqual([]);
+    const names = SHAPE_METHODS.map((m) => m.name);
+    assertEveryNameInSKILL(SKILL_MD, names, 'Shape methods');
   });
 });

--- a/tests/unit/skill/skillSketchMethodsDrift.test.ts
+++ b/tests/unit/skill/skillSketchMethodsDrift.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve as resolvePath, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { SKETCH_METHODS } from '../../../src/mcp/tools/listApi';
-import { escapeRegExp } from './_helpers';
+import { assertEveryNameInSKILL } from './_helpers';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SKILL_MD = readFileSync(
@@ -13,16 +13,7 @@ const SKILL_MD = readFileSync(
 
 describe('SKILL.md Sketch methods drift sentinel', () => {
   it('every SKETCH_METHODS entry name appears in SKILL.md (word-boundary match)', () => {
-    const missing: string[] = [];
-    for (const method of SKETCH_METHODS) {
-      const regex = new RegExp(`\\b${escapeRegExp(method.name)}\\b`);
-      if (!regex.test(SKILL_MD)) {
-        missing.push(method.name);
-      }
-    }
-    expect(
-      missing,
-      `SKILL.md does not mention these Sketch methods. Add an entry to the corresponding section: ${missing.join(', ')}`,
-    ).toEqual([]);
+    const names = SKETCH_METHODS.map((m) => m.name);
+    assertEveryNameInSKILL(SKILL_MD, names, 'Sketch methods');
   });
 });

--- a/tests/unit/skill/skillToolCountDrift.test.ts
+++ b/tests/unit/skill/skillToolCountDrift.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { resolve as resolvePath, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { TOOLS } from '../../../src/mcp/server';
-import { escapeRegExp } from './_helpers';
+import { assertEveryNameInSKILL } from './_helpers';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SKILL_MD = readFileSync(
@@ -35,14 +35,7 @@ describe('SKILL.md tool count drift sentinel', () => {
     // once. Catches the case where TOOLS adds a new entry but SKILL.md
     // doesn't get updated to describe it. Word-boundary regex avoids
     // false-positives when a tool name is a substring of a longer identifier.
-    const missing: string[] = [];
-    for (const tool of TOOLS) {
-      const name = (tool as { name: string }).name;
-      const regex = new RegExp(`\\b${escapeRegExp(name)}\\b`);
-      if (!regex.test(SKILL_MD)) {
-        missing.push(name);
-      }
-    }
-    expect(missing, `Tools missing from SKILL.md: ${missing.join(', ')}`).toEqual([]);
+    const names = TOOLS.map((tool) => (tool as { name: string }).name);
+    assertEveryNameInSKILL(SKILL_MD, names, 'MCP tools');
   });
 });


### PR DESCRIPTION
## Summary
Bundled feature + quality milestone. Upgrades `export_stl` from ASCII to true binary STL (rc.15 contract was right; impl finally matches). Closes rc.15 review punch list (2 Critical + 6 Important + 2 Nits) plus a new "deviation propagation" discipline memory entry.

### Feature
- **Binary STL output**: 684 bytes for a 12-triangle box (vs ~3052 ASCII). Direct mesh-primitive encoding; all three agent-readable surfaces (SKILL.md, MCP description, JSDoc) match.

### rc.15 review block
- **C1**: Binary STL — feature pivot above.
- **C2**: `'cli-path'` → `'tool-error-field'` reachability rename.
- **I1**: 3 new `feature_id` integration tests.
- **I2 + N1**: 6 sentinels adopt shared `assertEveryNameInSKILL` helper.
- **I3**: `validateOutputPath` gate (19 unit + 2 integration tests).
- **I4**: `formatScalarForError` helper preserves NaN/Infinity (4 new assertions).
- **I5**: `feature_count` semantics clarified across 3 surfaces.
- **I6**: rc.15 CHANGELOG count fix.

### Discipline
- New `feedback_propagate_implementer_deviations.md` memory entry codifies the rule: controller audits agent-readable surfaces when implementer reports spec deviations. Surfaced by rc.15's ASCII-vs-binary STL gap.

## Test plan
- [x] `npm run qc`: 810 tests passing
- [x] Bundle live-verify: `serverInfo.version: "0.13.0-rc.16"` ✅
- [x] `export_stl` binary live-verify: 684 bytes for a box ✅
- [ ] Playwright e2e: pre-existing env failure — not gating