### PR TITLE
feat(constraints): add concentric and symmetry support

### DIFF
--- a/src/components/Sketcher/ConstraintsToolbar.tsx
+++ b/src/components/Sketcher/ConstraintsToolbar.tsx
@@ -1,6 +1,6 @@
 import { useWorkbench } from '../../context/WorkbenchContext';
 import type { ConstraintType } from '../../lib/constraints/types';
-import { Anchor, ArrowLeftRight, MoveHorizontal, MoveVertical, Circle, Ruler, Equal } from 'lucide-react';
+import { Anchor, ArrowLeftRight, MoveHorizontal, MoveVertical, Circle, Ruler, Equal, CircleDot, FlipHorizontal2 } from 'lucide-react';
 
 export function ConstraintsToolbar() {
     const {
@@ -36,6 +36,16 @@ export function ConstraintsToolbar() {
         } else if (type === 'EQUAL_LENGTH') {
             if (selectedEntityIds.length !== 2) {
                 alert("Select exactly 2 lines");
+                return;
+            }
+        } else if (type === 'CONCENTRIC') {
+            if (selectedEntityIds.length !== 2) {
+                alert("Select exactly 2 circles");
+                return;
+            }
+        } else if (type === 'SYMMETRIC') {
+            if (selectedEntityIds.length !== 3) {
+                alert("Select 2 points and 1 mirror line");
                 return;
             }
         } else if (type === 'DISTANCE') {
@@ -121,6 +131,22 @@ export function ConstraintsToolbar() {
                 title="Equal"
             >
                 <Equal size={16} />
+            </button>
+
+            <button
+                onClick={() => handleAddConstraint('CONCENTRIC')}
+                className="p-1.5 hover:bg-[#333] rounded text-gray-300 hover:text-white flex items-center gap-2"
+                title="Concentric"
+            >
+                <CircleDot size={16} />
+            </button>
+
+            <button
+                onClick={() => handleAddConstraint('SYMMETRIC')}
+                className="p-1.5 hover:bg-[#333] rounded text-gray-300 hover:text-white flex items-center gap-2"
+                title="Symmetric"
+            >
+                <FlipHorizontal2 size={16} />
             </button>
 
             {/* Debug Info */}

--- a/src/features/core/constraintsE2E.test.tsx
+++ b/src/features/core/constraintsE2E.test.tsx
@@ -152,4 +152,71 @@ describe('Constraints E2E Integration (via SketchingContext)', () => {
             expect(Math.abs(Math.abs(center.y) - 10)).toBeLessThan(1.0);
         }, { timeout: 2000 });
     });
+
+    it('should solve CONCENTRIC constraint in context', async () => {
+        let capturedEntities: Map<string, SketchEntity> = new Map();
+
+        render(
+            <SketchingProvider>
+                <TestRunner setup={(ctx) => {
+                    ctx.addEntity({ id: 'c1_center', type: 'POINT', x: 0, y: 0, fixed: true });
+                    ctx.addEntity({ id: 'c1', type: 'CIRCLE', center: 'c1_center', radius: 10 });
+
+                    ctx.addEntity({ id: 'c2_center', type: 'POINT', x: 9, y: -3, fixed: false });
+                    ctx.addEntity({ id: 'c2', type: 'CIRCLE', center: 'c2_center', radius: 4 });
+
+                    ctx.addConstraint({
+                        id: 'concentric',
+                        type: 'CONCENTRIC',
+                        entities: ['c1', 'c2']
+                    });
+                }} />
+                <StateCapturer onUpdate={(ents) => capturedEntities = ents} />
+            </SketchingProvider>
+        );
+
+        await waitFor(() => {
+            const center = capturedEntities.get('c2_center');
+            if (!center || center.type !== 'POINT') {
+                throw new Error('Circle center not found');
+            }
+
+            expect(center.x).toBeCloseTo(0);
+            expect(center.y).toBeCloseTo(0);
+        }, { timeout: 2000 });
+    });
+
+    it('should solve SYMMETRIC point constraint in context', async () => {
+        let capturedEntities: Map<string, SketchEntity> = new Map();
+
+        render(
+            <SketchingProvider>
+                <TestRunner setup={(ctx) => {
+                    ctx.addEntity({ id: 'axis_p1', type: 'POINT', x: 0, y: 0, fixed: true });
+                    ctx.addEntity({ id: 'axis_p2', type: 'POINT', x: 0, y: 20, fixed: true });
+                    ctx.addEntity({ id: 'axis', type: 'LINE', p1: 'axis_p1', p2: 'axis_p2' });
+
+                    ctx.addEntity({ id: 'left', type: 'POINT', x: -8, y: 5, fixed: true });
+                    ctx.addEntity({ id: 'right', type: 'POINT', x: 3, y: 0, fixed: false });
+
+                    ctx.addConstraint({
+                        id: 'symmetric',
+                        type: 'SYMMETRIC',
+                        entities: ['left', 'right', 'axis']
+                    });
+                }} />
+                <StateCapturer onUpdate={(ents) => capturedEntities = ents} />
+            </SketchingProvider>
+        );
+
+        await waitFor(() => {
+            const right = capturedEntities.get('right');
+            if (!right || right.type !== 'POINT') {
+                throw new Error('Right point not found');
+            }
+
+            expect(right.x).toBeCloseTo(8);
+            expect(right.y).toBeCloseTo(5);
+        }, { timeout: 2000 });
+    });
 });

