### PR TITLE
feat(mcp): add sketch constraint commands

### DIFF
--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -11,3 +11,15 @@ export { addFeatureTool, type AddFeatureInput, type AddFeatureOutput } from './t
 export { removeFeatureTool, type RemoveFeatureInput, type RemoveFeatureOutput } from './tools/removeFeature';
 export { paramsListTool, type ParamsListInput, type ParamsListOutput } from './tools/paramsList';
 export { paramsUpdateTool, type ParamsUpdateInput, type ParamsUpdateOutput } from './tools/paramsUpdate';
+export {
+  addConstraintTool,
+  listConstraintsTool,
+  solveSketchTool,
+  SUPPORTED_CONSTRAINT_TYPES,
+  type AddConstraintInput,
+  type AddConstraintOutput,
+  type ListConstraintsInput,
+  type ListConstraintsOutput,
+  type SolveSketchInput,
+  type SolveSketchOutput,
+} from './tools/constraints';

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -21,6 +21,7 @@ import { exportStlTool } from './tools/exportStl';
 import { lookupCookbookTool } from './tools/lookupCookbook';
 import { paramsListTool } from './tools/paramsList';
 import { paramsUpdateTool } from './tools/paramsUpdate';
+import { addConstraintTool, listConstraintsTool, solveSketchTool } from './tools/constraints';
 
 const requireFromHere = createRequire(import.meta.url);
 const pkg = requireFromHere('../../package.json') as { version: string };
@@ -283,6 +284,51 @@ export const TOOLS = [
       required: ['edits'],
     },
   },
