### PR TITLE
test(site): add production release probe

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "site:build": "npx tsx site/scripts/build-demo.ts && node site/scripts/render-brand.mjs",
     "site:render-brand": "node site/scripts/render-brand.mjs",
     "site:test": "vitest run scripts/lib/selectHeroDemo.test.ts",
+    "site:verify-production": "npx tsx scripts/verifyProductionSite.ts",
     "test:watch": "vitest",
     "typecheck": "tsc -b --noEmit",
     "qc:lint": "npm run lint && npm run cookbook:validate",

--- a/scripts/lib/productionSiteProbe.test.ts
+++ b/scripts/lib/productionSiteProbe.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildProductionSiteChecks,
+  normalizeSiteBaseUrl,
+  type ProbeResponse,
+} from './productionSiteProbe';
+
+function response(opts: {
+  status: number;
+  headers?: Record<string, string>;
+  json?: unknown;
+  bodyBytes?: number;
+}): ProbeResponse {
+  return {
+    status: opts.status,
+    headers: new Headers(opts.headers ?? {}),
+    json: async () => opts.json,
+    arrayBuffer: async () => new ArrayBuffer(opts.bodyBytes ?? 0),
+  };
+}
+
+describe('normalizeSiteBaseUrl', () => {
+  it('normalizes trailing slashes', () => {
+    expect(normalizeSiteBaseUrl('https://kernelcad.com///')).toBe('https://kernelcad.com');
+  });
+
+  it('rejects non-http URLs', () => {
+    expect(() => normalizeSiteBaseUrl('file:///tmp/site')).toThrow(/http/i);
+  });
+});
+
+describe('buildProductionSiteChecks', () => {
+  it('accepts the current patch release pointing at its minor demo iteration', async () => {
+    const checks = buildProductionSiteChecks({
+      baseUrl: 'https://kernelcad.com/',
+      expectedVersion: 'v0.2.1',
+      expectedDemoIteration: 'v0.2',
+      fetch: async (url, init) => {
+        const path = new URL(url).pathname;
+        if (path === '/demo.json') {
+          return response({
+            status: 200,
+            json: {
+              version: 'v0.2.1',
+              demoIteration: 'v0.2',
+              task: 'subtract-then-fillet-rim',
+              source: 'docs/demos/v0.2/subtract-then-fillet-rim/demo.mp4',
+            },
+          });
+        }
+        if (path === '/demo.mp4') {
+          expect(init?.headers).toEqual({ Range: 'bytes=0-1023' });
+          return response({
+            status: 206,
+            headers: {
+              'content-type': 'video/mp4',
+              'content-range': 'bytes 0-1023/276295',
+            },
+            bodyBytes: 1024,
+          });
+        }
+        if (path === '/api/subscribe') {
+          expect(init?.method).toBe('POST');
+          return response({
+            status: 303,
+            headers: { location: '/?error=invalid_email#signup' },
+          });
+        }
+        throw new Error(`unexpected URL ${url}`);
+      },
+    });
+
+    await expect(Promise.all(checks.map((check) => check.run()))).resolves.toEqual([
+      { ok: true, name: 'demo metadata', detail: 'v0.2.1 -> v0.2/subtract-then-fillet-rim' },
+      { ok: true, name: 'demo mp4', detail: 'video/mp4 bytes 0-1023/276295' },
+      { ok: true, name: 'subscribe invalid-email path', detail: '/?error=invalid_email#signup' },
+    ]);
+  });
+
+  it('fails when live demo metadata reports the wrong version', async () => {
+    const checks = buildProductionSiteChecks({
+      baseUrl: 'https://kernelcad.com',
+      expectedVersion: 'v0.2.1',
+      fetch: async () =>
+        response({
+          status: 200,
+          json: {
+            version: 'v0.2',
+            demoIteration: 'v0.2',
+            task: 'subtract-then-fillet-rim',
+          },
+        }),
+    });
+
+    await expect(checks[0].run()).resolves.toEqual({
+      ok: false,
+      name: 'demo metadata',
+      detail: 'expected version v0.2.1, got v0.2',
+    });
+  });
+
+  it('defaults expected demo iteration from the expected patch version', async () => {
+    const checks = buildProductionSiteChecks({
+      baseUrl: 'https://kernelcad.com/',
+      expectedVersion: 'v0.2.1',
+      fetch: async () =>
+        response({
+          status: 200,
+          json: {
+            version: 'v0.2.1',
+            demoIteration: 'v0.3',
+            task: 'subtract-then-fillet-rim',
+            source: 'docs/demos/v0.2/subtract-then-fillet-rim/demo.mp4',
+          },
+        }),
+    });
+
+    await expect(checks[0].run()).resolves.toEqual({
+      ok: false,
+      name: 'demo metadata',
+      detail: 'expected demoIteration v0.2, got v0.3',
+    });
+  });
+
+  it('fails when demo.mp4 is not served as video', async () => {
+    const checks = buildProductionSiteChecks({
+      baseUrl: 'https://kernelcad.com',
+      expectedVersion: 'v0.2.1',
+      fetch: async () =>
+        response({
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+          bodyBytes: 512,
+        }),
+    });
+
+    await expect(checks[1].run()).resolves.toEqual({
+      ok: false,
+      name: 'demo mp4',
+      detail: 'expected 200/206 video/mp4 response, got 200 text/html',
+    });
+  });
+});

