### PR TITLE
feat(eval): agent eval harness v1 — inner-loop dev tool

### DIFF
--- a/eval/.gitignore
+++ b/eval/.gitignore
@@ -1,0 +1,3 @@
+# Live runs are not committed; only golden fixtures (runs/golden-*) are.
+runs/*
+!runs/golden-*/

--- a/eval/agent.test.ts
+++ b/eval/agent.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { MockAgentClient } from './agent';
+
+describe('MockAgentClient', () => {
+  it('replays canned responses in order', async () => {
+    const client = new MockAgentClient([
+      { text: '```typescript\nreturn box(1,1,1);\n```', tokens_in: 100, tokens_out: 20 },
+      { text: '```typescript\nreturn box(2,2,2);\n```', tokens_in: 110, tokens_out: 25 },
+    ]);
+    const r1 = await client.generate({ system: 'sys', messages: [], model: 'm', max_tokens: 1000 });
+    expect(r1.text).toContain('box(1,1,1)');
+    expect(r1.tokens_in).toBe(100);
+    const r2 = await client.generate({ system: 'sys', messages: [], model: 'm', max_tokens: 1000 });
+    expect(r2.text).toContain('box(2,2,2)');
+    expect(r2.tokens_out).toBe(25);
+  });
+
+  it('throws when responses are exhausted', async () => {
+    const client = new MockAgentClient([
+      { text: 'one', tokens_in: 1, tokens_out: 1 },
+    ]);
+    await client.generate({ system: '', messages: [], model: 'm', max_tokens: 1 });
+    await expect(
+      client.generate({ system: '', messages: [], model: 'm', max_tokens: 1 }),
+    ).rejects.toThrow(/exhausted/i);
+  });
+
+  it('records every call for inspection', async () => {
+    const client = new MockAgentClient([{ text: 'r', tokens_in: 1, tokens_out: 1 }]);
+    await client.generate({
+      system: 'sys',
+      messages: [{ role: 'user', content: 'hello' }],
+      model: 'm',
+      max_tokens: 100,
+    });
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0].messages[0].content).toBe('hello');
+  });
+});

--- a/eval/agent.ts
+++ b/eval/agent.ts
@@ -1,0 +1,62 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type { AgentClient, AgentMessage, AgentResponse } from './types';
+
+interface GenerateArgs {
+  system: string;
+  messages: AgentMessage[];
+  model: string;
+  max_tokens: number;
+}
+
+export class MockAgentClient implements AgentClient {
+  public calls: GenerateArgs[] = [];
+  private idx = 0;
+
+  constructor(private readonly responses: AgentResponse[]) {}
+
+  async generate(args: GenerateArgs): Promise<AgentResponse> {
+    this.calls.push(args);
+    if (this.idx >= this.responses.length) {
+      throw new Error(
+        `MockAgentClient: response queue exhausted (asked for #${this.idx + 1}, only ${this.responses.length} canned)`,
+      );
+    }
+    return this.responses[this.idx++];
+  }
+}
+
+export class AnthropicAgentClient implements AgentClient {
+  private client: Anthropic;
+
+  constructor(apiKey: string) {
+    this.client = new Anthropic({ apiKey });
+  }
+
+  async generate(args: GenerateArgs): Promise<AgentResponse> {
+    const resp = await this.client.messages.create({
+      model: args.model,
+      max_tokens: args.max_tokens,
+      // Cache the system prompt — SKILL.md is large and reused across every task.
+      system: [
+        {
+          type: 'text',
+          text: args.system,
+          cache_control: { type: 'ephemeral' },
+        },
+      ],
+      messages: args.messages.map((m) => ({ role: m.role, content: m.content })),
+    });
+
+    // Concatenate text content blocks. Tool-use isn't expected in CLI single-shot mode.
+    const text = resp.content
+      .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+      .map((b) => b.text)
+      .join('');
+
+    return {
+      text,
+      tokens_in: resp.usage.input_tokens + (resp.usage.cache_creation_input_tokens ?? 0) + (resp.usage.cache_read_input_tokens ?? 0),
+      tokens_out: resp.usage.output_tokens,
+    };
+  }
+}

--- a/eval/golden.test.ts
+++ b/eval/golden.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runTask } from './runner';
+import { MockAgentClient } from './agent';
+import { isKernelcadAvailable } from './oracle/kernelcad-client';
+
+const GOLDEN = 'eval/runs/golden-2026-05-02-bracket-holes';
+
+let kernelcadAvailable = false;
+
+beforeAll(async () => {
+  kernelcadAvailable = await isKernelcadAvailable();
+});
+
+describe('golden mock replay', () => {
+  it('replays the golden fixture and produces matching score (deterministic fields only)', async (ctx) => {
+    if (!kernelcadAvailable) return ctx.skip();
+
+    const fixture = JSON.parse(readFileSync(join(GOLDEN, 'fixture.json'), 'utf8'));
+    const client = new MockAgentClient(fixture.responses);
+    const tmpRun = mkdtempSync(join(tmpdir(), 'eval-golden-'));
+
+    const result = await runTask({
+      taskDir: 'eval/tasks/bracket-holes',
+      runDir: tmpRun,
+      agent: client,
+      model: 'mock-model',
+      skillMd: readFileSync('src/skill/SKILL.md', 'utf8'),
+      startedAt: 'GOLDEN',
+    });
+
+    // Compare score.json fields except time_ms (wall-clock).
+    const expectedScore = JSON.parse(readFileSync(join(GOLDEN, 'score.json'), 'utf8'));
+    const actualScore = JSON.parse(readFileSync(join(tmpRun, 'score.json'), 'utf8'));
+
+    expect(actualScore.gates).toEqual(expectedScore.gates);
+    expect(actualScore.scored).toEqual(expectedScore.scored);
+    expect(actualScore.gate_pass).toBe(expectedScore.gate_pass);
+    expect(actualScore.score).toBe(expectedScore.score);
+    expect(actualScore.attempts).toBe(expectedScore.attempts);
+    expect(actualScore.tokens).toEqual(expectedScore.tokens);
+
+    // Compare output.kcad.ts byte-for-byte.
+    const expectedScript = readFileSync(join(GOLDEN, 'output.kcad.ts'), 'utf8');
+    const actualScript = readFileSync(join(tmpRun, 'output.kcad.ts'), 'utf8');
+    expect(actualScript).toBe(expectedScript);
+
+    // Compare transcript after normalizing wall-clock time fields to 0.0s
+    // (same normalization the recorded golden underwent).
+    const expectedTx = readFileSync(join(GOLDEN, 'transcript.md'), 'utf8');
+    const actualTxRaw = readFileSync(join(tmpRun, 'transcript.md'), 'utf8');
+    const actualTx = actualTxRaw
+      .replace(/, [0-9]+\.[0-9]s\)$/gm, ', 0.0s)')         // per-turn elapsed
+      .replace(/^- Time: [0-9]+\.[0-9]s$/gm, '- Time: 0.0s'); // score block elapsed
+    expect(actualTx).toBe(expectedTx);
+
+    expect(result.score!.gate_pass).toBe(true);
+  }, 30000);
+});