+  {
+    name: 'solve_sketch',
+    description:
+      'Solve a 2D sketch constraint set. Side-effect-free: pass { entities, constraints } and receive solved entities plus the original constraints. Entities are POINT, LINE, and CIRCLE records; constraints use the kernelCAD constraint vocabulary.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        entities: {
+          type: 'array',
+          description: 'Sketch entities to solve. Lines reference point ids; circles reference a center point id.',
+          items: { type: 'object' },
+        },
+        constraints: {
+          type: 'array',
+          description: 'Constraints to apply to the entities.',
+          items: { type: 'object' },
+        },
+      },
+      required: ['entities', 'constraints'],
+    },
+  },
+  {
+    name: 'add_constraint',
+    description:
+      'Append one validated sketch constraint to a constraint list. Side-effect-free: pass { constraints, constraint } and receive the updated list.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        constraints: { type: 'array', items: { type: 'object' } },
+        constraint: { type: 'object' },
+      },
+      required: ['constraint'],
+    },
+  },
+  {
+    name: 'list_constraints',
+    description:
+      'List supported sketch constraint types and echo the provided constraint list. Use before add_constraint or solve_sketch to discover the vocabulary.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        constraints: { type: 'array', items: { type: 'object' } },
+      },
+    },
+  },
 ];
 
 export function createMcpServer(): Server {
@@ -358,6 +404,15 @@ export function createMcpServer(): Server {
         break;
       case 'params_update':
         result = await paramsUpdateTool(input as unknown as Parameters<typeof paramsUpdateTool>[0]);
+        break;
+      case 'solve_sketch':
+        result = await solveSketchTool(input as unknown as Parameters<typeof solveSketchTool>[0]);
+        break;
+      case 'add_constraint':
+        result = await addConstraintTool(input as unknown as Parameters<typeof addConstraintTool>[0]);
+        break;
+      case 'list_constraints':
+        result = await listConstraintsTool(input as unknown as Parameters<typeof listConstraintsTool>[0]);
         break;
       default:
         throw new Error(`Unknown tool: ${name}`);

--- a/src/mcp/tools/constraints.ts
+++ b/src/mcp/tools/constraints.ts
@@ -1,0 +1,241 @@
+import { ConstraintSolver } from '../../lib/constraints/solver';
+import type { Constraint, ConstraintType, SketchEntity } from '../../lib/constraints/types';
+
+export const SUPPORTED_CONSTRAINT_TYPES: ConstraintType[] = [
+  'COINCIDENT',
+  'DISTANCE',
+  'HORIZONTAL',
+  'VERTICAL',
+  'PARALLEL',
+  'PERPENDICULAR',
+  'EQUAL_LENGTH',
+  'TANGENT',
+  'RADIUS',
+  'ANGLE',
+  'CONCENTRIC',
+  'SYMMETRIC',
+];
+
+const constraintTypes = new Set<string>(SUPPORTED_CONSTRAINT_TYPES);
+
+const CONSTRAINT_ARITY: Record<ConstraintType, { min: number; max: number; valueRequired?: boolean }> = {
+  COINCIDENT: { min: 2, max: 2 },
+  DISTANCE: { min: 2, max: 2, valueRequired: true },
+  HORIZONTAL: { min: 2, max: 2 },
+  VERTICAL: { min: 2, max: 2 },
+  PARALLEL: { min: 2, max: 2 },
+  PERPENDICULAR: { min: 2, max: 2 },
+  EQUAL_LENGTH: { min: 2, max: 2 },
+  TANGENT: { min: 2, max: 2 },
+  RADIUS: { min: 1, max: 1, valueRequired: true },
+  ANGLE: { min: 1, max: 2, valueRequired: true },
+  CONCENTRIC: { min: 2, max: 2 },
+  SYMMETRIC: { min: 3, max: 3 },
+};
+
+export interface SolveSketchInput {
+  entities?: SketchEntity[];
+  constraints?: Constraint[];
+}
+
+export type SolveSketchOutput =
+  | {
+    ok: true;
+    entities: SketchEntity[];
+    constraints: Constraint[];
+  }
+  | {
+    ok: false;
+    errors: string[];
+    entities: SketchEntity[];
+    constraints: Constraint[];
+  };
+
+export interface AddConstraintInput {
+  constraints?: Constraint[];
+  constraint?: Constraint;
+}
+
+export type AddConstraintOutput =
+  | { ok: true; constraints: Constraint[] }
+  | { ok: false; errors: string[]; constraints: Constraint[] };
+
+export interface ListConstraintsInput {
+  constraints?: Constraint[];
+}
+
+export interface ListConstraintsOutput {
+  ok: true;
+  supportedTypes: ConstraintType[];
+  constraints: Constraint[];
+}
+
+export async function solveSketchTool(input: SolveSketchInput = {}): Promise<SolveSketchOutput> {
+  const shapeErrors = validateListInputs(input);
+  if (shapeErrors.length > 0) {
+    return { ok: false, errors: shapeErrors, entities: [], constraints: [] };
+  }
+
+  const entities = cloneEntities(input.entities ?? []);
+  const constraints = cloneConstraints(input.constraints ?? []);
+  const errors = validateEntities(entities);
+  errors.push(...validateConstraints(constraints, new Map(entities.map(entity => [entity.id, entity]))));
+
+  if (errors.length > 0) {
+    return { ok: false, errors, entities, constraints };
+  }
+
+  const entityMap = new Map(entities.map(entity => [entity.id, entity]));
+  new ConstraintSolver().solve({ entities: entityMap, constraints });
+
+  return {
+    ok: true,
+    entities: entities.map(entity => entityMap.get(entity.id) ?? entity),
+    constraints,
+  };
+}
+
+export async function addConstraintTool(input: AddConstraintInput = {}): Promise<AddConstraintOutput> {
+  if (input.constraints !== undefined && !Array.isArray(input.constraints)) {
+    return { ok: false, errors: ['constraints must be an array.'], constraints: [] };
+  }
+
+  const constraints = cloneConstraints(input.constraints ?? []);
+  if (!input.constraint) {
+    return { ok: false, errors: ['Missing required constraint.'], constraints };
+  }
+
+  const constraint = cloneConstraint(input.constraint);
+  const errors = validateConstraintShape(constraint);
+  if (constraints.some(existing => existing.id === constraint.id)) {
+    errors.push(`Duplicate constraint id "${constraint.id}".`);
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors, constraints };
+  }
+
+  return { ok: true, constraints: [...constraints, constraint] };
+}
+
+export async function listConstraintsTool(input: ListConstraintsInput = {}): Promise<ListConstraintsOutput> {
+  return {
+    ok: true,
+    supportedTypes: [...SUPPORTED_CONSTRAINT_TYPES],
+    constraints: Array.isArray(input.constraints) ? cloneConstraints(input.constraints) : [],
+  };
+}
+
+function validateListInputs(input: SolveSketchInput): string[] {
+  const errors: string[] = [];
+  if (input.entities !== undefined && !Array.isArray(input.entities)) {
+    errors.push('entities must be an array.');
+  }
+  if (input.constraints !== undefined && !Array.isArray(input.constraints)) {
+    errors.push('constraints must be an array.');
+  }
+  return errors;
+}
+
+function validateEntities(entities: SketchEntity[]): string[] {
+  const errors: string[] = [];
+  const ids = new Set<string>();
+
+  for (const entity of entities) {
+    if (!entity.id) {
+      errors.push('Entity id is required.');
+      continue;
+    }
+    if (ids.has(entity.id)) {
+      errors.push(`Duplicate entity id "${entity.id}".`);
+    }
+    ids.add(entity.id);
+  }
+
+  const entityMap = new Map(entities.map(entity => [entity.id, entity]));
+  for (const entity of entities) {
+    if (entity.type === 'LINE') {
+      validatePointReference(entityMap, entity.id, 'p1', entity.p1, errors);
+      validatePointReference(entityMap, entity.id, 'p2', entity.p2, errors);
+    } else if (entity.type === 'CIRCLE') {
+      validatePointReference(entityMap, entity.id, 'center', entity.center, errors);
+    }
+  }
+
+  return errors;
+}
+
+function validatePointReference(
+  entityMap: Map<string, SketchEntity>,
+  entityId: string,
+  field: string,
+  pointId: string,
+  errors: string[],
+): void {
+  const point = entityMap.get(pointId);
+  if (!point) {
+    errors.push(`Entity "${entityId}" ${field} references missing point "${pointId}".`);
+  } else if (point.type !== 'POINT') {
+    errors.push(`Entity "${entityId}" ${field} must reference a POINT, got "${point.type}".`);
+  }
+}
+
+function validateConstraints(
+  constraints: Constraint[],
+  entityMap: Map<string, SketchEntity>,
+): string[] {
+  const errors: string[] = [];
+  const ids = new Set<string>();
+
+  for (const constraint of constraints) {
+    errors.push(...validateConstraintShape(constraint));
+    if (ids.has(constraint.id)) {
+      errors.push(`Duplicate constraint id "${constraint.id}".`);
+    }
+    ids.add(constraint.id);
+
+    for (const entityId of constraint.entities ?? []) {
+      if (!entityMap.has(entityId)) {
+        errors.push(`Constraint "${constraint.id}" references missing entity "${entityId}".`);
+      }
+    }
+  }
+
+  return errors;
+}
+
+function validateConstraintShape(constraint: Constraint): string[] {
+  const errors: string[] = [];
+  if (!constraint.id) errors.push('Constraint id is required.');
+  if (!constraintTypes.has(constraint.type)) {
+    errors.push(`Unsupported constraint type "${String(constraint.type)}".`);
+    return errors;
+  }
+
+  const arity = CONSTRAINT_ARITY[constraint.type];
+  const entityCount = constraint.entities?.length ?? 0;
+  if (entityCount < arity.min || entityCount > arity.max) {
+    const expected = arity.min === arity.max ? `${arity.min}` : `${arity.min}-${arity.max}`;
+    errors.push(`Constraint "${constraint.id}" type ${constraint.type} expects ${expected} entities, got ${entityCount}.`);
+  }
+  if (arity.valueRequired && typeof constraint.value !== 'number') {
+    errors.push(`Constraint "${constraint.id}" type ${constraint.type} requires numeric value.`);
+  }
+
+  return errors;
+}
+
+function cloneEntities(entities: SketchEntity[]): SketchEntity[] {
+  return entities.map(entity => ({ ...entity }));
+}
+
+function cloneConstraints(constraints: Constraint[]): Constraint[] {
+  return constraints.map(cloneConstraint);
+}
+
+function cloneConstraint(constraint: Constraint): Constraint {
+  return {
+    ...constraint,
+    entities: [...(constraint.entities ?? [])],
+  };
+}

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -416,7 +416,7 @@ kernelcad mcp
 
 ## MCP Companion (introspection)
 
-When you have `kernelcad mcp` available, use the MCP tools for dynamic introspection rather than re-running the CLI. The MCP server exposes 18 tools:
+When you have `kernelcad mcp` available, use the MCP tools for dynamic introspection rather than re-running the CLI. The MCP server exposes 21 tools:
 
 - `evaluate_script({ file? code? })` — pass/fail + featureCount + diagnostics
 - `list_features({ file? code? })` — array of feature summaries (kind/id/params/inputs)
@@ -436,6 +436,9 @@ When you have `kernelcad mcp` available, use the MCP tools for dynamic introspec
 - `export_stl({ file? | code?, output_path, feature_id? })` — write a binary STL file server-side; returns `{ ok, output_path, byte_count, feature_count, diagnostics }`. `feature_count` is the total features in the script, not the count contributing to the exported shape.
 - `params_list({})` — list symbolic parameters declared on the active evaluated session, including current value, default, type, and metadata.
 - `params_update({ edits })` — edit one or more active-session params atomically and re-lower affected records; returns a shape preview, skipped/relowered record ids, and soft warnings.
+- `solve_sketch({ entities, constraints })` — solve a 2D POINT/LINE/CIRCLE sketch constraint set; returns `{ ok, entities, constraints }` or validation errors. Side-effect-free.
+- `add_constraint({ constraints?, constraint })` — validate and append one sketch constraint to a constraint list; returns the updated list. Side-effect-free.
+- `list_constraints({ constraints? })` — list supported sketch constraint types and echo the provided constraint list.
 
 ## Out of Scope
 

--- a/tests/integration/mcp/spawn.test.ts
+++ b/tests/integration/mcp/spawn.test.ts
@@ -164,4 +164,21 @@ describe.skipIf(SKIP)('MCP server (spawn)', () => {
     expect(payload.ok).toBe(true);
     expect(payload.new_code).not.toContain(`cylinder(5, 2)`);
   }, 90000);
+
+  it('responds to solve_sketch with solved constraint entities', async () => {
+    const result = await callTool('solve_sketch', {
+      entities: [
+        { id: 'p1', type: 'POINT', x: 0, y: 0, fixed: true },
+        { id: 'p2', type: 'POINT', x: 10, y: 0, fixed: false },
+      ],
+      constraints: [
+        { id: 'c1', type: 'DISTANCE', entities: ['p1', 'p2'], value: 20 },
+      ],
+    });
+    const text = (result as { content: { text: string }[] }).content[0].text;
+    const payload = JSON.parse(text);
+    const p2 = payload.entities.find((entity: { id: string }) => entity.id === 'p2');
+    expect(payload.ok).toBe(true);
+    expect(p2.x).toBeCloseTo(20, 3);
+  }, 90000);
 });