--- a/scripts/lib/productionSiteProbe.ts
+++ b/scripts/lib/productionSiteProbe.ts
@@ -1,0 +1,161 @@
+export interface ProbeResponse {
+  status: number;
+  headers: Headers;
+  json(): Promise<unknown>;
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+export type ProbeFetch = (
+  url: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    redirect?: RequestRedirect;
+  },
+) => Promise<ProbeResponse>;
+
+export interface ProbeResult {
+  ok: boolean;
+  name: string;
+  detail: string;
+}
+
+export interface ProductionSiteCheck {
+  name: string;
+  run(): Promise<ProbeResult>;
+}
+
+interface DemoJson {
+  version?: unknown;
+  demoIteration?: unknown;
+  task?: unknown;
+  source?: unknown;
+}
+
+function result(ok: boolean, name: string, detail: string): ProbeResult {
+  return { ok, name, detail };
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function expectedIterationForVersion(version: string): string {
+  const match = /^v?(\d+)\.(\d+)\.\d+/.exec(version);
+  if (!match) return version;
+  return `v${match[1]}.${match[2]}`;
+}
+
+export function normalizeSiteBaseUrl(input: string): string {
+  const url = new URL(input);
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`site URL must be http or https: ${input}`);
+  }
+  url.pathname = url.pathname.replace(/\/+$/, '');
+  url.search = '';
+  url.hash = '';
+  return url.toString().replace(/\/+$/, '');
+}
+
+export function buildProductionSiteChecks(opts: {
+  baseUrl: string;
+  expectedVersion: string;
+  expectedDemoIteration?: string;
+  fetch: ProbeFetch;
+}): ProductionSiteCheck[] {
+  const baseUrl = normalizeSiteBaseUrl(opts.baseUrl);
+  const expectedDemoIteration =
+    opts.expectedDemoIteration ?? expectedIterationForVersion(opts.expectedVersion);
+
+  return [
+    {
+      name: 'demo metadata',
+      async run() {
+        const res = await opts.fetch(`${baseUrl}/demo.json`);
+        if (res.status !== 200) {
+          return result(false, this.name, `expected 200 from /demo.json, got ${res.status}`);
+        }
+
+        const payload = await res.json();
+        if (!isObject(payload)) {
+          return result(false, this.name, 'expected /demo.json object payload');
+        }
+        const demo = payload as DemoJson;
+        if (demo.version !== opts.expectedVersion) {
+          return result(
+            false,
+            this.name,
+            `expected version ${opts.expectedVersion}, got ${String(demo.version)}`,
+          );
+        }
+        if (demo.demoIteration !== expectedDemoIteration) {
+          return result(
+            false,
+            this.name,
+            `expected demoIteration ${expectedDemoIteration}, got ${String(demo.demoIteration)}`,
+          );
+        }
+        if (typeof demo.task !== 'string' || demo.task.length === 0) {
+          return result(false, this.name, 'expected non-empty demo task');
+        }
+        if (typeof demo.source !== 'string' || !demo.source.endsWith('/demo.mp4')) {
+          return result(false, this.name, `expected demo.mp4 source, got ${String(demo.source)}`);
+        }
+
+        const iteration =
+          typeof demo.demoIteration === 'string' ? demo.demoIteration : 'unknown-iteration';
+        return result(true, this.name, `${opts.expectedVersion} -> ${iteration}/${demo.task}`);
+      },
+    },
+    {
+      name: 'demo mp4',
+      async run() {
+        const res = await opts.fetch(`${baseUrl}/demo.mp4`, {
+          headers: { Range: 'bytes=0-1023' },
+        });
+        const type = res.headers.get('content-type') ?? 'missing content-type';
+        if ((res.status !== 200 && res.status !== 206) || !type.includes('video/mp4')) {
+          return result(
+            false,
+            this.name,
+            `expected 200/206 video/mp4 response, got ${res.status} ${type}`,
+          );
+        }
+        const bytes = await res.arrayBuffer();
+        if (bytes.byteLength < 1024) {
+          return result(false, this.name, `expected at least 1024 bytes, got ${bytes.byteLength}`);
+        }
+        return result(
+          true,
+          this.name,
+          `${type} ${res.headers.get('content-range') ?? `${bytes.byteLength} bytes`}`,
+        );
+      },
+    },
+    {
+      name: 'subscribe invalid-email path',
+      async run() {
+        const body = new URLSearchParams({
+          email: 'not-an-email',
+          source: 'production_probe',
+        }).toString();
+        const res = await opts.fetch(`${baseUrl}/api/subscribe`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body,
+          redirect: 'manual',
+        });
+        const location = res.headers.get('location') ?? '';
+        if (res.status !== 303 || location !== '/?error=invalid_email#signup') {
+          return result(
+            false,
+            this.name,
+            `expected 303 invalid_email redirect, got ${res.status} ${location || '(no location)'}`,
+          );
+        }
+        return result(true, this.name, location);
+      },
+    },
+  ];
+}