--- a/eval/golden.test.ts
+++ b/eval/golden.test.ts
@@ -12,6 +12,13 @@ let kernelcadAvailable = false;
 
 beforeAll(async () => {
   kernelcadAvailable = await isKernelcadAvailable();
+  // In CI we must fail loudly rather than silently skip — a green build with
+  // zero golden coverage is worse than a red one. Local dev still gets the skip.
+  if (!kernelcadAvailable && process.env.CI) {
+    throw new Error(
+      'kernelcad CLI not available in CI. Set KERNELCAD_BIN=./dist/cli/index.js after `npm run build:cli`, or `npm link`.',
+    );
+  }
 });
 
 describe('golden mock replay', () => {

--- a/eval/lib.test.ts
+++ b/eval/lib.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractScript, formatDiagnostics } from './lib';
+import { extractScript, formatDiagnostics, computeScore } from './lib';
 import type { Diagnostic } from './types';
 
 describe('extractScript', () => {
@@ -85,5 +85,52 @@ describe('formatDiagnostics', () => {
 
   it('returns empty string for empty input', () => {
     expect(formatDiagnostics([])).toBe('');
+  });
+});
+
+describe('computeScore', () => {
+  const meta = { attempts: 1, tokens_in: 100, tokens_out: 50, time_ms: 5000 };
+
+  it('returns 0 when any gate fails', () => {
+    const s = computeScore(
+      { gates: { a: true, b: false }, scored: { x: true, y: true } },
+      meta,
+    );
+    expect(s.gate_pass).toBe(false);
+    expect(s.score).toBe(0);
+  });
+
+  it('returns passed/total when all gates pass and scored has entries', () => {
+    const s = computeScore(
+      { gates: { a: true }, scored: { x: true, y: true, z: false } },
+      meta,
+    );
+    expect(s.gate_pass).toBe(true);
+    expect(s.score).toBeCloseTo(2 / 3);
+  });
+
+  it('returns 1.0 when all gates pass and scored is empty (gates-only success)', () => {
+    const s = computeScore({ gates: { a: true, b: true }, scored: {} }, meta);
+    expect(s.gate_pass).toBe(true);
+    expect(s.score).toBe(1);
+  });
+
+  it('returns 0 when gates is empty (no gates ⇒ vacuously true ⇒ scored math applies)', () => {
+    // Empty gates: no false gates, so gate_pass = true; scored carries the weight.
+    const s = computeScore({ gates: {}, scored: { x: true } }, meta);
+    expect(s.gate_pass).toBe(true);
+    expect(s.score).toBe(1);
+  });
+
+  it('passes through metadata', () => {
+    const s = computeScore({ gates: { a: true }, scored: {} }, {
+      attempts: 3,
+      tokens_in: 1000,
+      tokens_out: 500,
+      time_ms: 30000,
+    });
+    expect(s.attempts).toBe(3);
+    expect(s.tokens).toEqual({ input: 1000, output: 500, total: 1500 });
+    expect(s.time_ms).toBe(30000);
   });
 });

--- a/eval/lib.test.ts
+++ b/eval/lib.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { extractScript, formatDiagnostics, computeScore } from './lib';
-import type { Diagnostic } from './types';
+import { extractScript, formatDiagnostics, computeScore, renderTranscript } from './lib';
+import type { Diagnostic, TranscriptEvent, Score } from './types';
 
 describe('extractScript', () => {
   it('extracts a typescript-fenced block', () => {
@@ -132,5 +132,115 @@ describe('computeScore', () => {
     expect(s.attempts).toBe(3);
     expect(s.tokens).toEqual({ input: 1000, output: 500, total: 1500 });
     expect(s.time_ms).toBe(30000);
+  });
+});
+
+describe('renderTranscript', () => {
+  it('renders a successful single-turn run', () => {
+    const events: TranscriptEvent[] = [
+      { kind: 'system_prompt', chars: 22000 },
+      { kind: 'user_prompt', content: 'Build an L-bracket.' },
+      {
+        kind: 'turn',
+        attempt: 1,
+        assistant_text: "Here's the bracket:\n```typescript\nreturn box(50, 30, 10);\n```",
+        script_extracted: 'return box(50, 30, 10);',
+        tokens_in: 4231,
+        tokens_out: 1892,
+        ms: 6300,
+      },
+      { kind: 'evaluate', attempt: 1, ok: true, diagnostics: [] },
+      { kind: 'score', gates: { 'evaluates clean': true }, scored: { 'L-shape': true } },
+    ];
+    const score: Score = {
+      gates: { 'evaluates clean': true },
+      scored: { 'L-shape': true },
+      gate_pass: true,
+      score: 1,
+      attempts: 1,
+      tokens: { input: 4231, output: 1892, total: 6123 },
+      time_ms: 6300,
+    };
+    const md = renderTranscript({
+      task: 'bracket-holes',
+      model: 'claude-sonnet-4-6',
+      started_at: '2026-05-02T14-32-01',
+      events,
+      score,
+    });
+
+    expect(md).toContain('# bracket-holes — claude-sonnet-4-6 — 2026-05-02T14-32-01');
+    expect(md).toContain('## Prompt');
+    expect(md).toContain('> Build an L-bracket.');
+    expect(md).toContain('## Turn 1 (in: 4,231 tok, out: 1,892 tok, 6.3s)');
+    expect(md).toContain('## Evaluate (attempt 1) — OK');
+    expect(md).toContain('## Score');
+    expect(md).toContain('- Gates: ✓ evaluates clean');
+    expect(md).toContain('- Scored: 1/1 — 100%');
+    expect(md).toContain('- Tokens: 4,231 in / 1,892 out / 6,123 total');
+    expect(md).toContain('- Time: 6.3s');
+    expect(md).toContain('- Attempts: 1');
+  });
+
+  it('renders a failed-then-retried run with diagnostics', () => {
+    const events: TranscriptEvent[] = [
+      { kind: 'system_prompt', chars: 22000 },
+      { kind: 'user_prompt', content: 'Build a thing.' },
+      {
+        kind: 'turn',
+        attempt: 1,
+        assistant_text: '```typescript\nreturn box(20,20,20).translate(5,0,0).fillet(2, { face: "top" });\n```',
+        script_extracted: 'return box(20,20,20).translate(5,0,0).fillet(2, { face: "top" });',
+        tokens_in: 4000,
+        tokens_out: 50,
+        ms: 3000,
+      },
+      {
+        kind: 'evaluate',
+        attempt: 1,
+        ok: false,
+        diagnostics: [
+          {
+            code: 'feature.edge-feature.face-ref-not-resolvable',
+            message: 'Canonical face refs only work on un-transformed primitives.',
+            hint: 'Apply transforms after the fillet/chamfer.',
+          },
+        ],
+      },
+      {
+        kind: 'turn',
+        attempt: 2,
+        assistant_text: '```typescript\nreturn box(20,20,20).fillet(2, { face: "top" }).translate(5,0,0);\n```',
+        script_extracted: 'return box(20,20,20).fillet(2, { face: "top" }).translate(5,0,0);',
+        tokens_in: 4500,
+        tokens_out: 60,
+        ms: 3500,
+      },
+      { kind: 'evaluate', attempt: 2, ok: true, diagnostics: [] },
+      { kind: 'score', gates: { 'evaluates clean': true }, scored: {} },
+    ];
+    const score: Score = {
+      gates: { 'evaluates clean': true },
+      scored: {},
+      gate_pass: true,
+      score: 1,
+      attempts: 2,
+      tokens: { input: 8500, output: 110, total: 8610 },
+      time_ms: 6500,
+    };
+    const md = renderTranscript({
+      task: 't',
+      model: 'm',
+      started_at: 's',
+      events,
+      score,
+    });
+
+    expect(md).toContain('## Evaluate (attempt 1) — FAIL');
+    expect(md).toContain('- `feature.edge-feature.face-ref-not-resolvable`');
+    expect(md).toContain('Hint: Apply transforms after the fillet/chamfer.');
+    expect(md).toContain('## Turn 2 (in: 4,500 tok, out: 60 tok, 3.5s)');
+    expect(md).toContain('## Evaluate (attempt 2) — OK');
+    expect(md).toContain('- Attempts: 2');
   });
 });

--- a/eval/lib.test.ts
+++ b/eval/lib.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { extractScript } from './lib';
+import { extractScript, formatDiagnostics } from './lib';
+import type { Diagnostic } from './types';
 
 describe('extractScript', () => {
   it('extracts a typescript-fenced block', () => {
@@ -39,5 +40,50 @@ describe('extractScript', () => {
   it('ignores fences with unrecognised language tags', () => {
     const input = '```python\nprint("nope")\n```\n```typescript\nreturn box(1,1,1);\n```';
     expect(extractScript(input)).toBe('return box(1,1,1);');
+  });
+});
+
+describe('formatDiagnostics', () => {
+  it('renders a single diagnostic with code and message', () => {
+    const diags: Diagnostic[] = [
+      { code: 'feature.fillet.failed', message: 'OCCT could not apply that fillet.' },
+    ];
+    expect(formatDiagnostics(diags)).toBe(
+      '- `feature.fillet.failed` — OCCT could not apply that fillet.',
+    );
+  });
+
+  it('appends hint on a new indented line when present', () => {
+    const diags: Diagnostic[] = [
+      {
+        code: 'feature.edge-feature.face-ref-not-resolvable',
+        message: 'Canonical face refs only work on un-transformed primitives.',
+        hint: 'Apply transforms after the fillet/chamfer.',
+      },
+    ];
+    expect(formatDiagnostics(diags)).toBe(
+      '- `feature.edge-feature.face-ref-not-resolvable` — Canonical face refs only work on un-transformed primitives.\n  Hint: Apply transforms after the fillet/chamfer.',
+    );
+  });
+
+  it('appends feature id when present', () => {
+    const diags: Diagnostic[] = [
+      { code: 'recompute.input.missing', message: 'Upstream feature failed.', featureId: 'fillet_3' },
+    ];
+    expect(formatDiagnostics(diags)).toBe(
+      '- `recompute.input.missing` — Upstream feature failed. (feature: fillet_3)',
+    );
+  });
+
+  it('joins multiple diagnostics with newlines', () => {
+    const diags: Diagnostic[] = [
+      { code: 'a', message: 'A.' },
+      { code: 'b', message: 'B.' },
+    ];
+    expect(formatDiagnostics(diags)).toBe('- `a` — A.\n- `b` — B.');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(formatDiagnostics([])).toBe('');
   });
 });

--- a/eval/lib.test.ts
+++ b/eval/lib.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { extractScript } from './lib';
+
+describe('extractScript', () => {
+  it('extracts a typescript-fenced block', () => {
+    const input = 'Here is the script:\n```typescript\nreturn box(10, 10, 10);\n```\nDone.';
+    expect(extractScript(input)).toBe('return box(10, 10, 10);');
+  });
+
+  it('extracts a ts-fenced block', () => {
+    const input = '```ts\nreturn box(1,2,3);\n```';
+    expect(extractScript(input)).toBe('return box(1,2,3);');
+  });
+
+  it('extracts a kcad-fenced block', () => {
+    const input = '```kcad\nreturn sphere(5);\n```';
+    expect(extractScript(input)).toBe('return sphere(5);');
+  });
+
+  it('extracts a fenced block with no language tag', () => {
+    const input = '```\nreturn cylinder(10, 5);\n```';
+    expect(extractScript(input)).toBe('return cylinder(10, 5);');
+  });
+
+  it('uses the first fence when multiple are present', () => {
+    const input = '```typescript\nreturn box(1,1,1);\n```\nNo wait:\n```typescript\nreturn box(2,2,2);\n```';
+    expect(extractScript(input)).toBe('return box(1,1,1);');
+  });
+
+  it('returns the whole text when no fence is present', () => {
+    expect(extractScript('return box(3,3,3);')).toBe('return box(3,3,3);');
+  });
+
+  it('returns null on empty input', () => {
+    expect(extractScript('')).toBeNull();
+    expect(extractScript('   \n\n  ')).toBeNull();
+  });
+
+  it('ignores fences with unrecognised language tags', () => {
+    const input = '```python\nprint("nope")\n```\n```typescript\nreturn box(1,1,1);\n```';
+    expect(extractScript(input)).toBe('return box(1,1,1);');
+  });
+});

--- a/eval/lib.ts
+++ b/eval/lib.ts
@@ -1,0 +1,18 @@
+const FENCED_LANGS = ['typescript', 'ts', 'kcad', ''];
+
+export function extractScript(text: string): string | null {
+  if (!text || !text.trim()) return null;
+
+  // Match fenced blocks: ``` followed by optional language tag, newline, body, then ```
+  const fenceRegex = /```(\w*)\n([\s\S]*?)```/g;
+  let m: RegExpExecArray | null;
+  while ((m = fenceRegex.exec(text)) !== null) {
+    const lang = (m[1] ?? '').toLowerCase();
+    if (FENCED_LANGS.includes(lang)) {
+      return m[2].trim();
+    }
+  }
+
+  // No matching fence — return the whole text trimmed.
+  return text.trim();
+}

--- a/eval/lib.ts
+++ b/eval/lib.ts
@@ -1,4 +1,4 @@
-import type { Diagnostic, HarnessResult, Score } from './types';
+import type { Diagnostic, HarnessResult, Score, TranscriptEvent } from './types';
 
 const FENCED_LANGS = ['typescript', 'ts', 'kcad', ''];
 
@@ -60,4 +60,74 @@ export function computeScore(
     tokens: { input: meta.tokens_in, output: meta.tokens_out, total: meta.tokens_in + meta.tokens_out },
     time_ms: meta.time_ms,
   };
+}
+
+export interface RenderTranscriptArgs {
+  task: string;
+  model: string;
+  started_at: string;
+  events: TranscriptEvent[];
+  score: Score;
+}
+
+const formatNum = (n: number) => n.toLocaleString('en-US');
+const formatSeconds = (ms: number) => `${(ms / 1000).toFixed(1)}s`;
+
+export function renderTranscript(args: RenderTranscriptArgs): string {
+  const lines: string[] = [];
+  lines.push(`# ${args.task} — ${args.model} — ${args.started_at}`);
+  lines.push('');
+
+  for (const ev of args.events) {
+    if (ev.kind === 'system_prompt') {
+      // We deliberately do not dump the full SKILL.md into the transcript;
+      // the chars count is enough for forensics.
+      continue;
+    }
+    if (ev.kind === 'user_prompt') {
+      lines.push('## Prompt');
+      for (const line of ev.content.split('\n')) {
+        lines.push(`> ${line}`);
+      }
+      lines.push('');
+    } else if (ev.kind === 'turn') {
+      lines.push(
+        `## Turn ${ev.attempt} (in: ${formatNum(ev.tokens_in)} tok, out: ${formatNum(
+          ev.tokens_out,
+        )} tok, ${formatSeconds(ev.ms)})`,
+      );
+      lines.push('');
+      lines.push(ev.assistant_text);
+      lines.push('');
+    } else if (ev.kind === 'evaluate') {
+      const verdict = ev.ok ? 'OK' : 'FAIL';
+      lines.push(`## Evaluate (attempt ${ev.attempt}) — ${verdict}`);
+      if (ev.diagnostics.length > 0) {
+        lines.push(formatDiagnostics(ev.diagnostics));
+      }
+      lines.push('');
+    } else if (ev.kind === 'score') {
+      // Score block is rendered at end from the score arg, not from this event.
+    }
+  }
+
+  // Final score block.
+  lines.push('## Score');
+  const gatesLine = Object.entries(args.score.gates)
+    .map(([n, v]) => `${v ? '✓' : '✗'} ${n}`)
+    .join(', ');
+  lines.push(`- Gates: ${gatesLine || '(none)'}`);
+
+  const scoredEntries = Object.entries(args.score.scored);
+  const passed = scoredEntries.filter(([, v]) => v).length;
+  const total = scoredEntries.length;
+  const pct = total === 0 ? (args.score.gate_pass ? 100 : 0) : Math.round((passed / total) * 100);
+  lines.push(`- Scored: ${passed}/${total} — ${pct}%`);
+
+  const t = args.score.tokens;
+  lines.push(`- Tokens: ${formatNum(t.input)} in / ${formatNum(t.output)} out / ${formatNum(t.total)} total`);
+  lines.push(`- Time: ${formatSeconds(args.score.time_ms)}`);
+  lines.push(`- Attempts: ${args.score.attempts}`);
+
+  return lines.join('\n');
 }

--- a/eval/lib.ts
+++ b/eval/lib.ts
@@ -1,3 +1,5 @@
+import type { Diagnostic } from './types';
+
 const FENCED_LANGS = ['typescript', 'ts', 'kcad', ''];
 
 export function extractScript(text: string): string | null {
@@ -15,4 +17,15 @@ export function extractScript(text: string): string | null {
 
   // No matching fence — return the whole text trimmed.
   return text.trim();
+}
+
+export function formatDiagnostics(diagnostics: Diagnostic[]): string {
+  return diagnostics
+    .map((d) => {
+      let line = `- \`${d.code}\` — ${d.message}`;
+      if (d.featureId) line += ` (feature: ${d.featureId})`;
+      if (d.hint) line += `\n  Hint: ${d.hint}`;
+      return line;
+    })
+    .join('\n');
 }

--- a/eval/lib.ts
+++ b/eval/lib.ts
@@ -1,4 +1,4 @@
-import type { Diagnostic } from './types';
+import type { Diagnostic, HarnessResult, Score } from './types';
 
 const FENCED_LANGS = ['typescript', 'ts', 'kcad', ''];
 
@@ -28,4 +28,36 @@ export function formatDiagnostics(diagnostics: Diagnostic[]): string {
       return line;
     })
     .join('\n');
+}
+
+export function computeScore(
+  result: HarnessResult,
+  meta: { attempts: number; tokens_in: number; tokens_out: number; time_ms: number },
+): Score {
+  const gateValues = Object.values(result.gates);
+  const gate_pass = gateValues.every((v) => v);
+
+  let score: number;
+  if (!gate_pass) {
+    score = 0;
+  } else {
+    const scoredValues = Object.values(result.scored);
+    const total = scoredValues.length;
+    if (total === 0) {
+      score = 1; // gates-only success
+    } else {
+      const passed = scoredValues.filter((v) => v).length;
+      score = passed / total;
+    }
+  }
+
+  return {
+    gates: result.gates,
+    scored: result.scored,
+    gate_pass,
+    score,
+    attempts: meta.attempts,
+    tokens: { input: meta.tokens_in, output: meta.tokens_out, total: meta.tokens_in + meta.tokens_out },
+    time_ms: meta.time_ms,
+  };
 }

--- a/eval/oracle/kernelcad-client.test.ts
+++ b/eval/oracle/kernelcad-client.test.ts
@@ -10,6 +10,13 @@ let tmpDir: string;
 beforeAll(async () => {
   kernelcadAvailable = await isKernelcadAvailable();
   if (!kernelcadAvailable) {
+    // In CI we must fail loudly rather than silently skip — a green build with
+    // zero kernelcad-client coverage is worse than a red one. Local dev still gets the skip.
+    if (process.env.CI) {
+      throw new Error(
+        'kernelcad CLI not available in CI. Set KERNELCAD_BIN=./dist/cli/index.js after `npm run build:cli`, or `npm link`.',
+      );
+    }
     console.warn(
       'kernelcad CLI not found on PATH and KERNELCAD_BIN not set — skipping kernelcad-client smoke tests. Run `npm run build:cli` and set KERNELCAD_BIN=./dist/cli/index.js, or `npm link`.',
     );

--- a/eval/oracle/kernelcad-client.test.ts
+++ b/eval/oracle/kernelcad-client.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { evaluateScript, getShapeInfo, isKernelcadAvailable } from './kernelcad-client';
+
+let kernelcadAvailable = false;
+let tmpDir: string;
+
+beforeAll(async () => {
+  kernelcadAvailable = await isKernelcadAvailable();
+  if (!kernelcadAvailable) {
+    console.warn(
+      'kernelcad CLI not found on PATH and KERNELCAD_BIN not set — skipping kernelcad-client smoke tests. Run `npm run build:cli` and set KERNELCAD_BIN=./dist/cli/index.js, or `npm link`.',
+    );
+  }
+  tmpDir = mkdtempSync(join(tmpdir(), 'kernelcad-client-test-'));
+});
+
+describe('kernelcad-client', () => {
+  it('evaluateScript returns ok=true for a valid script', async (ctx) => {
+    if (!kernelcadAvailable) return ctx.skip();
+    const path = join(tmpDir, 'box.kcad.ts');
+    writeFileSync(path, 'return box(10, 20, 30);');
+    const r = await evaluateScript(path);
+    expect(r.ok).toBe(true);
+    expect(r.diagnostics).toEqual([]);
+  });
+
+  it('evaluateScript returns ok=false with diagnostics for a broken script', async (ctx) => {
+    if (!kernelcadAvailable) return ctx.skip();
+    const path = join(tmpDir, 'broken.kcad.ts');
+    // Sphere with face filter — should fail per SKILL.md ("Sphere with any { face } filter → error.")
+    writeFileSync(path, 'return sphere(5).fillet(1, { face: "top" });');
+    const r = await evaluateScript(path);
+    expect(r.ok).toBe(false);
+    expect(r.diagnostics.length).toBeGreaterThan(0);
+    expect(r.diagnostics[0].code).toMatch(/^feature\./);
+  });
+
+  it('getShapeInfo returns volume and bbox for a known box', async (ctx) => {
+    if (!kernelcadAvailable) return ctx.skip();
+    const path = join(tmpDir, 'box-known.kcad.ts');
+    writeFileSync(path, 'return box(10, 20, 30);');
+    const info = await getShapeInfo(path);
+    expect(info.volume).toBeCloseTo(6000, 0); // 10 * 20 * 30
+    expect(info.bbox.min).toEqual([0, 0, 0]);
+    expect(info.bbox.max).toEqual([10, 20, 30]);
+  });
+});

--- a/eval/oracle/kernelcad-client.ts
+++ b/eval/oracle/kernelcad-client.ts
@@ -95,8 +95,12 @@ export async function getShapeInfo(scriptPath: string): Promise<ShapeInfo> {
         throw new Error(`get_shape_info returned no text content: ${JSON.stringify(result)}`);
       }
       const shapeJson = JSON.parse(text);
-      // The MCP tool returns { ok: boolean, shape: { volume, surfaceArea, bbox: { min, max } } }
-      const shape = shapeJson.shape ?? shapeJson;
+      // Contract: the MCP tool returns { ok: boolean, shape: { volume, surfaceArea, bbox: { min, max } } }.
+      // If the producer ever changes this shape, fail loudly here so the eval harness doesn't silently produce nonsense.
+      if (typeof shapeJson !== 'object' || shapeJson === null || typeof shapeJson.shape !== 'object' || shapeJson.shape === null) {
+        throw new Error(`get_shape_info returned unexpected envelope (expected { ok, shape: {...} }): ${text}`);
+      }
+      const shape = shapeJson.shape;
       if (
         typeof shape.volume !== 'number' ||
         typeof shape.surfaceArea !== 'number' ||
@@ -104,7 +108,7 @@ export async function getShapeInfo(scriptPath: string): Promise<ShapeInfo> {
         !Array.isArray(shape.bbox.min) ||
         !Array.isArray(shape.bbox.max)
       ) {
-        throw new Error(`get_shape_info returned unexpected shape: ${text}`);
+        throw new Error(`get_shape_info returned unexpected shape body: ${text}`);
       }
       return {
         volume: shape.volume,

--- a/eval/oracle/kernelcad-client.ts
+++ b/eval/oracle/kernelcad-client.ts
@@ -1,5 +1,8 @@
 import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import type { EvaluateResult, ShapeInfo } from '../types';
+
+const LOCAL_BUILD = './dist/cli/index.js';
 
 function getBin(): { cmd: string; baseArgs: string[] } {
   const override = process.env.KERNELCAD_BIN;
@@ -9,6 +12,12 @@ function getBin(): { cmd: string; baseArgs: string[] } {
       return { cmd: 'node', baseArgs: [override] };
     }
     return { cmd: override, baseArgs: [] };
+  }
+  // Fallback to the in-repo build if it exists. Lets CI work without setting
+  // KERNELCAD_BIN as long as `npm run build:cli` ran first (which `npm run qc`
+  // does). Local dev can still override via KERNELCAD_BIN or use `npm link`.
+  if (existsSync(LOCAL_BUILD)) {
+    return { cmd: 'node', baseArgs: [LOCAL_BUILD] };
   }
   return { cmd: 'kernelcad', baseArgs: [] };
 }

--- a/eval/oracle/kernelcad-client.ts
+++ b/eval/oracle/kernelcad-client.ts
@@ -1,0 +1,128 @@
+import { spawn } from 'node:child_process';
+import type { EvaluateResult, ShapeInfo } from '../types';
+
+function getBin(): { cmd: string; baseArgs: string[] } {
+  const override = process.env.KERNELCAD_BIN;
+  if (override) {
+    // If the override ends in .js, we run it via node.
+    if (override.endsWith('.js')) {
+      return { cmd: 'node', baseArgs: [override] };
+    }
+    return { cmd: override, baseArgs: [] };
+  }
+  return { cmd: 'kernelcad', baseArgs: [] };
+}
+
+async function runOnce(args: string[], stdin?: string): Promise<{ code: number; stdout: string; stderr: string }> {
+  const { cmd, baseArgs } = getBin();
+  return await new Promise((resolve, reject) => {
+    const child = spawn(cmd, [...baseArgs, ...args], { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => (stdout += d.toString()));
+    child.stderr.on('data', (d) => (stderr += d.toString()));
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code: code ?? -1, stdout, stderr }));
+    if (stdin !== undefined) {
+      child.stdin.write(stdin);
+    }
+    child.stdin.end();
+  });
+}
+
+export async function evaluateScript(scriptPath: string): Promise<EvaluateResult> {
+  const r = await runOnce(['evaluate', '--json', scriptPath]);
+  // The CLI may print the JSON to stdout regardless of exit code; try to parse.
+  try {
+    const parsed = JSON.parse(r.stdout);
+    return {
+      ok: !!parsed.ok && Array.isArray(parsed.diagnostics) && parsed.diagnostics.length === 0,
+      diagnostics: Array.isArray(parsed.diagnostics) ? parsed.diagnostics : [],
+      featureCount: parsed.featureCount,
+    };
+  } catch {
+    return {
+      ok: false,
+      diagnostics: [
+        {
+          code: 'cli.script.exception',
+          message: `kernelcad evaluate exited with code ${r.code}: ${r.stderr.trim() || r.stdout.trim() || '(no output)'}`,
+        },
+      ],
+    };
+  }
+}
+
+export async function getShapeInfo(scriptPath: string): Promise<ShapeInfo> {
+  // One-shot MCP call: open the server, send a single tools/call request, read response, kill.
+  // Per MCP stdio transport, requests are JSON-RPC newline-delimited.
+  const initialize = JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'kernelcad-eval', version: '0.1.0' } },
+  });
+  const initialized = JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' });
+  const callTool = JSON.stringify({
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/call',
+    params: { name: 'get_shape_info', arguments: { file: scriptPath } },
+  });
+  const stdin = `${initialize}\n${initialized}\n${callTool}\n`;
+
+  const r = await runOnce(['mcp'], stdin);
+  // Parse newline-delimited JSON responses; find the one with id === 2.
+  const lines = r.stdout.split('\n').filter((l) => l.trim().length > 0);
+  for (const line of lines) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      'id' in parsed &&
+      (parsed as { id: unknown }).id === 2 &&
+      'result' in parsed
+    ) {
+      // MCP tool result is a content array; the first item is text JSON for our tools.
+      const result = (parsed as { result: { content?: Array<{ type: string; text?: string }> } }).result;
+      const text = result.content?.[0]?.text;
+      if (typeof text !== 'string') {
+        throw new Error(`get_shape_info returned no text content: ${JSON.stringify(result)}`);
+      }
+      const shapeJson = JSON.parse(text);
+      // The MCP tool returns { ok: boolean, shape: { volume, surfaceArea, bbox: { min, max } } }
+      const shape = shapeJson.shape ?? shapeJson;
+      if (
+        typeof shape.volume !== 'number' ||
+        typeof shape.surfaceArea !== 'number' ||
+        !shape.bbox ||
+        !Array.isArray(shape.bbox.min) ||
+        !Array.isArray(shape.bbox.max)
+      ) {
+        throw new Error(`get_shape_info returned unexpected shape: ${text}`);
+      }
+      return {
+        volume: shape.volume,
+        surfaceArea: shape.surfaceArea,
+        bbox: { min: shape.bbox.min, max: shape.bbox.max },
+      };
+    }
+  }
+  throw new Error(
+    `get_shape_info: no response with id=2 in stdout. stdout=${r.stdout.slice(0, 500)} stderr=${r.stderr.slice(0, 500)}`,
+  );
+}
+
+export async function isKernelcadAvailable(): Promise<boolean> {
+  try {
+    const r = await runOnce(['--version']);
+    return r.code === 0;
+  } catch {
+    return false;
+  }
+}

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { runTask } from './runner';
+import { AnthropicAgentClient, MockAgentClient } from './agent';
+import { isKernelcadAvailable } from './oracle/kernelcad-client';
+import type { AgentClient, AgentResponse, TaskResult } from './types';
+
+const MODEL = process.env.EVAL_MODEL ?? 'claude-sonnet-4-6';
+const TASKS_DIR = resolve('eval/tasks');
+const RUNS_DIR = resolve('eval/runs');
+const SKILL_PATH = resolve('src/skill/SKILL.md');
+
+function timestamp(): string {
+  // YYYY-MM-DDTHH-MM-SS — filesystem-safe ISO.
+  return new Date().toISOString().replace(/\..+$/, '').replace(/:/g, '-');
+}
+
+function fail(message: string): never {
+  console.error(`\nERROR: ${message}\n`);
+  process.exit(1);
+}
+
+function discoverTasks(filter?: string): string[] {
+  if (!existsSync(TASKS_DIR)) {
+    fail(`Tasks directory not found: ${TASKS_DIR}`);
+  }
+  const all = readdirSync(TASKS_DIR).filter((name) => {
+    const full = join(TASKS_DIR, name);
+    return statSync(full).isDirectory() && existsSync(join(full, 'prompt.md')) && existsSync(join(full, 'harness.ts'));
+  });
+  return filter ? all.filter((n) => n === filter) : all;
+}
+
+function formatNum(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
+function printSummary(results: TaskResult[]): void {
+  const COLS = { task: 18, score: 8, attempts: 9, tokens: 9, time: 8 };
+  const pad = (s: string, w: number) => s.padEnd(w);
+
+  console.error('');
+  console.error(
+    `${pad('TASK', COLS.task)} ${pad('SCORE', COLS.score)} ${pad('ATTEMPTS', COLS.attempts)} ${pad('TOKENS', COLS.tokens)} ${pad('TIME', COLS.time)}`,
+  );
+
+  let totalTokens = 0;
+  let totalTimeMs = 0;
+  let passed = 0;
+  let infraErrors = 0;
+
+  for (const r of results) {
+    if (!r.score) {
+      console.error(`${pad(r.task, COLS.task)} ${pad('— infra —', COLS.score + COLS.attempts + COLS.tokens + COLS.time + 4)}`);
+      infraErrors++;
+      continue;
+    }
+    const s = r.score;
+    const mark = s.gate_pass && s.score === 1 ? '✓' : (s.gate_pass ? '~' : '✗');
+    if (s.gate_pass && s.score === 1) passed++;
+    const scoreStr = `${mark} ${s.score.toFixed(2)}`;
+    const tokensStr = formatNum(s.tokens.total);
+    const timeStr = `${(s.time_ms / 1000).toFixed(1)}s`;
+    const note = !s.gate_pass ? '   gate fail' : '';
+    console.error(
+      `${pad(r.task, COLS.task)} ${pad(scoreStr, COLS.score)} ${pad(String(s.attempts), COLS.attempts)} ${pad(tokensStr, COLS.tokens)} ${pad(timeStr, COLS.time)}${note}`,
+    );
+    totalTokens += s.tokens.total;
+    totalTimeMs += s.time_ms;
+  }
+
+  console.error('─'.repeat(60));
+  const counted = results.length - infraErrors;
+  console.error(
+    `${counted} tasks, ${passed} passed     ${formatNum(totalTokens)} total   ${(totalTimeMs / 1000).toFixed(1)}s${infraErrors > 0 ? `   (${infraErrors} infra failures)` : ''}`,
+  );
+}
+
+function loadFixture(fixturePath: string): AgentResponse[] {
+  const data = JSON.parse(readFileSync(fixturePath, 'utf8'));
+  if (!Array.isArray(data.responses)) {
+    fail(`Fixture missing responses array: ${fixturePath}`);
+  }
+  return data.responses;
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const isMock = args.includes('--mock');
+  const taskArg = args.find((a, i) => !a.startsWith('--') && args[i - 1] !== '--fixture');
+
+  // --mock fixture path (optional; defaults to runs/golden-2026-05-02-bracket-holes)
+  const fixtureFlagIdx = args.indexOf('--fixture');
+  const fixturePath =
+    fixtureFlagIdx >= 0 && args[fixtureFlagIdx + 1]
+      ? args[fixtureFlagIdx + 1]
+      : 'eval/runs/golden-2026-05-02-bracket-holes/fixture.json';
+
+  // Pre-flight
+  if (!existsSync(SKILL_PATH)) {
+    fail(`SKILL.md not found at ${SKILL_PATH}`);
+  }
+  if (!(await isKernelcadAvailable())) {
+    fail(
+      'kernelcad CLI not found. Run `npm run build:cli` and set KERNELCAD_BIN=./dist/cli/index.js, or `npm link` to make it global.',
+    );
+  }
+  if (!isMock && !process.env.ANTHROPIC_API_KEY) {
+    fail('ANTHROPIC_API_KEY env var is required (or pass --mock to replay a fixture).');
+  }
+
+  const skillMd = readFileSync(SKILL_PATH, 'utf8');
+  const tasks = discoverTasks(taskArg);
+  if (tasks.length === 0) {
+    fail(taskArg ? `No task named '${taskArg}' under ${TASKS_DIR}` : `No tasks found under ${TASKS_DIR}`);
+  }
+
+  const startedAt = timestamp();
+  const runRoot = join(RUNS_DIR, isMock ? `_mock-${startedAt}` : startedAt);
+
+  const results: TaskResult[] = [];
+  for (const task of tasks) {
+    let agent: AgentClient;
+    if (isMock) {
+      agent = new MockAgentClient(loadFixture(fixturePath));
+    } else {
+      agent = new AnthropicAgentClient(process.env.ANTHROPIC_API_KEY!);
+    }
+    try {
+      const r = await runTask({
+        taskDir: join(TASKS_DIR, task),
+        runDir: join(runRoot, task),
+        agent,
+        model: isMock ? 'mock-model' : MODEL,
+        skillMd,
+        startedAt,
+      });
+      results.push(r);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`\n[${task}] infra error: ${msg}`);
+      results.push({ task, score: null, infra_error: msg });
+    }
+  }
+
+  printSummary(results);
+
+  // Exit 0 unless every task was infra_error.
+  const allInfra = results.every((r) => r.infra_error);
+  process.exit(allInfra ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -116,17 +116,37 @@ async function main(): Promise<void> {
     fail(taskArg ? `No task named '${taskArg}' under ${TASKS_DIR}` : `No tasks found under ${TASKS_DIR}`);
   }
 
+  // Mock-mode pre-flight: validate the fixture file exists and parses cleanly,
+  // and that the v1 single-fixture format isn't being asked to drive multiple
+  // tasks (each would consume the same canned queue — wrong). Multi-task mock
+  // mode needs a per-task fixture map; until that lands, fail clearly here
+  // rather than producing nonsense scores.
+  let fixtureResponses: AgentResponse[] | null = null;
+  if (isMock) {
+    if (!existsSync(fixturePath)) {
+      fail(`Fixture file not found: ${fixturePath}\nPass --fixture <path> or commit a fixture at the default path.`);
+    }
+    try {
+      fixtureResponses = loadFixture(fixturePath);
+    } catch (err) {
+      fail(`Could not load fixture ${fixturePath}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    if (tasks.length > 1) {
+      fail(
+        `--mock with ${tasks.length} tasks is not supported in v1 — the flat fixture format would feed all tasks the same responses.\n` +
+        `Pass a single task argument: npm run eval -- --mock <task-id>`,
+      );
+    }
+  }
+
   const startedAt = timestamp();
   const runRoot = join(RUNS_DIR, isMock ? `_mock-${startedAt}` : startedAt);
 
   const results: TaskResult[] = [];
   for (const task of tasks) {
-    let agent: AgentClient;
-    if (isMock) {
-      agent = new MockAgentClient(loadFixture(fixturePath));
-    } else {
-      agent = new AnthropicAgentClient(process.env.ANTHROPIC_API_KEY!);
-    }
+    const agent: AgentClient = isMock
+      ? new MockAgentClient(fixtureResponses!)
+      : new AnthropicAgentClient(process.env.ANTHROPIC_API_KEY!);
     try {
       const r = await runTask({
         taskDir: join(TASKS_DIR, task),

--- a/eval/runner.test.ts
+++ b/eval/runner.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runTask } from './runner';
+import { MockAgentClient } from './agent';
+import { isKernelcadAvailable } from './oracle/kernelcad-client';
+
+let kernelcadAvailable = false;
+let runsDir: string;
+
+beforeAll(async () => {
+  kernelcadAvailable = await isKernelcadAvailable();
+});
+
+beforeEach(() => {
+  runsDir = mkdtempSync(join(tmpdir(), 'eval-runner-'));
+});
+
+describe('runTask', () => {
+  it('runs a task end-to-end and writes artifacts when the agent succeeds first try', async (ctx) => {
+    if (!kernelcadAvailable) return ctx.skip();
+
+    const expertScript = readFileSync('./eval/tasks/bracket-holes/solution-expert.kcad.ts', 'utf8');
+    const client = new MockAgentClient([
+      {
+        text: 'Here is the bracket:\n```typescript\n' + expertScript + '\n```',
+        tokens_in: 4000,
+        tokens_out: 200,
+      },
+    ]);
+
+    const result = await runTask({
+      taskDir: './eval/tasks/bracket-holes',
+      runDir: runsDir,
+      agent: client,
+      model: 'mock-model',
+      skillMd: 'fake skill content',
+      startedAt: '2026-05-02T14-00-00',
+    });
+
+    expect(result.score).not.toBeNull();
+    expect(result.score!.gate_pass).toBe(true);
+    expect(result.score!.score).toBe(1);
+    expect(result.score!.attempts).toBe(1);
+
+    expect(existsSync(join(runsDir, 'transcript.md'))).toBe(true);
+    expect(existsSync(join(runsDir, 'output.kcad.ts'))).toBe(true);
+    expect(existsSync(join(runsDir, 'score.json'))).toBe(true);
+
+    const score = JSON.parse(readFileSync(join(runsDir, 'score.json'), 'utf8'));
+    expect(score.gate_pass).toBe(true);
+    expect(score.score).toBe(1);
+
+    const tx = readFileSync(join(runsDir, 'transcript.md'), 'utf8');
+    expect(tx).toContain('# bracket-holes');
+    expect(tx).toContain('## Turn 1');
+    expect(tx).toContain('## Evaluate (attempt 1) — OK');
+  }, 30000);
+
+  it('retries up to 3 attempts when the agent first generates a broken script', async (ctx) => {
+    if (!kernelcadAvailable) return ctx.skip();
+
+    const expertScript = readFileSync('./eval/tasks/bracket-holes/solution-expert.kcad.ts', 'utf8');
+    const client = new MockAgentClient([
+      // Attempt 1: broken (sphere with face filter — guaranteed-fail diagnostic)
+      {
+        text: '```typescript\nreturn sphere(5).fillet(1, { face: "top" });\n```',
+        tokens_in: 4000,
+        tokens_out: 50,
+      },
+      // Attempt 2: correct
+      {
+        text: '```typescript\n' + expertScript + '\n```',
+        tokens_in: 4500,
+        tokens_out: 200,
+      },
+    ]);
+
+    const result = await runTask({
+      taskDir: './eval/tasks/bracket-holes',
+      runDir: runsDir,
+      agent: client,
+      model: 'mock-model',
+      skillMd: 'fake skill content',
+      startedAt: '2026-05-02T14-00-00',
+    });
+
+    expect(result.score!.attempts).toBe(2);
+    expect(result.score!.score).toBe(1);
+
+    const tx = readFileSync(join(runsDir, 'transcript.md'), 'utf8');
+    expect(tx).toContain('## Evaluate (attempt 1) — FAIL');
+    expect(tx).toContain('## Turn 2');
+    expect(tx).toContain('## Evaluate (attempt 2) — OK');
+  }, 30000);
+
+  it('gives up after 3 failed attempts and marks gate-fail', async (ctx) => {
+    if (!kernelcadAvailable) return ctx.skip();
+
+    const broken = '```typescript\nreturn sphere(5).fillet(1, { face: "top" });\n```';
+    const client = new MockAgentClient([
+      { text: broken, tokens_in: 4000, tokens_out: 50 },
+      { text: broken, tokens_in: 4000, tokens_out: 50 },
+      { text: broken, tokens_in: 4000, tokens_out: 50 },
+    ]);
+
+    const result = await runTask({
+      taskDir: './eval/tasks/bracket-holes',
+      runDir: runsDir,
+      agent: client,
+      model: 'mock-model',
+      skillMd: 'fake skill content',
+      startedAt: '2026-05-02T14-00-00',
+    });
+
+    expect(result.score!.attempts).toBe(3);
+    expect(result.score!.gate_pass).toBe(false);
+    expect(result.score!.score).toBe(0);
+  }, 30000);
+});

--- a/eval/runner.test.ts
+++ b/eval/runner.test.ts
@@ -11,6 +11,13 @@ let runsDir: string;
 
 beforeAll(async () => {
   kernelcadAvailable = await isKernelcadAvailable();
+  // In CI we must fail loudly rather than silently skip — a green build with
+  // zero runner coverage is worse than a red one. Local dev still gets the skip.
+  if (!kernelcadAvailable && process.env.CI) {
+    throw new Error(
+      'kernelcad CLI not available in CI. Set KERNELCAD_BIN=./dist/cli/index.js after `npm run build:cli`, or `npm link`.',
+    );
+  }
 });
 
 beforeEach(() => {

--- a/eval/runner.ts
+++ b/eval/runner.ts
@@ -1,0 +1,148 @@
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import type { AgentClient, AgentMessage, TranscriptEvent, TaskResult, HarnessResult } from './types';
+import { extractScript, formatDiagnostics, computeScore, renderTranscript } from './lib';
+import { evaluateScript } from './oracle/kernelcad-client';
+
+const MAX_ATTEMPTS = 3;
+const MAX_TOKENS = 8000;
+
+export interface RunTaskArgs {
+  taskDir: string;            // e.g. ./eval/tasks/bracket-holes
+  runDir: string;             // e.g. ./eval/runs/2026-05-02T14-00-00/bracket-holes
+  agent: AgentClient;
+  model: string;
+  skillMd: string;
+  startedAt: string;          // ISO timestamp string (filesystem-safe), used for transcript header
+}
+
+export async function runTask(args: RunTaskArgs): Promise<TaskResult> {
+  const taskDirAbs = resolve(args.taskDir);
+  const taskName = taskDirAbs.split('/').pop() ?? 'unknown';
+  const promptPath = join(taskDirAbs, 'prompt.md');
+  const harnessPath = join(taskDirAbs, 'harness.ts');
+  const prompt = readFileSync(promptPath, 'utf8');
+
+  mkdirSync(args.runDir, { recursive: true });
+  const outputScriptPath = join(args.runDir, 'output.kcad.ts');
+  const transcriptPath = join(args.runDir, 'transcript.md');
+  const scorePath = join(args.runDir, 'score.json');
+
+  const events: TranscriptEvent[] = [];
+  events.push({ kind: 'system_prompt', chars: args.skillMd.length });
+  events.push({ kind: 'user_prompt', content: prompt });
+
+  const messages: AgentMessage[] = [{ role: 'user', content: prompt }];
+  let attempts = 0;
+  let totalIn = 0;
+  let totalOut = 0;
+  let lastEvaluateOk = false;
+  let finalScript: string | null = null;
+
+  const start = Date.now();
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    attempts = attempt;
+    const turnStart = Date.now();
+    const resp = await args.agent.generate({
+      system: args.skillMd,
+      messages,
+      model: args.model,
+      max_tokens: MAX_TOKENS,
+    });
+    const turnMs = Date.now() - turnStart;
+    totalIn += resp.tokens_in;
+    totalOut += resp.tokens_out;
+    const script = extractScript(resp.text);
+
+    events.push({
+      kind: 'turn',
+      attempt,
+      assistant_text: resp.text,
+      script_extracted: script,
+      tokens_in: resp.tokens_in,
+      tokens_out: resp.tokens_out,
+      ms: turnMs,
+    });
+
+    if (!script) {
+      // Couldn't extract a script — append a guidance message and retry.
+      events.push({
+        kind: 'evaluate',
+        attempt,
+        ok: false,
+        diagnostics: [
+          { code: 'eval.no-script-extracted', message: 'No script extracted from model response.' },
+        ],
+      });
+      messages.push({ role: 'assistant', content: resp.text });
+      messages.push({
+        role: 'user',
+        content: 'I could not extract a script from your response. Please return the full script in a single ```typescript code block.',
+      });
+      continue;
+    }
+
+    writeFileSync(outputScriptPath, script);
+    finalScript = script;
+
+    const ev = await evaluateScript(outputScriptPath);
+    events.push({ kind: 'evaluate', attempt, ok: ev.ok, diagnostics: ev.diagnostics });
+
+    if (ev.ok) {
+      lastEvaluateOk = true;
+      break;
+    }
+
+    // Feed diagnostics back and retry (unless this was the last attempt).
+    if (attempt < MAX_ATTEMPTS) {
+      messages.push({ role: 'assistant', content: resp.text });
+      messages.push({
+        role: 'user',
+        content: `Diagnostics:\n${formatDiagnostics(ev.diagnostics)}\nFix and return the full corrected script.`,
+      });
+    }
+  }
+
+  // If we never got a clean evaluate, finalScript may still be the last broken attempt or null.
+  // Write whatever we have so the human can read it; harness will mark gate-fail.
+  if (!finalScript) {
+    writeFileSync(outputScriptPath, '// (no script extracted from any attempt)');
+  }
+
+  // Run the task's harness against the final output.
+  let harnessResult: HarnessResult;
+  if (lastEvaluateOk) {
+    const harnessModule = await import(harnessPath);
+    harnessResult = await harnessModule.default(outputScriptPath);
+  } else {
+    harnessResult = { gates: { 'evaluates clean': false }, scored: {} };
+  }
+
+  events.push({
+    kind: 'score',
+    gates: harnessResult.gates,
+    scored: harnessResult.scored,
+  });
+
+  const score = computeScore(harnessResult, {
+    attempts,
+    tokens_in: totalIn,
+    tokens_out: totalOut,
+    time_ms: Date.now() - start,
+  });
+
+  writeFileSync(scorePath, JSON.stringify(score, null, 2));
+  writeFileSync(
+    transcriptPath,
+    renderTranscript({
+      task: taskName,
+      model: args.model,
+      started_at: args.startedAt,
+      events,
+      score,
+    }),
+  );
+
+  return { task: taskName, score };
+}

--- a/eval/runs/golden-2026-05-02-bracket-holes/fixture.json
+++ b/eval/runs/golden-2026-05-02-bracket-holes/fixture.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Golden mock fixture for bracket-holes. Two attempts: attempt 1 fails with face-ref-not-resolvable (sphere+face filter), attempt 2 succeeds. Attempt 2 script body is the current expert solution verbatim.",
+  "_authored": "2026-05-02",
+  "responses": [
+    {
+      "text": "Here's a first attempt — I'll just round the top:\n\n```typescript\nreturn sphere(5).fillet(1, { face: 'top' });\n```",
+      "tokens_in": 4231,
+      "tokens_out": 60
+    },
+    {
+      "text": "I see — sphere doesn't accept a { face } filter. Here's the proper L-bracket per the prompt:\n\n```typescript\nconst boltDiam = param(\"Bolt Diameter\", 5, { unit: 'mm', min: 3, max: 10 });\n\nconst t = 2 * boltDiam;       // wall thickness\nconst w = 4 * boltDiam;       // plate width/length (>= 3 * boltDiam)\nconst h = 3 * boltDiam;       // plate height (>= 3 * boltDiam)\nconst holeR = (boltDiam + 0.5) / 2;\n\n// Horizontal plate (foot of the L): x in [0,w], y in [0,h], z in [0,t].\n// Hole through Z at plate centroid.\nconst horiz = box(w, h, t).subtract(\n  cylinder(t + 2, holeR).translate(w / 2, h / 2, -1),\n);\n\n// Vertical plate (upright of the L): x in [0,t], y in [0,h], z in [t, t+w].\n// Sits flush on top of the horizontal plate's near edge — no volume overlap.\n// Hole through X at the centroid of the vertical face.\nconst vert = box(t, h, w).subtract(\n  cylinder(t + 2, holeR).rotate([0, 1, 0], 90).translate(-1, h / 2, w / 2),\n).translate(0, 0, t);\n\nreturn horiz.union(vert);\n\n```",
+      "tokens_in": 4801,
+      "tokens_out": 290
+    }
+  ]
+}

--- a/eval/runs/golden-2026-05-02-bracket-holes/output.kcad.ts
+++ b/eval/runs/golden-2026-05-02-bracket-holes/output.kcad.ts
@@ -1,0 +1,21 @@
+const boltDiam = param("Bolt Diameter", 5, { unit: 'mm', min: 3, max: 10 });
+
+const t = 2 * boltDiam;       // wall thickness
+const w = 4 * boltDiam;       // plate width/length (>= 3 * boltDiam)
+const h = 3 * boltDiam;       // plate height (>= 3 * boltDiam)
+const holeR = (boltDiam + 0.5) / 2;
+
+// Horizontal plate (foot of the L): x in [0,w], y in [0,h], z in [0,t].
+// Hole through Z at plate centroid.
+const horiz = box(w, h, t).subtract(
+  cylinder(t + 2, holeR).translate(w / 2, h / 2, -1),
+);
+
+// Vertical plate (upright of the L): x in [0,t], y in [0,h], z in [t, t+w].
+// Sits flush on top of the horizontal plate's near edge — no volume overlap.
+// Hole through X at the centroid of the vertical face.
+const vert = box(t, h, w).subtract(
+  cylinder(t + 2, holeR).rotate([0, 1, 0], 90).translate(-1, h / 2, w / 2),
+).translate(0, 0, t);
+
+return horiz.union(vert);

--- a/eval/runs/golden-2026-05-02-bracket-holes/score.json
+++ b/eval/runs/golden-2026-05-02-bracket-holes/score.json
@@ -1,0 +1,20 @@
+{
+  "gates": {
+    "evaluates clean": true,
+    "non-empty solid": true
+  },
+  "scored": {
+    "L-shape (2 axes > 10mm)": true,
+    "has holes (vol < 70% bbox)": true,
+    "not paper-thin (min dim > 2mm)": true
+  },
+  "gate_pass": true,
+  "score": 1,
+  "attempts": 2,
+  "tokens": {
+    "input": 9032,
+    "output": 350,
+    "total": 9382
+  },
+  "time_ms": 0
+}

--- a/eval/runs/golden-2026-05-02-bracket-holes/transcript.md
+++ b/eval/runs/golden-2026-05-02-bracket-holes/transcript.md
@@ -1,0 +1,74 @@
+# bracket-holes — mock-model — GOLDEN
+
+## Prompt
+> # Task: Parametric L-Bracket
+> 
+> Build an L-shaped mounting bracket that works for different bolt sizes.
+> 
+> The script must accept this parameter (verbatim — name and unit matter):
+> 
+> ```typescript
+> const boltDiam = param("Bolt Diameter", 5, { unit: 'mm', min: 3, max: 10 });
+> ```
+> 
+> Functional requirements:
+> 
+> - The bracket is L-shaped: two perpendicular flat plates joined at a right angle.
+> - Each plate has a single mounting hole. Hole diameter = `boltDiam + 0.5` mm (a 0.5mm clearance fit).
+> - Wall thickness (the dimension across each plate's smallest face) is at least `2 * boltDiam` mm.
+> - Each plate is at least `3 * boltDiam` mm in width and at least `3 * boltDiam` mm in height.
+> - The plates are connected (a single solid, not two free-floating slabs).
+> 
+> The script must `return` a single Shape.
+> 
+> Use kernelCAD's primitives and boolean operations. Z-up, millimetres, degrees.
+> 
+
+## Turn 1 (in: 4,231 tok, out: 60 tok, 0.0s)
+
+Here's a first attempt — I'll just round the top:
+
+```typescript
+return sphere(5).fillet(1, { face: 'top' });
+```
+
+## Evaluate (attempt 1) — FAIL
+- `feature.edge-feature.face-ref-not-applicable` — Canonical face 'top' is not applicable to 'sphere' primitive. (feature: fillet_1)
+
+## Turn 2 (in: 4,801 tok, out: 290 tok, 0.0s)
+
+I see — sphere doesn't accept a { face } filter. Here's the proper L-bracket per the prompt:
+
+```typescript
+const boltDiam = param("Bolt Diameter", 5, { unit: 'mm', min: 3, max: 10 });
+
+const t = 2 * boltDiam;       // wall thickness
+const w = 4 * boltDiam;       // plate width/length (>= 3 * boltDiam)
+const h = 3 * boltDiam;       // plate height (>= 3 * boltDiam)
+const holeR = (boltDiam + 0.5) / 2;
+
+// Horizontal plate (foot of the L): x in [0,w], y in [0,h], z in [0,t].
+// Hole through Z at plate centroid.
+const horiz = box(w, h, t).subtract(
+  cylinder(t + 2, holeR).translate(w / 2, h / 2, -1),
+);
+
+// Vertical plate (upright of the L): x in [0,t], y in [0,h], z in [t, t+w].
+// Sits flush on top of the horizontal plate's near edge — no volume overlap.
+// Hole through X at the centroid of the vertical face.
+const vert = box(t, h, w).subtract(
+  cylinder(t + 2, holeR).rotate([0, 1, 0], 90).translate(-1, h / 2, w / 2),
+).translate(0, 0, t);
+
+return horiz.union(vert);
+
+```
+
+## Evaluate (attempt 2) — OK
+
+## Score
+- Gates: ✓ evaluates clean, ✓ non-empty solid
+- Scored: 3/3 — 100%
+- Tokens: 9,032 in / 350 out / 9,382 total
+- Time: 0.0s
+- Attempts: 2

--- a/eval/tasks/bracket-holes/harness.ts
+++ b/eval/tasks/bracket-holes/harness.ts
@@ -1,0 +1,29 @@
+import { evaluateScript, getShapeInfo } from '../../oracle/kernelcad-client';
+import type { HarnessResult } from '../../types';
+
+export default async function harness(scriptPath: string): Promise<HarnessResult> {
+  const ev = await evaluateScript(scriptPath);
+  if (!ev.ok) {
+    return { gates: { 'evaluates clean': false }, scored: {} };
+  }
+
+  const s = await getShapeInfo(scriptPath);
+  const dims = [
+    s.bbox.max[0] - s.bbox.min[0],
+    s.bbox.max[1] - s.bbox.min[1],
+    s.bbox.max[2] - s.bbox.min[2],
+  ].sort((a, b) => b - a); // sorted descending: [largest, mid, smallest]
+  const bboxVol = dims[0] * dims[1] * dims[2];
+
+  return {
+    gates: {
+      'evaluates clean': true,
+      'non-empty solid': s.volume > 0,
+    },
+    scored: {
+      'L-shape (2 axes > 10mm)': dims[0] > 10 && dims[1] > 10,
+      'has holes (vol < 70% bbox)': s.volume < bboxVol * 0.7,
+      'not paper-thin (min dim > 2mm)': dims[2] > 2,
+    },
+  };
+}

--- a/eval/tasks/bracket-holes/prompt.md
+++ b/eval/tasks/bracket-holes/prompt.md
@@ -1,0 +1,21 @@
+# Task: Parametric L-Bracket
+
+Build an L-shaped mounting bracket that works for different bolt sizes.
+
+The script must accept this parameter (verbatim — name and unit matter):
+
+```typescript
+const boltDiam = param("Bolt Diameter", 5, { unit: 'mm', min: 3, max: 10 });
+```
+
+Functional requirements:
+
+- The bracket is L-shaped: two perpendicular flat plates joined at a right angle.
+- Each plate has a single mounting hole. Hole diameter = `boltDiam + 0.5` mm (a 0.5mm clearance fit).
+- Wall thickness (the dimension across each plate's smallest face) is at least `2 * boltDiam` mm.
+- Each plate is at least `3 * boltDiam` mm in width and at least `3 * boltDiam` mm in height.
+- The plates are connected (a single solid, not two free-floating slabs).
+
+The script must `return` a single Shape.
+
+Use kernelCAD's primitives and boolean operations. Z-up, millimetres, degrees.

--- a/eval/tasks/bracket-holes/solution-expert.kcad.ts
+++ b/eval/tasks/bracket-holes/solution-expert.kcad.ts
@@ -1,0 +1,21 @@
+const boltDiam = param("Bolt Diameter", 5, { unit: 'mm', min: 3, max: 10 });
+
+const t = 2 * boltDiam;       // wall thickness
+const w = 4 * boltDiam;       // plate width/length (>= 3 * boltDiam)
+const h = 3 * boltDiam;       // plate height (>= 3 * boltDiam)
+const holeR = (boltDiam + 0.5) / 2;
+
+// Horizontal plate (foot of the L): x in [0,w], y in [0,h], z in [0,t].
+// Hole through Z at plate centroid.
+const horiz = box(w, h, t).subtract(
+  cylinder(t + 2, holeR).translate(w / 2, h / 2, -1),
+);
+
+// Vertical plate (upright of the L): x in [0,t], y in [0,h], z in [t, t+w].
+// Sits flush on top of the horizontal plate's near edge — no volume overlap.
+// Hole through X at the centroid of the vertical face.
+const vert = box(t, h, w).subtract(
+  cylinder(t + 2, holeR).rotate([0, 1, 0], 90).translate(-1, h / 2, w / 2),
+).translate(0, 0, t);
+
+return horiz.union(vert);

--- a/eval/types.ts
+++ b/eval/types.ts
@@ -1,0 +1,84 @@
+// Shared types for the eval harness. No runtime code here.
+
+export interface Diagnostic {
+  code: string;
+  message: string;
+  hint?: string;
+  featureId?: string;
+  // Whatever else `kernelcad evaluate --json` returns; we use these fields
+  // for retry feedback and transcript rendering.
+}
+
+export interface EvaluateResult {
+  ok: boolean;
+  diagnostics: Diagnostic[];
+  featureCount?: number;
+}
+
+export interface ShapeInfo {
+  volume: number;
+  surfaceArea: number;
+  bbox: {
+    min: [number, number, number];
+    max: [number, number, number];
+  };
+}
+
+export interface HarnessResult {
+  gates: Record<string, boolean>;
+  scored: Record<string, boolean>;
+}
+
+export interface Score {
+  gates: Record<string, boolean>;
+  scored: Record<string, boolean>;
+  gate_pass: boolean;
+  score: number; // 0..1
+  attempts: number; // 1..3
+  tokens: { input: number; output: number; total: number };
+  time_ms: number;
+}
+
+// Transcript events — captured during a run, rendered to markdown afterward.
+export type TranscriptEvent =
+  | { kind: 'system_prompt'; chars: number } // we don't dump the full SKILL.md into the transcript; just record its size
+  | { kind: 'user_prompt'; content: string }
+  | {
+      kind: 'turn';
+      attempt: number;
+      assistant_text: string;
+      script_extracted: string | null;
+      tokens_in: number;
+      tokens_out: number;
+      ms: number;
+    }
+  | { kind: 'evaluate'; attempt: number; ok: boolean; diagnostics: Diagnostic[] }
+  | { kind: 'score'; gates: Record<string, boolean>; scored: Record<string, boolean> };
+
+// Agent client abstraction — lets us swap in a MockAgentClient for tests.
+export interface AgentMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface AgentResponse {
+  text: string;
+  tokens_in: number;
+  tokens_out: number;
+}
+
+export interface AgentClient {
+  generate(opts: {
+    system: string;
+    messages: AgentMessage[];
+    model: string;
+    max_tokens: number;
+  }): Promise<AgentResponse>;
+}
+
+// Aggregate result for the summary table.
+export interface TaskResult {
+  task: string;
+  score: Score | null; // null ⇒ infra_error
+  infra_error?: string; // when set, this task is excluded from the summary aggregate
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "kernelcad",
-  "version": "0.2.0-alpha.2",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kernelcad",
-      "version": "0.2.0-alpha.2",
+      "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.92.0",
         "@babel/generator": "^7.28.6",
         "@babel/parser": "^7.28.6",
         "@babel/traverse": "^7.28.6",
@@ -80,6 +81,26 @@
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.92.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.92.0.tgz",
+      "integrity": "sha512-l653JFC83wCglH8H83t1xpgDurCyPyslYW1maPRdCsfuNuGbLvQjQ81sWd3Go3LWRm0jNspzAhuqAYV8r9joSw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "4.1.1",
@@ -5802,6 +5823,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -8451,6 +8485,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "build:cli": "tsc --noEmit -p tsconfig.cli.json && node -e \"const b=require('./node_modules/esbuild/lib/main.js');b.build({entryPoints:['src/cli/index.ts'],bundle:true,platform:'node',format:'esm',target:'node20',outfile:'dist/cli/index.js',external:['commander','typescript','replicad'],banner:{js:[\\\"#!/usr/bin/env node\\\",\\\"import{createRequire as __bcr}from'node:module';\\\",\\\"const require=__bcr(import.meta.url);\\\",\\\"const __filename=new URL(import.meta.url).pathname;\\\",\\\"const __dirname=new URL('.',import.meta.url).pathname;\\\"].join('\\\\n')}}).then(()=>{require('fs').copyFileSync('node_modules/replicad-opencascadejs/src/replicad_single.wasm','dist/cli/replicad_single.wasm');require('fs').copyFileSync('src/skill/SKILL.md','dist/cli/SKILL.md');console.log('dist/cli/index.js built')}).catch(e=>{console.error(e);process.exit(1)})\"",
+    "eval": "npx tsx eval/run.ts",
     "lint": "eslint .",
     "preview": "vite preview",
     "release": "npx tsx scripts/release.ts",
@@ -30,6 +31,7 @@
     "qc:full": "npm run qc && npm run test:e2e && npm run build"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.92.0",
     "@babel/generator": "^7.28.6",
     "@babel/parser": "^7.28.6",
     "@babel/traverse": "^7.28.6",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
             'tests/unit/**/*.test.{ts,tsx}',
             'tests/e2e/**/*.test.ts',
             'tests/integration/**/*.test.ts',
+            'eval/**/*.test.ts',
         ],
         exclude: ['**/node_modules/**', '**/dist/**', 'tests/playwright/**', 'playwright-report/**', 'test-results/**'],
         deps: {


### PR DESCRIPTION
## Summary

Ships v1 of the kernelCAD agent eval harness — an inner-loop dev tool for optimizing the agent-facing surfaces (MCP tools, SKILL.md, diagnostic messages) by running agents against scored CAD-construction tasks and producing eyeball-able transcripts.

- **Spec:** `docs/superpowers/specs/2026-05-02-agent-eval-harness-design.md`
- **Plan:** `docs/superpowers/plans/2026-05-02-agent-eval-harness-v1.md`

## What's in v1

- `eval/run.ts` — CLI entry: `npm run eval [task-id]` or `npm run eval -- --mock` for fixture replay.
- `eval/runner.ts` — `runTask()` orchestrator: load → generate → evaluate → retry up to 3 → score → write artifacts.
- `eval/lib.ts` — pure helpers (`extractScript`, `formatDiagnostics`, `computeScore`, `renderTranscript`).
- `eval/agent.ts` — `AgentClient` interface + `MockAgentClient` (replays canned responses) + `AnthropicAgentClient` (real API with prompt caching on SKILL.md).
- `eval/oracle/kernelcad-client.ts` — subprocess wrapper for `kernelcad evaluate --json` and one-shot MCP `get_shape_info`.
- `eval/tasks/bracket-holes/` — seed task with prompt + gold expert solution + harness rubric.
- `eval/runs/golden-2026-05-02-bracket-holes/` — committed CI fixture for deterministic mock-replay.
- 30 new tests (lib: 20, agent: 3, oracle: 3, runner: 3, golden: 1). Vitest config updated to include `eval/**/*.test.ts`.

## Deferred to v2 (extension points designed in but not built)

- MCP-mode agent loop (`--mode mcp` flag), Tier-2 reconstruction-from-real-CAD oracle, friction auto-tagger, baseline / delta tooling, parallelism, multi-task `--mock` (currently guarded with a clear error).

## Test Plan

- [x] `KERNELCAD_BIN=./dist/cli/index.js npm test` — 863 passing, 0 failing.
- [x] `npm run lint` — clean.
- [x] `npm run typecheck` — clean.
- [x] `npm run eval -- --mock --fixture eval/runs/golden-2026-05-02-bracket-holes/fixture.json bracket-holes` — score 1.00, 2 attempts, full retry-and-recover loop exercised end-to-end.
- [x] Pre-flight error paths: missing API key, missing kernelcad CLI, missing fixture all surface as clean `ERROR:` messages with remediation pointers.
- [ ] Live API run with `ANTHROPIC_API_KEY` set — manual smoke (acceptance criteria 1 + 4).