### PR TITLE
fix(demos): swap v0.2 hero to subtract-then-fillet-rim (broken 3D pane in labeled-cylinder-cap)

### DIFF
--- a/docs/demos/v0.2/labeled-cylinder-cap/meta.json
+++ b/docs/demos/v0.2/labeled-cylinder-cap/meta.json
@@ -7,5 +7,5 @@
   "gitSha": "aa60406aa73439640c68e4f5e2617c5e46122993",
   "heroArtifact": "labeled-cylinder-cap",
   "catalogSource": "memorable-builds-policy/v0.2",
-  "overrideApprovedBy": null
+  "overrideApprovedBy": "broken-3d-pane: 3D viewport rendered black during May-04 capture; demote until re-recorded with the fixed pipeline."
 }

--- a/docs/demos/v0.2/subtract-then-fillet-rim/meta.json
+++ b/docs/demos/v0.2/subtract-then-fillet-rim/meta.json
@@ -4,5 +4,8 @@
   "capturedAt": "2026-05-04T08:54:39.243Z",
   "durationMs": 16400,
   "truncated": false,
-  "gitSha": "b75fb93b7d0669662baf5e98548575aecb4e7a4f"
+  "gitSha": "b75fb93b7d0669662baf5e98548575aecb4e7a4f",
+  "heroArtifact": "subtract-then-fillet-rim",
+  "catalogSource": "memorable-builds-policy/v0.2",
+  "overrideApprovedBy": null
 }


### PR DESCRIPTION
## Summary
- The current v0.2 hero (`labeled-cylinder-cap`) has a 3D viewport rendered black throughout its demo.mp4 — captured May 4 during a faceLabels capture-pipeline regression. This is what's currently shipping on https://kernelcad.com (black right pane).
- This PR demotes `labeled-cylinder-cap` via `overrideApprovedBy`, promotes `subtract-then-fillet-rim` (older but working capture) to the v0.2 hero. `build-demo.ts` then picks the working video for the marketing site deploy.

## Visual verification
Local preview at http://localhost:8765/ confirmed before push: 3D pane shows the plate + hole geometry filleting correctly. The labeled-cylinder-cap recording bug remains tracked for re-record with the fixed pipeline (separate cycle).

## Test plan
- [x] `npx tsx site/scripts/build-demo.ts` picks `v0.2/subtract-then-fillet-rim`
- [x] `selectHeroDemo` resolves to single primary candidate (no ambiguity)
- [x] Local preview at localhost:8765 plays through and shows working geometry

## Out of scope (follow-ups)
- Re-record `labeled-cylinder-cap` and `labeled-extrude-bracket` with the fixed capture pipeline (faceLabels demos).
- Add CI gate that rejects deploys when the selected hero demo has a black 3D pane (per "ensure we never ship broken videos" feedback).