--- a/src/lib/constraints/solver.test.ts
+++ b/src/lib/constraints/solver.test.ts
@@ -228,4 +228,45 @@ describe('ConstraintSolver', () => {
         // L1 is fixed at 10. L2 should grow to 10.
         expect(len2).toBeCloseTo(10);
     });
+
+    it('should solve CONCENTRIC constraint', () => {
+        state.entities.set('c1_center', { id: 'c1_center', type: 'POINT', x: 0, y: 0, fixed: true });
+        state.entities.set('c1', { id: 'c1', type: 'CIRCLE', center: 'c1_center', radius: 8 });
+
+        state.entities.set('c2_center', { id: 'c2_center', type: 'POINT', x: 12, y: -6, fixed: false });
+        state.entities.set('c2', { id: 'c2', type: 'CIRCLE', center: 'c2_center', radius: 3 });
+
+        state.constraints.push({
+            id: 'concentric',
+            type: 'CONCENTRIC',
+            entities: ['c1', 'c2']
+        });
+
+        solver.solve(state);
+
+        const center = asPoint(state.entities.get('c2_center'));
+        expect(center.x).toBeCloseTo(0);
+        expect(center.y).toBeCloseTo(0);
+    });
+
+    it('should solve SYMMETRIC point constraint across a line', () => {
+        state.entities.set('axis_p1', { id: 'axis_p1', type: 'POINT', x: 0, y: 0, fixed: true });
+        state.entities.set('axis_p2', { id: 'axis_p2', type: 'POINT', x: 0, y: 10, fixed: true });
+        state.entities.set('axis', { id: 'axis', type: 'LINE', p1: 'axis_p1', p2: 'axis_p2' });
+
+        state.entities.set('left', { id: 'left', type: 'POINT', x: -10, y: 4, fixed: true });
+        state.entities.set('right', { id: 'right', type: 'POINT', x: 6, y: 1, fixed: false });
+
+        state.constraints.push({
+            id: 'symmetric',
+            type: 'SYMMETRIC',
+            entities: ['left', 'right', 'axis']
+        });
+
+        solver.solve(state);
+
+        const right = asPoint(state.entities.get('right'));
+        expect(right.x).toBeCloseTo(10);
+        expect(right.y).toBeCloseTo(4);
+    });
 });

