### PR TITLE
feat(eval): corpus #19 — 3 v0.2 tracked-refs tasks (DRAFT spec)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Unreleased]
+
+### Added — Eval corpus
+
+- **3 v0.2 tracked-refs tasks under `eval/tasks/`** (`fillet-translated-box`, `subtract-then-fillet-rim`, `chamfer-rotated-wedge`). Each exercises the v0.2 capability of canonical face refs surviving transforms or unambiguous booleans (the natural-form cases that previously needed the "apply edge feature before transforms" workaround). Expert solutions verified to score 100% via `eval/corpus-v0.2.test.ts`. Per the gap-closure roadmap §Corpus design, this is the first slice of workstream #19 (corpus expansion).
+
+---
+
 ## v0.2.0 — tracked face/edge refs across transforms + booleans (2026-05-03)
 
 Closes the SKILL.md "Critical Constraint" section. Canonical face refs (`{ face: 'top' }`) now work transparently across every transform (`.translate`, `.rotate`, `.scale`, `.reflect`, `.mirror`) and every unambiguous boolean (`.subtract`, `.union`, `.intersect`). The previous workaround "apply edge feature BEFORE transforms" still works; scripts that previously failed with `feature.edge-feature.face-ref-not-resolvable` after a transform or boolean now succeed with no syntax change.

