### PR TITLE
fix(site): bust cached v0.2.1 marketing demo video

### DIFF
--- a/scripts/lib/marketingDemoCacheBust.test.ts
+++ b/scripts/lib/marketingDemoCacheBust.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('marketing demo video cache busting', () => {
+  it('uses demo.json metadata to load a versioned MP4 URL', () => {
+    const html = readFileSync('site/index.html', 'utf8');
+
+    expect(html).toContain("const demoCacheKey = encodeURIComponent");
+    expect(html).toContain("`/demo.mp4?v=${demoCacheKey}`");
+    expect(html).not.toContain("src = '/demo.mp4'");
+  });
+});

--- a/site/index.html
+++ b/site/index.html
@@ -117,7 +117,8 @@
       .then(r => r.ok ? r.json() : null)
       .then(d => {
         if (!d) return;
-        document.getElementById('demo-video').src = '/demo.mp4';
+        const demoCacheKey = encodeURIComponent(d.captured_at || d.source || d.version);
+        document.getElementById('demo-video').src = `/demo.mp4?v=${demoCacheKey}`;
         document.getElementById('demo-version').textContent = d.version;
       });
 

--- a/site/scripts/build-demo.ts
+++ b/site/scripts/build-demo.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-// Picks the catalog-conformant hero demo for the current package.json.version,
-// copies its mp4 into site/public/demo.mp4, and writes site/public/demo.json.
+// Picks the hero demo for the current package.json release, copies its mp4
+// into site/public/demo.mp4, and writes site/public/demo.json.
 
 import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
@@ -23,7 +23,8 @@ function main() {
   copyFileSync(result.mp4Path, path.join(PUBLIC_DIR, 'demo.mp4'));
 
   const meta = {
-    version: result.iterationKey,
+    version: `v${pkg.version}`,
+    demoIteration: result.iterationKey,
     task: result.task,
     heroArtifact: result.heroArtifact,
     source: path.relative(REPO_ROOT, result.mp4Path),


### PR DESCRIPTION
## Summary
- keep the marketing demo tied to package release v0.2.1, which maps to docs/demos/v0.2
- write v0.2.1 into demo.json while retaining demoIteration=v0.2 for traceability
- load /demo.mp4 with a cache-busting query string from demo.json metadata so browsers do not replay the stale blank MP4

## Test plan
- npx vitest run scripts/lib/selectHeroDemo.test.ts scripts/lib/marketingDemoCacheBust.test.ts scripts/lib/cloudflareDeployWorkflow.test.ts site/functions/api/subscribe.test.ts
- npm run site:build (confirmed v0.2/subtract-then-fillet-rim selected and demo.json version is v0.2.1)