### PR TITLE
fix(deploy): use Wrangler action workingDirectory for marketing site

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -48,7 +48,8 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy . --cwd=site --project-name=kernelcad-marketing --branch=main --commit-dirty=true
+          workingDirectory: site
+          command: pages deploy . --project-name=kernelcad-marketing --branch=main --commit-dirty=true
 
   app:
     name: Deploy visual debugger app

--- a/scripts/lib/cloudflareDeployWorkflow.test.ts
+++ b/scripts/lib/cloudflareDeployWorkflow.test.ts
@@ -14,8 +14,9 @@ describe('Cloudflare Pages deploy workflow', () => {
       step.name?.includes('Deploy to Cloudflare Pages'),
     );
 
+    expect(deployStep?.with?.workingDirectory).toBe('site');
     expect(deployStep?.with?.command).toBe(
-      'pages deploy . --cwd=site --project-name=kernelcad-marketing --branch=main --commit-dirty=true',
+      'pages deploy . --project-name=kernelcad-marketing --branch=main --commit-dirty=true',
     );
   });
 });


### PR DESCRIPTION
## Summary
- use cloudflare/wrangler-action's workingDirectory input so Wrangler runs from site/
- keep the Pages deploy directory as . so site/functions and site/wrangler.toml are discovered
- update the workflow regression test to pin the action contract

## Test plan
- npx vitest run scripts/lib/cloudflareDeployWorkflow.test.ts site/functions/api/subscribe.test.ts