### PR TITLE
fix(deploy): restore Pages Function routing for subscribe API

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy site --project-name=kernelcad-marketing --branch=main --commit-dirty=true
+          command: pages deploy . --cwd=site --project-name=kernelcad-marketing --branch=main --commit-dirty=true
 
   app:
     name: Deploy visual debugger app

--- a/scripts/lib/cloudflareDeployWorkflow.test.ts
+++ b/scripts/lib/cloudflareDeployWorkflow.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import YAML from 'yaml';
+
+describe('Cloudflare Pages deploy workflow', () => {
+  it('runs the marketing Pages deploy from site/ so Pages Functions and wrangler.toml are discovered', () => {
+    const workflow = YAML.parse(readFileSync('.github/workflows/deploy-cloudflare.yml', 'utf8'));
+    const marketingSteps = workflow.jobs.marketing.steps as Array<{
+      name?: string;
+      with?: { command?: string };
+    }>;
+
+    const deployStep = marketingSteps.find((step) =>
+      step.name?.includes('Deploy to Cloudflare Pages'),
+    );
+
+    expect(deployStep?.with?.command).toBe(
+      'pages deploy . --cwd=site --project-name=kernelcad-marketing --branch=main --commit-dirty=true',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- run the marketing Cloudflare Pages deploy with site/ as Wrangler cwd so site/functions and site/wrangler.toml are discovered
- add a workflow regression test for the deploy command

## Test plan
- npx vitest run scripts/lib/cloudflareDeployWorkflow.test.ts site/functions/api/subscribe.test.ts