### PR TITLE
chore(release): bump to 0.2.1 + rename CHANGELOG section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ Per the gap-closure roadmap §I4 / first-wave dispatch doc, this is workstream #
 
 ---
 
-## [0.2.0] — 2026-05-04
+## [0.2.1] — 2026-05-04
 
 Closes workstream #1 (v0.2 finish). Delivers a complete face-reference story: canonical tracked refs across transforms and booleans (PR #53, already on `develop`), user-named face labels via `faceLabels` on creating ops, `FaceQuery` polish with four new filter keys, two new label-driven eval tasks, and expanded MCP introspection. No npm publish.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kernelcad",
   "private": false,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",


### PR DESCRIPTION
Companion to PR #64 merge: bumps `package.json` from 0.2.0 → 0.2.1 and renames the new CHANGELOG section to match.

`v0.2.0` was already tagged + released on 2026-05-02 (PR #53 — original tracked-refs ship). This iteration's additive work (`faceLabels` API + FaceQuery polish + demos) ships as v0.2.1 per semver.

After merge: `git tag -a v0.2.1` on develop + `gh release create v0.2.1`. No npm publish per spec.