### PR TITLE
chore(user-tracking): provision D1 + Web Analytics tokens

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -18,10 +18,10 @@
   <!--
     Cloudflare Web Analytics — anonymous beacon (no cookies, no IP storage).
     The token is the public site-token from the Cloudflare Web Analytics
-    dashboard. Replace REPLACE_WITH_CF_WEB_ANALYTICS_TOKEN once-only after
+    dashboard. Replace e5f5f4c6464f456d8f5376411e77f545 once-only after
     enabling Web Analytics for kernelcad.com in the Cloudflare account.
   -->
-  <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "REPLACE_WITH_CF_WEB_ANALYTICS_TOKEN"}'></script>
+  <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "e5f5f4c6464f456d8f5376411e77f545"}'></script>
 </head>
 <body>
   <div class="page-wrap">

--- a/site/thanks.html
+++ b/site/thanks.html
@@ -12,10 +12,10 @@
   <title>kernelCAD — subscribed</title>
   <!--
     Cloudflare Web Analytics — anonymous beacon (no cookies, no IP storage).
-    Replace REPLACE_WITH_CF_WEB_ANALYTICS_TOKEN once-only after enabling
+    Replace e5f5f4c6464f456d8f5376411e77f545 once-only after enabling
     Web Analytics in the Cloudflare dashboard for kernelcad.com.
   -->
-  <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "REPLACE_WITH_CF_WEB_ANALYTICS_TOKEN"}'></script>
+  <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "e5f5f4c6464f456d8f5376411e77f545"}'></script>
 </head>
 <body>
   <div class="page-wrap">

--- a/site/wrangler.toml
+++ b/site/wrangler.toml
@@ -17,4 +17,4 @@ pages_build_output_dir = "."
 [[d1_databases]]
 binding = "DB"
 database_name = "kernelcad-subscribers"
-database_id = "REPLACE_WITH_D1_DATABASE_ID"
+database_id = "8c284024-f44d-4a80-ac87-9212029725ac"


### PR DESCRIPTION
Companion to the user-tracking iteration (PR #67 — already merged). Replaces the placeholders `REPLACE_WITH_D1_DATABASE_ID` and `REPLACE_WITH_CF_WEB_ANALYTICS_TOKEN` with the actual provisioned values.

Provisioned via local wrangler+curl using the Cloudflare account secrets (Global API Key + email):

- **D1 database** `kernelcad-subscribers` created and bound in `site/wrangler.toml`. Schema migration applied — `subscribers` table is empty (0 rows).
- **Web Analytics site** for `kernelcad.com` created. Site token written into `site/index.html` and `site/thanks.html`.

After merge, Cloudflare Pages will redeploy automatically — the form goes live and the Web Analytics beacon starts collecting.