### PR TITLE
Fix npm global install runtime deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "shiki": "^1.29.2",
         "three": "^0.182.0",
         "ts-morph": "^27.0.2",
+        "typescript": "~5.9.3",
         "yaml": "^2.8.4",
         "zod": "^4.3.6"
       },
@@ -58,7 +59,6 @@
         "playwright": "^1.58.0",
         "tailwindcss": "^4.1.18",
         "tsx": "^4.21.0",
-        "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
         "vite": "^7.2.4",
         "vitest": "^4.0.18"
@@ -9147,7 +9147,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "shiki": "^1.29.2",
     "three": "^0.182.0",
     "ts-morph": "^27.0.2",
+    "typescript": "~5.9.3",
     "yaml": "^2.8.4",
     "zod": "^4.3.6"
   },
@@ -96,7 +97,6 @@
     "playwright": "^1.58.0",
     "tailwindcss": "^4.1.18",
     "tsx": "^4.21.0",
-    "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
     "vite": "^7.2.4",
     "vitest": "^4.0.18"

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,15 +1,19 @@
 // src/cli/index.ts
 import { Command } from 'commander';
+import { createRequire } from 'node:module';
 import { evaluateCommand } from './commands/evaluate';
 import { exportCommand } from './commands/export';
 import { mcpCommand } from './commands/mcp';
 import { skillCommand } from './commands/skill';
 
+const requireFromHere = createRequire(import.meta.url);
+const pkg = requireFromHere('../../package.json') as { version: string };
+
 const program = new Command();
 program
   .name('kernelcad')
-  .description('kernelCAD — agent-first parametric CAD CLI (v0.1)')
-  .version('0.1.0');
+  .description('kernelCAD — agent-first parametric CAD CLI')
+  .version(pkg.version);
 
 program.addCommand(evaluateCommand());
 program.addCommand(exportCommand());

--- a/tests/integration/cli-bundle/startup.test.ts
+++ b/tests/integration/cli-bundle/startup.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { spawn } from 'node:child_process';
 import { resolve as resolvePath, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI_BIN = resolvePath(__dirname, '../../../dist/cli/index.js');
@@ -17,6 +17,26 @@ const CLI_BIN = resolvePath(__dirname, '../../../dist/cli/index.js');
 describe('CLI bundle startup', () => {
   it('the bundle artifact exists at dist/cli/index.js', () => {
     expect(existsSync(CLI_BIN)).toBe(true);
+  });
+
+  it('reports the package version', async () => {
+    const pkg = JSON.parse(readFileSync(resolvePath(__dirname, '../../../package.json'), 'utf8')) as { version: string };
+    const child = spawn('node', [CLI_BIN, '--version'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdoutBuf = '';
+    let stderrBuf = '';
+    child.stdout!.on('data', (chunk) => { stdoutBuf += chunk.toString(); });
+    child.stderr!.on('data', (chunk) => { stderrBuf += chunk.toString(); });
+
+    const code = await new Promise<number | null>((resolve) => {
+      child.on('exit', resolve);
+    });
+
+    expect(code).toBe(0);
+    expect(stderrBuf).toBe('');
+    expect(stdoutBuf.trim()).toBe(pkg.version);
   });
 
   it('the bundle boots without crashing and answers a JSON-RPC initialize', async () => {


### PR DESCRIPTION
## Summary
- move TypeScript into production dependencies because the CLI runtime imports it after install
- derive kernelcad --version from package.json instead of a hardcoded 0.1.0
- add a bundle startup assertion for --version matching package.json

## Root cause
npm install -g kernelcad currently fails at the registry because the package has not been published. A local tarball smoke also showed the current package would crash after publish because TypeScript was externalized but dev-only.

## Verification
- npm run build:cli
- npx vitest run tests/integration/cli-bundle/startup.test.ts
- npm pack --pack-destination /tmp/kernelcad-pack
- npm install -g --prefix /tmp/kernelcad-global-smoke /tmp/kernelcad-pack/kernelcad-0.3.0.tgz
- /tmp/kernelcad-global-smoke/bin/kernelcad --version => 0.3.0
- /tmp/kernelcad-global-smoke/bin/kernelcad evaluate examples/bracket-with-hole.kcad.ts --json => ok true, diagnostics 0
- npm run lint
- npm run typecheck