--- a/src/lib/constraints/solver.ts
+++ b/src/lib/constraints/solver.ts
@@ -35,6 +35,10 @@ export class ConstraintSolver {
                 return this.solveRadius(constraint, entities);
             case 'ANGLE':
                 return this.solveAngle(constraint, entities);
+            case 'CONCENTRIC':
+                return this.solveConcentric(constraint, entities);
+            case 'SYMMETRIC':
+                return this.solveSymmetric(constraint, entities);
             case 'EQUAL_LENGTH':
                 return this.solveConnect(constraint, entities); // Equal length logic
             default:
@@ -468,6 +472,42 @@ export class ConstraintSolver {
         return Math.abs(err);
     }
 
+    private solveConcentric(c: Constraint, entities: Map<string, SketchEntity>): number {
+        if (c.entities.length !== 2) return 0;
+        const c1 = this.getCircle(c.entities[0], entities);
+        const c2 = this.getCircle(c.entities[1], entities);
+        if (!c1 || !c2) return 0;
+
+        return this.movePointsTogether(c1.center, c2.center);
+    }
+
+    private solveSymmetric(c: Constraint, entities: Map<string, SketchEntity>): number {
+        if (c.entities.length !== 3) return 0;
+        const p1 = this.getPoint(c.entities[0], entities);
+        const p2 = this.getPoint(c.entities[1], entities);
+        const axis = this.getLine(c.entities[2], entities);
+        if (!p1 || !p2 || !axis) return 0;
+
+        const reflectedP1 = this.reflectPointAcrossLine(p1, axis);
+        const reflectedP2 = this.reflectPointAcrossLine(p2, axis);
+        const errorToP2 = this.distanceBetween(p2, reflectedP1);
+        const errorToP1 = this.distanceBetween(p1, reflectedP2);
+
+        if (errorToP1 < 0.0001 && errorToP2 < 0.0001) return 0;
+        if (p1.fixed && p2.fixed) return errorToP1 + errorToP2;
+
+        if (p1.fixed) {
+            this.movePointTo(p2, reflectedP1);
+        } else if (p2.fixed) {
+            this.movePointTo(p1, reflectedP2);
+        } else {
+            this.movePointHalfwayTo(p1, reflectedP2);
+            this.movePointHalfwayTo(p2, reflectedP1);
+        }
+
+        return errorToP1 + errorToP2;
+    }
+
     private solveAngle(c: Constraint, entities: Map<string, SketchEntity>): number {
         // Absolute Angle (Single Line relative to X-axis)
         if (c.entities.length === 1 && c.value !== undefined) {
@@ -584,6 +624,69 @@ export class ConstraintSolver {
         }
     }
 
+    private movePointsTogether(p1: Point, p2: Point): number {
+        const dx = p2.x - p1.x;
+        const dy = p2.y - p1.y;
+        const error = Math.sqrt(dx * dx + dy * dy);
+
+        if (error < 0.0001) return 0;
+
+        if (!p1.fixed && !p2.fixed) {
+            p1.x += dx * 0.5;
+            p1.y += dy * 0.5;
+            p2.x -= dx * 0.5;
+            p2.y -= dy * 0.5;
+        } else if (!p1.fixed) {
+            p1.x += dx;
+            p1.y += dy;
+        } else if (!p2.fixed) {
+            p2.x -= dx;
+            p2.y -= dy;
+        }
+
+        return error;
+    }
+
+    private reflectPointAcrossLine(
+        point: Point,
+        axis: { line: Line, p1: Point, p2: Point }
+    ): { x: number; y: number } {
+        const dx = axis.p2.x - axis.p1.x;
+        const dy = axis.p2.y - axis.p1.y;
+        const lenSq = dx * dx + dy * dy;
+
+        if (lenSq < 0.000001) {
+            return { x: point.x, y: point.y };
+        }
+
+        const t = ((point.x - axis.p1.x) * dx + (point.y - axis.p1.y) * dy) / lenSq;
+        const projX = axis.p1.x + t * dx;
+        const projY = axis.p1.y + t * dy;
+
+        return {
+            x: 2 * projX - point.x,
+            y: 2 * projY - point.y
+        };
+    }
+
+    private distanceBetween(p: Point, target: { x: number; y: number }): number {
+        const dx = target.x - p.x;
+        const dy = target.y - p.y;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    private movePointTo(p: Point, target: { x: number; y: number }) {
+        if (p.fixed) return;
+        p.x = target.x;
+        p.y = target.y;
+    }
+
+    private movePointHalfwayTo(p: Point, target: { x: number; y: number }) {
+        if (p.fixed) return;
+        p.x += (target.x - p.x) * 0.5;
+        p.y += (target.y - p.y) * 0.5;
+    }
+
     private solveConnect(c: Constraint, entities: Map<string, SketchEntity>): number {
         // Equal Length
         if (c.entities.length !== 2) return 0;
@@ -652,4 +755,3 @@ export class ConstraintSolver {
         }
     }
 }
-

--- a/src/lib/constraints/types.ts
+++ b/src/lib/constraints/types.ts
@@ -34,7 +34,9 @@ export type ConstraintType =
     | 'EQUAL_LENGTH'
     | 'TANGENT'
     | 'RADIUS'
-    | 'ANGLE';
+    | 'ANGLE'
+    | 'CONCENTRIC'
+    | 'SYMMETRIC';
 
 export interface Constraint {
     id: string;


### PR DESCRIPTION
## Summary
- Add `CONCENTRIC` and `SYMMETRIC` to the sketch constraint type vocabulary.
- Implement concentric circle-center solving and point symmetry across a mirror line.
- Expose both constraints in the sketch toolbar and cover solver + SketchingContext integration paths.

## Test Plan
- `npm run test -- src/lib/constraints/solver.test.ts src/lib/constraints/advanced_constraints.test.ts src/features/core/constraintsE2E.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run build:cli`
- `PATH="/tmp/kernelcad-local-bin:$PATH" npm run test`

Note: plain `npm run test` initially failed because two v0.3 corpus tests spawn `kernelcad` and this shell did not have the CLI binary on PATH. After rebuilding `dist/cli/index.js` and adding a local shim at `/tmp/kernelcad-local-bin/kernelcad`, the full suite passed.