--- a/scripts/verifyProductionSite.ts
+++ b/scripts/verifyProductionSite.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildProductionSiteChecks } from './lib/productionSiteProbe';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+function readPackageVersion(): string {
+  const pkg = JSON.parse(readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'));
+  if (typeof pkg.version !== 'string' || pkg.version.length === 0) {
+    throw new Error('package.json version is missing');
+  }
+  return `v${pkg.version}`;
+}
+
+function argValue(name: string): string | undefined {
+  const prefix = `${name}=`;
+  const inline = process.argv.find((arg) => arg.startsWith(prefix));
+  if (inline) return inline.slice(prefix.length);
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+async function main() {
+  const baseUrl = argValue('--url') ?? 'https://kernelcad.com';
+  const expectedVersion = argValue('--expected-version') ?? readPackageVersion();
+  const expectedDemoIteration = argValue('--expected-demo-iteration');
+  const checks = buildProductionSiteChecks({
+    baseUrl,
+    expectedVersion,
+    expectedDemoIteration,
+    fetch,
+  });
+
+  let failed = false;
+  for (const check of checks) {
+    const res = await check.run();
+    const mark = res.ok ? 'PASS' : 'FAIL';
+    console.log(`${mark} ${res.name}: ${res.detail}`);
+    failed ||= !res.ok;
+  }
+
+  if (failed) process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary\n- add a production probe for kernelcad.com demo metadata, demo.mp4 response, and invalid-email subscribe route\n- derive expected demo iteration from package patch versions, so v0.2.1 expects the v0.2 demo iteration\n- expose it as npm run site:verify-production\n\n## Verification\n- npm run lint\n- npm run site:build\n- npm run site:verify-production\n- npm test (fails until dist/cli/index.js exists; after npm run build:cli, the failing cli-bundle startup test passes)\n- npm run build:cli\n- npx vitest run tests/integration/cli-bundle/startup.test.ts