### PR TITLE
feat(v0.1.0): NORTHSTAR re-baseline + first public ship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -702,7 +702,7 @@ The decision to ship just `set_param_value` for v0.12-beta is deliberate YAGNI �
 - Canonical face refs on transformed primitives
 - shell, hole, cut, draft features
 
-## v0.1.0 — 2026-04-29
+## v0.1.0 (internal architecture milestone, never published) — 2026-04-29
 
 ### Added
 - New flat feature-graph IR (`src/intent/`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,44 @@
+## v0.1.0 — first public release + NORTHSTAR re-baseline (2026-05-02)
+
+The first kernelCAD release published to the npm registry. Install with `npm install -g kernelcad`.
+
+### Re-baseline note
+
+Prior to this release, the repo carried 34 internal tags (`v0.0.1` through `v0.13.0-rc.17`) reflecting iterative development. None were ever published. All have been deleted; this release starts a clean, NORTHSTAR-aligned numbering line where each `v0.N.0` corresponds to one NORTHSTAR module fully delivered.
+
+`v0.1.0` ships NORTHSTAR's v0.1 module ("Foundation"): feature graph, recompute engine, OCCT backend via Replicad, primitives (box/cylinder/sphere), CLI (`evaluate`, `export stl`, `export step`), JSON diagnostics, canonical face refs.
+
+### Bonus surface (NORTHSTAR modules partly delivered out-of-order)
+
+Beyond the v0.1 contract, this release also includes:
+
+- **v0.2 partial** — `.fillet()`, `.chamfer()`, `.shell()`, `path()` builder with `lineTo`/`tangentArc`/`threePointsArc`/`sagittaArc`/`bulgeArc`/`radiusArc`, `.label()`. Tracked face/edge refs across transforms/booleans **deferred to v0.2.0**.
+- **v0.3 partial** — `.shell()` ships. `hole`/`cut`/`draft` as first-class features and `created` face refs **deferred to v0.3.0**.
+- **v0.7** — `.sweep()` and `.loft()` (curves + surfacing).
+- **v0.11** — MCP server with 13 introspection tools (`why_did_this_fail`, `list_topology`, `get_shape_info`, `list_edges`, `list_faces`, `list_face_labels`, `list_features`, `list_api`, `evaluate_script`, `get_edges_of`, `set_param_value`, `add_feature`, `remove_feature`).
+- **v0.12 partial** — MCP AST-edit tools (`add_feature`, `remove_feature`, `set_param_value`). Skill installer and one-file context bundler **deferred to v0.12.0**.
+
+### Symmetry features (not on the NORTHSTAR module roadmap, additive)
+
+- `.mirror(plane)` / `.reflect(plane)` for symmetric parts.
+- Binary STL export (`kernelcad export stl ...` and `export_stl` MCP tool).
+- Variable-radius fillet/chamfer.
+- Edge/face query selectors (`selectEdges`, `selectEdge`, `EdgeQuery`, `FaceQuery`).
+
+### Diagnostic surface
+
+53 documented diagnostic codes across feature/recompute/cli/export categories, each with a HINTS entry, structurally enforced by a CI sentinel.
+
+### Positioning
+
+kernelCAD is the open, MCP-native, AST-edit-primacy CAD kernel for iterative agent workflows. Source is on GitHub. Diagnostics are structured and hint-rich. The MCP server lets an agent introspect a live model across many queries in one session instead of re-running the script per question.
+
+### License
+
+MIT License.
+
+---
+
 ## v0.13.0-rc.17 — quality pass v5 (2026-05-01)
 
 A pure quality milestone closing the rc.16 review punch list (1 Critical + 5 Important + 8 Nits) plus a structural backstop for the entire "diagnostic emitted but no hint" failure class.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Andrii Shylenko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -17,61 +17,47 @@
  -   **Standard Exports**: STEP/STL generation.
  -   **Robust Kernel**: Built on OpenCASCADE (via Replicad).
   
-## Getting Started
+## Get Started
 
-### Prerequisites
+```bash
+npm install -g kernelcad
+```
 
--   Node.js (v22.12.0+)
--   npm
+Drop this in `bracket.kcad.ts`:
 
-### Installation
+```typescript
+const w = param('Width', 60, { unit: 'mm' });
+const h = param('Height', 40, { unit: 'mm' });
+const t = param('Thickness', 5, { unit: 'mm' });
 
-1.  Clone the repository:
-    ```bash
-    git clone https://github.com/w1ne/kernelCAD.git
-    cd kernelCAD
-    ```
-2.  Install dependencies:
-    ```bash
-    npm install
-    ```
-3.  Start the development server:
-    ```bash
-    npm run dev
-    ```
-4.  Open [http://localhost:5173](http://localhost:5173) in your browser.
+const base = box(w, h, t);
+const hole = cylinder(t + 2, 4).translate(w / 2, h / 2, -1);
+return base.subtract(hole).fillet(1);
+```
 
-## Usage
+Run it:
 
-1.  **Write Code**: Use the editor on the left to define your shape.
-    ```javascript
-    const { Sketcher } = replicad;
-    const base = new Sketcher().hLine(50).vLine(50).hLine(-50).close().extrude(20);
-    return base.fillet(5);
-    ```
-2.  **View**: The 3D view updates automatically when you stop typing or save.
-3.  **Export**: Click the download icons in the top-right to export STEP or STL files.
+```bash
+kernelcad evaluate bracket.kcad.ts
+kernelcad export stl bracket.kcad.ts -o bracket.stl
+```
 
-## Architecture
+That's it. For agents: `kernelcad mcp` runs an MCP server with 13 introspection tools. See `SKILL.md` (bundled with the install) for the full API surface and authoring guide.
 
-kernelCAD consists of three main parts:
-1.  **Editor**: Monaco-based code editor.
-2.  **Viewer**: Three.js/React-Three-Fiber viewport.
-3.  **Engine**: A Web Worker that runs Replicad/OpenCASCADE to compute geometry asynchronously.
+## Contributing
 
-### Documentation Index
+Web app + dev workflow (clone the repo, `npm install`, `npm run dev`) for contributors who want to hack on the kernel or the visual debugger:
 
-- **[Architecture](./doc/ARCHITECTURE.md)**: High-level system design and component overview.
-- **[Refactoring Analysis](./doc/REFACTORING_ANALYSIS.md)**: Root-cause flow/logic gaps and staged refactor plan.
-- **[CAD Engineering Standards](./doc/CAD_ENGINEERING_STANDARDS.md)**: Best-in-class CAD practices translated into kernelCAD implementation standards.
-- **[Implementation Details](./doc/IMPLEMENTATION_DETAILS.md)**: Deep dive into the Visual Feedback System, Solver, and Code Generation.
-- **[Interfaces & APIs](./doc/INTERFACES.md)**: Detailed API references for Extensibility.
-- **[Roadmap](./doc/ROADMAP.md)**: Future plans and current status.
-- **[Keyboard Shortcuts](./doc/KEYBOARD_SHORTCUTS.md)**: Speed up your workflow.
-- **[CAD Query Guide](./doc/CAD_QUERY_GUIDE.md)**: Guide to robust selector-based modeling.
-- **[Core Workflows](./doc/CORE_WORKFLOWS.md)**: Step-by-step user interaction references.
-- **[Competitive Analysis](./doc/COMPETITIVE_ANALYSIS.md)**: Comparison with CascadeStudio and Chilli3D.
+```bash
+git clone https://github.com/w1ne/kernelCAD-web.git
+cd kernelCAD-web
+npm install
+npm run dev          # web visual debugger at localhost:5173
+npm run build:cli    # build the CLI bundle into dist/cli/
+npm run test         # full vitest suite
+npm run qc           # quick quality gate (lint + typecheck + tests)
+```
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # kernelCAD - Agentic CAD Platform
- 
- **kernelCAD** is a **Headless-First CAD Platform** designed for AI Agents.
- 
- It provides a robust, scriptable API for agents to generate, analyze, and modify 3D geometry using the OpenCASCADE kernel. A web-based "Visual Debugger" allows human engineers to verify and tweak the agent's output.
- 
- ## Philosophy
- 1.  **Agent-Driven**: The primary interface is the `AgentAPI` (Node.js/TS), not the mouse.
- 2.  **Verifiable**: Geometry is produced by deterministic code, not manual clicks.
- 3.  **Visual Debugging**: Humans trust what they can see. The Web App acts as a high-fidelity viewer for the headless core.
- 
- ## Features
- 
- -   **Headless Core**: Run CAD operations in Node.js or Web Workers without a DOM.
- -   **Agent API**: JSON-serializable commands, introspection, and feedback loops.
- -   **Visual Debugger**: Real-time 3D preview powered by React Three Fiber.
- -   **Standard Exports**: STEP/STL generation.
- -   **Robust Kernel**: Built on OpenCASCADE (via Replicad).
+
+**kernelCAD** is a **Headless-First CAD Platform** designed for AI Agents.
+
+It provides a robust, scriptable API for agents to generate, analyze, and modify 3D geometry using the OpenCASCADE kernel. A web-based "Visual Debugger" allows human engineers to verify and tweak the agent's output.
+
+## Philosophy
+1.  **Agent-Driven**: The primary interface is the `AgentAPI` (Node.js/TS), not the mouse.
+2.  **Verifiable**: Geometry is produced by deterministic code, not manual clicks.
+3.  **Visual Debugging**: Humans trust what they can see. The Web App acts as a high-fidelity viewer for the headless core.
+
+## Features
+
+-   **Headless Core**: Run CAD operations in Node.js or Web Workers without a DOM.
+-   **Agent API**: JSON-serializable commands, introspection, and feedback loops.
+-   **Visual Debugger**: Real-time 3D preview powered by React Three Fiber.
+-   **Standard Exports**: STEP/STL generation.
+-   **Robust Kernel**: Built on OpenCASCADE (via Replicad).
   
 ## Get Started
 

--- a/docs/superpowers/plans/2026-05-02-v0.1.0-northstar-rebaseline.md
+++ b/docs/superpowers/plans/2026-05-02-v0.1.0-northstar-rebaseline.md
@@ -1,0 +1,984 @@
+# v0.1.0 — NORTHSTAR Re-baseline + First Public Ship — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-baseline the project to NORTHSTAR-honest version `v0.1.0`, publish it to the public npm registry under `kernelcad`, and prove the install path works on a clean machine. After this milestone, an agent reading SKILL.md can run `npm install -g kernelcad` and use the platform — that has never been true before.
+
+**Architecture:** Pure ship-readiness milestone — no kernel changes, no new geometry surface, no new MCP tools. Eight focused tasks executed against a feature branch off `develop`, merged via PR, then a single Task 8 bundles the destructive-on-origin operations (tag wipe + npm publish + fresh tag + GH release).
+
+**Tech Stack:** No additions. Existing TypeScript 5.9 / Replicad 0.20.5 / vitest 4 / esbuild CLI bundle. New external dependency: the public npm registry. Companion: a `node:22-slim` Docker image for the post-publish smoke test (one-shot, not gated in CI).
+
+**Spec:** `docs/superpowers/specs/2026-05-02-v0.1.0-northstar-rebaseline-design.md` (read first if any task feels under-specified).
+
+---
+
+## File structure
+
+Files this plan creates or modifies, with single-responsibility intent:
+
+| Path | Action | Responsibility |
+|------|--------|----------------|
+| `LICENSE` | create | MIT license text + copyright line |
+| `package.json` | modify | flip `private:false`, version → `0.1.0`, add `files` field |
+| `examples/bracket-with-hole.kcad.ts` | create | the v0.1 acceptance demo (matches README quickstart) |
+| `src/skill/SKILL.md` | modify | insert `## Installation` section with npm install line |
+| `README.md` | rewrite the `## Getting Started` block | flat install + first-script flow + brief MCP note |
+| `CHANGELOG.md` | prepend | new `v0.1.0` entry + Positioning section + License line |
+| `scripts/smokeTest.sh` | create | one-shot Docker-based post-publish install verification |
+| `dist/cli/` | regenerate (build artifact, not committed) | the npm tarball payload (CLI bundle + WASM + SKILL.md) |
+
+Files NOT touched by this plan:
+- `docs/superpowers/specs/2026-04-29-kernelcad-NORTHSTAR.md` — locked, walked sequentially after this milestone
+- `doc/ROADMAP.md` — content drift exists but rewriting belongs to the post-v0.1.0 gap-closure brainstorm
+- Any source under `src/` (kernel, capture, compute, backends, intent, mcp, etc.) — no kernel changes in this milestone
+- Any test under `tests/` — no behavior changes; existing drift sentinels validate the SKILL.md edit
+
+---
+
+## Task 0: Create feature branch + open draft PR
+
+**Files:** none (git/GitHub state only)
+
+**Why first:** subsequent tasks make commits that need a target branch; opening the PR draft early lets CI start running qc + Build on every push so failures surface fast.
+
+- [ ] **Step 1: Verify clean tree on `develop`**
+
+```bash
+cd ~/projects/kernelCAD-web
+git status
+git rev-parse --abbrev-ref HEAD
+```
+
+Expected: `nothing to commit, working tree clean` and current branch `develop`.
+
+- [ ] **Step 2: Pull latest develop**
+
+```bash
+git pull --ff-only origin develop
+```
+
+Expected: `Already up to date.` (or fast-forwarded with no surprises).
+
+- [ ] **Step 3: Create feature branch**
+
+```bash
+git checkout -b feat/v0.1.0-northstar-rebaseline
+```
+
+Expected: `Switched to a new branch 'feat/v0.1.0-northstar-rebaseline'`.
+
+- [ ] **Step 4: Push branch + open draft PR**
+
+```bash
+git push -u origin feat/v0.1.0-northstar-rebaseline
+gh pr create --draft --title "feat(v0.1.0): NORTHSTAR re-baseline + first public ship" --body "$(cat <<'EOF'
+## Summary
+- Re-version `v0.13.0-rc.17` → `v0.1.0` (NORTHSTAR-strict honest baseline)
+- Publish `kernelcad@0.1.0` to public npm registry
+- Add MIT LICENSE
+- Add `examples/bracket-with-hole.kcad.ts` acceptance demo
+- SKILL.md gets `## Installation` section with `npm install -g kernelcad`
+- README quickstart rewrite (flat install + first-script flow)
+- CHANGELOG re-baseline entry + Positioning section
+- Smoke test script (`scripts/smokeTest.sh`) for post-publish install verification
+- Delete all 34 cruft tags from local + origin (Task 8, gated)
+- Close stale PR #19
+
+Spec: `docs/superpowers/specs/2026-05-02-v0.1.0-northstar-rebaseline-design.md`
+
+## Test plan
+- [ ] `npm run qc` passes locally
+- [ ] `npm pack --dry-run` produces a tarball <10 MB
+- [ ] `npm run dev:cli evaluate examples/bracket-with-hole.kcad.ts` returns ok
+- [ ] SKILL.md drift sentinels still pass after Installation section insert
+- [ ] (Post-merge, Task 8) Smoke test on clean `node:22-slim` container passes
+- [ ] (Post-merge, Task 8) `kernelcad@0.1.0` resolves on `npm view`
+EOF
+)"
+```
+
+Expected: PR URL printed. CI should start running `qc` + `Build` workflows on the branch within ~30s.
+
+- [ ] **Step 5: Note PR number for later**
+
+Capture the PR number from the previous step's output (e.g., `#52`). Used in Task 8 for the squash-merge.
+
+---
+
+## Task 1: Pre-publish hygiene (LICENSE + `files` manifest)
+
+**Files:**
+- Create: `LICENSE`
+- Modify: `package.json` (add `files` array; do NOT change `private` or `version` yet — Task 6 does that)
+
+- [ ] **Step 1: Create LICENSE file with MIT text**
+
+```bash
+cat > LICENSE << 'EOF'
+MIT License
+
+Copyright (c) 2026 Andrii Shylenko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+EOF
+```
+
+- [ ] **Step 2: Verify LICENSE content**
+
+```bash
+head -3 LICENSE
+```
+
+Expected first three lines:
+```
+MIT License
+
+Copyright (c) 2026 Andrii Shylenko
+```
+
+- [ ] **Step 3: Add `files` field to `package.json`**
+
+Use Edit tool (not bash) to insert the `files` array immediately after the `bin` block in `package.json`. The `files` field controls what `npm publish` includes in the tarball — by default npm includes everything not in `.gitignore`, which would balloon the package with `dist/` (web app), `tests/`, `playwright-report/`, etc.
+
+Edit `package.json`: insert after the closing `}` of the `bin` block:
+
+```json
+  "files": [
+    "dist/cli",
+    "README.md",
+    "LICENSE"
+  ],
+```
+
+The result should look like:
+
+```json
+  "bin": {
+    "kernelcad": "./dist/cli/index.js"
+  },
+  "files": [
+    "dist/cli",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+```
+
+- [ ] **Step 4: Build the CLI bundle so `dist/cli/` exists**
+
+```bash
+npm run build:cli
+```
+
+Expected: `dist/cli/index.js built` printed. Verify the directory:
+
+```bash
+ls -la dist/cli/
+```
+
+Expected three files: `index.js`, `replicad_single.wasm`, `SKILL.md`.
+
+- [ ] **Step 5: Run `npm pack --dry-run` to verify tarball contents**
+
+```bash
+npm pack --dry-run 2>&1 | head -50
+```
+
+Expected output should list `dist/cli/index.js`, `dist/cli/replicad_single.wasm`, `dist/cli/SKILL.md`, `LICENSE`, `README.md`, `package.json`. Should NOT include `src/`, `tests/`, `node_modules/`, `dist/assets/` (web app), `playwright-report/`, `archive/`, `docs/`.
+
+- [ ] **Step 6: Verify tarball size <10 MB**
+
+```bash
+npm pack --dry-run 2>&1 | grep -E "package size|unpacked size"
+```
+
+Expected: `package size` <10 MB. The WASM blob (~5 MB) is the dominant payload.
+
+If the tarball is >10 MB, investigate which file is too large (likely missing exclusions). Add to `.npmignore` or refine `files` array.
+
+- [ ] **Step 7: Verify pack does not actually publish**
+
+`npm pack --dry-run` does not write or upload anything. Confirm no `kernelcad-*.tgz` was created in the cwd:
+
+```bash
+ls *.tgz 2>/dev/null && echo "FAIL — tarball was created" || echo "OK — no tarball written"
+```
+
+Expected: `OK — no tarball written`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add LICENSE package.json
+git commit -m "chore(release): add MIT LICENSE and npm files manifest
+
+- LICENSE: MIT, copyright Andrii Shylenko
+- package.json: add files=[dist/cli, README.md, LICENSE] to scope npm publish payload
+- Verified tarball <10 MB via npm pack --dry-run
+
+Part of v0.1.0 NORTHSTAR re-baseline (spec: docs/superpowers/specs/2026-05-02-v0.1.0-northstar-rebaseline-design.md)."
+```
+
+Expected: commit succeeds; pre-commit hooks pass.
+
+---
+
+## Task 2: Acceptance demo script
+
+**Files:**
+- Create: `examples/bracket-with-hole.kcad.ts`
+
+The script body is the same as the README quickstart (Task 4) and the smoke test (Task 7) — they all run this file. NORTHSTAR has been asking for "the exact `.kcad.ts` script v0.1 must successfully run end-to-end" since 2026-04-29; this is that script.
+
+- [ ] **Step 1: Verify `examples/` directory exists**
+
+```bash
+ls examples/ 2>/dev/null && echo "exists" || mkdir examples
+```
+
+If `mkdir` is needed, expected: silent success, directory now exists.
+
+- [ ] **Step 2: Create the demo script**
+
+```bash
+cat > examples/bracket-with-hole.kcad.ts << 'EOF'
+const w = param('Width', 60, { unit: 'mm', min: 30, max: 200 });
+const h = param('Height', 40, { unit: 'mm', min: 20, max: 120 });
+const t = param('Thickness', 5, { unit: 'mm', min: 2, max: 15 });
+
+const base = box(w, h, t);
+const hole = cylinder(t + 2, 4).translate(w / 2, h / 2, -1);
+return base.subtract(hole).fillet(1);
+EOF
+```
+
+- [ ] **Step 3: Verify the script evaluates ok via the dev CLI**
+
+```bash
+node --import tsx scripts/test-headless.ts examples/bracket-with-hole.kcad.ts 2>&1 | tail -20
+```
+
+If `scripts/test-headless.ts` doesn't accept arguments that way, fall back to invoking the built CLI directly:
+
+```bash
+node dist/cli/index.js evaluate examples/bracket-with-hole.kcad.ts --json 2>&1 | tail -20
+```
+
+Expected: JSON output with `"status": "ok"` (or human-readable equivalent ending in success). If it errors, the bug is in the script — fix and re-run.
+
+- [ ] **Step 4: Verify STL export works**
+
+```bash
+node dist/cli/index.js export stl examples/bracket-with-hole.kcad.ts -o /tmp/bracket.stl
+test -s /tmp/bracket.stl && echo "OK: STL written ($(wc -c < /tmp/bracket.stl) bytes)" || echo "FAIL"
+```
+
+Expected: `OK: STL written (XXXX bytes)` with byte count >0. The STL should be binary (header `kernelcad 0.13.0-rc.17 ...` per rc.17 forensic stamping — version string updates automatically when Task 6 changes `package.json`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/bracket-with-hole.kcad.ts
+git commit -m "feat(examples): add v0.1 acceptance demo (bracket with hole + fillet)
+
+The exact .kcad.ts script v0.1 must successfully run end-to-end —
+NORTHSTAR open question #1 (open since 2026-04-29). Used by:
+
+- README quickstart (Task 4 of v0.1.0 plan)
+- scripts/smokeTest.sh (Task 7 of v0.1.0 plan, post-publish verification)
+- GitHub Release artifact (Task 8 of v0.1.0 plan)
+
+Exercises: param() with 3 axes (Width/Height/Thickness), box primitive,
+cylinder primitive, .translate(), .subtract(), .fillet()."
+```
+
+---
+
+## Task 3: SKILL.md installation section
+
+**Files:**
+- Modify: `src/skill/SKILL.md` (insert `## Installation` section between `# kernelCAD` intro and `## Coordinate System`)
+
+- [ ] **Step 1: Read the current SKILL.md head to confirm insertion point**
+
+```bash
+head -20 src/skill/SKILL.md
+```
+
+Expected: should show frontmatter, `# kernelCAD` heading, the intro paragraph, then `## Coordinate System`.
+
+- [ ] **Step 2: Insert `## Installation` section**
+
+Use the Edit tool (not bash) to insert the new section. The `old_string` is the line `## Coordinate System` (assuming it's unique — verify with `grep -c "^## Coordinate System$" src/skill/SKILL.md`, expected output `1`). The `new_string` is:
+
+```markdown
+## Installation
+
+```bash
+npm install -g kernelcad
+kernelcad evaluate path/to/script.kcad.ts
+```
+
+Verify the install with `kernelcad --version` (should print `0.1.0` or higher).
+
+## Coordinate System
+```
+
+- [ ] **Step 3: Verify the insertion**
+
+```bash
+sed -n '11,25p' src/skill/SKILL.md
+```
+
+Expected: should show the new `## Installation` heading, the bash code block, the verify line, then `## Coordinate System` immediately after.
+
+- [ ] **Step 4: Verify SKILL.md drift sentinels still pass**
+
+```bash
+NODE_OPTIONS='--max-old-space-size=8192' npx vitest run tests/unit/skill 2>&1 | tail -20
+```
+
+Expected: all 6 drift sentinel tests pass (`skillDiagnosticCodesDrift`, `skillGlobalsDrift`, `skillPathBuilderMethodsDrift`, `skillShapeMethodsDrift`, `skillSketchMethodsDrift`, `skillToolCountDrift`). They assert presence of names, not section ordering — adding a section does not affect them.
+
+If any sentinel fails, the failure message will be specific (e.g., "expected SKILL.md to mention X"); investigate and fix.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/skill/SKILL.md
+git commit -m "docs(skill): add npm install path to SKILL.md
+
+New '## Installation' section between intro and Coordinate System.
+Replaces the implicit clone-the-repo install path with a one-line
+'npm install -g kernelcad'. Drift sentinels still pass (they assert
+name presence, not section ordering).
+
+Part of v0.1.0 NORTHSTAR re-baseline."
+```
+
+---
+
+## Task 4: README quickstart rewrite
+
+**Files:**
+- Modify: `README.md` (replace the `## Getting Started` section block with a flat install-then-first-script flow; move web-app dev instructions under `## Contributing`)
+
+- [ ] **Step 1: Read the current README to find the exact `## Getting Started` block boundaries**
+
+```bash
+grep -n "^## " README.md
+```
+
+Expected: shows all `##` section headings and their line numbers. Identify the start line of `## Getting Started` and the start line of the next `##` heading after it. The block to replace is everything from `## Getting Started` (inclusive) up to but not including the next `##` heading.
+
+- [ ] **Step 2: Replace `## Getting Started` block with the new quickstart**
+
+Use the Edit tool. The `old_string` should be the entire `## Getting Started` block as it currently exists (verify with `head -<line> README.md` against the line numbers from Step 1). Replace it with:
+
+````markdown
+## Get Started
+
+```bash
+npm install -g kernelcad
+```
+
+Drop this in `bracket.kcad.ts`:
+
+```typescript
+const w = param('Width', 60, { unit: 'mm' });
+const h = param('Height', 40, { unit: 'mm' });
+const t = param('Thickness', 5, { unit: 'mm' });
+
+const base = box(w, h, t);
+const hole = cylinder(t + 2, 4).translate(w / 2, h / 2, -1);
+return base.subtract(hole).fillet(1);
+```
+
+Run it:
+
+```bash
+kernelcad evaluate bracket.kcad.ts
+kernelcad export stl bracket.kcad.ts -o bracket.stl
+```
+
+That's it. For agents: `kernelcad mcp` runs an MCP server with 13 introspection tools. See `SKILL.md` (bundled with the install) for the full API surface and authoring guide.
+
+## Contributing
+
+Web app + dev workflow (clone the repo, `npm install`, `npm run dev`) for contributors who want to hack on the kernel or the visual debugger:
+
+```bash
+git clone https://github.com/w1ne/kernelCAD-web.git
+cd kernelCAD-web
+npm install
+npm run dev          # web visual debugger at localhost:5173
+npm run build:cli    # build the CLI bundle into dist/cli/
+npm run test         # full vitest suite
+npm run qc           # quick quality gate (lint + typecheck + tests)
+```
+````
+
+- [ ] **Step 3: Verify the README rendering looks reasonable**
+
+```bash
+head -60 README.md
+```
+
+Expected: should now show the flat `## Get Started` block at the top of the user-facing section, with the `## Contributing` block immediately after it. The pre-existing intro/Philosophy/Features sections at the top of the README stay unchanged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): flat install + first-script quickstart for v0.1.0
+
+Replace the multi-step 'Prerequisites / Installation / Clone' wall
+with a one-line install + drop-this-in-a-file demo + run commands.
+Web-app dev workflow moves to '## Contributing'.
+
+Part of v0.1.0 NORTHSTAR re-baseline."
+```
+
+---
+
+## Task 5: CHANGELOG re-baseline entry
+
+**Files:**
+- Modify: `CHANGELOG.md` (prepend new `v0.1.0` entry above the existing `v0.13.0-rc.17` entry; do NOT delete the rc.1-rc.17 history below)
+
+- [ ] **Step 1: Read current CHANGELOG.md head to confirm insertion point**
+
+```bash
+head -3 CHANGELOG.md
+```
+
+Expected: should show the existing top entry, which is `## v0.13.0-rc.17 — quality pass v5 (2026-05-01)` (or similar). The new entry inserts ABOVE this line.
+
+- [ ] **Step 2: Insert the v0.1.0 entry**
+
+Use the Edit tool. The `old_string` is the line `## v0.13.0-rc.17 — quality pass v5 (2026-05-01)` (verify it's unique — if not, include enough surrounding lines to disambiguate). The `new_string` is the new entry followed by the original line:
+
+```markdown
+## v0.1.0 — first public release + NORTHSTAR re-baseline (2026-05-02)
+
+The first kernelCAD release published to the npm registry. Install with `npm install -g kernelcad`.
+
+### Re-baseline note
+
+Prior to this release, the repo carried 34 internal tags (`v0.0.1` through `v0.13.0-rc.17`) reflecting iterative development. None were ever published. All have been deleted; this release starts a clean, NORTHSTAR-aligned numbering line where each `v0.N.0` corresponds to one NORTHSTAR module fully delivered.
+
+`v0.1.0` ships NORTHSTAR's v0.1 module ("Foundation"): feature graph, recompute engine, OCCT backend via Replicad, primitives (box/cylinder/sphere), CLI (`evaluate`, `export stl`, `export step`), JSON diagnostics, canonical face refs.
+
+### Bonus surface (NORTHSTAR modules partly delivered out-of-order)
+
+Beyond the v0.1 contract, this release also includes:
+
+- **v0.2 partial** — `.fillet()`, `.chamfer()`, `.shell()`, `path()` builder with `lineTo`/`tangentArc`/`threePointsArc`/`sagittaArc`/`bulgeArc`/`radiusArc`, `.label()`. Tracked face/edge refs across transforms/booleans **deferred to v0.2.0**.
+- **v0.3 partial** — `.shell()` ships. `hole`/`cut`/`draft` as first-class features and `created` face refs **deferred to v0.3.0**.
+- **v0.7** — `.sweep()` and `.loft()` (curves + surfacing).
+- **v0.11** — MCP server with 13 introspection tools (`why_did_this_fail`, `list_topology`, `get_shape_info`, `list_edges`, `list_faces`, `list_face_labels`, `list_features`, `list_api`, `evaluate_script`, `get_edges_of`, `set_param_value`, `add_feature`, `remove_feature`).
+- **v0.12 partial** — MCP AST-edit tools (`add_feature`, `remove_feature`, `set_param_value`). Skill installer and one-file context bundler **deferred to v0.12.0**.
+
+### Symmetry features (not on the NORTHSTAR module roadmap, additive)
+
+- `.mirror(plane)` / `.reflect(plane)` for symmetric parts.
+- Binary STL export (`kernelcad export stl ...` and `export_stl` MCP tool).
+- Variable-radius fillet/chamfer.
+- Edge/face query selectors (`selectEdges`, `selectEdge`, `EdgeQuery`, `FaceQuery`).
+
+### Diagnostic surface
+
+53 documented diagnostic codes across feature/recompute/cli/export categories, each with a HINTS entry, structurally enforced by a CI sentinel.
+
+### Positioning
+
+kernelCAD is the open, MCP-native, AST-edit-primacy CAD kernel for iterative agent workflows. Source is on GitHub. Diagnostics are structured and hint-rich. The MCP server lets an agent introspect a live model across many queries in one session instead of re-running the script per question.
+
+### License
+
+MIT License.
+
+---
+
+## v0.13.0-rc.17 — quality pass v5 (2026-05-01)
+```
+
+- [ ] **Step 3: Verify the insertion**
+
+```bash
+head -45 CHANGELOG.md
+```
+
+Expected: shows the new `## v0.1.0` heading at line 1, the full new entry, then `## v0.13.0-rc.17 — quality pass v5 (2026-05-01)` immediately after the `---` separator. The rc.17 entry and everything below stays untouched.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): v0.1.0 re-baseline entry
+
+First entry above the rc.17 history. Documents:
+- The version reset rationale (NORTHSTAR-strict, every v0.N.0 = one NORTHSTAR module)
+- What ships in v0.1.0 (Foundation contract + bonus surface from later modules)
+- Diagnostic surface (53 codes, HINTS-enforced)
+- Strategic positioning (open, MCP-native, AST-edit-primacy, diagnostic-rigorous)
+- License (MIT)
+
+The rc.1-rc.17 history below stays as development record."
+```
+
+---
+
+## Task 6: Version flip + private:false
+
+**Files:**
+- Modify: `package.json` (`"private": true` → `false`; `"version": "0.13.0-rc.17"` → `"0.1.0"`)
+
+- [ ] **Step 1: Edit `package.json` — flip `private`**
+
+Use Edit tool. `old_string`: `  "private": true,` → `new_string`: `  "private": false,`.
+
+- [ ] **Step 2: Edit `package.json` — set version**
+
+Use Edit tool. `old_string`: `  "version": "0.13.0-rc.17",` → `new_string`: `  "version": "0.1.0",`.
+
+- [ ] **Step 3: Verify the changes**
+
+```bash
+head -5 package.json
+```
+
+Expected:
+```json
+{
+  "name": "kernelcad",
+  "private": false,
+  "version": "0.1.0",
+  "type": "module",
+```
+
+- [ ] **Step 4: Run `npm run qc:full`**
+
+```bash
+npm run qc:full 2>&1 | tail -40
+```
+
+Expected: lint + typecheck + tests pass. Playwright env failure is acceptable per established precedent — if it fires, note it in the commit message but do not block.
+
+If a real failure surfaces (lint error, typecheck error, vitest failure unrelated to Playwright), investigate and fix before committing.
+
+- [ ] **Step 5: Verify the bundled SKILL.md picks up the version line**
+
+The `build:cli` script copies `src/skill/SKILL.md` into `dist/cli/SKILL.md`. The `--version` line in SKILL.md (Task 3) says "should print `0.1.0` or higher" — this matches the new package.json version. No additional action needed; just verify:
+
+```bash
+grep "0.1.0" src/skill/SKILL.md && echo "OK"
+```
+
+Expected: matches the line `Verify the install with \`kernelcad --version\` (should print \`0.1.0\` or higher).`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json
+git commit -m "release(v0.1.0): private:false + version 0.1.0
+
+NORTHSTAR-strict re-baseline. Every v0.N.0 from this point corresponds
+to one NORTHSTAR module fully delivered. The 17-rc cycle ends here.
+
+private:false unblocks 'npm publish' for Task 8.
+
+qc:full status: pass (Playwright env failure acceptable per established precedent).
+
+Part of v0.1.0 NORTHSTAR re-baseline."
+```
+
+---
+
+## Task 7: Smoke test script
+
+**Files:**
+- Create: `scripts/smokeTest.sh`
+
+The script is invoked manually post-publish in Task 8. It does not run as part of CI.
+
+- [ ] **Step 1: Create the smoke test script**
+
+```bash
+cat > scripts/smokeTest.sh << 'EOF'
+#!/usr/bin/env bash
+# Post-publish install verification.
+# Runs in a clean node:22-slim container, installs kernelcad@latest from the
+# public npm registry, evaluates the v0.1 acceptance demo, and exports STL.
+# Pass criteria:
+#   - npm install exits 0
+#   - kernelcad evaluate exits 0 with status: ok
+#   - kernelcad export stl produces a non-empty file with a valid binary STL header
+#
+# Usage:
+#   bash scripts/smokeTest.sh
+#
+# Requires: docker installed and runnable by the current user.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+EXAMPLES_DIR="$REPO_DIR/examples"
+
+if [ ! -f "$EXAMPLES_DIR/bracket-with-hole.kcad.ts" ]; then
+  echo "FAIL: examples/bracket-with-hole.kcad.ts missing — run from repo root." >&2
+  exit 1
+fi
+
+echo "==> Pulling node:22-slim if needed..."
+docker pull node:22-slim
+
+echo "==> Running smoke test in clean container..."
+docker run --rm -v "$EXAMPLES_DIR:/work:ro" node:22-slim bash -c '
+  set -euo pipefail
+  apt-get update -qq && apt-get install -y -qq jq file > /dev/null
+  echo "  - npm install -g kernelcad"
+  npm install -g kernelcad@latest 2>&1 | tail -5
+  echo "  - kernelcad --version"
+  kernelcad --version
+  echo "  - kernelcad evaluate (json)"
+  kernelcad evaluate /work/bracket-with-hole.kcad.ts --json > /tmp/out.json
+  status=$(jq -r .status /tmp/out.json)
+  if [ "$status" != "ok" ]; then
+    echo "FAIL: evaluate returned status=$status (expected ok)" >&2
+    cat /tmp/out.json >&2
+    exit 1
+  fi
+  echo "  - kernelcad export stl"
+  kernelcad export stl /work/bracket-with-hole.kcad.ts -o /tmp/out.stl
+  if [ ! -s /tmp/out.stl ]; then
+    echo "FAIL: STL is empty" >&2
+    exit 1
+  fi
+  bytes=$(wc -c < /tmp/out.stl)
+  echo "  - STL written: $bytes bytes"
+  # Verify binary STL header starts with "kernelcad" forensic stamp
+  header=$(head -c 80 /tmp/out.stl | tr -d "\\0" || true)
+  case "$header" in
+    kernelcad*) echo "  - Header OK: $header" ;;
+    *) echo "WARN: STL header does not start with kernelcad ($header) — may be ASCII fallback" >&2 ;;
+  esac
+  echo "==> Smoke test PASSED"
+'
+EOF
+```
+
+- [ ] **Step 2: Make the script executable**
+
+```bash
+chmod +x scripts/smokeTest.sh
+```
+
+- [ ] **Step 3: Verify file mode and shebang**
+
+```bash
+ls -l scripts/smokeTest.sh && head -1 scripts/smokeTest.sh
+```
+
+Expected: `-rwxrwxr-x ... scripts/smokeTest.sh` and shebang `#!/usr/bin/env bash`.
+
+- [ ] **Step 4: Do NOT run the script yet**
+
+The script will fail at this point because `kernelcad@latest` does not exist on npm yet — Task 8 publishes it. Running now would correctly fail and waste a Docker pull. Skip the dry run; Task 8 includes the real run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/smokeTest.sh
+git commit -m "chore(release): smoke test for npm install path
+
+scripts/smokeTest.sh runs a clean node:22-slim container, installs
+kernelcad@latest from npm, evaluates examples/bracket-with-hole.kcad.ts,
+exports STL, and verifies the binary header forensic stamp.
+
+Invoked manually post-publish in Task 8. Not gated in CI for v0.1.0
+(CI sandbox + Docker-in-CI is out of scope per spec)."
+```
+
+---
+
+## Task 8: Tag cleanup, npm publish, smoke verify, GH release, close PR #19
+
+**Files:** none (git/npm/GitHub state only — destructive on origin)
+
+This is the integration / cutover task. It is **destructive on origin** (deletes 34 tags) and **publishes to a public registry** (immutable). Each substep has explicit pass criteria; any failure halts the task for diagnosis.
+
+- [ ] **Step 1: Pre-flight — confirm CI is green on the PR**
+
+```bash
+gh pr view --json statusCheckRollup,number,headRefName 2>&1 | jq '.statusCheckRollup[] | {name, conclusion, status}'
+```
+
+Expected: every check in the rollup has `conclusion: "SUCCESS"` (or `"NEUTRAL"`). If any check is `"FAILURE"` or still `IN_PROGRESS`, halt and resolve before proceeding.
+
+- [ ] **Step 2: Squash-merge the PR**
+
+```bash
+gh pr merge --squash --auto --delete-branch
+```
+
+Expected: PR state becomes `MERGED`, source branch `feat/v0.1.0-northstar-rebaseline` deleted from origin. Local branch may still exist — that's fine.
+
+- [ ] **Step 3: Switch back to develop and pull the merge**
+
+```bash
+git checkout develop
+git pull --ff-only origin develop
+```
+
+Expected: local develop now contains the squashed merge commit.
+
+- [ ] **Step 4: CONFIRMATION GATE — pause for human re-confirmation before destructive ops**
+
+Before deleting 34 tags from origin, the executor (controller / human) must explicitly re-confirm. The spec was approved with tag deletion on 2026-05-02; this gate is defense-in-depth.
+
+Print:
+```
+TAG DELETION GATE.
+About to delete 34 tags from local AND origin:
+$(git tag -l | sort -V)
+
+Origin will permanently lose these refs. Spec was approved with this
+deletion (2026-05-02). External blast radius: zero (no GH Releases,
+no npm publishes against these tags).
+
+Type 'DELETE' to proceed, anything else to halt.
+```
+
+If running automated, the executor must capture explicit "DELETE" confirmation from the human controller. Do not auto-proceed.
+
+- [ ] **Step 5: Delete all tags from local**
+
+```bash
+git tag -l | xargs git tag -d
+```
+
+Expected: 34 lines of `Deleted tag 'vX.Y.Z' (was <sha>)`.
+
+- [ ] **Step 6: Delete all tags from origin (batched)**
+
+The `git push --delete` syntax accepts multiple refs in one push, much faster than per-tag. Batch in groups of 10 to stay under SSH command-length limits:
+
+```bash
+# Get the original tag list from a fresh fetch (since local was just wiped).
+git fetch origin --tags
+ORIGIN_TAGS=$(git ls-remote --tags origin | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}' | sort -V)
+echo "$ORIGIN_TAGS" | wc -l   # Should print 34 (or whatever the current origin has)
+
+echo "$ORIGIN_TAGS" | xargs -n 10 git push origin --delete
+```
+
+Expected: each batch prints `- [deleted]         vX.Y.Z` lines. Total: 34 deleted.
+
+If a batch fails (e.g., GH branch-protection blocks tag deletion), halt and diagnose. Per spec R2, tags have no attached Releases so deletion should be unblocked.
+
+- [ ] **Step 7: Verify origin is clean**
+
+```bash
+git ls-remote --tags origin | wc -l
+```
+
+Expected: `0`.
+
+- [ ] **Step 8: Re-confirm local has no tags**
+
+```bash
+git tag | wc -l
+```
+
+Expected: `0`.
+
+- [ ] **Step 9: Build the CLI bundle on the merged commit**
+
+```bash
+npm run build:cli
+ls -la dist/cli/
+```
+
+Expected: `dist/cli/index.js`, `dist/cli/replicad_single.wasm`, `dist/cli/SKILL.md` all present.
+
+- [ ] **Step 10: Final pre-publish dry run**
+
+```bash
+npm pack --dry-run 2>&1 | tail -20
+```
+
+Expected: tarball contents include the four `dist/cli/*` files plus `LICENSE`, `README.md`, `package.json`. Tarball size <10 MB.
+
+- [ ] **Step 11: Verify npm credentials**
+
+```bash
+npm whoami
+```
+
+Expected: prints the publishing npm username. If "you must be logged in", run `npm login` first.
+
+If publishing under a personal scope (per spec R1 fallback for name conflicts), update `package.json` `name` field to `@<user>/kernelcad` first, then re-commit, re-merge a hotfix PR. For this milestone, the spec assumes the unscoped name `kernelcad` is available (verified earlier — registry returned 404).
+
+- [ ] **Step 12: Publish to npm**
+
+```bash
+npm publish 2>&1 | tail -20
+```
+
+Expected: `+ kernelcad@0.1.0`. The package is now public and immutable at this version.
+
+If publish fails with 403 (name reserved), halt — the spec R1 mitigation (scope under `@<user>/kernelcad`) requires reverting + re-PR'ing a name change, which is out of scope for in-task auto-recovery.
+
+- [ ] **Step 13: Verify the registry sees the new version**
+
+```bash
+sleep 10  # registry CDN propagation lag
+npm view kernelcad@0.1.0 version
+```
+
+Expected: prints `0.1.0`. (Note: if this is the first-ever publish, the package itself is also new — `npm view kernelcad name` should now succeed.)
+
+- [ ] **Step 14: Run the smoke test**
+
+```bash
+bash scripts/smokeTest.sh 2>&1 | tee /tmp/smoke.log
+```
+
+Expected: ends with `==> Smoke test PASSED`. If it fails, the bundle is broken on a clean container — investigate, fix, and patch-bump to `v0.1.1`. Do NOT proceed to tagging until smoke passes.
+
+- [ ] **Step 15: Tag fresh `v0.1.0`**
+
+```bash
+git tag v0.1.0 -m "First public release. Install: npm install -g kernelcad"
+git push origin v0.1.0
+```
+
+Expected: tag pushed; `git ls-remote --tags origin | wc -l` now prints `1`.
+
+- [ ] **Step 16: Cut GitHub Release**
+
+```bash
+gh release create v0.1.0 \
+  --title "v0.1.0 — First Public Release" \
+  --notes "kernelCAD's first release on the public npm registry.
+
+\`\`\`bash
+npm install -g kernelcad
+kernelcad evaluate examples/bracket-with-hole.kcad.ts
+\`\`\`
+
+See [CHANGELOG.md](./CHANGELOG.md) for full details, including the NORTHSTAR re-baseline rationale and the surface shipped in v0.1.0.
+
+License: MIT." \
+  examples/bracket-with-hole.kcad.ts
+```
+
+Expected: Release URL printed. The acceptance demo `.kcad.ts` is attached as a downloadable artifact.
+
+- [ ] **Step 17: Close stale PR #19**
+
+```bash
+gh pr close 19 --comment "Closing — predates the rc.6 query-first topology refactor and the rc.13 mirror/reflect surface; the underlying alignment behavior is now handled differently. Reopen if the original symptom recurs. Branch ref preserved (not deleted)."
+```
+
+Expected: PR #19 state becomes `CLOSED`. The branch `fix/extrude-visibility-alignment` remains on origin per the spec note.
+
+- [ ] **Step 18: End-to-end live verify on a fresh shell session**
+
+Open a NEW terminal (not the one this task is running in — guarantees no cached env). Run:
+
+```bash
+npm install -g kernelcad@0.1.0
+kernelcad --version
+kernelcad evaluate ~/projects/kernelCAD-web/examples/bracket-with-hole.kcad.ts --json | jq .status
+kernelcad export stl ~/projects/kernelCAD-web/examples/bracket-with-hole.kcad.ts -o /tmp/v010.stl
+file /tmp/v010.stl
+ls -la /tmp/v010.stl
+```
+
+Expected:
+- `npm install` exits 0
+- `kernelcad --version` prints `0.1.0`
+- `jq .status` prints `"ok"`
+- `file /tmp/v010.stl` reports a binary file (NOT ASCII text) — for a true binary STL, file may report "data" or similar; the byte-0 check matters more than file's heuristic
+- `ls -la /tmp/v010.stl` shows a non-zero size
+
+Per `feedback_actually_use_what_you_ship`, also open the resulting STL in a viewer (e.g., `xdg-open /tmp/v010.stl` to launch the system's default 3D viewer, or copy to a host with a slicer). Visually confirm it looks like a bracket with a hole. Do not declare done until the visual check passes.
+
+- [ ] **Step 19: Final commit (post-task housekeeping)**
+
+The plan execution itself produced no commits in Task 8 (it's pure side-effect on origin/npm/GitHub). If the executor wants to mark milestone completion, that happens in the project's own log / memory entry — not as a commit.
+
+If anything from steps 1-18 wrote files locally that should be committed (e.g., a CHANGELOG note about the smoke result), that's a follow-up commit on develop, not part of this task.
+
+- [ ] **Step 20: Declare milestone complete**
+
+Verification checklist (all must be true):
+- [ ] `npm view kernelcad@0.1.0 version` prints `0.1.0`
+- [ ] `git ls-remote --tags origin` lists exactly `refs/tags/v0.1.0`
+- [ ] GitHub Release `v0.1.0` exists and is public
+- [ ] PR #19 is closed
+- [ ] Smoke test on a fresh shell verified install + evaluate + export
+- [ ] Visual STL inspection confirmed reasonable geometry
+
+Update memory entry (per `feedback_actually_use_what_you_ship`): note in conversational log that v0.1.0 ships, the install path is verified, and the next milestone (per NORTHSTAR sequence) is **v0.2.0 — tracked face/edge refs across transforms/booleans**, which closes the SKILL.md "Critical Constraint" section.
+
+---
+
+## Risks (per spec)
+
+- **R1 — npm name reserved.** Mitigation: pre-verified registry returns 404. If publish 403s in Task 8 Step 12, halt and re-spec name to `@<user>/kernelcad`; this requires a follow-up PR cycle, not an in-task recovery.
+- **R2 — tag deletion blocked.** Mitigation: per-tag deletion in Task 8 Step 6 will surface any blocked tags; halt and diagnose.
+- **R3 — bundle broken on clean container.** Mitigation: Task 8 Step 14 smoke test catches this. If it fails, do NOT publish a fix as `v0.1.0` (immutable on npm); patch-bump to `v0.1.1` after the fix lands on develop.
+- **R4 — old tag rediscovered via cache.** Mitigation: CHANGELOG re-baseline note (Task 5) is the canonical explanation; point any confused user to it.
+
+---
+
+## Self-review (post-write)
+
+**Spec coverage check:**
+- S1 (private:false + version 0.1.0) → Task 6 ✓
+- S2 (npm publish + smoke verify) → Task 8 Steps 12-14 ✓
+- S3 (SKILL.md install section) → Task 3 ✓
+- S4 (README quickstart rewrite) → Task 4 ✓
+- S5 (CHANGELOG re-baseline entry) → Task 5 ✓
+- S6 (tag cleanup local + origin) → Task 8 Steps 4-8 ✓
+- S7 (GitHub Release) → Task 8 Step 16 ✓
+- S8 (close PR #19) → Task 8 Step 17 ✓
+- S9 (strategic positioning anchor) → Tasks 5 (CHANGELOG Positioning section) + 4 (README "for agents" line) ✓
+
+A1 (v0.1.0 baseline) → Task 6 ✓
+A2 (full tag reset) → Task 8 Steps 4-8 ✓
+A3 (MIT LICENSE) → Task 1 ✓
+A4 (Docker smoke test) → Task 7 + Task 8 Step 14 ✓
+A5 (SKILL.md ## Installation section) → Task 3 ✓
+A6 (CHANGELOG entry text) → Task 5 ✓
+A7 (README quickstart text) → Task 4 ✓
+A8 (PR #19 close + comment) → Task 8 Step 17 ✓
+A9 (4-anchor positioning) → Tasks 4, 5 (CHANGELOG Positioning section) ✓
+
+**Type/identifier consistency:**
+- `examples/bracket-with-hole.kcad.ts` — referenced consistently in Tasks 2, 4 (README), 7 (smoke test), 8 (release artifact + verify) ✓
+- `kernelcad@0.1.0` — version string consistent across Tasks 5 (CHANGELOG), 6 (package.json), 8 (publish + tag + verify) ✓
+- `feat/v0.1.0-northstar-rebaseline` — branch name consistent in Task 0 + Task 8 Step 2 ✓
+- `scripts/smokeTest.sh` — path consistent across Task 7 + Task 8 Step 14 ✓
+
+**Placeholder scan:** No "TODO / TBD / fill in / similar to Task N / appropriate error handling" patterns found.

--- a/docs/superpowers/specs/2026-05-02-v0.1.0-northstar-rebaseline-design.md
+++ b/docs/superpowers/specs/2026-05-02-v0.1.0-northstar-rebaseline-design.md
@@ -36,11 +36,12 @@ The version-number reset is the deliberate honest move: ship as **v0.1.0** becau
 | S1 | Version + private flag flip | `package.json`: `"private": false`, `"version": "0.1.0"` |
 | S2 | npm publish + smoke verify | Publish `kernelcad@0.1.0` to public registry; verify install path on clean container |
 | S3 | SKILL.md install section | Replace clone-the-repo path with `npm install -g kernelcad` at top of file |
-| S4 | README quickstart rewrite | Trim to install + first-script flow, mirror ForgeCAD's flat structure |
+| S4 | README quickstart rewrite | Trim to install + first-script flow; flat structure (install → first script → run → export) |
 | S5 | CHANGELOG re-baseline entry | Single `v0.1.0` entry summarizing the shipped surface and the version reset |
 | S6 | Tag cleanup | Delete all 34 existing tags from local + origin; tag fresh `v0.1.0` |
 | S7 | GitHub Release | Cut a public Release for `v0.1.0` with at least one demo `.kcad.ts` artifact |
 | S8 | Stale PR #19 disposition | Close PR #19 (3 months stale, predates the rc.13+ topology refactor) |
+| S9 | Strategic positioning anchor | Document the four anchor properties (open, MCP-native, AST-edit-primacy, diagnostic-rigorous) for use by future milestones in priority decisions |
 
 **Out of scope:**
 
@@ -84,7 +85,7 @@ Pre-publish steps:
 3. Run `npm pack --dry-run` to verify the resulting tarball is reasonable (target: <10 MB; the WASM blob is the dominant payload at ~5 MB).
 4. Run `npm publish` (no `--access` flag needed for public packages).
 
-LICENSE: the repo currently has none in the root. Add **Business Source License 1.1** (matches ForgeCAD's choice; non-production-free, converts to MIT after change date). This is a one-file add, not a full licensing review — if the user wants MIT or another license later, that's a downstream change.
+LICENSE: the repo currently has none in the root. Add **MIT License**. The strategic positioning (see A9) is "the open, MCP-native, AST-edit-primacy CAD kernel for agent workflows" — MIT is the maximally-open license that lets that positioning be true without legal asterisks. Adoption surface is the moat, not commercial restriction.
 
 ### A4 — Smoke test: clean Docker container (closes S2)
 
@@ -157,16 +158,20 @@ Beyond the v0.1 contract, this release also includes:
 
 53 documented diagnostic codes across feature/recompute/cli/export categories, each with a HINTS entry, structurally enforced by a CI sentinel.
 
+### Positioning
+
+kernelCAD is the open, MCP-native, AST-edit-primacy CAD kernel for iterative agent workflows. Source is on GitHub. Diagnostics are structured and hint-rich. The MCP server lets an agent introspect a live model across many queries in one session instead of re-running the script per question.
+
 ### License
 
-Business Source License 1.1.
+MIT License.
 ```
 
 Older CHANGELOG entries (the rc.1 through rc.17 history) are **kept** in the file below this entry. They document the development journey, even though the tags they reference no longer exist. Future readers can see "this was developed across 17 internal iterations before the first public release".
 
 ### A7 — README quickstart rewrite (closes S4)
 
-**Decision.** Replace the current `## Getting Started` section with a flat, ForgeCAD-style structure:
+**Decision.** Replace the current `## Getting Started` section with a flat install-then-first-script structure:
 
 ```markdown
 ## Get Started
@@ -199,6 +204,19 @@ That's it. For agents: `kernelcad mcp` runs an MCP server with 13 introspection 
 
 Everything below this section in the current README — the multi-step "Prerequisites / Installation / Clone the repo / npm install" wall — gets cut. The web-app dev instructions move down into a `## Contributing` block (or get dropped if they belong to a non-shipped surface).
 
+### A9 — Strategic positioning (informs A3, A6, A7)
+
+**Decision.** kernelCAD is positioned as **the open, MCP-native, AST-edit-primacy CAD kernel for iterative agent workflows**. Four anchor properties:
+
+1. **Open** — full source on GitHub under MIT. Engineers can audit the geometry pipeline that produces their STEP/STL files.
+2. **MCP-native** — the agent surface is a persistent MCP server with introspection tools (`why_did_this_fail`, `list_topology`, `get_shape_info`, etc.) that share a session-resident kernel; not a one-shot CLI per query.
+3. **AST-edit-primacy** — every script-modifying operation (UI, MCP, future plugins) is an AST edit to the canonical `.kcad.ts`. Direct IR mutation is forbidden (NORTHSTAR Q6b). Agents can use ts-morph deterministically and trust the IR follows.
+4. **Diagnostic-rigorous** — every emitted diagnostic code has a structured HINTS entry, structurally enforced by a CI sentinel. When something breaks, the agent gets a hint with reachability classification, not a stack trace.
+
+The NORTHSTAR module roadmap (assemblies, constraints, sheet metal, SDF, etc.) is the table-stakes surface kernelCAD must cover to be a complete CAD platform. The four anchor properties above are the differentiator surface — what makes kernelCAD distinct on top of that table-stakes surface.
+
+This positioning informs every milestone decision: when forced to choose between feature breadth and depth on the four anchor properties, depth wins. Module-roadmap order (per NORTHSTAR) determines feature sequencing; the anchor properties determine implementation discipline.
+
 ### A8 — Stale PR #19 disposition (closes S8)
 
 **Decision.** Close PR #19 ("fix: implement robust geometry alignment and auto return") with a one-line comment: "Closing — predates the rc.6 query-first topology refactor and the rc.13 mirror/reflect surface; the underlying alignment behavior is now handled differently. Reopen if the original symptom recurs."
@@ -211,7 +229,7 @@ The PR is from 2026-02-14, three months stale. The branch (`fix/extrude-visibili
 
 Eight tasks, each one focused and bounded. Suggested order — but each is independent enough to be reordered if dispatch dynamics call for it:
 
-1. **Task 1 — Pre-publish hygiene.** Add `LICENSE` (BUSL-1.1). Add `files` field to `package.json` listing the npm tarball contents. Run `npm pack --dry-run` and verify tarball <10 MB. Commit: `chore(release): add LICENSE and npm files manifest`.
+1. **Task 1 — Pre-publish hygiene.** Add `LICENSE` (MIT, with copyright line `Copyright (c) 2026 Andrii Shylenko`). Add `files` field to `package.json` listing the npm tarball contents. Run `npm pack --dry-run` and verify tarball <10 MB. Commit: `chore(release): add MIT LICENSE and npm files manifest`.
 
 2. **Task 2 — Acceptance demo script.** Create `examples/bracket-with-hole.kcad.ts` with the README quickstart contents. Verify `npm run dev:cli evaluate examples/bracket-with-hole.kcad.ts` returns ok. Commit: `feat(examples): add v0.1 acceptance demo (bracket with hole + fillet)`.
 
@@ -242,7 +260,7 @@ Eight tasks, each one focused and bounded. Suggested order — but each is indep
 
 1. **Which version number?** v0.1.0 (NORTHSTAR-strict). v0.2.0 / v0.7.0 ruled out per A1.
 2. **Tag cleanup strategy?** Full reset, all 34 tags deleted, no soft-deprecate. Per A2.
-3. **License?** BUSL-1.1, per A3 — matches ForgeCAD precedent. Single-file add, no licensing-review project.
+3. **License?** MIT, per A3 + A9. Optimizes for adoption surface; positioning is "open kernel", legal restriction would undercut the moat.
 4. **Web app on npm?** No. `kernelcad` package is CLI + agent surface only. Web app stays in the repo for `npm run dev`.
 5. **Smoke test in CI?** Not for v0.1.0. Manual post-publish verification only. CI sandbox + Docker-in-CI is out of scope.
 6. **Old CHANGELOG entries?** Kept in the file as development history. Tags they reference will be gone, but commit SHAs and PR links survive.

--- a/docs/superpowers/specs/2026-05-02-v0.1.0-northstar-rebaseline-design.md
+++ b/docs/superpowers/specs/2026-05-02-v0.1.0-northstar-rebaseline-design.md
@@ -1,0 +1,267 @@
+# v0.1.0 — NORTHSTAR Re-baseline + First Public Ship — Design Spec
+
+**Goal:** End the rc-treadmill. Re-version the codebase to honest NORTHSTAR semantics, publish the package to npm under `kernelcad`, and prove the install path works on a clean machine. After this milestone, an agent reading SKILL.md can run `npm install -g kernelcad` and use the platform — that has never been true before.
+
+**Architecture:** Pure ship-readiness milestone — no new user-facing API, no kernel changes. Eight focused tasks. Largest single change is the version-number reset (v0.13.0-rc.17 → v0.1.0) and the destructive cleanup of 34 cruft tags from origin.
+
+**Tech Stack:** No additions. Existing TypeScript 5.9 / Replicad 0.20.5 / vitest 4 / esbuild CLI bundle. New external dependency: the public npm registry.
+
+---
+
+## Why this milestone
+
+After 17 release candidates inside a single "v0.13.0" line, the project has shipped a lot of geometry surface but no usable artifact. Hard facts:
+
+- `package.json` has `"private": true` — npm publish is mechanically blocked.
+- **Zero non-prerelease tags exist.** Every tag is `-alpha.N`, `-beta.N`, or `-rc.N`. There has never been a `v0.x.0` cut.
+- `npm view kernelcad` returns 404 — the package has never been published to a registry.
+- SKILL.md tells agents to clone the repo. There is no `npm install -g kernelcad` line because there is nothing on npm.
+- The version number `0.13.0` is dishonest against NORTHSTAR: NORTHSTAR's v0.13 is **sheet metal**, of which we have shipped exactly zero. We have been bumping minor versions per feature, not per NORTHSTAR module completion.
+
+NORTHSTAR's own "Open Questions" section, written 2026-04-29, lists three unresolved items:
+- v0.1 acceptance demo: never written
+- Distribution: npm package name, CLI binary packaging — **never shipped**
+- Public release cadence: commit to v0.1 ship date — **never committed**
+
+This milestone closes all three at once. It is the smallest possible thing that turns kernelCAD from "private repo with lots of code" into "public npm package an agent can install".
+
+The version-number reset is the deliberate honest move: ship as **v0.1.0** because v0.1 (Foundation) is the only fully-complete NORTHSTAR module today. Out-of-order extras (sweep, loft, MCP server, AST-edit MCP tools, mirror/reflect, binary STL) ship as bonus surface inside v0.1.0; they do not buy version inflation. From v0.2.0 onward, every minor-version bump corresponds to a NORTHSTAR module gap closed (next: v0.2.0 = tracked face/edge refs).
+
+---
+
+## Scope (closed-set list)
+
+| ID | Component | What it does |
+|----|-----------|--------------|
+| S1 | Version + private flag flip | `package.json`: `"private": false`, `"version": "0.1.0"` |
+| S2 | npm publish + smoke verify | Publish `kernelcad@0.1.0` to public registry; verify install path on clean container |
+| S3 | SKILL.md install section | Replace clone-the-repo path with `npm install -g kernelcad` at top of file |
+| S4 | README quickstart rewrite | Trim to install + first-script flow, mirror ForgeCAD's flat structure |
+| S5 | CHANGELOG re-baseline entry | Single `v0.1.0` entry summarizing the shipped surface and the version reset |
+| S6 | Tag cleanup | Delete all 34 existing tags from local + origin; tag fresh `v0.1.0` |
+| S7 | GitHub Release | Cut a public Release for `v0.1.0` with at least one demo `.kcad.ts` artifact |
+| S8 | Stale PR #19 disposition | Close PR #19 (3 months stale, predates the rc.13+ topology refactor) |
+
+**Out of scope:**
+
+- Gap-closure roadmap document (covering tracked refs / hole / cut / constrained sketches / assemblies / sheet metal / SDF / wood / etc.) — separate brainstorm + spec, queued after v0.1.0 ships.
+- API-stability promise document — implicitly declared by shipping a non-prerelease tag; formal written promise can wait until the first external user asks.
+- Any new feature surface. No `export_step`, no STEP MCP wrapper, no tracked refs work, no schema changes.
+- ROADMAP.md update — content is stale (still references v0.10), but rewriting it is a content task that belongs to the gap-closure brainstorm, not this milestone.
+
+---
+
+## Architecture decisions
+
+### A1 — Re-baseline as `v0.1.0`, NORTHSTAR-strict (supports S1, S5)
+
+**Decision.** Ship as `v0.1.0`. NORTHSTAR's v0.1 module ("Foundation: feature graph, recompute, OCCT backend, primitives, STL+STEP CLI export, JSON diagnostics, canonical face refs only") is the only NORTHSTAR module fully delivered today. Everything beyond — fillet, chamfer, shell, sketches, mirror, reflect, sweep, loft, the entire MCP server, the AST-edit MCP tools, binary STL — ships as bonus surface inside v0.1.0 without inflating the version.
+
+**Why.** Two competing options were ruled out:
+- **`v0.2.0` (generous)** — we have ~80% of NORTHSTAR v0.2 (fillet/chamfer/sketches done; tracked refs missing). Tempting but incoherent — `v0.N.0` should mean "module N is delivered, no exceptions"; partial-with-asterisk is the same dishonesty we're cleaning up.
+- **`v0.7.0` (reflect highest completed)** — we have all of v0.7 (loft + sweep). Reasonable but optimizes for "highest number we can claim" instead of "lowest honest number that matches semver semantics". Future versions would still need to back-fill v0.2-0.6 gaps — better to do that within a clean numbering line than out of one.
+
+The strict re-baseline sets a sustainable cadence: from this point, every minor-version bump = one NORTHSTAR module's gap fully closed. v0.2.0 = tracked refs land. v0.3.0 = hole/cut/created refs land. And so on through v1.0 = polish + docs + the entire NORTHSTAR module surface delivered.
+
+### A2 — Tag cleanup: full reset (closes S6)
+
+**Decision.** Delete all 34 existing tags from local AND origin. They divide into two cruft categories, both safely droppable:
+
+- **Pre-NORTHSTAR legacy** (12 tags): `v0.0.1`, `v0.0.2`, `v0.1.0`, `v0.1.0-arch.2`, `v0.2.0`, `v0.2.0-alpha.1`, `v0.2.0-alpha.2`, `v0.2.1`, `v0.4.0`, `v0.10.0`, `v0.11.0`, `v0.11.0-alpha.1`. These predate the 2026-04-29 NORTHSTAR architecture; their version numbers mean different things than they do now. The new `v0.1.0` collides nominally with the legacy `v0.1.0` — clean reset avoids the ambiguity.
+- **Post-NORTHSTAR mis-versioned** (22 tags): all `v0.12.0-*` and `v0.13.0-*` tags. These were the rc-treadmill cruft — they claimed NORTHSTAR module deliveries that never happened (v0.13 = sheet metal, of which we shipped zero).
+
+External blast radius is **zero**: no GitHub Releases are attached to any tag (`gh release list` returned empty), no npm publish has ever happened, no documentation links to specific tags. Commit history is unaffected — every shipped feature remains reachable via the merge SHA referenced in CHANGELOG.md and the closed-PR list.
+
+**Why not soft-deprecate** (keep tags, mark deprecated in CHANGELOG)? A clean break is more honest than a confusing deprecation overlay. The CHANGELOG re-baseline entry (A6) explains the reset once, in one place; future readers don't need to mentally filter "real" vs "deprecated" tags.
+
+### A3 — npm publish surface (closes S2)
+
+**Decision.** Publish exactly what `npm pack` produces from the existing build pipeline — no new bundle work. The `package.json` `bin` field already points at `dist/cli/index.js`; the `build:cli` script already produces a self-contained esbuild bundle plus the OpenCASCADE WASM blob and `SKILL.md`.
+
+Pre-publish steps:
+1. Run `npm run build:cli` to produce `dist/cli/index.js`, `dist/cli/replicad_single.wasm`, `dist/cli/SKILL.md`.
+2. Add a `files` field to `package.json` listing exactly: `dist/cli/`, `README.md`, `LICENSE`. Excludes `src/`, `tests/`, `node_modules/`, `dist/` (the web-app bundle), `playwright-report/`, `test-results/`, `archive/`, `docs/`. The web app does not ship to npm — `kernelcad` is the CLI + agent surface only.
+3. Run `npm pack --dry-run` to verify the resulting tarball is reasonable (target: <10 MB; the WASM blob is the dominant payload at ~5 MB).
+4. Run `npm publish` (no `--access` flag needed for public packages).
+
+LICENSE: the repo currently has none in the root. Add **Business Source License 1.1** (matches ForgeCAD's choice; non-production-free, converts to MIT after change date). This is a one-file add, not a full licensing review — if the user wants MIT or another license later, that's a downstream change.
+
+### A4 — Smoke test: clean Docker container (closes S2)
+
+**Decision.** Add a one-shot script `scripts/smokeTest.sh` that runs:
+
+```bash
+docker run --rm -v "$PWD/examples:/work" node:22-slim bash -c '
+  npm install -g kernelcad &&
+  kernelcad evaluate /work/bracket-with-hole.kcad.ts --json > /tmp/out.json &&
+  test "$(jq -r .status /tmp/out.json)" = "ok" &&
+  kernelcad export stl /work/bracket-with-hole.kcad.ts -o /tmp/out.stl &&
+  test -s /tmp/out.stl
+'
+```
+
+Pass criteria: exit 0, evaluate JSON `.status == "ok"`, STL file is non-empty. The script is invoked manually post-publish; not gated in CI for this milestone (CI sandbox concerns are out of scope for v0.1.0).
+
+The example script `examples/bracket-with-hole.kcad.ts` ships in the repo (not in the npm tarball — `examples/` is excluded). It's the v0.1 acceptance demo NORTHSTAR has been asking for since 2026-04-29.
+
+### A5 — SKILL.md install section (closes S3)
+
+**Decision.** Insert a new `## Installation` section between the existing `## Coordinate System` and `## API Surface` sections:
+
+```markdown
+## Installation
+
+```bash
+npm install -g kernelcad
+kernelcad evaluate path/to/script.kcad.ts
+```
+
+Verify with `kernelcad --version` (should print `0.1.0` or higher).
+```
+
+Existing `## CLI Commands` section stays as-is. The drift sentinels that already exist for SKILL.md will not flag this insertion (they assert presence of names, not section ordering).
+
+### A6 — CHANGELOG re-baseline entry (closes S5)
+
+**Decision.** Single new entry at the top of `CHANGELOG.md`:
+
+```markdown
+## v0.1.0 — first public release + NORTHSTAR re-baseline (2026-05-02)
+
+The first kernelCAD release published to the npm registry. Install with `npm install -g kernelcad`.
+
+### Re-baseline note
+
+Prior to this release, the repo carried 34 internal tags (`v0.0.1` through `v0.13.0-rc.17`) reflecting iterative development. None were ever published. All have been deleted; this release starts a clean, NORTHSTAR-aligned numbering line where each `v0.N.0` corresponds to one NORTHSTAR module fully delivered.
+
+`v0.1.0` ships NORTHSTAR's v0.1 module ("Foundation"): feature graph, recompute engine, OCCT backend via Replicad, primitives (box/cylinder/sphere), CLI (`evaluate`, `export stl`, `export step`), JSON diagnostics, canonical face refs.
+
+### Bonus surface (NORTHSTAR modules partly delivered out-of-order)
+
+Beyond the v0.1 contract, this release also includes:
+
+- **v0.2 partial** — `.fillet()`, `.chamfer()`, `.shell()`, `path()` builder with `lineTo`/`tangentArc`/`threePointsArc`/`sagittaArc`/`bulgeArc`/`radiusArc`, `.label()`. Tracked face/edge refs across transforms/booleans **deferred to v0.2.0**.
+- **v0.3 partial** — `.shell()` ships. `hole`/`cut`/`draft` as first-class features and `created` face refs **deferred to v0.3.0**.
+- **v0.7** — `.sweep()` and `.loft()` (curves + surfacing).
+- **v0.11** — MCP server with 13 introspection tools (`why_did_this_fail`, `list_topology`, `get_shape_info`, `list_edges`, `list_faces`, `list_face_labels`, `list_features`, `list_api`, `evaluate_script`, `get_edges_of`, `set_param_value`, `add_feature`, `remove_feature`).
+- **v0.12 partial** — MCP AST-edit tools (`add_feature`, `remove_feature`, `set_param_value`). Skill installer and one-file context bundler **deferred to v0.12.0**.
+
+### Symmetry features (not on the NORTHSTAR module roadmap, additive)
+
+- `.mirror(plane)` / `.reflect(plane)` for symmetric parts.
+- Binary STL export (`kernelcad export stl ...` and `export_stl` MCP tool).
+- Variable-radius fillet/chamfer.
+- Edge/face query selectors (`selectEdges`, `selectEdge`, `EdgeQuery`, `FaceQuery`).
+
+### Diagnostic surface
+
+53 documented diagnostic codes across feature/recompute/cli/export categories, each with a HINTS entry, structurally enforced by a CI sentinel.
+
+### License
+
+Business Source License 1.1.
+```
+
+Older CHANGELOG entries (the rc.1 through rc.17 history) are **kept** in the file below this entry. They document the development journey, even though the tags they reference no longer exist. Future readers can see "this was developed across 17 internal iterations before the first public release".
+
+### A7 — README quickstart rewrite (closes S4)
+
+**Decision.** Replace the current `## Getting Started` section with a flat, ForgeCAD-style structure:
+
+```markdown
+## Get Started
+
+```bash
+npm install -g kernelcad
+```
+
+Drop this in `bracket.kcad.ts`:
+
+```typescript
+const w = param('Width', 60, { unit: 'mm' });
+const h = param('Height', 40, { unit: 'mm' });
+const t = param('Thickness', 5, { unit: 'mm' });
+
+const base = box(w, h, t);
+const hole = cylinder(t + 2, 4).translate(w / 2, h / 2, -1);
+return base.subtract(hole).fillet(1);
+```
+
+Run it:
+
+```bash
+kernelcad evaluate bracket.kcad.ts
+kernelcad export stl bracket.kcad.ts -o bracket.stl
+```
+
+That's it. For agents: `kernelcad mcp` runs an MCP server with 13 introspection tools. See `SKILL.md` (bundled with the install) for the full API surface and authoring guide.
+```
+
+Everything below this section in the current README — the multi-step "Prerequisites / Installation / Clone the repo / npm install" wall — gets cut. The web-app dev instructions move down into a `## Contributing` block (or get dropped if they belong to a non-shipped surface).
+
+### A8 — Stale PR #19 disposition (closes S8)
+
+**Decision.** Close PR #19 ("fix: implement robust geometry alignment and auto return") with a one-line comment: "Closing — predates the rc.6 query-first topology refactor and the rc.13 mirror/reflect surface; the underlying alignment behavior is now handled differently. Reopen if the original symptom recurs."
+
+The PR is from 2026-02-14, three months stale. The branch (`fix/extrude-visibility-alignment`) has not been rebased since. The "extrude visibility alignment" symptom it targeted involved code paths that have been substantially restructured since. Merging it cleanly is unlikely to be possible; carrying it as open noise is worse than closing it. The branch ref is preserved (not deleted) in case the symptom reappears.
+
+---
+
+## Implementation tasks (for the writing-plans handoff)
+
+Eight tasks, each one focused and bounded. Suggested order — but each is independent enough to be reordered if dispatch dynamics call for it:
+
+1. **Task 1 — Pre-publish hygiene.** Add `LICENSE` (BUSL-1.1). Add `files` field to `package.json` listing the npm tarball contents. Run `npm pack --dry-run` and verify tarball <10 MB. Commit: `chore(release): add LICENSE and npm files manifest`.
+
+2. **Task 2 — Acceptance demo script.** Create `examples/bracket-with-hole.kcad.ts` with the README quickstart contents. Verify `npm run dev:cli evaluate examples/bracket-with-hole.kcad.ts` returns ok. Commit: `feat(examples): add v0.1 acceptance demo (bracket with hole + fillet)`.
+
+3. **Task 3 — SKILL.md installation section + drift sentinel update.** Insert the `## Installation` section per A5. Verify the SKILL.md drift sentinel still passes (it should — it asserts name presence, not ordering). Commit: `docs(skill): add npm install path to SKILL.md`.
+
+4. **Task 4 — README rewrite.** Replace `## Getting Started` per A7. Move web-app dev instructions to `## Contributing`. Commit: `docs(readme): flat install + first-script quickstart for v0.1.0`.
+
+5. **Task 5 — CHANGELOG re-baseline entry.** Insert the `v0.1.0` entry per A6 above the existing rc.17 entry. The rc.17 entry and below stays. Commit: `docs(changelog): v0.1.0 re-baseline entry`.
+
+6. **Task 6 — Version flip + private:false.** `package.json`: `"private": false`, `"version": "0.1.0"`. Run `npm run qc:full` (Playwright env failure acceptable per established precedent — note in commit if it fires). Commit: `release(v0.1.0): private:false + version 0.1.0`.
+
+7. **Task 7 — Smoke test script.** Create `scripts/smokeTest.sh` per A4. Make executable. Do **not** run yet (requires npm publish first). Commit: `chore(release): smoke test for npm install path`.
+
+8. **Task 8 — Tag cleanup, npm publish, smoke verify, GH release, close PR #19.**
+   - **CONFIRMATION GATE.** Before running, controller verifies the spec's tag-deletion call is still wanted. (Spec was approved with tag deletion; this gate is defense-in-depth — destructive on origin.)
+   - Delete all 34 tags from local: `git tag -l | xargs git tag -d`
+   - Delete all 34 tags from origin: `git tag -l | xargs -I{} git push origin --delete {}` (batched in groups of 10 to stay under SSH command-length limits)
+   - `npm publish` (will publish `kernelcad@0.1.0` from `dist/cli/`).
+   - Run `bash scripts/smokeTest.sh`. Pass criteria per A4.
+   - Tag fresh `v0.1.0` on the merge commit: `git tag v0.1.0 && git push origin v0.1.0`.
+   - Cut GitHub Release: `gh release create v0.1.0 --title "v0.1.0 — First Public Release" --notes-from-tag examples/bracket-with-hole.kcad.ts`.
+   - Close PR #19 per A8.
+   - **End-to-end live verify** (per `feedback_actually_use_what_you_ship`): on a fresh shell session, run `npm install -g kernelcad@0.1.0` and verify `kernelcad evaluate examples/bracket-with-hole.kcad.ts --json` reports `status: ok`. Open the resulting STL in a viewer (or at minimum `file out.stl` and confirm it's a valid binary STL header). Do not declare done until both pass.
+
+---
+
+## Open questions resolved at the top of this plan
+
+1. **Which version number?** v0.1.0 (NORTHSTAR-strict). v0.2.0 / v0.7.0 ruled out per A1.
+2. **Tag cleanup strategy?** Full reset, all 34 tags deleted, no soft-deprecate. Per A2.
+3. **License?** BUSL-1.1, per A3 — matches ForgeCAD precedent. Single-file add, no licensing-review project.
+4. **Web app on npm?** No. `kernelcad` package is CLI + agent surface only. Web app stays in the repo for `npm run dev`.
+5. **Smoke test in CI?** Not for v0.1.0. Manual post-publish verification only. CI sandbox + Docker-in-CI is out of scope.
+6. **Old CHANGELOG entries?** Kept in the file as development history. Tags they reference will be gone, but commit SHAs and PR links survive.
+
+---
+
+## Risks
+
+- **R1 (low):** npm package name `kernelcad` is taken or reserved. Mitigation: verified earlier, registry returns 404. If publish 403s, scope under `@andrii/kernelcad` and update README + SKILL.md install lines accordingly.
+- **R2 (low):** Tag deletion on origin runs into GH branch-protection or workflow-trigger issues. Mitigation: deletion is per-tag; on first failure, halt, diagnose, and adjust. None of the 34 tags has an attached Release, so the GH Release deletion side-effect is a non-concern.
+- **R3 (medium):** `dist/cli/index.js` bundle is broken on a clean container (missing native dep, hardcoded path, etc.). Mitigation: this is exactly what the smoke test catches. If it fails, fix the bundle and re-publish as `v0.1.1`. (npm versions are immutable — we cannot re-publish `0.1.0` after a failed verify; we patch-bump and move on.)
+- **R4 (low):** A future contributor or external user rediscovers a deleted tag via cached refs. Mitigation: the CHANGELOG re-baseline note is the canonical explanation; pointing them to it resolves any confusion.
+
+---
+
+## What this milestone is NOT
+
+- Not a feature release. No new geometry surface, no new MCP tool, no new CLI subcommand.
+- Not a quality pass. The rc.17 review hasn't been filed; if it surfaces issues, they ship as `v0.1.1`.
+- Not a NORTHSTAR module delivery. v0.2 (tracked refs) is the next NORTHSTAR module, and it's deliberately NOT in this milestone.
+- Not the gap-closure roadmap. That document is a separate brainstorm queued for after v0.1.0 ships.
+- Not a pivot away from the rc cadence forever. Future milestones may use rcs again if a feature is large enough to warrant staged shipping — but the rc tags will be local-only or short-lived, not the de-facto release line.

--- a/examples/bracket-with-hole.kcad.ts
+++ b/examples/bracket-with-hole.kcad.ts
@@ -1,0 +1,7 @@
+const w = param('Width', 60, { unit: 'mm', min: 30, max: 200 });
+const h = param('Height', 40, { unit: 'mm', min: 20, max: 120 });
+const t = param('Thickness', 5, { unit: 'mm', min: 2, max: 15 });
+
+const base = box(w, h, t);
+const hole = cylinder(t + 2, 4).translate(w / 2, h / 2, -1);
+return base.subtract(hole).fillet(1);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
   "bin": {
     "kernelcad": "./dist/cli/index.js"
   },
+  "files": [
+    "dist/cli",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kernelcad",
-  "private": true,
-  "version": "0.13.0-rc.17",
+  "private": false,
+  "version": "0.1.0",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/scripts/smokeTest.sh
+++ b/scripts/smokeTest.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Post-publish install verification.
+# Runs in a clean node:22-slim container, installs kernelcad@latest from the
+# public npm registry, evaluates the v0.1 acceptance demo, and exports STL.
+# Pass criteria:
+#   - npm install exits 0
+#   - kernelcad evaluate exits 0 with status: ok
+#   - kernelcad export stl produces a non-empty file with a valid binary STL header
+#
+# Usage:
+#   bash scripts/smokeTest.sh
+#
+# Requires: docker installed and runnable by the current user.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+EXAMPLES_DIR="$REPO_DIR/examples"
+
+if [ ! -f "$EXAMPLES_DIR/bracket-with-hole.kcad.ts" ]; then
+  echo "FAIL: examples/bracket-with-hole.kcad.ts missing — run from repo root." >&2
+  exit 1
+fi
+
+echo "==> Pulling node:22-slim if needed..."
+docker pull node:22-slim
+
+echo "==> Running smoke test in clean container..."
+docker run --rm -v "$EXAMPLES_DIR:/work:ro" node:22-slim bash -c '
+  set -euo pipefail
+  apt-get update -qq && apt-get install -y -qq jq file > /dev/null
+  echo "  - npm install -g kernelcad"
+  npm install -g kernelcad@latest 2>&1 | tail -5
+  echo "  - kernelcad --version"
+  kernelcad --version
+  echo "  - kernelcad evaluate (json)"
+  kernelcad evaluate /work/bracket-with-hole.kcad.ts --json > /tmp/out.json
+  status=$(jq -r ".ok" /tmp/out.json)
+  if [ "$status" != "true" ]; then
+    echo "FAIL: evaluate returned ok=$status (expected true)" >&2
+    cat /tmp/out.json >&2
+    exit 1
+  fi
+  echo "  - kernelcad export stl"
+  kernelcad export stl /work/bracket-with-hole.kcad.ts -o /tmp/out.stl
+  if [ ! -s /tmp/out.stl ]; then
+    echo "FAIL: STL is empty" >&2
+    exit 1
+  fi
+  bytes=$(wc -c < /tmp/out.stl)
+  echo "  - STL written: $bytes bytes"
+  # Verify binary STL header starts with "kernelcad" forensic stamp
+  header=$(head -c 80 /tmp/out.stl | tr -d "\0" || true)
+  case "$header" in
+    kernelcad*) echo "  - Header OK: $header" ;;
+    *) echo "WARN: STL header does not start with kernelcad ($header) — may be ASCII fallback" >&2 ;;
+  esac
+  echo "==> Smoke test PASSED"
+'

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -9,6 +9,15 @@ Author or modify kernelCAD models in TypeScript. Scripts live in `.kcad.ts` file
 
 This skill is the one-shot authoring companion to the kernelCAD MCP server (`kernelcad mcp`). Use this skill to write scripts; use the MCP server when you need to introspect a running model dynamically (volume, edge counts, why a feature failed).
 
+## Installation
+
+```bash
+npm install -g kernelcad
+kernelcad evaluate path/to/script.kcad.ts
+```
+
+Verify the install with `kernelcad --version` (should print `0.1.0` or higher).
+
 ## Coordinate System
 
 - **Z-up**, right-handed.


### PR DESCRIPTION
## Summary
- Re-version `v0.13.0-rc.17` → `v0.1.0` (NORTHSTAR-strict honest baseline)
- Publish `kernelcad@0.1.0` to public npm registry
- Add MIT LICENSE (copyright Andrii Shylenko)
- Add `examples/bracket-with-hole.kcad.ts` v0.1 acceptance demo
- SKILL.md gets `## Installation` section with `npm install -g kernelcad`
- README quickstart rewrite (flat install + first-script flow); web-app dev moves to `## Contributing`
- CHANGELOG re-baseline entry + Positioning section
- Smoke test script (`scripts/smokeTest.sh`) for post-publish install verification on clean Docker container
- Delete all 34 cruft tags from local + origin (Task 8, gated)
- Close stale PR #19

Spec: `docs/superpowers/specs/2026-05-02-v0.1.0-northstar-rebaseline-design.md`
Plan: `docs/superpowers/plans/2026-05-02-v0.1.0-northstar-rebaseline.md`

## Test plan
- [ ] `npm run qc` passes locally
- [ ] `npm pack --dry-run` produces a tarball <10 MB
- [ ] `node dist/cli/index.js evaluate examples/bracket-with-hole.kcad.ts --json` returns ok
- [ ] SKILL.md drift sentinels still pass after Installation section insert
- [ ] (Post-merge, Task 8) Smoke test on clean `node:22-slim` container passes
- [ ] (Post-merge, Task 8) `kernelcad@0.1.0` resolves on `npm view`
- [ ] (Post-merge, Task 8) Visual STL inspection of bracket geometry confirms reasonable shape