### PR TITLE
policy(memorable-builds): catalog + lint + whats-new template + captureDemo --hero-artifact

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+# Repo conventions for Claude Code agents working in kernelCAD-web
+
+## Demo discipline (v0.X.0-tag PR review rule)
+
+When reviewing a PR that ships a `v0.X.0` tag (cuts a per-module release):
+
+1. Verify `docs/demos/v0.X/<task>/whats-new.md` contains a `## Hero artifact` section, a `## Why memorable` section with all three bullets filled (no `TODO:`), and a `## What's new` section.
+2. Verify `docs/demos/v0.X/<task>/meta.json` contains `heroArtifact`, `catalogSource`, and `overrideApprovedBy` keys.
+3. Verify the §1 bar of [`docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md`](docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md) is satisfied by the *artifact itself*, not by the prose. If `heroArtifact` is generic (box, bracket, plate, etc.) or the new tool isn't visibly central to the build, fail the review and cite the policy spec.
+4. If `meta.json.overrideApprovedBy` is non-null, the override path was used. Surface this to the controller for traceability — it is not automatically a fail, but should not be a default.
+
+This rule binds the `superpowers:code-reviewer` agent and any human reviewer working in this repo.

--- a/docs/demos/README.md
+++ b/docs/demos/README.md
@@ -22,6 +22,7 @@ docs/demos/
 - **Per coverage-gate transition** also adds an aggregate reel under `docs/demos/gates/G<N>/`.
 - **Captured during a real harness run, not staged.** The agent loop must be visible in the terminal capture.
 - **Embedded in:** GitHub release notes (mandatory), CHANGELOG entries (markdown image embed), public-benchmark submission notes, the public examples gallery.
+- **Hero artifact must be drawn from the catalog in [`docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md`](../superpowers/specs/2026-05-04-memorable-builds-policy-design.md)** (or have a non-null `meta.json.overrideApprovedBy` recording controller approval). Generic primitives (box, bracket, plate, cylinder, cube, sphere) are denylisted by `scripts/lint-demos.ts`. No catalog-conformant artifact, no `v0.X.0` tag.
 
 ## Authoring
 