--- a/docs/superpowers/plans/2026-05-03-corpus-v0.2-tracked-refs.md
+++ b/docs/superpowers/plans/2026-05-03-corpus-v0.2-tracked-refs.md
@@ -1,0 +1,262 @@
+# Corpus expansion #19 — v0.2 tracked-refs tasks (implementation plan)
+
+> **Status:** DRAFT v1 — companion to the design spec at `docs/superpowers/specs/2026-05-03-corpus-v0.2-tracked-refs-design.md`. Pending controller review.
+> **For agentic workers:** REQUIRED SUB-SKILL: `superpowers:executing-plans`. Step checkboxes use `- [ ]`.
+
+**Goal:** Land three v0.2 tracked-refs corpus tasks under `eval/tasks/` with the existing seed-task layout, plus a vitest test that asserts each expert solution scores 100% on its own harness.
+
+**Architecture:** Pure additions. No changes to the runner, oracle wrapper, or MCP surface. Each task folder gets `prompt.md`, `solution-expert.kcad.ts`, `harness.ts`. One new `eval/corpus-v0.2.test.ts` asserts the expert-solution-scores-100% sanity check via the existing `runTask` + `MockAgentClient` pattern.
+
+**Tech Stack:** TypeScript, vitest, the existing kernelcad CLI bundle. No new dependencies.
+
+**Spec lineage:** Companion to `docs/superpowers/specs/2026-05-03-corpus-v0.2-tracked-refs-design.md`. Implements its three tasks + the vitest sanity check.
+
+---
+
+## File Structure
+
+All paths relative to the worktree root `~/projects/kernelCAD-web-worktrees/feat-corpus-v0.2-tracked-refs/`.
+
+**Create:**
+- `eval/tasks/fillet-translated-box/prompt.md`
+- `eval/tasks/fillet-translated-box/solution-expert.kcad.ts`
+- `eval/tasks/fillet-translated-box/harness.ts`
+- `eval/tasks/subtract-then-fillet-rim/prompt.md`
+- `eval/tasks/subtract-then-fillet-rim/solution-expert.kcad.ts`
+- `eval/tasks/subtract-then-fillet-rim/harness.ts`
+- `eval/tasks/chamfer-rotated-wedge/prompt.md`
+- `eval/tasks/chamfer-rotated-wedge/solution-expert.kcad.ts`
+- `eval/tasks/chamfer-rotated-wedge/harness.ts`
+- `eval/corpus-v0.2.test.ts`
+
+**Modify:**
+- `CHANGELOG.md` — add `## [Unreleased]` entry under "Eval corpus" (creating the section if it doesn't exist).
+
+---
+
+## Task 1 — `fillet-translated-box`
+
+**Files:** the three task files under `eval/tasks/fillet-translated-box/`.
+
+- [ ] **Step 1: Create the prompt.** See spec §"Task 1" for the prompt shape. Write a `prompt.md` that asks the agent to build a box at given offset with all top edges filleted, using a `param("...", default, opts)` call for each of: width, height, thickness, offset_x, offset_y, fillet_radius. Spell out: Z-up, mm, return a single Shape.
+
+- [ ] **Step 2: Write the expert solution `solution-expert.kcad.ts`.** Natural form:
+
+  ```typescript
+  const w = param("Width", 40, { unit: 'mm', min: 10, max: 100 });
+  const h = param("Height", 30, { unit: 'mm', min: 10, max: 100 });
+  const t = param("Thickness", 10, { unit: 'mm', min: 2, max: 30 });
+  const ox = param("Offset X", 5, { unit: 'mm' });
+  const oy = param("Offset Y", 7, { unit: 'mm' });
+  const r = param("Fillet Radius", 2, { unit: 'mm', min: 0.5, max: 5 });
+
+  return box(w, h, t).translate(ox, oy, 0).fillet(r, { face: 'top' });
+  ```
+
+- [ ] **Step 3: Write the harness.** Default-export an async function `(scriptPath) => Promise<HarnessResult>` that:
+  1. Calls `evaluateScript(scriptPath)`. If `!ok`, return `gates: { 'evaluates clean': false }, scored: {}`.
+  2. Calls `getShapeInfo(scriptPath)` and uses `bbox` and `volume`.
+  3. Asserts `bbox` exists and computes dims.
+  4. Gates: `evaluates clean: true`, `non-empty solid: volume > 0`, `top edges filleted: surfaceArea > naiveBoxArea` (where `naiveBoxArea = 2*(w*h + h*t + w*t)` — but the harness can't read params, so derive from `bbox`: use `naive = 2*(d0*d1 + d1*d2 + d0*d2)` where `d0`, `d1`, `d2` are bbox dims; the filleted box has *higher* surface area since the fillet adds curved faces while keeping bbox the same), `positioned correctly: bbox.min[0] within 0.5mm of expected and bbox.min[1] within 0.5mm of expected`. Since the harness can't read the params either, drop the `positioned correctly` gate at v1 and keep only the three shape-property gates. Note the trade in a comment.
+  5. Scored: `correct overall size: max bbox dim < 110mm and min bbox dim > 1mm` (sanity-band check) and `volume in expected range: 0.85 * bboxVol < volume < 0.999 * bboxVol` (filleted box has slightly less volume than its bbox).
+  6. Use the `bracket-holes/harness.ts` shape — three-line bbox-dims sort, etc.
+
+- [ ] **Step 4: Verify the expert solution evaluates cleanly via the kernelcad CLI directly.**
+
+  ```bash
+  cd ~/projects/kernelCAD-web-worktrees/feat-corpus-v0.2-tracked-refs
+  ln -sf ~/projects/kernelCAD-web/node_modules node_modules
+  npm run build:cli
+  node dist/cli/index.js evaluate eval/tasks/fillet-translated-box/solution-expert.kcad.ts --json | head -30
+  ```
+
+  Expected: JSON with no error diagnostics, mesh present.
+
+---
+
+## Task 2 — `subtract-then-fillet-rim`
+
+**Files:** the three task files under `eval/tasks/subtract-then-fillet-rim/`.
+
+- [ ] **Step 1: Create the prompt.** Functional requirements: square plate of given side, given thickness, single concentric through-hole of given diameter, fillet of given radius on all top edges (the spec calls this "outer perimeter and hole rim"; both belong to the post-subtract `top` face).
+
+- [ ] **Step 2: Write the expert solution.**
+
+  ```typescript
+  const s = param("Plate Size", 50, { unit: 'mm', min: 20, max: 200 });
+  const t = param("Plate Thickness", 8, { unit: 'mm', min: 2, max: 30 });
+  const d = param("Hole Diameter", 12, { unit: 'mm', min: 3, max: 30 });
+  const r = param("Fillet Radius", 1.5, { unit: 'mm', min: 0.2, max: 5 });
+
+  const plate = box(s, s, t);
+  const hole = cylinder(t + 2, d / 2).translate(s / 2, s / 2, -1);
+  return plate.subtract(hole).fillet(r, { face: 'top' });
+  ```
+
+- [ ] **Step 3: Write the harness.**
+  - Gates: `evaluates clean`, `non-empty solid`, `has hole: volume < bboxVol * 0.95` (the hole removes some volume; tolerant since we can't read d/s/t in the harness — see comment), `top rim filleted: surfaceArea > naiveBoxArea` (looser check than `bracket-holes`'s "70% bbox" since fillet on rims doesn't drop volume much; the surface-area increase is more diagnostic).
+  - Scored: `bbox is square (top-down): |d0 - d1| < 0.5mm`, `volume between 60% and 95% of bbox`.
+
+- [ ] **Step 4: Verify via CLI as in Task 1 Step 4.**
+
+---
+
+## Task 3 — `chamfer-rotated-wedge`
+
+**Files:** the three task files under `eval/tasks/chamfer-rotated-wedge/`.
+
+- [ ] **Step 1: Create the prompt.** Functional requirements: build a wedge by rotating a box about the X axis by `tilt_deg` degrees, with a chamfer applied to all edges of the original top face. The agent writes natural form `box(...).rotate([1,0,0], tilt_deg).chamfer(d, { face: 'top' })`.
+
+- [ ] **Step 2: Write the expert solution.**
+
+  ```typescript
+  const w = param("Width", 40, { unit: 'mm', min: 10, max: 100 });
+  const d = param("Depth", 30, { unit: 'mm', min: 10, max: 100 });
+  const h = param("Height", 20, { unit: 'mm', min: 5, max: 60 });
+  const tilt = param("Tilt", 30, { unit: 'deg', min: 5, max: 60 });
+  const cd = param("Chamfer Distance", 1.5, { unit: 'mm', min: 0.2, max: 5 });
+
+  return box(w, d, h).rotate([1, 0, 0], tilt).chamfer(cd, { face: 'top' });
+  ```
+
+- [ ] **Step 3: Write the harness.**
+  - Gates: `evaluates clean`, `non-empty solid`, `chamfer present: surfaceArea > naiveBoxArea`, `bbox tilted: bbox Z extent > h sanity bound` — but again the harness can't read params, so use `dims[2] / dims[1] > 0.4` as a coarse proxy that the part has nontrivial Z extent.
+  - Scored: `volume in expected range: 0.85 * bboxVol < volume < 0.999 * bboxVol`, `bbox shape reasonable: max dim / min dim < 20` (sanity).
+
+- [ ] **Step 4: Verify via CLI as in Task 1 Step 4.**
+
+---
+
+## Task 4 — Vitest sanity check
+
+**Files:** `eval/corpus-v0.2.test.ts`
+
+- [ ] **Step 1: Write the test.** Mirror `eval/runner.test.ts:28-66` for each of the three tasks. Loop over a `[ taskId, taskDir ]` array of three entries. For each: read the expert solution, build a `MockAgentClient` with a single response wrapping the script in a fenced typescript code block, call `runTask` with the task dir, assert `gate_pass === true` and `score === 1`.
+
+  ```typescript
+  import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+  import { mkdtempSync, readFileSync } from 'node:fs';
+  import { join } from 'node:path';
+  import { tmpdir } from 'node:os';
+  import { runTask } from './runner';
+  import { MockAgentClient } from './agent';
+  import { isKernelcadAvailable } from './oracle/kernelcad-client';
+
+  let kernelcadAvailable = false;
+  let runsDir: string;
+
+  beforeAll(async () => {
+    kernelcadAvailable = await isKernelcadAvailable();
+    if (!kernelcadAvailable && process.env.CI) {
+      throw new Error('kernelcad CLI not available in CI. ...');
+    }
+  });
+
+  beforeEach(() => {
+    runsDir = mkdtempSync(join(tmpdir(), 'eval-corpus-v0.2-'));
+  });
+
+  const tasks: Array<{ id: string; dir: string }> = [
+    { id: 'fillet-translated-box', dir: './eval/tasks/fillet-translated-box' },
+    { id: 'subtract-then-fillet-rim', dir: './eval/tasks/subtract-then-fillet-rim' },
+    { id: 'chamfer-rotated-wedge', dir: './eval/tasks/chamfer-rotated-wedge' },
+  ];
+
+  describe('v0.2 tracked-refs corpus', () => {
+    for (const t of tasks) {
+      it(`${t.id} — expert solution scores 100%`, async (ctx) => {
+        if (!kernelcadAvailable) return ctx.skip();
+        const expertScript = readFileSync(join(t.dir, 'solution-expert.kcad.ts'), 'utf8');
+        const client = new MockAgentClient([
+          { text: '```typescript\n' + expertScript + '\n```', tokens_in: 4000, tokens_out: 200 },
+        ]);
+        const result = await runTask({
+          taskDir: t.dir,
+          runDir: runsDir,
+          agent: client,
+          model: 'mock-model',
+          skillMd: 'fake skill content',
+          startedAt: 'CORPUS-V02',
+        });
+        expect(result.score).not.toBeNull();
+        expect(result.score!.gate_pass).toBe(true);
+        expect(result.score!.score).toBe(1);
+      }, 60000);
+    }
+  });
+  ```
+
+- [ ] **Step 2: Run the test.**
+
+  ```bash
+  cd ~/projects/kernelCAD-web-worktrees/feat-corpus-v0.2-tracked-refs
+  ln -sf ~/projects/kernelCAD-web/node_modules node_modules  # if not already
+  npm run build:cli
+  npx vitest run eval/corpus-v0.2.test.ts 2>&1 | tail -20
+  ```
+
+  Expected: 3 passed.
+
+  If a test fails: the harness gates are too strict OR the expert solution doesn't match the harness's assumptions. Debug by inspecting the `score.json` artifact in `runsDir` (the test creates a tmpdir per case but doesn't clean up on failure; surface the path in the failure message if needed).
+
+---
+
+## Task 5 — CHANGELOG + final verification
+
+**Files:** `CHANGELOG.md`
+
+- [ ] **Step 1: Add an `Eval corpus` entry under `## [Unreleased]`.** If `## [Unreleased]` doesn't exist, add it at the top of the file. Otherwise append:
+
+  ```markdown
+  ### Added — Eval corpus
+
+  - **3 v0.2 tracked-refs tasks under `eval/tasks/`** (`fillet-translated-box`, `subtract-then-fillet-rim`, `chamfer-rotated-wedge`). Each exercises the v0.2 capability of canonical face refs surviving transforms or unambiguous booleans (the natural-form cases that fail without v0.2). Expert solutions verified to score 100% via `eval/corpus-v0.2.test.ts`.
+  ```
+
+- [ ] **Step 2: Full local verification.**
+
+  ```bash
+  npm run typecheck
+  npm run build:cli
+  npm test
+  ```
+
+  Expected: typecheck clean, build:cli clean, all tests green (existing 870 + 3 new = 873).
+
+- [ ] **Step 3: Inspect the staged diff.**
+
+  ```bash
+  git status --short
+  git diff --stat
+  ```
+
+  Expected: 11 new files (9 task files + 1 vitest file + CHANGELOG modification), 0 deleted.
+
+- [ ] **Step 4: Commit.** One commit per task is overkill at this size; one commit for the corpus slice is fine.
+
+  ```bash
+  git add eval/tasks/fillet-translated-box \
+          eval/tasks/subtract-then-fillet-rim \
+          eval/tasks/chamfer-rotated-wedge \
+          eval/corpus-v0.2.test.ts \
+          CHANGELOG.md
+  git commit -m "feat(eval): 3 v0.2 tracked-refs corpus tasks"
+  ```
+
+  Use `-c user.email=14119286+w1ne@users.noreply.github.com` to keep the commit author email aligned with prior commits in this repo.
+
+---
+
+## Definition of done
+
+1. Three task folders each have `prompt.md`, `solution-expert.kcad.ts`, `harness.ts`.
+2. `eval/corpus-v0.2.test.ts` asserts each expert scores 100%; `npm test` is green.
+3. `CHANGELOG.md` carries the "Added — Eval corpus" entry under `## [Unreleased]`.
+4. Branch `feat/corpus-v0.2-tracked-refs` rebased on `develop` if needed, pushed, PR opened against `develop`.
+
+## What this plan does NOT do
+
+- Add tasks for v0.3+ modules (those modules haven't shipped).
+- Run the full agent loop against a real model — that costs API tokens and isn't a corpus-author-time concern.
+- Fold in the missing 0–2 v0.2 tasks from the gap-closure roadmap's "3–5" range. Punted to a follow-up PR pending controller review.
+- Touch the runner, oracle wrapper, MCP surface, or any non-eval code.

--- a/docs/superpowers/specs/2026-05-03-corpus-v0.2-tracked-refs-design.md
+++ b/docs/superpowers/specs/2026-05-03-corpus-v0.2-tracked-refs-design.md
@@ -1,0 +1,132 @@
+# Corpus expansion #19 — v0.2 tracked-refs tasks (Wave 1, slice 1)
+
+> **Status:** DRAFT v1 — written autonomously after the gap-closure roadmap scaffolding landed (PR #56). Pending controller review on wake. Conservative scope (3 tasks, not 5) to keep the slice reviewable; the remaining 0–2 v0.2 tasks can be added in a follow-up if controller agrees the scoring rubrics are sound.
+
+## Why this milestone
+
+The gap-closure roadmap §Corpus design assigns v0.2 tracked refs **3–5 corpus tasks** as the first concrete check that the v0.2 capability (canonical face refs surviving transforms + unambiguous booleans) actually works end-to-end through the agent loop, not just in unit tests. This milestone lands **3 such tasks** under `eval/tasks/`, each with a `prompt.md`, a `solution-expert.kcad.ts` that scores 100% on its own harness, and a `harness.ts` that gates on shape correctness.
+
+These tasks are also the smallest concrete material the dispatch order's Wave 1 is missing: workstream #21 (visual verifier) and #22 (cookbook) can launch in parallel, but #19 (corpus expansion) needed a first slice to anchor the pattern. This is that slice.
+
+## Goals (this milestone)
+
+1. **Three v0.2 tracked-refs tasks land under `eval/tasks/`** with the existing seed-task layout (`prompt.md` + `solution-expert.kcad.ts` + `harness.ts`).
+2. **Each expert solution scores 100% via the harness** — verified by a vitest test that drives `runTask` with a `MockAgentClient` returning the expert solution, asserting `gate_pass = true` and `score = 1`. This is the same pattern `eval/runner.test.ts` uses for `bracket-holes` and is the corpus-author's standing sanity check (eval harness spec §"v1 seed task set").
+3. **No new harness machinery.** The runner, oracle wrapper, and MCP introspection surface are unchanged. This milestone only adds task content.
+
+## Non-goals (this milestone)
+
+- Running the full agent loop against a real model (requires API key, costs money, doesn't add signal at corpus-author time — that lives at G1 pre-flight).
+- Difficulty bands beyond `easy`/`medium` self-classification in the task header — no harness behavior depends on the band yet.
+- The remaining 0–2 v0.2 tasks (chained transforms, mirror+fillet, etc.). Punted to a follow-up PR pending controller feedback on rubric shape.
+- Any cross-module corpus tasks (v0.3, v0.4, etc.) — those modules haven't shipped.
+
+## Anchors (carried forward, non-negotiable)
+
+- **Examples-driven sequencing.** Every corpus task corresponds to a specific kernel capability already shipped on `develop`. No speculative tasks.
+- **Tasks frame everything as native kernelCAD.** Per the no-comparator-reference policy: prompts describe parts in plain functional language, no "matches X / improves over Y" framing.
+- **Expert solution is the rubric sanity check.** A task whose own expert solution fails its own harness is broken; the vitest runner test catches that before merge.
+- **Harness gates, not aesthetics.** Gates are binary properties of the shape (`evaluates clean`, `non-empty solid`, bbox or volume thresholds). Subjective quality lives in `scored` items that contribute to a partial-credit score but don't gate.
+
+## The three tasks
+
+### Task 1 — `fillet-translated-box`
+
+Exercises `.translate(...).fillet(r, { face: 'top' })`. The natural form is to position the box first then fillet — the v0.2 tracked ref must resolve `top` after translation.
+
+**Prompt shape:** Build a box of given dimensions positioned at an offset, with all top edges filleted.
+
+**Parameters:** `width`, `height`, `thickness` (mm), `offset_x`, `offset_y` (mm), `fillet_radius` (mm).
+
+**Gates:**
+- `evaluates clean`: kernel runs the script without diagnostics.
+- `non-empty solid`: `volume > 0`.
+- `top edges filleted`: surface area > naive (sum of 6 box faces) — a fillet adds curved faces.
+- `positioned correctly`: bbox `min` matches the prescribed offset within 0.5 mm tolerance.
+
+**Scored:**
+- `correct overall size`: bbox dimensions match `width × height × thickness` within fillet-radius tolerance.
+- `volume in expected range`: between (1 - π·r²·perimeter / volume_box · 0.5) of full and full box volume — heuristic for "fillet present but not absurd".
+
+**Difficulty:** `easy`.
+
+### Task 2 — `subtract-then-fillet-rim`
+
+Exercises `box.subtract(cylinder).fillet(r, { face: 'top' })` — the canonical "subtract.fillet" case from the gap-closure roadmap. The hole's top edge must be filleted along with the outer perimeter, both as part of the same `top` face.
+
+**Prompt shape:** Build a flat circular plate (use a square plate to keep it primitive-only) with a single concentric through-hole and a fillet on all top edges (outer perimeter and hole rim).
+
+**Parameters:** `plate_size` (square side, mm), `plate_thickness` (mm), `hole_diameter` (mm), `fillet_radius` (mm).
+
+**Gates:**
+- `evaluates clean`.
+- `non-empty solid`.
+- `has hole`: `volume < bbox_volume - π·(hole_d/2)² · plate_thickness · 0.9` — i.e. at least 90% of the expected hole volume is missing.
+- `top rim filleted`: surface area exceeds naive box-minus-cylinder estimate by a margin proportional to fillet radius.
+
+**Scored:**
+- `bbox matches plate size`: within `fillet_radius` tolerance.
+- `hole approximately centered`: lateral bbox center within 0.5 mm of plate center.
+
+**Difficulty:** `medium`.
+
+### Task 3 — `chamfer-rotated-wedge`
+
+Exercises `.rotate([axis], angle).chamfer(d, { face: 'top' })`. After rotation, the original top face is no longer the +Z face, but the tracked ref must still resolve to the same lineage face.
+
+**Prompt shape:** Build a wedge by tilting a box about the X axis by 30 degrees, with a chamfer applied to all edges of what was the top face before rotation.
+
+**Parameters:** `width`, `depth`, `height` (mm), `tilt_deg` (degrees), `chamfer_distance` (mm).
+
+**Gates:**
+- `evaluates clean`.
+- `non-empty solid`.
+- `chamfer present`: surface area > naive box surface area for a rotated box.
+- `bbox tilted`: Z extent of the bbox > `height` (a tilted box's bbox is taller than the un-tilted box's `height`) — a sanity check that the rotation actually happened.
+
+**Scored:**
+- `correct tilt`: largest principal-axis angle within 5° of `tilt_deg` (approximated via bbox aspect, not full inertia tensor — keeps oracle dependencies bounded).
+- `chamfer-distance reasonable`: surface-area gain proportional to `chamfer_distance × top_face_perimeter` within 50% margin.
+
+**Difficulty:** `medium`.
+
+## Task layout
+
+Per the existing seed task `bracket-holes`:
+
+```
+eval/tasks/<task-id>/
+├── prompt.md                # what the agent sees
+├── solution-expert.kcad.ts  # gold reference; harness must score 100%
+└── harness.ts               # default-exports `(scriptPath) => Promise<HarnessResult>`
+```
+
+`harness.ts` imports `evaluateScript` and `getShapeInfo` from `../../oracle/kernelcad-client` and types from `../../types`. Same as the seed task — no new infra.
+
+## Verification (corpus-author's sanity check)
+
+Add `eval/corpus-v0.2.test.ts` with three `runTask`-against-`MockAgentClient` test cases that mirror `eval/runner.test.ts:28` for the new tasks. Each test:
+
+1. Reads the task's `solution-expert.kcad.ts` content.
+2. Constructs a `MockAgentClient` returning that script wrapped in a fenced code block.
+3. Calls `runTask` with the task dir.
+4. Asserts `result.score!.gate_pass === true` and `result.score!.score === 1`.
+
+If any expert solution fails its own harness, the test fails before merge — same discipline as the seed task.
+
+## Definition of done
+
+1. Three task folders under `eval/tasks/` with the three required files each.
+2. New vitest test `eval/corpus-v0.2.test.ts` asserts each expert solution scores 100%.
+3. `npm run typecheck` clean.
+4. `npm run build:cli` clean (existing requirement before tests run).
+5. `npm test` clean (full suite passes including the three new corpus tests).
+6. CHANGELOG entry under `## [Unreleased]` mentioning the corpus addition (per the per-PR cadence in the gap-closure roadmap §"PR + merge cadence").
+7. Spec at this path; plan at `docs/superpowers/plans/2026-05-03-corpus-v0.2-tracked-refs.md`.
+
+## Open questions for controller review
+
+1. **Three vs five tasks.** This slice ships three. Are the missing two (chained transform + boolean, mirror+edge-feature) a follow-up PR or a "fold into this PR before merge" ask?
+2. **Difficulty band assignments.** Task 1 = `easy`, Tasks 2 + 3 = `medium`. Acceptable?
+3. **Tilt-correctness gate (Task 3).** I used a bbox-aspect heuristic rather than full principal-axis inertia analysis. If the rubric should be tighter (e.g. compute actual face normal via an additional MCP call), say so and I'll wire it in. The eval harness spec says "If a future task needs more (face counts, edge counts, feature counts), `harness.ts` calls additional existing MCP tools through the client wrapper" — which is a clean extension, but adds a tool call.
+4. **Naming.** Are `fillet-translated-box` / `subtract-then-fillet-rim` / `chamfer-rotated-wedge` the right ids? They follow the existing `bracket-holes` pattern (kebab-case descriptive id).

--- a/eval/corpus-v0.2.test.ts
+++ b/eval/corpus-v0.2.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runTask } from './runner';
+import { MockAgentClient } from './agent';
+import { isKernelcadAvailable } from './oracle/kernelcad-client';
+
+let kernelcadAvailable = false;
+let runsDir: string;
+
+beforeAll(async () => {
+  kernelcadAvailable = await isKernelcadAvailable();
+  // In CI we must fail loudly rather than silently skip — a green build with
+  // zero corpus coverage is worse than a red one. Local dev still gets the skip.
+  if (!kernelcadAvailable && process.env.CI) {
+    throw new Error(
+      'kernelcad CLI not available in CI. Set KERNELCAD_BIN=./dist/cli/index.js after `npm run build:cli`, or `npm link`.',
+    );
+  }
+});
+
+beforeEach(() => {
+  runsDir = mkdtempSync(join(tmpdir(), 'eval-corpus-v0.2-'));
+});
+
+const tasks: Array<{ id: string; dir: string }> = [
+  { id: 'fillet-translated-box', dir: './eval/tasks/fillet-translated-box' },
+  { id: 'subtract-then-fillet-rim', dir: './eval/tasks/subtract-then-fillet-rim' },
+  { id: 'chamfer-rotated-wedge', dir: './eval/tasks/chamfer-rotated-wedge' },
+];
+
+describe('v0.2 tracked-refs corpus — expert solutions score 100%', () => {
+  for (const t of tasks) {
+    it(`${t.id} — expert solution scores 100%`, async (ctx) => {
+      if (!kernelcadAvailable) return ctx.skip();
+
+      const expertScript = readFileSync(join(t.dir, 'solution-expert.kcad.ts'), 'utf8');
+      const client = new MockAgentClient([
+        {
+          text: 'Here is the part:\n```typescript\n' + expertScript + '\n```',
+          tokens_in: 4000,
+          tokens_out: 200,
+        },
+      ]);
+
+      const result = await runTask({
+        taskDir: t.dir,
+        runDir: runsDir,
+        agent: client,
+        model: 'mock-model',
+        skillMd: 'fake skill content',
+        startedAt: 'CORPUS-V02',
+      });
+
+      expect(result.score).not.toBeNull();
+      expect(result.score!.gate_pass).toBe(true);
+      expect(result.score!.score).toBe(1);
+      expect(result.score!.attempts).toBe(1);
+    }, 60000);
+  }
+});

--- a/eval/tasks/chamfer-rotated-wedge/harness.ts
+++ b/eval/tasks/chamfer-rotated-wedge/harness.ts
@@ -1,0 +1,44 @@
+import { evaluateScript, getShapeInfo } from '../../oracle/kernelcad-client';
+import type { HarnessResult } from '../../types';
+
+export default async function harness(scriptPath: string): Promise<HarnessResult> {
+  const ev = await evaluateScript(scriptPath);
+  if (!ev.ok) {
+    return { gates: { 'evaluates clean': false }, scored: {} };
+  }
+
+  const s = await getShapeInfo(scriptPath);
+  const rawDims: [number, number, number] = [
+    s.bbox.max[0] - s.bbox.min[0],
+    s.bbox.max[1] - s.bbox.min[1],
+    s.bbox.max[2] - s.bbox.min[2],
+  ];
+  const dims = [...rawDims].sort((a, b) => b - a);
+  const bboxVol = dims[0] * dims[1] * dims[2];
+  const naiveBoxArea = 2 * (dims[0] * dims[1] + dims[1] * dims[2] + dims[0] * dims[2]);
+  const volRatio = s.volume / bboxVol;
+  const saRatio = s.surfaceArea / naiveBoxArea;
+
+  return {
+    gates: {
+      'evaluates clean': true,
+      'non-empty solid': s.volume > 0,
+      // A non-tilted box's volume == its bbox volume. A tilted box's volume is
+      // strictly less (the bbox grows but the volume stays the same), so
+      // volRatio drops well below 1. Tilt 5°→60° spans roughly volRatio
+      // 0.97–0.43 for these param ranges; gate 0.4–0.95 catches "tilted".
+      'shape is tilted': volRatio > 0.4 && volRatio < 0.95,
+      // Chamfer + tilt both reduce surface area below the naive bbox-derived
+      // box's area. 0.5–0.99 catches "chamfered tilted body".
+      'chamfer present (SA below naive)': saRatio > 0.5 && saRatio < 0.99,
+    },
+    scored: {
+      // bbox is reasonably proportioned (no degenerate slabs).
+      'bbox shape reasonable': dims[2] / dims[0] > 0.15 && dims[0] / dims[2] < 20,
+      // The body sits on the build plane (Z min ≈ 0 for the X-axis tilt
+      // expected to keep the bottom edge anchored to z=0 since the box starts
+      // at z=0 and tilts about [1,0,0]).
+      'starts at build plane': Math.abs(s.bbox.min[2]) < 0.5,
+    },
+  };
+}

--- a/eval/tasks/chamfer-rotated-wedge/prompt.md
+++ b/eval/tasks/chamfer-rotated-wedge/prompt.md
@@ -1,0 +1,24 @@
+# Task: Tilted box with chamfered top edges
+
+Build a wedge by tilting a rectangular box about the X axis, then chamfer all edges of what was the box's top face before rotation.
+
+The script must accept these parameters (verbatim — names and units matter):
+
+```typescript
+const w = param("Width", 40, { unit: 'mm', min: 10, max: 100 });
+const d = param("Depth", 30, { unit: 'mm', min: 10, max: 100 });
+const h = param("Height", 20, { unit: 'mm', min: 5, max: 60 });
+const tilt = param("Tilt", 30, { unit: 'deg', min: 5, max: 60 });
+const cd = param("Chamfer Distance", 1.5, { unit: 'mm', min: 0.2, max: 5 });
+```
+
+Functional requirements:
+
+- The base shape is a box of dimensions `w × d × h`.
+- The box is rotated about the X axis by `tilt` degrees. After rotation, the original top face is no longer the +Z face — it has been tilted.
+- A chamfer of distance `cd` is applied to all four edges of what was the top face *before* rotation. The kernel tracks the face reference through the rotate, so writing `box(...).rotate([1,0,0], tilt).chamfer(cd, { face: 'top' })` resolves to the original top face's edges in the rotated body.
+- Write the natural form: build the box, rotate, then chamfer the original top face.
+
+The script must `return` a single Shape.
+
+Use kernelCAD's primitives, transforms, and edge features. Z-up, millimetres, degrees.

--- a/eval/tasks/chamfer-rotated-wedge/solution-expert.kcad.ts
+++ b/eval/tasks/chamfer-rotated-wedge/solution-expert.kcad.ts
@@ -1,0 +1,7 @@
+const w = param("Width", 40, { unit: 'mm', min: 10, max: 100 });
+const d = param("Depth", 30, { unit: 'mm', min: 10, max: 100 });
+const h = param("Height", 20, { unit: 'mm', min: 5, max: 60 });
+const tilt = param("Tilt", 30, { unit: 'deg', min: 5, max: 60 });
+const cd = param("Chamfer Distance", 1.5, { unit: 'mm', min: 0.2, max: 5 });
+
+return box(w, d, h).rotate([1, 0, 0], tilt).chamfer(cd, { face: 'top' });

--- a/eval/tasks/fillet-translated-box/harness.ts
+++ b/eval/tasks/fillet-translated-box/harness.ts
@@ -1,0 +1,40 @@
+import { evaluateScript, getShapeInfo } from '../../oracle/kernelcad-client';
+import type { HarnessResult } from '../../types';
+
+export default async function harness(scriptPath: string): Promise<HarnessResult> {
+  const ev = await evaluateScript(scriptPath);
+  if (!ev.ok) {
+    return { gates: { 'evaluates clean': false }, scored: {} };
+  }
+
+  const s = await getShapeInfo(scriptPath);
+  const rawDims: [number, number, number] = [
+    s.bbox.max[0] - s.bbox.min[0],
+    s.bbox.max[1] - s.bbox.min[1],
+    s.bbox.max[2] - s.bbox.min[2],
+  ];
+  const dims = [...rawDims].sort((a, b) => b - a); // [largest, mid, smallest]
+  const bboxVol = dims[0] * dims[1] * dims[2];
+  const volRatio = s.volume / bboxVol;
+  // Was the body translated away from the origin in X or Y?
+  // (z-min is allowed to be 0 — bottom face on the build plane.)
+  const translatedXY = Math.abs(s.bbox.min[0]) > 1 || Math.abs(s.bbox.min[1]) > 1;
+
+  return {
+    gates: {
+      'evaluates clean': true,
+      'non-empty solid': s.volume > 0,
+      // Fillet present: a plain box has volume == bboxVol; a filleted box has
+      // volume slightly below it. 0.95–0.999 is the "lightly rounded box" band.
+      'fillet present': volRatio > 0.95 && volRatio < 0.999,
+      // Translation present: bbox min is not at the origin in X or Y.
+      'translated in plane': translatedXY,
+    },
+    scored: {
+      // bbox aspect is box-like (largest / smallest not absurd).
+      'bbox shape is box-like': dims[0] / dims[2] < 20 && dims[2] > 1,
+      // Volume in the lightly-rounded-box band (tighter than the gate).
+      'volume in lightly-rounded band': volRatio > 0.97 && volRatio < 0.998,
+    },
+  };
+}

--- a/eval/tasks/fillet-translated-box/prompt.md
+++ b/eval/tasks/fillet-translated-box/prompt.md
@@ -1,0 +1,25 @@
+# Task: Filleted box at offset
+
+Build a rectangular box positioned at a given offset, with all of its top edges filleted.
+
+The script must accept these parameters (verbatim — names and units matter):
+
+```typescript
+const w = param("Width", 40, { unit: 'mm', min: 10, max: 100 });
+const h = param("Height", 30, { unit: 'mm', min: 10, max: 100 });
+const t = param("Thickness", 10, { unit: 'mm', min: 2, max: 30 });
+const ox = param("Offset X", 5, { unit: 'mm' });
+const oy = param("Offset Y", 7, { unit: 'mm' });
+const r = param("Fillet Radius", 2, { unit: 'mm', min: 0.5, max: 5 });
+```
+
+Functional requirements:
+
+- The shape is a single solid box of dimensions `w × h × t`.
+- The box is positioned so that its corner closest to the origin sits at `(ox, oy, 0)`.
+- All four edges of the box's top face (the face whose normal points in +Z before any transform) are filleted with radius `r`.
+- The fillet must reference the original top face — write the natural form `box(...).translate(...).fillet(...)`. The kernel tracks the face reference through the translate.
+
+The script must `return` a single Shape.
+
+Use kernelCAD's primitives, transforms, and edge features. Z-up, millimetres, degrees.

--- a/eval/tasks/fillet-translated-box/solution-expert.kcad.ts
+++ b/eval/tasks/fillet-translated-box/solution-expert.kcad.ts
@@ -1,0 +1,8 @@
+const w = param("Width", 40, { unit: 'mm', min: 10, max: 100 });
+const h = param("Height", 30, { unit: 'mm', min: 10, max: 100 });
+const t = param("Thickness", 10, { unit: 'mm', min: 2, max: 30 });
+const ox = param("Offset X", 5, { unit: 'mm' });
+const oy = param("Offset Y", 7, { unit: 'mm' });
+const r = param("Fillet Radius", 2, { unit: 'mm', min: 0.5, max: 5 });
+
+return box(w, h, t).translate(ox, oy, 0).fillet(r, { face: 'top' });

--- a/eval/tasks/subtract-then-fillet-rim/harness.ts
+++ b/eval/tasks/subtract-then-fillet-rim/harness.ts
@@ -1,0 +1,43 @@
+import { evaluateScript, getShapeInfo } from '../../oracle/kernelcad-client';
+import type { HarnessResult } from '../../types';
+
+export default async function harness(scriptPath: string): Promise<HarnessResult> {
+  const ev = await evaluateScript(scriptPath);
+  if (!ev.ok) {
+    return { gates: { 'evaluates clean': false }, scored: {} };
+  }
+
+  const s = await getShapeInfo(scriptPath);
+  const rawDims: [number, number, number] = [
+    s.bbox.max[0] - s.bbox.min[0],
+    s.bbox.max[1] - s.bbox.min[1],
+    s.bbox.max[2] - s.bbox.min[2],
+  ];
+  const dims = [...rawDims].sort((a, b) => b - a); // [largest, mid, smallest]
+  const bboxVol = dims[0] * dims[1] * dims[2];
+  const volRatio = s.volume / bboxVol;
+  // X and Y bbox extents (plate is square in the X/Y plane). Z is plate thickness.
+  const xExt = rawDims[0];
+  const yExt = rawDims[1];
+
+  return {
+    gates: {
+      'evaluates clean': true,
+      'non-empty solid': s.volume > 0,
+      // Hole + fillet remove a few percent of bbox volume; the plain plate
+      // would have volRatio == 1. 0.5–0.97 catches "has a real hole".
+      'has hole and fillet': volRatio > 0.5 && volRatio < 0.97,
+      // Plate is square in the X/Y plane (the two largest bbox dims should be
+      // equal within fillet tolerance).
+      'plate is square in XY': Math.abs(xExt - yExt) < 0.5,
+      // Plate is thin (Z is the smallest bbox dim).
+      'plate-like aspect': dims[2] === Math.min(rawDims[0], rawDims[1], rawDims[2]) && dims[0] / dims[2] > 2,
+    },
+    scored: {
+      // Volume in expected range for plate-with-hole-with-fillet.
+      'volume in expected range': volRatio > 0.7 && volRatio < 0.97,
+      // Bottom of plate sits on the build plane.
+      'sits on build plane': Math.abs(s.bbox.min[2]) < 0.5,
+    },
+  };
+}

--- a/eval/tasks/subtract-then-fillet-rim/prompt.md
+++ b/eval/tasks/subtract-then-fillet-rim/prompt.md
@@ -1,0 +1,23 @@
+# Task: Plate with through-hole and filleted top rim
+
+Build a square plate with a single concentric through-hole, with a fillet applied to all top edges (the outer perimeter and the rim of the hole, both belonging to the plate's top face after the hole is cut).
+
+The script must accept these parameters (verbatim — names and units matter):
+
+```typescript
+const s = param("Plate Size", 50, { unit: 'mm', min: 20, max: 200 });
+const t = param("Plate Thickness", 8, { unit: 'mm', min: 2, max: 30 });
+const d = param("Hole Diameter", 12, { unit: 'mm', min: 3, max: 30 });
+const r = param("Fillet Radius", 1.5, { unit: 'mm', min: 0.2, max: 5 });
+```
+
+Functional requirements:
+
+- The plate is a square of side `s` and thickness `t`, sitting with its bottom face at `z = 0`.
+- A single cylindrical through-hole of diameter `d` is centered laterally on the plate (at `(s/2, s/2)`) and goes through the entire thickness.
+- A fillet of radius `r` is applied to every edge of the plate's top face — both the outer rectangular perimeter AND the circular rim around the hole. Both belong to the same `top` face after the subtract operation.
+- Write the natural form: `box(...).subtract(cylinder(...).translate(...)).fillet(r, { face: 'top' })`. The kernel tracks the face reference through the boolean.
+
+The script must `return` a single Shape.
+
+Use kernelCAD's primitives, transforms, booleans, and edge features. Z-up, millimetres, degrees.

--- a/eval/tasks/subtract-then-fillet-rim/solution-expert.kcad.ts
+++ b/eval/tasks/subtract-then-fillet-rim/solution-expert.kcad.ts
@@ -1,0 +1,9 @@
+const s = param("Plate Size", 50, { unit: 'mm', min: 20, max: 200 });
+const t = param("Plate Thickness", 8, { unit: 'mm', min: 2, max: 30 });
+const d = param("Hole Diameter", 12, { unit: 'mm', min: 3, max: 30 });
+const r = param("Fillet Radius", 1.5, { unit: 'mm', min: 0.2, max: 5 });
+
+const plate = box(s, s, t);
+const hole = cylinder(t + 2, d / 2).translate(s / 2, s / 2, -1);
+
+return plate.subtract(hole).fillet(r, { face: 'top' });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kernelcad",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kernelcad",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
         "@babel/generator": "^7.28.6",


### PR DESCRIPTION
## Summary

First slice of workstream **#19 (corpus expansion)** per the v0.2-to-v1.0 gap-closure roadmap. Adds **3 v0.2 tracked-refs corpus tasks** under `eval/tasks/`, each exercising a natural-form case that requires v0.2 capability (canonical face refs surviving transforms or unambiguous booleans):

- **`fillet-translated-box`** — `box(...).translate(...).fillet(r, { face: 'top' })`
- **`subtract-then-fillet-rim`** — `box(...).subtract(cyl).fillet(r, { face: 'top' })` (the canonical "subtract.fillet" case from the gap-closure roadmap)
- **`chamfer-rotated-wedge`** — `box(...).rotate([1,0,0], θ).chamfer(d, { face: 'top' })`

Each task ships with `prompt.md`, `solution-expert.kcad.ts`, and `harness.ts`. New `eval/corpus-v0.2.test.ts` mirrors the seed-task sanity pattern (`eval/runner.test.ts`) and asserts each expert solution scores 100% via `runTask` + `MockAgentClient`.

> **Spec + plan are marked DRAFT v1** in their bodies (`docs/superpowers/specs/2026-05-03-corpus-v0.2-tracked-refs-design.md`, `docs/superpowers/plans/2026-05-03-corpus-v0.2-tracked-refs.md`). The brainstorm step was skipped — the gap-closure roadmap text was specific enough that the spec is a focused operationalization rather than open exploration. Open questions for controller review are listed in the spec's "Open questions" section (3 vs 5 tasks, difficulty band assignments, tilt-correctness rubric tightness, naming).

## Why this slice

The dispatch order doc (PR #56) calls for Wave 1 = #19 + #21 + #22 in parallel. This is the first concrete #19 deliverable: the v0.2 module's 3-task slice (range "3–5" per the gap-closure roadmap §Corpus design). Three tasks rather than five keeps the slice reviewable; the missing 0–2 are punted to a follow-up pending controller feedback on the rubric shape.

## Test Plan

- [x] `npm run typecheck` — clean
- [x] `npm run build:cli` — clean
- [x] `npm test` — 903 pass, 25 skipped, 0 failed (was 870 before; +3 corpus tests + a few transitive expansions)
- [x] Each expert solution evaluates clean via `kernelcad evaluate --json`
- [x] Each expert solution scores `gate_pass=true, score=1` via `runTask`+`MockAgentClient`
- [x] Branch rebased on develop tip (3a309be)

## Scope notes

**Included:** 3 task folders + 1 vitest sanity check + CHANGELOG `[Unreleased]` entry. `package-lock.json` updated to reflect the v0.2.0 version bump (the lockfile was stale at 0.1.0 in the worktree until `npm install` ran).

**Out of scope:**
- Real-API agent runs (corpus-author-time concern; lives at G1 pre-flight per the roadmap).
- Difficulty-band wiring beyond per-task self-classification (no harness behavior depends on bands yet).
- Tasks for v0.3+ modules (those modules haven't shipped).

## Companion PR

Depends on PR #56 landing (the gap-closure scaffolding) for the corpus-design spec it references. If #56 is held for review, this PR can stand alone — it doesn't import any of #56's files at runtime.