--- a/tests/unit/mcp/tools/constraints.test.ts
+++ b/tests/unit/mcp/tools/constraints.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import type { ConstraintType, SketchEntity } from '../../../../src/lib/constraints/types';
+import {
+  addConstraintTool,
+  listConstraintsTool,
+  solveSketchTool,
+  SUPPORTED_CONSTRAINT_TYPES,
+} from '../../../../src/mcp/tools/constraints';
+
+function entity<T extends SketchEntity>(entities: SketchEntity[], id: string): T {
+  const found = entities.find(e => e.id === id);
+  if (!found) throw new Error(`Missing entity ${id}`);
+  return found as T;
+}
+
+describe('MCP constraint tools', () => {
+  it('solves a distance constraint and returns serializable entities', async () => {
+    const result = await solveSketchTool({
+      entities: [
+        { id: 'p1', type: 'POINT', x: 0, y: 0, fixed: true },
+        { id: 'p2', type: 'POINT', x: 10, y: 0, fixed: false },
+      ],
+      constraints: [
+        { id: 'c1', type: 'DISTANCE', entities: ['p1', 'p2'], value: 20 },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(entity<{ x: number; type: 'POINT' }>(result.entities, 'p2').x).toBeCloseTo(20, 3);
+    expect(result.constraints).toHaveLength(1);
+  });
+
+  it('solves concentric circles and symmetric point pairs', async () => {
+    const result = await solveSketchTool({
+      entities: [
+        { id: 'center_a', type: 'POINT', x: 0, y: 0, fixed: true },
+        { id: 'center_b', type: 'POINT', x: 5, y: 0, fixed: false },
+        { id: 'circle_a', type: 'CIRCLE', center: 'center_a', radius: 5 },
+        { id: 'circle_b', type: 'CIRCLE', center: 'center_b', radius: 2 },
+        { id: 'axis_a', type: 'POINT', x: 0, y: -10, fixed: true },
+        { id: 'axis_b', type: 'POINT', x: 0, y: 10, fixed: true },
+        { id: 'axis', type: 'LINE', p1: 'axis_a', p2: 'axis_b' },
+        { id: 'left', type: 'POINT', x: -4, y: 3, fixed: true },
+        { id: 'right', type: 'POINT', x: 7, y: 2, fixed: false },
+      ],
+      constraints: [
+        { id: 'concentric', type: 'CONCENTRIC', entities: ['circle_a', 'circle_b'] },
+        { id: 'symmetric', type: 'SYMMETRIC', entities: ['left', 'right', 'axis'] },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    const centerB = entity<{ x: number; y: number; type: 'POINT' }>(result.entities, 'center_b');
+    const right = entity<{ x: number; y: number; type: 'POINT' }>(result.entities, 'right');
+    expect(centerB.x).toBeCloseTo(0, 3);
+    expect(centerB.y).toBeCloseTo(0, 3);
+    expect(right.x).toBeCloseTo(4, 3);
+    expect(right.y).toBeCloseTo(3, 3);
+  });
+
+  it('rejects duplicate entity ids before solving', async () => {
+    const result = await solveSketchTool({
+      entities: [
+        { id: 'p1', type: 'POINT', x: 0, y: 0, fixed: true },
+        { id: 'p1', type: 'POINT', x: 10, y: 0, fixed: false },
+      ],
+      constraints: [],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain('Duplicate entity id');
+  });
+
+  it('rejects constraints that reference missing entities', async () => {
+    const result = await solveSketchTool({
+      entities: [{ id: 'p1', type: 'POINT', x: 0, y: 0, fixed: true }],
+      constraints: [{ id: 'c1', type: 'DISTANCE', entities: ['p1', 'p2'], value: 10 }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain('references missing entity "p2"');
+  });
+
+  it('returns validation errors for malformed list inputs instead of throwing', async () => {
+    await expect(solveSketchTool({
+      entities: { id: 'p1' } as unknown as SketchEntity[],
+      constraints: [] as const,
+    })).resolves.toMatchObject({
+      ok: false,
+      errors: ['entities must be an array.'],
+    });
+
+    await expect(addConstraintTool({
+      constraints: { id: 'c1' } as unknown as [],
+      constraint: { id: 'c2', type: 'HORIZONTAL', entities: ['p1', 'p2'] },
+    })).resolves.toMatchObject({
+      ok: false,
+      errors: ['constraints must be an array.'],
+    });
+  });
+
+  it('adds valid constraints without mutating the input list', async () => {
+    const existing = [{ id: 'c1', type: 'HORIZONTAL' as const, entities: ['p1', 'p2'] }];
+    const result = await addConstraintTool({
+      constraints: existing,
+      constraint: { id: 'c2', type: 'VERTICAL', entities: ['p3', 'p4'] },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.constraints.map(c => c.id)).toEqual(['c1', 'c2']);
+    expect(existing).toHaveLength(1);
+  });
+
+  it('rejects invalid add-constraint arity and unknown types', async () => {
+    await expect(addConstraintTool({
+      constraints: [],
+      constraint: { id: 'bad', type: 'DISTANCE', entities: ['p1'] },
+    })).resolves.toMatchObject({ ok: false });
+
+    await expect(addConstraintTool({
+      constraints: [],
+      constraint: { id: 'bad', type: 'LOCKED' as ConstraintType, entities: ['p1'] },
+    })).resolves.toMatchObject({ ok: false });
+  });
+
+  it('lists the complete supported constraint vocabulary', async () => {
+    const result = await listConstraintsTool({
+      constraints: [{ id: 'c1', type: 'ANGLE', entities: ['l1'], value: 45 }],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.supportedTypes).toEqual(SUPPORTED_CONSTRAINT_TYPES);
+    expect(result.supportedTypes).toEqual([
+      'COINCIDENT',
+      'DISTANCE',
+      'HORIZONTAL',
+      'VERTICAL',
+      'PARALLEL',
+      'PERPENDICULAR',
+      'EQUAL_LENGTH',
+      'TANGENT',
+      'RADIUS',
+      'ANGLE',
+      'CONCENTRIC',
+      'SYMMETRIC',
+    ]);
+    expect(result.constraints).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add side-effect-free MCP tools for solve_sketch, add_constraint, and list_constraints
- validate constraint type, arity, required values, duplicate ids, missing entity refs, and malformed list inputs
- add unit coverage, spawned MCP coverage, and update SKILL.md tool drift docs

## Verification
- npm run test -- tests/unit/mcp/tools/constraints.test.ts tests/integration/mcp/serverToolDispatch.test.ts tests/unit/skill/skillToolCountDrift.test.ts
- npm run typecheck && npm run lint && npm run build && npm run build:cli
- KERNELCAD_BIN="/home/andrii/.config/superpowers/worktrees/kernelCAD-web/fix-v030-demo-artifacts/dist/cli/index.js" PATH="/home/andrii/.config/superpowers/worktrees/kernelCAD-web/fix-v030-demo-artifacts/dist/cli:/home/andrii/.local/bin:/home/andrii/.codex/tmp/arg0/codex-arg0uAKrDp:/home/andrii/.nvm/versions/node/v20.20.2/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/andrii/.nvm/versions/node/v20.20.2/bin:/home/andrii/.local/bin:/home/andrii/.local/bin:/home/andrii/.local/bin:/home/andrii/.cargo/bin:/home/andrii/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin" npm run test