--- a/docs/superpowers/specs/2026-05-03-v0.2-to-v1.0-gap-closure-roadmap-design.md
+++ b/docs/superpowers/specs/2026-05-03-v0.2-to-v1.0-gap-closure-roadmap-design.md
@@ -558,7 +558,7 @@ Every new diagnostic code added by any workstream must:
 
 **Embedded in:** GitHub release notes (mandatory), CHANGELOG entries (markdown image embed), public-benchmark submission notes (workstream #24), public examples gallery (H9).
 
-**Enforcement:** per-module ship gate gains a 6th criterion — "visual artifact set committed under `docs/demos/v0.X/`." No artifact, no `v0.X.0` tag.
+**Enforcement:** per-module ship gate gains a 6th criterion — "visual artifact set committed under `docs/demos/v0.X/`." No artifact, no `v0.X.0` tag. Hero artifact selection is governed by [`2026-05-04-memorable-builds-policy-design.md`](./2026-05-04-memorable-builds-policy-design.md): the catalog (§2 there) binds per-module brainstorms; lint-demos.ts denylist + catalog-match enforce at ship-gate time.
 
 ### H12 — Demo automation infrastructure (folded into workstream #21)
 

--- a/docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md
+++ b/docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md
@@ -1,0 +1,307 @@
+# Memorable builds policy — design
+
+**Date:** 2026-05-04
+**Status:** Draft (spec)
+**Scope:** Meta-policy binding the per-module visual-demo discipline (§H11) of the v0.2 → v1.0 gap-closure roadmap. Constrains how every per-module brainstorm picks its demo hero artifact through v1.0.
+**Supersedes:** Implicit "promo-grade MP4" guidance under gap-closure roadmap §H11.
+**Goal:** Replace utilitarian demo defaults (`bracket-holes`, `box-minus-divider`-style outputs) with recognizable, scroll-stopping hero artifacts that make the new tool central to the build, doubling as build-in-public assets without extra authoring effort.
+
+## Why this milestone
+
+The v0.21 synchronized live-build pipeline shipped under a roadmap that called for promo-grade demos, but the first artifact that landed (`bracket-holes`) is a generic L-bracket with two through-holes. Generic geometry is the path of least resistance whenever no upstream constraint forces a memorable build. This policy adds that constraint with teeth — at metadata, lint, template, ship-gate, and reviewer-agent layers — so future per-module specs inherit a recognizable shortlist and can't silently default to a primitive.
+
+## Goals (this milestone)
+
+1. Define the bar a demo's hero artifact must clear ("memorable").
+2. Pre-commit a 16-artifact catalog (one shortlist per shipping iteration from v0.21 re-shoot through v1.0 capstone).
+3. Bind the bar structurally — `meta.json` field, `lint-demos.ts` denylist + catalog match, `whats-new.md` template sections, ship-gate checklist line, reviewer-agent prompt addition.
+4. Define the per-module brainstorm protocol that inherits the catalog.
+5. Couple the catalog to the @KernelCAD build-in-public daily cadence without adding new posting work.
+
+## Non-goals
+
+- Re-authoring demos for already-shipped iterations other than v0.21 (v0.2's `box-minus-divider` is grandfathered as honest tracked-refs content).
+- Defining new MCP tools, kernel features, or capture-pipeline behavior — the v0.21 pipeline already produces the artifacts; this spec only governs *what* it captures.
+- Style/branding decisions for the rendered output (lighting, materials, color palette) — owned by the v0.21.1+ visual-quality stream.
+- Scheduling daily build-in-public posts — this spec only formalizes the natural coupling; cadence is owned by the build-in-public note.
+
+## §1 — The "memorable build" bar
+
+A demo's hero artifact passes if and only if every rule below is true. Rules 1–4 are judgment calls (reviewer-agent enforces). Rule 5 is a scope-discipline anchor for per-module spec authors.
+
+1. **Recognizable in one second.** A non-CAD viewer scrolling past must name the object out loud (donut, mug, guitar pick, octopus). Abstract geometry, brackets, plates, or named primitives fail.
+2. **The new tool is central, not garnish.** Removing the iteration's new feature must visibly break the build. Tested by: "if I delete the new tool from the build script, what's left?"
+3. **Reads at 360° rotate.** The hero animation is build sequence + rotation. The shape must remain recognizable from every angle the rotation passes through.
+4. **Single shot, no labels needed.** The MP4 stands alone without text overlays explaining what the object is. Outside-the-frame post copy is unrelated.
+5. **Authored within the iteration's scope budget.** The build script is part of the per-module spec's scope estimate; if it would take more than ~1 day on top of the feature work, the spec picks a simpler shortlist candidate.
+
+## §2 — Catalog (16 hero artifacts, v0.21 + v0.3 → v1.0)
+
+Format: ★ = recommended pick. Each entry names the artifact, asserts the new tool is central, and ties to §1 rule 2. v0.2 (`box-minus-divider`) is grandfathered. v0.21 is re-shot under this policy as the launch artifact.
+
+### v0.21 — Synchronized live-build pipeline (re-shoot, replaces `bracket-holes`)
+
+Pipeline is the feature; geometry is the showcase. Target maximum-meme since this re-launches demo discipline.
+
+- ★ **donut** — torus + glaze ring booleaned on top + scattered sprinkles (small extrudes). Iconic 3D-tutorial archetype; reads from any angle; build-step animation is satisfying.
+- **apple-core** — revolved profile + boolean cuts for bites.
+- **rubber-duck-silhouette** — *deprioritized; wants NURBS, see v0.7.*
+
+### v0.3 — shell + hole + cut + face lineage
+
+- ★ **espresso-cup** — revolve profile, shell to hollow, cut for handle slot, face-ref to fillet rim. Removes shell → solid blob; removes hole → no handle.
+- **tiny-pumpkin** — gourd revolve, shell, eye/mouth cuts.
+- **watering-can** — revolve + shell + perforation pattern on spout.
+
+### v0.4 — constrained sketches (DISTANCE / ANGLE / TANGENT / SYMMETRIC / CONCENTRIC)
+
+- ★ **guitar-pick** — single closed profile, three tangent arcs, dimensioned. Without tangent + dimension constraints it doesn't read as a pick.
+- **house-key-silhouette** — bow + tooth pattern, dimensioned distances, symmetric constraints.
+- **heart** — symmetric tangent arcs.
+
+### v0.5 — Studio UI: CADCommand, undo, AST edits, param sliders
+
+Hero must visibly morph live as a slider drags.
+
+- ★ **parametric-mug** — slider drives wall thickness + height + handle radius; same mug morphs in real time. Without sliders it's a static mug.
+- **parametric-lego-brick** — slider drives stud count.
+- **parametric-phone-case** — sliders for thickness + cutouts.
+
+### v0.6 — Assemblies + joints + connectors + FK
+
+Hero MOVES.
+
+- ★ **articulated-desk-lamp** — base + 3 articulated arms + hinged head; FK demo: head looks around as joints rotate. Without joints it's disconnected parts on the floor.
+- **crank-slider-piston** — engineer-meme; satisfying motion.
+- **robot-finger** — three phalanges, FK curl.
+
+### v0.7 — NURBS curves
+
+Sweep + loft already shipped (v0.1 bonus); only NURBS curves remain.
+
+- ★ **computer-mouse-shell** — lofted ergonomic top surface using NURBS curves, scroll-wheel slot, button split line. Without NURBS the shell looks like a brick.
+- **electric-guitar-body** — lofted top profile + carved cutaways.
+- **perfume-bottle** — lofted curves.
+
+### v0.8 — BOM, dimensions, drawings, BREP export
+
+Hero needs a dimensioned drawing + BOM table; the 3D model is incidental.
+
+- ★ **three-leg-stool-with-assembly-diagram** — exploded view + dimensioned drawing + BOM (3× legs, 1× seat, 6× bolts, 6× washers). Without BOM/drawing tools, just a stool.
+- **mini-drone-frame** — carbon plate + 4 motor mounts, BOM for fasteners.
+- **skateboard-truck** — axle + hanger + baseplate + BOM.
+
+### v0.9 — Toolbox: bolts, nuts, washers, gears, pipes
+
+Hero must use library parts as primary structural elements.
+
+- ★ **mechanical-keyboard-chassis** — toolbox bolts hold case corners, arrayed key switches as toolbox-style modules.
+- **warp-pipe** — uses pipe + flange library; high meme value.
+- **rube-goldberg-gear-train** — toolbox gears chained, animated rotation (depends on v0.6 FK).
+
+### v0.10 — Viewport: cutPlane, jointsView, explodeView, animation
+
+- ★ **engine-block-exploded-view** — depends on a v0.6 multi-part assembly (pistons + crankshaft + cylinder head); animated explode reveals each part flying out, then cutPlane reveals interior.
+- **nesting-doll-cross-section** — cutPlane reveals nested matryoshkas.
+- **onion-cross-section** — cutPlane through layers.
+
+### v0.11 finish — CLI render/capture
+
+Hero is the render itself, generated entirely from CLI with no UI.
+
+- ★ **kernelcad-logo-extruded** — self-referential meta-demo.
+- **hello-world-3d-text** — extruded letters.
+- **engraved-postcard** — "Greetings from kernelCAD" engraved on a 3D postcard.
+
+### v0.12 finish — skill installer + bundler
+
+Meta — the skill installer IS the demo.
+
+- ★ **rubber-duck-skill** — installer pulls a duck-builder skill, runs it, ducks proliferate.
+- **self-bundling-build** — a `.kcad.ts` that imports its own helpers from a one-file context bundle.
+
+### v0.13 — Sheet metal: bends, K-factor, flat-pattern
+
+Hero is bent.
+
+- ★ **origami-crane-in-steel** — folded sheet, K-factor exercised on every fold, flat-pattern roundtrip exports the unfolded silhouette.
+- **pencil-cup** — rolled cylinder + folded base.
+- **letter-holder** — multi-bend mail tray.
+
+### v0.14 — SDF: smooth booleans, TPMS, organic
+
+Hero is squishy or biological.
+
+- ★ **octopus** — body sphere + 8 tentacles smooth-blended via SDF; impossible with hard booleans.
+- **gyroid-lattice-cube** — TPMS exhibit.
+- **coral-cluster** — organic.
+
+### v0.15 — Wood-specific helpers (mortise / tenon / dado / rabbet)
+
+Hero shows joinery at corners.
+
+- ★ **tiny-wooden-chair** — four legs joined to seat with mortise-and-tenon, stretchers via dado. Joinery visible at every corner.
+- **picture-frame** — mitered + rabbet for backing.
+- **birdhouse** — rabbet roof joint.
+
+### v0.16 — Vision: image-to-CAD
+
+The input image is half the demo.
+
+- ★ **napkin-sketch-to-3d** — phone-camera shot of a hand-drawn star (or heart, or initials), kernel infers extrude depth, outputs 3D model. The juxtaposition is the post.
+- **whiteboard-sketch-to-3d**.
+- **photo-of-flat-object-to-3d** — key, gear, etc.
+
+### v0.17 — GCode/CAM: 2.5D toolpaths
+
+Hero must show the toolpath, not just the geometry.
+
+- ★ **engraved-nameplate** — 2.5D pocket toolpath cuts a nameplate; demo shows toolpath visualization sweeping over it.
+- **engraved-coaster** — wooden coaster with logo.
+- **cookie-cutter-shape** — face-mill demo.
+
+### v1.0 — Capstone (polish + docs + full surface)
+
+Multi-module flex. Must use a meaningful subset of features shipped.
+
+- ★ **mechanical-music-box** — wooden case (v0.15 joinery), brass cylinder with pins (v0.4 sketches + v0.13 sheet for comb), hand-crank gear train (v0.6 joints + v0.9 toolbox gears), shaped wooden lid (v0.7 NURBS surface), assembled with BOM + exploded view (v0.8, v0.10). Plays a 5-second animation when cranked.
+- **articulated-robot-arm** — joints + toolbox parts + sheet-metal panels.
+- **pinball-machine-table** — sheet metal + wood + assembly + animation.
+
+### Catalog slug rule
+
+Slugs are kebab-case, verb-free, scoped to the iteration version. They serve as the canonical `heroArtifact` value in `meta.json`.
+
+## §3 — Enforcement (six structural touchpoints)
+
+### 3.1 — `docs/demos/README.md` adds a 7th rule
+
+Append to the policy block (under the existing six):
+
+> 7. **Hero artifact must be drawn from the catalog in `docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md`** (or be a controller-approved override that meets the §1 bar). No catalog-conformant artifact, no `v0.X.0` tag.
+
+### 3.2 — `docs/demos/v0.X/meta.json` schema additions
+
+Add three fields to every iteration's `meta.json`:
+
+```json
+{
+  "heroArtifact": "<slug from §2 catalog>",
+  "catalogSource": "memorable-builds-policy/<iteration version, e.g. v0.3>",
+  "overrideApprovedBy": null
+}
+```
+
+`heroArtifact` MUST equal a §2 slug for that iteration version, OR `overrideApprovedBy` MUST be set to a non-null controller name and a one-line reason.
+
+### 3.3 — `scripts/lint-demos.ts` metadata gate
+
+Add three checks to the existing v0.21 ship-gate lint:
+
+1. **Field presence:** `heroArtifact`, `catalogSource`, `overrideApprovedBy` all present.
+2. **Generic-name denylist:** reject `heroArtifact` values matching `box`, `bracket`, `plate`, `cylinder`, `cube`, `sphere`, `torus-only`, or any other named primitive (denylist in lint config, easy to extend).
+3. **Catalog match:** `heroArtifact` matches a catalog slug for the iteration's version, unless `overrideApprovedBy` is set.
+
+Lint failure blocks the per-module ship gate, identical to existing v0.21 ship-gate behavior.
+
+### 3.4 — `whats-new.md` template additions
+
+Extend `scripts/demo-template/whats-new.md` with three required sections:
+
+```markdown
+## Hero artifact
+<Slug from §2 catalog (or override slug)>
+
+## Why memorable (against §1 bar)
+- Recognizable in one second: <1 line>
+- New tool central: <1 line — what visibly breaks if you remove the new tool?>
+- Reads at 360°: <1 line>
+
+## What's new (capability gain)
+<Existing template content moves here>
+```
+
+Reviewer-agent fails the PR if any of the three new fields is missing, blank, or boilerplate.
+
+### 3.5 — Gap-closure roadmap §H11 update
+
+Replace the existing one-line §H11 reference to "promo-grade MP4" with a pointer to this spec:
+
+> Per-module ship gates require a hero-artifact MP4 + panel + `whats-new.md` per `docs/demos/README.md`. Hero artifact selection is governed by `docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md` (the catalog binds per-module brainstorms).
+
+### 3.6 — `superpowers:code-reviewer` prompt addition
+
+Add to the reviewer-agent prompt template a one-line clause for `v0.X.0`-tag PRs:
+
+> When the PR ships a `v0.X.0` tag, verify `docs/demos/v0.X/whats-new.md` names a §2 catalog hero artifact (or has a non-null `overrideApprovedBy` in `meta.json`) and that the §1 bar is satisfied by the artifact (not by the prose). If the artifact is generic or the new tool isn't central to it, fail the review and cite this spec.
+
+## §4 — Per-module brainstorm protocol
+
+Future per-module brainstorm dispatches inherit four obligations:
+
+1. **Boilerplate prefix.** Each per-module brainstorm prompt starts with: *"Read `docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md`. Your iteration's shortlist is in §2 under v0.X. Pick one of {★ / backup / backup}, or propose a 4th meeting §1, with reasoning."*
+2. **Mandatory `## Hero artifact` section.** Every per-module spec adds a `## Hero artifact` section that names the locked pick + cites the catalog entry. This section feeds `meta.json` and `whats-new.md`.
+3. **Lock-in moment is brainstorm-approval, not implementation.** Build script is part of the spec's scope estimate (per §1 rule 5); iterations can't discover halfway through that the build is too ambitious.
+4. **Override path.** If during implementation the chosen artifact turns out infeasible, the implementer escalates to controller — does NOT silently swap for a generic shape. Override is logged in `docs/superpowers/cross-workstream-decisions.md` (existing append-only log) so the precedent is searchable.
+
+## §5 — Build-in-public coupling
+
+The catalog feeds @KernelCAD daily posts naturally — no new posting policy required, but three natural couplings worth recording:
+
+1. **Per-iteration daily post visual.** Each shipped `docs/demos/v0.X/demo.mp4` is the Day-N post visual on @KernelCAD (X) + LinkedIn company page, per the existing build-in-public note.
+2. **Pre-iteration shortlist teaser (optional, recommended).** Before each iteration ships, the §2 shortlist itself becomes content: *"v0.3 next — picking between espresso cup, tiny pumpkin, watering can. What should I build?"* Crowd-sources taste-testing and surfaces weak candidates.
+3. **Catalog-reveal post (one-time, on this spec's commit).** A single thread/post unveils the full 16-build roadmap as a build-in-public teaser, setting narrative for the sprint.
+
+## Architecture & components
+
+This spec is a meta-policy, not a code change. Components added:
+
+| Touchpoint | File / location | Owner |
+|---|---|---|
+| Policy spec | `docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md` | this doc |
+| Catalog (the 16 shortlists) | §2 of this doc | this doc |
+| 7th demo rule | `docs/demos/README.md` | follow-up plan |
+| `meta.json` schema | `docs/demos/v0.X/meta.json` (per iteration) | follow-up plan |
+| Lint gate | `scripts/lint-demos.ts` | follow-up plan |
+| `whats-new.md` template | `scripts/demo-template/whats-new.md` | follow-up plan |
+| Roadmap §H11 update | gap-closure roadmap design doc | follow-up plan |
+| Reviewer-agent prompt update | reviewer-agent definition | follow-up plan |
+| Per-module brainstorm protocol | inherited by all v0.3 → v1.0 specs | follow-up plan |
+
+## Data flow
+
+1. Per-module brainstorm reads §2 catalog → selects hero artifact slug.
+2. Per-module spec records `## Hero artifact: <slug>`.
+3. Implementation captures demo via v0.21 pipeline → `docs/demos/v0.X/{demo.mp4, panel.png, hero-frame.png, meta.json, pacing.json, whats-new.md}`.
+4. `lint-demos.ts` validates `meta.json.heroArtifact` against §2 catalog (or override).
+5. `whats-new.md` validation enforces three required sections.
+6. Reviewer-agent on the `v0.X.0`-tag PR confirms §1 bar satisfied by the artifact, not the prose.
+7. On merge, `demo.mp4` becomes the Day-N build-in-public post visual.
+
+## Error handling
+
+- **Lint rejects unknown `heroArtifact` slug:** implementer either picks a §2 candidate or sets `overrideApprovedBy` after controller approval.
+- **Reviewer-agent rejects "memorable" judgment:** PR blocked; spec author re-picks from §2 or escalates to controller.
+- **Override approved mid-implementation:** logged in `cross-workstream-decisions.md` with date + reason. No silent fallback to a primitive.
+
+## Testing
+
+This is a doc + lint + template change. Test coverage:
+
+- **Lint test (`tests/lint-demos.spec.ts`):** add cases for (a) valid catalog slug, (b) generic denylist hit, (c) missing fields, (d) override path with `overrideApprovedBy` set.
+- **Template test:** snapshot the new `whats-new.md` template; assert reviewer-agent prompt loader picks up the new clause.
+- **Catalog roundtrip:** integration test that walks every §2 entry slug and confirms it's reachable from at least one iteration's expected `heroArtifact` set.
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Catalog picks turn out infeasible at implementation time | Medium | Per §4.3, build script is part of spec's scope estimate; per §4.4, override path with paper trail. |
+| "Memorable" judgment is subjective; reviewer-agent calls it inconsistently | Medium | §1 rules 1–4 are concrete tests; rule 2 is mechanical ("delete the new tool, what's left?"). Reviewer prompt cites this spec. |
+| Pre-iteration teaser posts (§5.2) fail to engage and become noise | Low | §5.2 is recommended-not-required; can drop without policy change. |
+| Catalog locks us out of better artifacts that emerge later | Low | "We can improve it later" — catalog is editable as a normal spec amendment; not a frozen contract. |
+| Generic-name denylist (§3.3.2) blocks a legitimately memorable build that happens to match a primitive name | Very low | Override path covers it; denylist also extensible in lint config. |
+
+## Open questions
+
+None at design time. Catalog content is committed; refinements happen via amendment.

--- a/docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md
+++ b/docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md
@@ -20,7 +20,7 @@ The v0.21 synchronized live-build pipeline shipped under a roadmap that called f
 
 ## Non-goals
 
-- Re-authoring demos for already-shipped iterations other than v0.21 (v0.2's `box-minus-divider` is grandfathered as honest tracked-refs content).
+- Re-authoring demos for already-shipped iterations other than v0.21. v0.1 (`bracket-with-hole`) and v0.2 (`subtract-then-fillet-rim`) are grandfathered as honest pre-policy content; their legacy fields (gitSha/capturedAt/taskId) are still enforced by `lint-demos.ts`, but they are exempt from the §1 hero-artifact bar and §3 catalog-match requirements. The grandfathered set is encoded in `scripts/lib/memorableBuildsCatalog.ts` as `GRANDFATHERED_VERSIONS`.
 - Defining new MCP tools, kernel features, or capture-pipeline behavior — the v0.21 pipeline already produces the artifacts; this spec only governs *what* it captures.
 - Style/branding decisions for the rendered output (lighting, materials, color palette) — owned by the v0.21.1+ visual-quality stream.
 - Scheduling daily build-in-public posts — this spec only formalizes the natural coupling; cadence is owned by the build-in-public note.

--- a/docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md
+++ b/docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md
@@ -4,7 +4,7 @@
 **Status:** Draft (spec)
 **Scope:** Meta-policy binding the per-module visual-demo discipline (§H11) of the v0.2 → v1.0 gap-closure roadmap. Constrains how every per-module brainstorm picks its demo hero artifact through v1.0.
 **Supersedes:** Implicit "promo-grade MP4" guidance under gap-closure roadmap §H11.
-**Goal:** Replace utilitarian demo defaults (`bracket-holes`, `box-minus-divider`-style outputs) with recognizable, scroll-stopping hero artifacts that make the new tool central to the build, doubling as build-in-public assets without extra authoring effort.
+**Goal:** Replace utilitarian demo defaults (`bracket-holes`, `subtract-then-fillet-rim`-style outputs) with recognizable, scroll-stopping hero artifacts that make the new tool central to the build, doubling as build-in-public assets without extra authoring effort.
 
 ## Why this milestone
 

--- a/docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md
+++ b/docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md
@@ -37,7 +37,7 @@ A demo's hero artifact passes if and only if every rule below is true. Rules 1�
 
 ## §2 — Catalog (16 hero artifacts, v0.21 + v0.3 → v1.0)
 
-Format: ★ = recommended pick. Each entry names the artifact, asserts the new tool is central, and ties to §1 rule 2. v0.2 (`box-minus-divider`) is grandfathered. v0.21 is re-shot under this policy as the launch artifact.
+Format: ★ = recommended pick. Each entry names the artifact, asserts the new tool is central, and ties to §1 rule 2. v0.2 (`subtract-then-fillet-rim`) is grandfathered. v0.21 is re-shot under this policy as the launch artifact.
 
 ### v0.21 — Synchronized live-build pipeline (re-shoot, replaces `bracket-holes`)
 

--- a/docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md
+++ b/docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md
@@ -206,7 +206,7 @@ Lint failure blocks the per-module ship gate, identical to existing v0.21 ship-g
 
 ### 3.4 — `whats-new.md` template additions
 
-Extend `scripts/demo-template/whats-new.md` with three required sections:
+Extend the template body returned by `scripts/lib/whatsNewTemplate.ts` (`whatsNewTemplate()`) with three required sections, and strengthen `whatsNewIsFilled()` in the same module to verify they're filled:
 
 ```markdown
 ## Hero artifact
@@ -263,7 +263,7 @@ This spec is a meta-policy, not a code change. Components added:
 | 7th demo rule | `docs/demos/README.md` | follow-up plan |
 | `meta.json` schema | `docs/demos/v0.X/meta.json` (per iteration) | follow-up plan |
 | Lint gate | `scripts/lint-demos.ts` | follow-up plan |
-| `whats-new.md` template | `scripts/demo-template/whats-new.md` | follow-up plan |
+| `whats-new.md` template | `scripts/lib/whatsNewTemplate.ts` | follow-up plan |
 | Roadmap §H11 update | gap-closure roadmap design doc | follow-up plan |
 | Reviewer-agent prompt update | reviewer-agent definition | follow-up plan |
 | Per-module brainstorm protocol | inherited by all v0.3 → v1.0 specs | follow-up plan |

--- a/examples/v0.21/donut.kcad.ts
+++ b/examples/v0.21/donut.kcad.ts
@@ -1,0 +1,60 @@
+// v0.21 hero artifact: donut with glaze and sprinkles.
+//
+// Built using only v0.1/v0.2/v0.21-available primitives (no torus primitive
+// in current API). Body is a square-cross-section ring via revolveRect, then
+// .fillet() rounds every edge so it reads as a torus. Glaze is a thinner
+// ring sitting on top, slightly oversized for a "drip" silhouette. Sprinkles
+// are small extruded cylinders scattered on the glaze top.
+//
+// Per memorable-builds policy spec §2 (v0.21 catalog entry).
+
+const bodyInnerR = param('Hole radius', 12, { unit: 'mm', min: 8, max: 20 });
+const bodyOuterR = param('Outer radius', 35, { unit: 'mm', min: 25, max: 50 });
+const bodyHeight = param('Body height', 18, { unit: 'mm', min: 12, max: 24 });
+const bodyFillet = param('Body fillet', 7, { unit: 'mm', min: 3, max: 12 });
+
+const glazeOverhang = param('Glaze overhang', 1, { unit: 'mm', min: 0, max: 4 });
+const glazeInset = param('Glaze inset', 1, { unit: 'mm', min: 0, max: 4 });
+const glazeHeight = param('Glaze height', 5, { unit: 'mm', min: 2, max: 8 });
+const glazeFillet = param('Glaze fillet', 1.5, { unit: 'mm', min: 0.5, max: 3 });
+
+const sprinkleR = param('Sprinkle radius', 1, { unit: 'mm', min: 0.5, max: 2 });
+const sprinkleH = param('Sprinkle height', 3, { unit: 'mm', min: 1.5, max: 5 });
+
+const body = revolveRect(
+  bodyOuterR - bodyInnerR,
+  bodyHeight,
+  bodyInnerR,
+).fillet(bodyFillet);
+
+const glaze = revolveRect(
+  (bodyOuterR + glazeOverhang) - (bodyInnerR + glazeInset),
+  glazeHeight,
+  bodyInnerR + glazeInset,
+)
+  .translate(0, 0, bodyHeight)
+  .fillet(glazeFillet);
+
+const sprinkleZ = bodyHeight + glazeHeight;
+
+const sprinklePolar: Array<[number, number]> = [
+  [22, 15],
+  [18, 60],
+  [25, 105],
+  [20, 150],
+  [23, 200],
+  [19, 245],
+  [22, 290],
+  [21, 335],
+];
+
+const sprinkles = sprinklePolar.map(([r, deg]) => {
+  const rad = (deg * Math.PI) / 180;
+  return cylinder(sprinkleH, sprinkleR).translate(
+    r * Math.cos(rad),
+    r * Math.sin(rad),
+    sprinkleZ,
+  );
+});
+
+return body.union(glaze, ...sprinkles);

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "qc": "npm run lint && npm run typecheck && npm run build:cli && npm run cookbook:validate && npm run cookbook:evaluate && npm run cookbook:build && git diff --exit-code src/skill/SKILL.md && npm test",
     "qc:full": "npm run qc && npm run test:e2e && npm run build",
     "capture-demo": "npx tsx scripts/captureDemo.ts",
-    "capture-demo:hero": "npx tsx scripts/captureDemo.ts --task bracket-holes --module v0.21 --output docs/demos/v0.21/bracket-holes/",
-    "capture-demo:retro-v0.1": "npx tsx scripts/captureDemo.ts --script examples/bracket-with-hole.kcad.ts --prompt scripts/demo-prompts/v0.1-bracket.md --module v0.1 --output docs/demos/v0.1/bracket-with-hole/",
-    "capture-demo:retro-v0.2": "npx tsx scripts/captureDemo.ts --task subtract-then-fillet-rim --module v0.2 --output docs/demos/v0.2/subtract-then-fillet-rim/",
+    "capture-demo:hero": "npx tsx scripts/captureDemo.ts --task bracket-holes --module v0.21 --output docs/demos/v0.21/bracket-holes/ --hero-artifact bracket-holes --override-approved-by 'pre-Task-10: bracket-holes scheduled for replacement by donut'",
+    "capture-demo:retro-v0.1": "npx tsx scripts/captureDemo.ts --script examples/bracket-with-hole.kcad.ts --prompt scripts/demo-prompts/v0.1-bracket.md --module v0.1 --output docs/demos/v0.1/bracket-with-hole/ --hero-artifact bracket-with-hole --override-approved-by 'grandfathered: pre-policy v0.1 retro capture'",
+    "capture-demo:retro-v0.2": "npx tsx scripts/captureDemo.ts --task subtract-then-fillet-rim --module v0.2 --output docs/demos/v0.2/subtract-then-fillet-rim/ --hero-artifact subtract-then-fillet-rim --override-approved-by 'grandfathered: pre-policy v0.2 retro capture'",
     "lint-demos": "npx tsx scripts/lint-demos.ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "qc:full": "npm run qc && npm run test:e2e && npm run build",
     "capture-demo": "npx tsx scripts/captureDemo.ts",
     "capture-demo:hero": "npx tsx scripts/captureDemo.ts --task bracket-holes --module v0.21 --output docs/demos/v0.21/bracket-holes/ --hero-artifact bracket-holes --override-approved-by 'pre-Task-10: bracket-holes scheduled for replacement by donut'",
+    "capture-demo:donut": "npx tsx scripts/captureDemo.ts --script examples/v0.21/donut.kcad.ts --prompt scripts/demo-prompts/v0.21-donut.md --module v0.21 --output docs/demos/v0.21/donut/ --hero-artifact donut",
     "capture-demo:retro-v0.1": "npx tsx scripts/captureDemo.ts --script examples/bracket-with-hole.kcad.ts --prompt scripts/demo-prompts/v0.1-bracket.md --module v0.1 --output docs/demos/v0.1/bracket-with-hole/ --hero-artifact bracket-with-hole --override-approved-by 'grandfathered: pre-policy v0.1 retro capture'",
     "capture-demo:retro-v0.2": "npx tsx scripts/captureDemo.ts --task subtract-then-fillet-rim --module v0.2 --output docs/demos/v0.2/subtract-then-fillet-rim/ --hero-artifact subtract-then-fillet-rim --override-approved-by 'grandfathered: pre-policy v0.2 retro capture'",
     "lint-demos": "npx tsx scripts/lint-demos.ts"

--- a/scripts/captureDemo.ts
+++ b/scripts/captureDemo.ts
@@ -53,10 +53,13 @@ function parseArgs(argv: string[]): Args {
     console.error('Must specify either --task or both --script and --prompt');
     process.exit(2);
   }
-  if (!a.heroArtifact) {
+  if (!a.heroArtifact && !a.rotateOnly) {
     console.error('Missing --hero-artifact <slug>. See docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md §2 for the catalog.');
     process.exit(2);
   }
+  // rotate-only re-renders cached output and never writes meta.json or whats-new.md;
+  // a slug isn't required for that path.
+  if (!a.heroArtifact) a.heroArtifact = '';
   if (!a.overrideApprovedBy) a.overrideApprovedBy = null;
   return a as Args;
 }

--- a/scripts/captureDemo.ts
+++ b/scripts/captureDemo.ts
@@ -25,6 +25,8 @@ interface Args {
   pacing?: string;
   titleCardSvg?: string;
   rotateOnly: boolean;
+  heroArtifact: string;
+  overrideApprovedBy: string | null;
 }
 
 function parseArgs(argv: string[]): Args {
@@ -40,15 +42,22 @@ function parseArgs(argv: string[]): Args {
     else if (arg === '--pacing') { a.pacing = next; i++; }
     else if (arg === '--title-card-svg') { a.titleCardSvg = next; i++; }
     else if (arg === '--rotate-only') { a.rotateOnly = true; }
+    else if (arg === '--hero-artifact') { a.heroArtifact = next; i++; }
+    else if (arg === '--override-approved-by') { a.overrideApprovedBy = next; i++; }
   }
   if (!a.module || !a.output) {
-    console.error('Usage: captureDemo --module v0.X --output <dir> (--task <id> | --script <path> --prompt <path>)');
+    console.error('Usage: captureDemo --module v0.X --output <dir> --hero-artifact <slug> (--task <id> | --script <path> --prompt <path>) [--override-approved-by "<name>: <reason>"]');
     process.exit(2);
   }
   if (!a.task && !(a.script && a.prompt)) {
     console.error('Must specify either --task or both --script and --prompt');
     process.exit(2);
   }
+  if (!a.heroArtifact) {
+    console.error('Missing --hero-artifact <slug>. See docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md §2 for the catalog.');
+    process.exit(2);
+  }
+  if (!a.overrideApprovedBy) a.overrideApprovedBy = null;
   return a as Args;
 }
 
@@ -306,7 +315,7 @@ async function main(): Promise<void> {
   const partName = args.task ?? basename(scriptPath, '.kcad.ts');
   writeWhatsNewIfMissing(
     join(args.output, 'whats-new.md'),
-    whatsNewTemplate({ module: args.module, partName }),
+    whatsNewTemplate({ module: args.module, partName, heroArtifact: args.heroArtifact }),
   );
 
   // Metadata.
@@ -319,6 +328,9 @@ async function main(): Promise<void> {
       durationMs: pacing.totalDurationMs,
       truncated: pacing.truncated,
       gitSha: execSync('git rev-parse HEAD').toString().trim(),
+      heroArtifact: args.heroArtifact,
+      catalogSource: `memorable-builds-policy/${args.module}`,
+      overrideApprovedBy: args.overrideApprovedBy,
     }, null, 2),
   );
   writeFileSync(

--- a/scripts/demo-prompts/v0.21-donut.md
+++ b/scripts/demo-prompts/v0.21-donut.md
@@ -1,0 +1,9 @@
+# Build a donut with glaze and sprinkles
+
+Build a recognizable donut: a torus-shaped body with a smaller glaze ring sitting on top and small sprinkle pieces scattered across the glaze.
+
+The donut body should read as a classic ring shape (rounded edges, hole through the middle, height comfortable to the eye). The glaze should overhang slightly on the outside and inset slightly into the hole, giving a soft "drip" silhouette. Sprinkles should be cylindrical pieces, irregularly placed across the glaze top.
+
+Constraints: build using only primitives + booleans + fillets available at v0.21 (no `torus` primitive — use `revolveRect` + `fillet` to approximate). All distances in mm.
+
+Parameters: hole radius, outer radius, body height, body fillet, glaze overhang, glaze inset, glaze height, glaze fillet, sprinkle radius, sprinkle height.

--- a/scripts/lib/demoMetaValidator.test.ts
+++ b/scripts/lib/demoMetaValidator.test.ts
@@ -112,6 +112,24 @@ describe('validateDemoMeta', () => {
     expect(validateDemoMeta(meta, 'v0.2')).toEqual([]);
   });
 
+  it('grandfathered version silently accepts stray policy fields (denylist not enforced)', () => {
+    // Documenting intentional behavior: pre-policy versions are exempt from
+    // §3 enforcement entirely. Even a denylisted heroArtifact on a v0.1 demo
+    // is accepted — the policy simply does not apply to grandfathered versions.
+    const meta = {
+      taskId: 'bracket-with-hole',
+      module: 'v0.1',
+      capturedAt: '2026-05-02T00:00:00Z',
+      durationMs: 21500,
+      truncated: false,
+      gitSha: 'abc123',
+      heroArtifact: 'box', // would be denylisted on a policy-enforced version
+      catalogSource: 'memorable-builds-policy/v0.1',
+      overrideApprovedBy: null,
+    } as Record<string, unknown>;
+    expect(validateDemoMeta(meta, 'v0.1')).toEqual([]);
+  });
+
   it('grandfathered versions still require legacy fields (gitSha/capturedAt/taskId)', () => {
     const meta = {
       module: 'v0.1',

--- a/scripts/lib/demoMetaValidator.test.ts
+++ b/scripts/lib/demoMetaValidator.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { validateDemoMeta } from './demoMetaValidator';
+
+describe('validateDemoMeta', () => {
+  const validBase = {
+    taskId: 'donut',
+    module: 'v0.21',
+    capturedAt: '2026-05-04T00:00:00Z',
+    durationMs: 21500,
+    truncated: false,
+    gitSha: 'abc123',
+    heroArtifact: 'donut',
+    catalogSource: 'memorable-builds-policy/v0.21',
+    overrideApprovedBy: null,
+  };
+
+  it('passes a fully-valid catalog match', () => {
+    expect(validateDemoMeta(validBase, 'v0.21')).toEqual([]);
+  });
+
+  it('rejects missing pre-existing fields (gitSha/capturedAt/taskId)', () => {
+    const errs = validateDemoMeta({ ...validBase, gitSha: undefined as unknown as string }, 'v0.21');
+    expect(errs.some((e) => e.includes("missing key 'gitSha'"))).toBe(true);
+  });
+
+  it('rejects missing heroArtifact', () => {
+    const meta = { ...validBase } as Record<string, unknown>;
+    delete meta.heroArtifact;
+    const errs = validateDemoMeta(meta, 'v0.21');
+    expect(errs.some((e) => e.includes("missing key 'heroArtifact'"))).toBe(true);
+  });
+
+  it('rejects missing catalogSource', () => {
+    const meta = { ...validBase } as Record<string, unknown>;
+    delete meta.catalogSource;
+    const errs = validateDemoMeta(meta, 'v0.21');
+    expect(errs.some((e) => e.includes("missing key 'catalogSource'"))).toBe(true);
+  });
+
+  it('rejects missing overrideApprovedBy (must be present even if null)', () => {
+    const meta = { ...validBase } as Record<string, unknown>;
+    delete meta.overrideApprovedBy;
+    const errs = validateDemoMeta(meta, 'v0.21');
+    expect(errs.some((e) => e.includes("missing key 'overrideApprovedBy'"))).toBe(true);
+  });
+
+  it('rejects denylisted heroArtifact (e.g. "box")', () => {
+    const errs = validateDemoMeta({ ...validBase, heroArtifact: 'box' }, 'v0.21');
+    expect(errs.some((e) => e.includes('denylisted'))).toBe(true);
+  });
+
+  it('rejects denylisted heroArtifact even with override set', () => {
+    const errs = validateDemoMeta(
+      { ...validBase, heroArtifact: 'bracket', overrideApprovedBy: 'controller' },
+      'v0.21',
+    );
+    expect(errs.some((e) => e.includes('denylisted'))).toBe(true);
+  });
+
+  it('rejects heroArtifact that does not match the version catalog', () => {
+    const errs = validateDemoMeta({ ...validBase, heroArtifact: 'espresso-cup' }, 'v0.21');
+    expect(errs.some((e) => e.includes('does not match catalog for v0.21'))).toBe(true);
+  });
+
+  it('accepts heroArtifact off-catalog if overrideApprovedBy is set', () => {
+    const errs = validateDemoMeta(
+      { ...validBase, heroArtifact: 'custom-hero', overrideApprovedBy: 'controller: spike-day' },
+      'v0.21',
+    );
+    expect(errs).toEqual([]);
+  });
+
+  it('rejects unknown module version (no catalog entry)', () => {
+    const errs = validateDemoMeta(validBase, 'v9.9');
+    expect(errs.some((e) => e.includes('no catalog entry for v9.9'))).toBe(true);
+  });
+});

--- a/scripts/lib/demoMetaValidator.test.ts
+++ b/scripts/lib/demoMetaValidator.test.ts
@@ -19,8 +19,12 @@ describe('validateDemoMeta', () => {
   });
 
   it('rejects missing pre-existing fields (gitSha/capturedAt/taskId)', () => {
-    const errs = validateDemoMeta({ ...validBase, gitSha: undefined as unknown as string }, 'v0.21');
-    expect(errs.some((e) => e.includes("missing key 'gitSha'"))).toBe(true);
+    for (const key of ['gitSha', 'capturedAt', 'taskId'] as const) {
+      const meta = { ...validBase } as Record<string, unknown>;
+      delete meta[key];
+      const errs = validateDemoMeta(meta, 'v0.21');
+      expect(errs.some((e) => e.includes(`missing key '${key}'`))).toBe(true);
+    }
   });
 
   it('rejects missing heroArtifact', () => {
@@ -73,5 +77,13 @@ describe('validateDemoMeta', () => {
   it('rejects unknown module version (no catalog entry)', () => {
     const errs = validateDemoMeta(validBase, 'v9.9');
     expect(errs.some((e) => e.includes('no catalog entry for v9.9'))).toBe(true);
+  });
+
+  it('rejects non-string heroArtifact (e.g. number, object, boolean)', () => {
+    const errsNum = validateDemoMeta({ ...validBase, heroArtifact: 42 as unknown as string }, 'v0.21');
+    expect(errsNum.some((e) => e.includes('heroArtifact must be a string'))).toBe(true);
+
+    const errsObj = validateDemoMeta({ ...validBase, heroArtifact: {} as unknown as string }, 'v0.21');
+    expect(errsObj.some((e) => e.includes('heroArtifact must be a string'))).toBe(true);
   });
 });

--- a/scripts/lib/demoMetaValidator.test.ts
+++ b/scripts/lib/demoMetaValidator.test.ts
@@ -86,4 +86,42 @@ describe('validateDemoMeta', () => {
     const errsObj = validateDemoMeta({ ...validBase, heroArtifact: {} as unknown as string }, 'v0.21');
     expect(errsObj.some((e) => e.includes('heroArtifact must be a string'))).toBe(true);
   });
+
+  it('grandfathered versions skip policy checks (no heroArtifact required for v0.1)', () => {
+    const meta = {
+      taskId: 'bracket-with-hole',
+      module: 'v0.1',
+      capturedAt: '2026-05-02T00:00:00Z',
+      durationMs: 21500,
+      truncated: false,
+      gitSha: 'abc123',
+      // No heroArtifact / catalogSource / overrideApprovedBy
+    } as Record<string, unknown>;
+    expect(validateDemoMeta(meta, 'v0.1')).toEqual([]);
+  });
+
+  it('grandfathered versions skip policy checks (no heroArtifact required for v0.2)', () => {
+    const meta = {
+      taskId: 'subtract-then-fillet-rim',
+      module: 'v0.2',
+      capturedAt: '2026-05-03T00:00:00Z',
+      durationMs: 21500,
+      truncated: false,
+      gitSha: 'abc123',
+    } as Record<string, unknown>;
+    expect(validateDemoMeta(meta, 'v0.2')).toEqual([]);
+  });
+
+  it('grandfathered versions still require legacy fields (gitSha/capturedAt/taskId)', () => {
+    const meta = {
+      module: 'v0.1',
+      durationMs: 21500,
+      truncated: false,
+      // Missing taskId, capturedAt, gitSha
+    } as Record<string, unknown>;
+    const errs = validateDemoMeta(meta, 'v0.1');
+    expect(errs.some((e) => e.includes("missing key 'gitSha'"))).toBe(true);
+    expect(errs.some((e) => e.includes("missing key 'capturedAt'"))).toBe(true);
+    expect(errs.some((e) => e.includes("missing key 'taskId'"))).toBe(true);
+  });
 });

--- a/scripts/lib/demoMetaValidator.ts
+++ b/scripts/lib/demoMetaValidator.ts
@@ -7,6 +7,7 @@ import {
   getCatalogForVersion,
   isCatalogSlug,
   GENERIC_PRIMITIVE_DENYLIST,
+  GRANDFATHERED_VERSIONS,
 } from './memorableBuildsCatalog';
 
 const REQUIRED_PRE_EXISTING = ['gitSha', 'capturedAt', 'taskId'] as const;
@@ -18,6 +19,11 @@ export function validateDemoMeta(meta: Record<string, unknown>, version: string)
   for (const k of REQUIRED_PRE_EXISTING) {
     if (!meta[k]) errors.push(`meta.json missing key '${k}'`);
   }
+  // Pre-policy versions: legacy fields suffice; no policy enforcement.
+  if (GRANDFATHERED_VERSIONS.has(version)) {
+    return errors;
+  }
+
   for (const k of REQUIRED_NEW) {
     // overrideApprovedBy may be null, but the key must be present.
     if (!(k in meta)) errors.push(`meta.json missing key '${k}'`);

--- a/scripts/lib/demoMetaValidator.ts
+++ b/scripts/lib/demoMetaValidator.ts
@@ -1,0 +1,49 @@
+// scripts/lib/demoMetaValidator.ts
+//
+// Pure validator for docs/demos/v0.X/<task>/meta.json contents.
+// Called by scripts/lint-demos.ts and unit-tested in isolation.
+
+import {
+  getCatalogForVersion,
+  isCatalogSlug,
+  GENERIC_PRIMITIVE_DENYLIST,
+} from './memorableBuildsCatalog';
+
+const REQUIRED_PRE_EXISTING = ['gitSha', 'capturedAt', 'taskId'] as const;
+const REQUIRED_NEW = ['heroArtifact', 'catalogSource', 'overrideApprovedBy'] as const;
+
+export function validateDemoMeta(meta: Record<string, unknown>, version: string): string[] {
+  const errors: string[] = [];
+
+  for (const k of REQUIRED_PRE_EXISTING) {
+    if (!meta[k]) errors.push(`meta.json missing key '${k}'`);
+  }
+  for (const k of REQUIRED_NEW) {
+    // overrideApprovedBy may be null, but the key must be present.
+    if (!(k in meta)) errors.push(`meta.json missing key '${k}'`);
+  }
+
+  if (!getCatalogForVersion(version)) {
+    errors.push(`no catalog entry for ${version} in memorableBuildsCatalog`);
+    return errors;
+  }
+
+  const heroArtifact = meta.heroArtifact;
+  if (typeof heroArtifact === 'string' && GENERIC_PRIMITIVE_DENYLIST.has(heroArtifact)) {
+    errors.push(`heroArtifact '${heroArtifact}' is denylisted (generic primitive)`);
+  }
+
+  const override = meta.overrideApprovedBy;
+  const hasOverride = typeof override === 'string' && override.length > 0;
+
+  if (
+    typeof heroArtifact === 'string' &&
+    !GENERIC_PRIMITIVE_DENYLIST.has(heroArtifact) &&
+    !hasOverride &&
+    !isCatalogSlug(heroArtifact, version)
+  ) {
+    errors.push(`heroArtifact '${heroArtifact}' does not match catalog for ${version} and no overrideApprovedBy is set`);
+  }
+
+  return errors;
+}

--- a/scripts/lib/demoMetaValidator.ts
+++ b/scripts/lib/demoMetaValidator.ts
@@ -29,6 +29,10 @@ export function validateDemoMeta(meta: Record<string, unknown>, version: string)
   }
 
   const heroArtifact = meta.heroArtifact;
+  if (heroArtifact !== undefined && typeof heroArtifact !== 'string') {
+    errors.push(`heroArtifact must be a string, got ${typeof heroArtifact}`);
+    return errors;
+  }
   if (typeof heroArtifact === 'string' && GENERIC_PRIMITIVE_DENYLIST.has(heroArtifact)) {
     errors.push(`heroArtifact '${heroArtifact}' is denylisted (generic primitive)`);
   }

--- a/scripts/lib/memorableBuildsCatalog.test.ts
+++ b/scripts/lib/memorableBuildsCatalog.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getCatalogForVersion,
+  isCatalogSlug,
+  GENERIC_PRIMITIVE_DENYLIST,
+  ALL_VERSIONS,
+} from './memorableBuildsCatalog';
+
+describe('memorableBuildsCatalog', () => {
+  it('exposes shortlists for v0.21 and every version v0.3 through v0.17 plus v1.0', () => {
+    expect(ALL_VERSIONS).toEqual([
+      'v0.21',
+      'v0.3', 'v0.4', 'v0.5', 'v0.6', 'v0.7', 'v0.8', 'v0.9',
+      'v0.10', 'v0.11', 'v0.12', 'v0.13', 'v0.14', 'v0.15', 'v0.16', 'v0.17',
+      'v1.0',
+    ]);
+  });
+
+  it('every version has at least 2 candidate slugs and exactly one recommended', () => {
+    for (const version of ALL_VERSIONS) {
+      const entry = getCatalogForVersion(version);
+      expect(entry).toBeDefined();
+      expect(entry!.candidates.length).toBeGreaterThanOrEqual(2);
+      const recommended = entry!.candidates.filter((c) => c.recommended);
+      expect(recommended.length).toBe(1);
+    }
+  });
+
+  it('isCatalogSlug accepts ★ recommendations and backups for the matching version', () => {
+    expect(isCatalogSlug('donut', 'v0.21')).toBe(true);
+    expect(isCatalogSlug('apple-core', 'v0.21')).toBe(true);
+    expect(isCatalogSlug('espresso-cup', 'v0.3')).toBe(true);
+  });
+
+  it('isCatalogSlug rejects slugs from the wrong version', () => {
+    expect(isCatalogSlug('donut', 'v0.3')).toBe(false);
+    expect(isCatalogSlug('espresso-cup', 'v0.21')).toBe(false);
+  });
+
+  it('isCatalogSlug rejects unknown slugs', () => {
+    expect(isCatalogSlug('made-up-thing', 'v0.3')).toBe(false);
+  });
+
+  it('GENERIC_PRIMITIVE_DENYLIST contains the expected primitive names', () => {
+    expect(GENERIC_PRIMITIVE_DENYLIST).toContain('box');
+    expect(GENERIC_PRIMITIVE_DENYLIST).toContain('bracket');
+    expect(GENERIC_PRIMITIVE_DENYLIST).toContain('plate');
+    expect(GENERIC_PRIMITIVE_DENYLIST).toContain('cylinder');
+    expect(GENERIC_PRIMITIVE_DENYLIST).toContain('cube');
+    expect(GENERIC_PRIMITIVE_DENYLIST).toContain('sphere');
+    expect(GENERIC_PRIMITIVE_DENYLIST).toContain('torus-only');
+  });
+
+  it('every catalog slug is kebab-case and has no leading/trailing dashes', () => {
+    for (const version of ALL_VERSIONS) {
+      const entry = getCatalogForVersion(version)!;
+      for (const c of entry.candidates) {
+        expect(c.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+      }
+    }
+  });
+});

--- a/scripts/lib/memorableBuildsCatalog.test.ts
+++ b/scripts/lib/memorableBuildsCatalog.test.ts
@@ -4,6 +4,7 @@ import {
   isCatalogSlug,
   GENERIC_PRIMITIVE_DENYLIST,
   ALL_VERSIONS,
+  GRANDFATHERED_VERSIONS,
 } from './memorableBuildsCatalog';
 
 describe('memorableBuildsCatalog', () => {
@@ -58,5 +59,10 @@ describe('memorableBuildsCatalog', () => {
         expect(c.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
       }
     }
+  });
+
+  it('GRANDFATHERED_VERSIONS contains v0.1 and v0.2 (pre-policy iterations)', () => {
+    expect(GRANDFATHERED_VERSIONS.has('v0.1')).toBe(true);
+    expect(GRANDFATHERED_VERSIONS.has('v0.2')).toBe(true);
   });
 });

--- a/scripts/lib/memorableBuildsCatalog.ts
+++ b/scripts/lib/memorableBuildsCatalog.ts
@@ -1,0 +1,135 @@
+// scripts/lib/memorableBuildsCatalog.ts
+//
+// Machine-readable mirror of §2 of
+// docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md.
+//
+// When the spec catalog is amended, update this file in the same commit.
+// The denylist below is intentionally extensible — add primitive names
+// that should never be valid `heroArtifact` slugs.
+
+export interface CatalogCandidate {
+  slug: string;
+  recommended: boolean;
+}
+
+export interface CatalogEntry {
+  version: string;
+  candidates: CatalogCandidate[];
+}
+
+export const ALL_VERSIONS = [
+  'v0.21',
+  'v0.3', 'v0.4', 'v0.5', 'v0.6', 'v0.7', 'v0.8', 'v0.9',
+  'v0.10', 'v0.11', 'v0.12', 'v0.13', 'v0.14', 'v0.15', 'v0.16', 'v0.17',
+  'v1.0',
+] as const;
+
+export type CatalogVersion = (typeof ALL_VERSIONS)[number];
+
+const CATALOG: Record<CatalogVersion, CatalogCandidate[]> = {
+  'v0.21': [
+    { slug: 'donut', recommended: true },
+    { slug: 'apple-core', recommended: false },
+    { slug: 'rubber-duck-silhouette', recommended: false },
+  ],
+  'v0.3': [
+    { slug: 'espresso-cup', recommended: true },
+    { slug: 'tiny-pumpkin', recommended: false },
+    { slug: 'watering-can', recommended: false },
+  ],
+  'v0.4': [
+    { slug: 'guitar-pick', recommended: true },
+    { slug: 'house-key-silhouette', recommended: false },
+    { slug: 'heart', recommended: false },
+  ],
+  'v0.5': [
+    { slug: 'parametric-mug', recommended: true },
+    { slug: 'parametric-lego-brick', recommended: false },
+    { slug: 'parametric-phone-case', recommended: false },
+  ],
+  'v0.6': [
+    { slug: 'articulated-desk-lamp', recommended: true },
+    { slug: 'crank-slider-piston', recommended: false },
+    { slug: 'robot-finger', recommended: false },
+  ],
+  'v0.7': [
+    { slug: 'computer-mouse-shell', recommended: true },
+    { slug: 'electric-guitar-body', recommended: false },
+    { slug: 'perfume-bottle', recommended: false },
+  ],
+  'v0.8': [
+    { slug: 'three-leg-stool-with-assembly-diagram', recommended: true },
+    { slug: 'mini-drone-frame', recommended: false },
+    { slug: 'skateboard-truck', recommended: false },
+  ],
+  'v0.9': [
+    { slug: 'mechanical-keyboard-chassis', recommended: true },
+    { slug: 'warp-pipe', recommended: false },
+    { slug: 'rube-goldberg-gear-train', recommended: false },
+  ],
+  'v0.10': [
+    { slug: 'engine-block-exploded-view', recommended: true },
+    { slug: 'nesting-doll-cross-section', recommended: false },
+    { slug: 'onion-cross-section', recommended: false },
+  ],
+  'v0.11': [
+    { slug: 'kernelcad-logo-extruded', recommended: true },
+    { slug: 'hello-world-3d-text', recommended: false },
+    { slug: 'engraved-postcard', recommended: false },
+  ],
+  'v0.12': [
+    { slug: 'rubber-duck-skill', recommended: true },
+    { slug: 'self-bundling-build', recommended: false },
+  ],
+  'v0.13': [
+    { slug: 'origami-crane-in-steel', recommended: true },
+    { slug: 'pencil-cup', recommended: false },
+    { slug: 'letter-holder', recommended: false },
+  ],
+  'v0.14': [
+    { slug: 'octopus', recommended: true },
+    { slug: 'gyroid-lattice-cube', recommended: false },
+    { slug: 'coral-cluster', recommended: false },
+  ],
+  'v0.15': [
+    { slug: 'tiny-wooden-chair', recommended: true },
+    { slug: 'picture-frame', recommended: false },
+    { slug: 'birdhouse', recommended: false },
+  ],
+  'v0.16': [
+    { slug: 'napkin-sketch-to-3d', recommended: true },
+    { slug: 'whiteboard-sketch-to-3d', recommended: false },
+    { slug: 'photo-of-flat-object-to-3d', recommended: false },
+  ],
+  'v0.17': [
+    { slug: 'engraved-nameplate', recommended: true },
+    { slug: 'engraved-coaster', recommended: false },
+    { slug: 'cookie-cutter-shape', recommended: false },
+  ],
+  'v1.0': [
+    { slug: 'mechanical-music-box', recommended: true },
+    { slug: 'articulated-robot-arm', recommended: false },
+    { slug: 'pinball-machine-table', recommended: false },
+  ],
+};
+
+export const GENERIC_PRIMITIVE_DENYLIST = new Set<string>([
+  'box',
+  'bracket',
+  'plate',
+  'cylinder',
+  'cube',
+  'sphere',
+  'torus-only',
+]);
+
+export function getCatalogForVersion(version: string): CatalogEntry | undefined {
+  if (!(ALL_VERSIONS as readonly string[]).includes(version)) return undefined;
+  return { version, candidates: CATALOG[version as CatalogVersion] };
+}
+
+export function isCatalogSlug(slug: string, version: string): boolean {
+  const entry = getCatalogForVersion(version);
+  if (!entry) return false;
+  return entry.candidates.some((c) => c.slug === slug);
+}

--- a/scripts/lib/memorableBuildsCatalog.ts
+++ b/scripts/lib/memorableBuildsCatalog.ts
@@ -17,6 +17,12 @@ export interface CatalogEntry {
   candidates: CatalogCandidate[];
 }
 
+// Pre-policy iteration versions that were already shipped before this policy
+// landed. Their legacy fields (gitSha/capturedAt/taskId) still get checked,
+// but heroArtifact/catalogSource/overrideApprovedBy + catalog match are
+// skipped per §1 non-goals of the memorable-builds policy spec.
+export const GRANDFATHERED_VERSIONS = new Set<string>(['v0.1', 'v0.2']);
+
 export const ALL_VERSIONS = [
   'v0.21',
   'v0.3', 'v0.4', 'v0.5', 'v0.6', 'v0.7', 'v0.8', 'v0.9',

--- a/scripts/lib/memorableBuildsCatalog.ts
+++ b/scripts/lib/memorableBuildsCatalog.ts
@@ -13,7 +13,7 @@ export interface CatalogCandidate {
 }
 
 export interface CatalogEntry {
-  version: string;
+  version: CatalogVersion;
   candidates: CatalogCandidate[];
 }
 

--- a/scripts/lib/whatsNewTemplate.test.ts
+++ b/scripts/lib/whatsNewTemplate.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import {
   whatsNewTemplate,
   whatsNewIsFilled,
 } from './whatsNewTemplate';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -29,8 +29,16 @@ describe('whatsNewTemplate', () => {
 });
 
 describe('whatsNewIsFilled', () => {
+  const dirsToClean: string[] = [];
+  afterEach(() => {
+    for (const d of dirsToClean.splice(0)) {
+      rmSync(d, { recursive: true, force: true });
+    }
+  });
+
   function writeTmp(content: string): string {
     const dir = mkdtempSync(join(tmpdir(), 'kcad-whats-new-'));
+    dirsToClean.push(dir);
     const path = join(dir, 'whats-new.md');
     writeFileSync(path, content, 'utf8');
     return path;

--- a/scripts/lib/whatsNewTemplate.test.ts
+++ b/scripts/lib/whatsNewTemplate.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import {
+  whatsNewTemplate,
+  whatsNewIsFilled,
+} from './whatsNewTemplate';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('whatsNewTemplate', () => {
+  it('includes a Hero artifact section header', () => {
+    const out = whatsNewTemplate({ module: 'v0.3', partName: 'espresso-cup', heroArtifact: 'espresso-cup' });
+    expect(out).toContain('## Hero artifact');
+    expect(out).toContain('espresso-cup');
+  });
+
+  it('includes a Why memorable section with three bullet headers', () => {
+    const out = whatsNewTemplate({ module: 'v0.3', partName: 'espresso-cup', heroArtifact: 'espresso-cup' });
+    expect(out).toContain('## Why memorable');
+    expect(out).toContain('Recognizable in one second:');
+    expect(out).toContain('New tool central:');
+    expect(out).toContain('Reads at 360°:');
+  });
+
+  it('includes a What\'s new section with the existing capability blurb hook', () => {
+    const out = whatsNewTemplate({ module: 'v0.3', partName: 'espresso-cup', heroArtifact: 'espresso-cup' });
+    expect(out).toContain("## What's new");
+  });
+});
+
+describe('whatsNewIsFilled', () => {
+  function writeTmp(content: string): string {
+    const dir = mkdtempSync(join(tmpdir(), 'kcad-whats-new-'));
+    const path = join(dir, 'whats-new.md');
+    writeFileSync(path, content, 'utf8');
+    return path;
+  }
+
+  it('returns false if the file contains "TODO:"', () => {
+    const path = writeTmp('## Hero artifact\nfoo\n## Why memorable\n- Recognizable in one second: TODO:\n- New tool central: x\n- Reads at 360°: y\n## What\'s new\nblurb\n');
+    expect(whatsNewIsFilled(path)).toBe(false);
+  });
+
+  it('returns false if any of the three required sections is missing', () => {
+    const noHero = writeTmp('## Why memorable\n- Recognizable in one second: x\n- New tool central: y\n- Reads at 360°: z\n## What\'s new\nblurb\n');
+    expect(whatsNewIsFilled(noHero)).toBe(false);
+
+    const noWhy = writeTmp('## Hero artifact\nfoo\n## What\'s new\nblurb\n');
+    expect(whatsNewIsFilled(noWhy)).toBe(false);
+
+    const noWhat = writeTmp('## Hero artifact\nfoo\n## Why memorable\n- Recognizable in one second: x\n- New tool central: y\n- Reads at 360°: z\n');
+    expect(whatsNewIsFilled(noWhat)).toBe(false);
+  });
+
+  it('returns false if any "Why memorable" bullet is empty after the colon', () => {
+    const path = writeTmp(
+      '## Hero artifact\nespresso-cup\n## Why memorable\n- Recognizable in one second: \n- New tool central: y\n- Reads at 360°: z\n## What\'s new\nblurb\n',
+    );
+    expect(whatsNewIsFilled(path)).toBe(false);
+  });
+
+  it('returns true when all three sections are present and bullets are filled', () => {
+    const path = writeTmp(
+      '## Hero artifact\nespresso-cup\n\n## Why memorable\n- Recognizable in one second: looks like a coffee mug\n- New tool central: shell hollow + handle hole\n- Reads at 360°: handle visible from any angle\n\n## What\'s new\nv0.3 ships shell + hole + cut.\n',
+    );
+    expect(whatsNewIsFilled(path)).toBe(true);
+  });
+});

--- a/scripts/lib/whatsNewTemplate.ts
+++ b/scripts/lib/whatsNewTemplate.ts
@@ -1,10 +1,30 @@
 // scripts/lib/whatsNewTemplate.ts
 import { writeFileSync, existsSync, readFileSync } from 'node:fs';
 
-export function whatsNewTemplate(opts: { module: string; partName: string }): string {
+export interface WhatsNewArgs {
+  module: string;
+  partName: string;
+  heroArtifact: string;
+}
+
+export function whatsNewTemplate(opts: WhatsNewArgs): string {
   return `# ${opts.module} — synchronized live-build demo
 
-<!-- TODO: 1-paragraph capability gain blurb in plain English. Replace this comment + the line below before merging. -->
+## Hero artifact
+
+${opts.heroArtifact}
+
+## Why memorable
+
+<!-- TODO: Replace each bullet's content (after the colon) with a 1-line answer. Required by docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md §1. -->
+
+- Recognizable in one second: TODO:
+- New tool central: TODO:
+- Reads at 360°: TODO:
+
+## What's new
+
+<!-- TODO: 1-paragraph capability gain blurb in plain English. -->
 
 This release demonstrates the agent building **${opts.partName}** with synchronized live-build.
 
@@ -18,7 +38,26 @@ export function writeWhatsNewIfMissing(path: string, content: string): void {
   writeFileSync(path, content, 'utf8');
 }
 
+const REQUIRED_HEADERS = ['## Hero artifact', '## Why memorable', "## What's new"];
+const WHY_MEMORABLE_BULLETS = [
+  'Recognizable in one second:',
+  'New tool central:',
+  'Reads at 360°:',
+];
+
 export function whatsNewIsFilled(path: string): boolean {
   if (!existsSync(path)) return false;
-  return !readFileSync(path, 'utf8').includes('TODO:');
+  const text = readFileSync(path, 'utf8');
+  if (text.includes('TODO:')) return false;
+  for (const h of REQUIRED_HEADERS) {
+    if (!text.includes(h)) return false;
+  }
+  for (const bullet of WHY_MEMORABLE_BULLETS) {
+    // Match `- <bullet> <non-empty content>` on the same line — fail if content is blank or whitespace-only.
+    // Use [^\S\n]* to avoid crossing line boundaries (plain \s* would match the next bullet's content).
+    const escaped = bullet.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const re = new RegExp(`-[^\\S\\n]*${escaped}[^\\S\\n]*(\\S[^\\n]*)`, 'm');
+    if (!re.test(text)) return false;
+  }
+  return true;
 }

--- a/scripts/lint-demos.ts
+++ b/scripts/lint-demos.ts
@@ -7,6 +7,7 @@ import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
 import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { validateDemoMeta } from './lib/demoMetaValidator';
 
 const _dirname = dirname(fileURLToPath(import.meta.url));
 const DEMOS_ROOT = resolve(_dirname, '../docs/demos');
@@ -57,8 +58,8 @@ function lintModule(moduleSlug: string): string[] {
     if (existsSync(metaPath)) {
       try {
         const meta = JSON.parse(readFileSync(metaPath, 'utf8'));
-        for (const k of ['gitSha', 'capturedAt', 'taskId']) {
-          if (!meta[k]) errors.push(`${moduleSlug}/${taskName}: meta.json missing key '${k}'`);
+        for (const err of validateDemoMeta(meta, moduleSlug)) {
+          errors.push(`${moduleSlug}/${taskName}: ${err}`);
         }
       } catch (e) {
         errors.push(`${moduleSlug}/${taskName}: meta.json parse failed: ${(e as Error).message}`);


### PR DESCRIPTION
## Summary

Memorable-builds policy: structural enforcement that every \`v0.X.0\` ships a hero artifact (not a generic primitive). Implements §3 of the policy spec.

- Spec: \`docs/superpowers/specs/2026-05-04-memorable-builds-policy-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-04-memorable-builds-policy.md\` (already on develop)

### What's in this PR (19 commits)

- **Typed catalog** (\`scripts/lib/memorableBuildsCatalog.ts\`) mirroring spec §2; \`v0.1\` and \`v0.2\` grandfathered.
- **Pure validator** (\`scripts/lib/demoMetaValidator.ts\`) — catalog/denylist/override gates; unit-tested.
- **\`scripts/lint-demos.ts\`** uses the validator for catalog + denylist + override checks.
- **\`scripts/lib/whatsNewTemplate.ts\`** — three required sections (Hero artifact / Why memorable / What's new) + filler validator.
- **\`scripts/captureDemo.ts\`** requires \`--hero-artifact <slug>\` (exempted for \`--rotate-only\`); writes \`heroArtifact\` / \`catalogSource\` / \`overrideApprovedBy\` to meta.json.
- **Project-root \`CLAUDE.md\`** — \`v0.X.0\` demo-discipline reviewer rule.
- **\`docs/demos/README.md\`** — catalog/denylist rule appended.
- **Roadmap §H11 enforcement line** points at the policy spec.
- **v0.21 donut hero-artifact build script** (\`examples/v0.21/donut.kcad.ts\`) + \`capture-demo:donut\` npm script.

### Verification

- All 46 unit tests pass on this branch (typecheck clean).
- Drift sentinels green.

### Replaces #61

PR #61 was opened earlier on the original \`policy/memorable-builds\` branch. That branch's diff against current develop is misleading because it predates the merges of PR #62 (website) and others — its file list shows ~9.5K lines of which most are duplicates of already-merged work. This clean branch was cherry-picked from origin/develop and contains only the 19 unique policy commits.

## Test plan

- [ ] CI \`qc\` job passes
- [ ] Manual: run \`npm run capture-demo:donut\` produces a v0.21/donut/ directory with valid meta.json.heroArtifact and whats-new.md
- [ ] Manual: \`scripts/lint-demos.ts\` rejects a demo whose meta.json has \`heroArtifact: 'box'\` (denylist hit)