### PR TITLE
Standardize release notes and product plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,77 +1,61 @@
-# 🚀 kernelCAD v0.4.0
+# kernelCAD v0.4.0
 
-**Modern Programmable CAD for the Web**
+v0.4.0 is focused on constrained sketching for agent-authored CAD. The release
+adds the missing sketch constraint operations needed to build and verify a
+recognizable object from a 2D reference, then turn that solved sketch into
+deterministic 3D geometry.
 
----
+## Highlights
 
-## 📋 What's New
+- Added sketch constraint commands for agent workflows, including symmetry,
+  concentric, angle, tangent, distance, radius, diameter, horizontal, vertical,
+  coincident, parallel, and perpendicular constraints.
+- Exposed the complete solver toolbar actions in the web UI so the visual
+  debugger can exercise the same constraint system as scripts and MCP tools.
+- Centralized MCP tool registration and added a constrained-sketch round-trip
+  test so new tools are covered through the public agent interface.
+- Added a v0.4 rocket keychain demo: a CC0 Wikimedia rocket reference converted
+  into a solved constrained sketch, then extruded into a printable keychain with
+  raised porthole rings and through holes.
+- Hardened the release demo pipeline so non-catalog, explicitly approved hero
+  demos can pass release preflight without weakening catalog validation.
+- Fixed command palette dialog accessibility by using Radix dialog title and
+  description primitives.
+- Cleaned up test quality by removing dead skips and strengthening codegen
+  assertions.
 
-- docs(demos): capture v0.4 rocket keychain (300cd8f)
-- fix(ui): satisfy command palette dialog accessibility (2a10964)
-- test: remove dead skips and harden codegen assertions (d41a745)
-- docs(testing): audit test suite quality risks (1e315db)
-- refactor(v0.4): harden rocket proof and demo framing (c89b747)
-- docs(demos): capture v0.4 rocket keychain (9ff9a16)
-- feat(demo): add v0.4 rocket keychain script (941273a)
-- docs(skill): document constrained sketch tools (37c91b9)
-- test(mcp): prove constrained sketch round trip (319a829)
-- test(constraints): prove v0.4 rocket sketch solve (d0769e8)
-- refactor(mcp): centralize tool registry (295cb51)
-- feat(mcp): add sketch constraint commands (1727f0c)
-- feat(constraints): expose complete solver toolbar actions (#86) (0cd569b)
-- feat(constraints): add concentric and symmetry solver support (#85) (3042c07)
-- Fix npm global install runtime deps (#84) (d9a4750)
-- Remove internal solution label from v0.3 demo (#83) (72e89ec)
-- Fix v0.3 demo video artifacts (#82) (70e526d)
+## Demo
 
----
+- Release capture:
+  https://github.com/w1ne/kernelCAD-web/releases/download/v0.4.0/demo.mp4
+- Static panel:
+  https://github.com/w1ne/kernelCAD-web/releases/download/v0.4.0/panel.png
+- Source reference:
+  https://commons.wikimedia.org/wiki/File:Rocket_with_boosters_icon.svg, CC0.
 
-## ✅ Test Results (Automated)
+## Quality Gates
 
-- **QC Check**: Passed (Linting & Build)
-- **Unit Tests**: Ran successfully
-- **E2E Tests**: Manual verification recommended
+- Local release QC passed through `npm run release -- 0.4.0`.
+- Vitest during release: 1297 passed, 16 skipped, 1 todo.
+- PR checks passed before merge: lint, build-and-checks, and test.
+- Release deploys passed for Cloudflare Pages. GitHub Pages deploy passed; e2e
+  was still running when the release notes were first published.
 
----
-
-## 📦 Build Information
-
-- **Version**: 0.4.0
-- **Build Date**: 2026-05-06 23:42:35 UTC
-- **Platform**: Web / linux
-
-## 🎯 Supported Features
-
-kernelCAD v0.4.0 supports:
-
-| Feature | Description | Status |
-|---------|-------------|--------|
-| Sketcher | 2D constraint solver | Stable |
-| Extrude | 3D extrusion from faces | Stable |
-| Fillet/Chamfer | Edge modifications | Beta |
-| STEP Export | CNC/CAM compatibility | Stable |
-
----
-
-## 📥 Installation
-
-### Use Online
-Visit [kernelcad.com](https://kernelcad.com).
-
-### Run Locally
+## Install And Upgrade
 
 ```bash
-git clone https://github.com/w1ne/kernelCAD.git
-cd kernelCAD
+npm install -g kernelcad@0.4.0
+```
+
+For repo development:
+
+```bash
+git clone https://github.com/w1ne/kernelCAD-web.git
+cd kernelCAD-web
 git checkout v0.4.0
 npm install
 npm run dev
 ```
-
----
-
-## 🐛 Report Issues
-Found a bug? [Open an issue](https://github.com/w1ne/kernelCAD/issues)
 
 
 ## [Unreleased]

--- a/README.md
+++ b/README.md
@@ -1,21 +1,31 @@
-# kernelCAD - Agentic CAD Platform
+# kernelCAD - AI-Native CAD Workbench
 
-**kernelCAD** is a **Headless-First CAD Platform** designed for AI Agents.
+**kernelCAD** turns mechanical intent into validated, editable, manufacturable
+design artifacts.
 
-It provides a robust, scriptable API for agents to generate, analyze, and modify 3D geometry using the OpenCASCADE kernel. A web-based "Visual Debugger" allows human engineers to verify and tweak the agent's output.
+The core loop is: intent -> generated `.kcad.ts` -> rendered model ->
+validation checks -> guided revision -> export package.
+
+kernelCAD is not trying to be a browser clone of Fusion, Onshape, or SolidWorks,
+and it is not just a Replicad wrapper. Replicad/OpenCASCADE are the kernel
+layer. kernelCAD is the agent-first workflow layer above the kernel: deterministic
+CAD source, feature history, diagnostics, validation, variants, and human review.
 
 ## Philosophy
-1.  **Agent-Driven**: The primary interface is the `AgentAPI` (Node.js/TS), not the mouse.
-2.  **Verifiable**: Geometry is produced by deterministic code, not manual clicks.
-3.  **Visual Debugging**: Humans trust what they can see. The Web App acts as a high-fidelity viewer for the headless core.
+
+1.  **Agent-First**: The primary interface is `.kcad.ts`, CLI, and MCP. The UI reviews and steers generated designs.
+2.  **Verifiable**: Geometry is deterministic source code with explicit feature history and diagnostics.
+3.  **Validation-Centered**: Useful CAD output needs checks for constraints, hardware fit, clearances, and exportability.
+4.  **Workflow Over Primitives**: Product progress is measured by intent-level workflows, not by copying every traditional CAD button.
 
 ## Features
 
 -   **Headless Core**: Run CAD operations in Node.js or Web Workers without a DOM.
 -   **Agent API**: JSON-serializable commands, introspection, and feedback loops.
--   **Visual Debugger**: Real-time 3D preview powered by React Three Fiber.
+-   **Review Cockpit**: Browser-based 3D preview for inspecting generated designs and validation results.
 -   **Standard Exports**: STEP/STL generation.
 -   **Robust Kernel**: Built on OpenCASCADE (via Replicad).
+-   **Product Plan**: See [docs/PRODUCT_PLAN.md](docs/PRODUCT_PLAN.md) for the north star and v0.5 direction.
   
 ## Get Started
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,74 +1,47 @@
-# 🚀 kernelCAD v0.4.0
+# kernelCAD v0.4.0
 
-**Modern Programmable CAD for the Web**
+v0.4.0 is focused on constrained sketching for agent-authored CAD. The release adds the missing sketch constraint operations needed to build and verify a recognizable object from a 2D reference, then turn that solved sketch into deterministic 3D geometry.
 
----
+## Highlights
 
-## 📋 What's New
+- Added sketch constraint commands for agent workflows, including symmetry, concentric, angle, tangent, distance, radius, diameter, horizontal, vertical, coincident, parallel, and perpendicular constraints.
+- Exposed the complete solver toolbar actions in the web UI so the visual debugger can exercise the same constraint system as scripts and MCP tools.
+- Centralized MCP tool registration and added a constrained-sketch round-trip test so new tools are covered through the public agent interface.
+- Added a v0.4 rocket keychain demo: a CC0 Wikimedia rocket reference converted into a solved constrained sketch, then extruded into a printable keychain with raised porthole rings and through holes.
+- Hardened the release demo pipeline so non-catalog, explicitly approved hero demos can pass release preflight without weakening catalog validation.
+- Fixed command palette dialog accessibility by using Radix dialog title and description primitives.
+- Cleaned up test quality by removing dead skips and strengthening codegen assertions.
 
-- docs(demos): capture v0.4 rocket keychain (300cd8f)
-- fix(ui): satisfy command palette dialog accessibility (2a10964)
-- test: remove dead skips and harden codegen assertions (d41a745)
-- docs(testing): audit test suite quality risks (1e315db)
-- refactor(v0.4): harden rocket proof and demo framing (c89b747)
-- docs(demos): capture v0.4 rocket keychain (9ff9a16)
-- feat(demo): add v0.4 rocket keychain script (941273a)
-- docs(skill): document constrained sketch tools (37c91b9)
-- test(mcp): prove constrained sketch round trip (319a829)
-- test(constraints): prove v0.4 rocket sketch solve (d0769e8)
-- refactor(mcp): centralize tool registry (295cb51)
-- feat(mcp): add sketch constraint commands (1727f0c)
-- feat(constraints): expose complete solver toolbar actions (#86) (0cd569b)
-- feat(constraints): add concentric and symmetry solver support (#85) (3042c07)
-- Fix npm global install runtime deps (#84) (d9a4750)
-- Remove internal solution label from v0.3 demo (#83) (72e89ec)
-- Fix v0.3 demo video artifacts (#82) (70e526d)
+## Demo
 
----
+- Watch the release capture: [v0.4 rocket keychain demo](https://github.com/w1ne/kernelCAD-web/releases/download/v0.4.0/demo.mp4)
+- View the static panel: [v0.4 rocket keychain panel](https://github.com/w1ne/kernelCAD-web/releases/download/v0.4.0/panel.png)
+- Source reference: [Wikimedia Commons rocket with boosters icon](https://commons.wikimedia.org/wiki/File:Rocket_with_boosters_icon.svg), CC0.
 
-## ✅ Test Results (Automated)
+## Quality Gates
 
-- **QC Check**: Passed (Linting & Build)
-- **Unit Tests**: Ran successfully
-- **E2E Tests**: Manual verification recommended
+- Local release QC passed through `npm run release -- 0.4.0`.
+- Vitest during release: 1297 passed, 16 skipped, 1 todo.
+- PR checks passed before merge: lint, build-and-checks, and test.
+- Release deploys passed for Cloudflare Pages. GitHub Pages deploy passed; e2e was still running when the release notes were first published.
 
----
-
-## 📦 Build Information
-
-- **Version**: 0.4.0
-- **Build Date**: 2026-05-06 23:42:35 UTC
-- **Platform**: Web / linux
-
-## 🎯 Supported Features
-
-kernelCAD v0.4.0 supports:
-
-| Feature | Description | Status |
-|---------|-------------|--------|
-| Sketcher | 2D constraint solver | Stable |
-| Extrude | 3D extrusion from faces | Stable |
-| Fillet/Chamfer | Edge modifications | Beta |
-| STEP Export | CNC/CAM compatibility | Stable |
-
----
-
-## 📥 Installation
-
-### Use Online
-Visit [kernelcad.com](https://kernelcad.com).
-
-### Run Locally
+## Install And Upgrade
 
 ```bash
-git clone https://github.com/w1ne/kernelCAD.git
-cd kernelCAD
+npm install -g kernelcad@0.4.0
+```
+
+For repo development:
+
+```bash
+git clone https://github.com/w1ne/kernelCAD-web.git
+cd kernelCAD-web
 git checkout v0.4.0
 npm install
 npm run dev
 ```
 
----
+## Links
 
-## 🐛 Report Issues
-Found a bug? [Open an issue](https://github.com/w1ne/kernelCAD/issues)
+- Release PR: https://github.com/w1ne/kernelCAD-web/pull/89
+- Tag: https://github.com/w1ne/kernelCAD-web/releases/tag/v0.4.0

--- a/docs/PRODUCT_PLAN.md
+++ b/docs/PRODUCT_PLAN.md
@@ -1,0 +1,117 @@
+# kernelCAD Product Plan
+
+## North Star
+
+kernelCAD is an AI-native CAD workbench that turns mechanical intent into
+validated, editable, manufacturable design artifacts.
+
+The core loop is:
+
+1. Capture mechanical intent.
+2. Generate deterministic `.kcad.ts`.
+3. Render and explain the model.
+4. Validate constraints, hardware fit, clearances, and exportability.
+5. Revise through agent-readable feedback.
+6. Export source, preview assets, and manufacturing files.
+
+## Differentiation
+
+kernelCAD is not a browser clone of Fusion, Onshape, or SolidWorks. It is also
+not a Replicad wrapper with a friendlier editor. Replicad/OpenCASCADE are the
+kernel layer. kernelCAD must own the workflow above the kernel:
+
+- intent-level design tasks instead of primitive-first modeling;
+- agent-readable feature history, names, diagnostics, and validation;
+- generated part families and variants, not one opaque shape;
+- review and steering UI, not a traditional CAD toolbar clone;
+- export packages that include `.kcad.ts`, STEP/STL/DXF when available,
+  preview images, validation results, and assumptions.
+
+Every new feature should answer: does this help an agent produce, prove, revise,
+or package a real mechanical artifact?
+
+## Product Boundaries
+
+### Browser App
+
+The browser is the review cockpit. It should help a human inspect generated
+designs, edit parameters, compare variants, read validation failures, and export
+artifacts. It should not become the main place where users manually draw CAD
+from primitives.
+
+### CLI And MCP
+
+The CLI and MCP server are the automation surface. They should let agents
+generate `.kcad.ts`, evaluate geometry, inspect topology, run validation, and
+produce export packages without depending on browser state.
+
+### Core Kernel Layer
+
+The core remains platform-neutral: `.kcad.ts` evaluation, feature records,
+geometry lowering, diagnostics, meshing, and exports. Kernel operations are
+important only when they support higher-level mechanical workflows.
+
+## Next Differentiating Cut: Desktop Robot Arm Kit
+
+The next major slice should be a bounded but non-trivial vertical workflow:
+a parametric 3-axis desktop robot arm kit.
+
+This is deliberately more demanding than another flat plate. It forces the
+capabilities that distinguish kernelCAD from primitive scripting:
+
+- multiple generated parts from one design intent;
+- named assembly instances and transforms;
+- revolute joint definitions and motion ranges;
+- servo or bearing hardware patterns;
+- screw-hole and shaft alignment validation;
+- collision or clearance checks across the motion envelope;
+- separate exports plus a manifest describing each part.
+
+The target is not an industrial robot. The target is a believable printable or
+laser-cut desktop kit with three links, three pivots, a simple end-effector
+placeholder, and visible validation.
+
+## v0.5 Scope
+
+v0.5 should prove the vertical workflow end to end:
+
+- define a robot-arm intent schema with link lengths, plate thickness, servo
+  class, screw pattern, and joint limits;
+- generate a part set as `.kcad.ts` from that intent;
+- render the assembled arm in the browser review cockpit;
+- expose parameter editing for the intent, not raw primitive editing;
+- run validation checks for reach, hole alignment, joint spacing, and clearance;
+- show validation results beside the model;
+- export individual part files and a manifest;
+- include one release demo showing intent to generated model to validation.
+
+Deferred from v0.5:
+
+- full inverse kinematics;
+- electrical routing;
+- dynamic simulation;
+- production drawings;
+- arbitrary assembly authoring UI;
+- generic manual sketch/feature editing as the main workflow.
+
+## Gates
+
+A slice is not product-complete unless it ships:
+
+- an intent-level entry point;
+- generated `.kcad.ts`;
+- rendered geometry;
+- meaningful validation results;
+- at least one revision path when validation fails;
+- exportable artifacts;
+- tests that cover the workflow promise, not only helper functions;
+- a release demo that a new user can understand without reading internals.
+
+## Anti-Goals
+
+- Do not compete with mature manual CAD tools on generic modeling UX.
+- Do not add primitives solely because traditional CAD has them.
+- Do not ship demos that are just boxes, plates, cylinders, or decorative
+  trinkets unless they prove a workflow capability.
+- Do not hide failures behind polished renders; validation failures are part of
+  the product loop.

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -32,6 +32,34 @@ const getCurrentVersion = () => {
     return pkg.version;
 };
 
+const formatReleaseChanges = (log: string): string => {
+    if (!log) return '- No significant changes captured in git log.';
+
+    const groups = [
+        { heading: 'Features', prefixes: ['feat'] },
+        { heading: 'Fixes', prefixes: ['fix'] },
+        { heading: 'Quality And Robustness', prefixes: ['test', 'refactor', 'perf'] },
+        { heading: 'Documentation And Demos', prefixes: ['docs'] },
+    ];
+    const lines = log.split('\n').filter(Boolean);
+    const used = new Set<number>();
+
+    const sections = groups.flatMap((group) => {
+        const matches = lines.filter((line, index) => {
+            const normalized = line.replace(/^- /, '');
+            const hit = group.prefixes.some((prefix) => normalized.startsWith(`${prefix}:`) || normalized.startsWith(`${prefix}(`));
+            if (hit) used.add(index);
+            return hit;
+        });
+        return matches.length ? [`### ${group.heading}\n\n${matches.join('\n')}`] : [];
+    });
+
+    const other = lines.filter((_, index) => !used.has(index));
+    if (other.length) sections.push(`### Other Changes\n\n${other.join('\n')}`);
+
+    return sections.join('\n\n');
+};
+
 // --- Main Script ---
 const args = process.argv.slice(2);
 const firstArg = args[0];
@@ -113,64 +141,47 @@ if (newVersion !== projectedVersion) {
 
 // 5. Create Release Notes File
 const date = new Date().toISOString().replace('T', ' ').substring(0, 19) + ' UTC';
-const releaseNotes = `# 🚀 kernelCAD v${newVersion}
+const releaseChanges = formatReleaseChanges(commitLog);
+const releaseNotes = `# kernelCAD v${newVersion}
 
-**Modern Programmable CAD for the Web**
+## Summary
 
----
+This release contains the changes merged since ${lastTag || 'the previous tag'}. For milestone releases, keep this summary focused on the main user-facing workflow and link the release demo or assets below.
 
-## 📋 What's New
+## Highlights
 
-${commitLog || '- No significant changes captured in git log.'}
+${releaseChanges}
 
----
+## Demo Or Assets
 
-## ✅ Test Results (Automated)
+Release assets are attached separately when a version has a demo capture, static panel, or source reference that should be linked from GitHub Releases.
 
-- **QC Check**: Passed (Linting & Build)
-- **Unit Tests**: Ran successfully
-- **E2E Tests**: Manual verification recommended
+## Quality Gates
 
----
+- Release QC: passed via \`${fullQC ? 'npm run qc:full' : 'npm run qc'}\`.
+- Build date: ${date}.
+- Platform: ${process.platform}.
 
-## 📦 Build Information
-
-- **Version**: ${newVersion}
-- **Build Date**: ${date}
-- **Platform**: Web / ${process.platform}
-
-## 🎯 Supported Features
-
-kernelCAD v${newVersion} supports:
-
-| Feature | Description | Status |
-|---------|-------------|--------|
-| Sketcher | 2D constraint solver | Stable |
-| Extrude | 3D extrusion from faces | Stable |
-| Fillet/Chamfer | Edge modifications | Beta |
-| STEP Export | CNC/CAM compatibility | Stable |
-
----
-
-## 📥 Installation
-
-### Use Online
-Visit [kernelcad.com](https://kernelcad.com).
-
-### Run Locally
+## Install And Upgrade
 
 \`\`\`bash
-git clone https://github.com/w1ne/kernelCAD.git
-cd kernelCAD
+npm install -g kernelcad@${newVersion}
+\`\`\`
+
+For repo development:
+
+\`\`\`bash
+git clone https://github.com/w1ne/kernelCAD-web.git
+cd kernelCAD-web
 git checkout v${newVersion}
 npm install
 npm run dev
 \`\`\`
 
----
+## Links
 
-## 🐛 Report Issues
-Found a bug? [Open an issue](https://github.com/w1ne/kernelCAD/issues)
+- Web app: https://kernelcad.com
+- Issues: https://github.com/w1ne/kernelCAD-web/issues
 `;
 
 writeFileSync(RELEASE_NOTES_PATH, releaseNotes);


### PR DESCRIPTION
## Summary
- replace the v0.4.0 generated release dump with a product-focused release description
- update CHANGELOG.md to match the useful v0.4 release body
- make scripts/release.ts generate a structured, categorized release note instead of unsupported feature tables and generic boilerplate
- add docs/PRODUCT_PLAN.md with the AI-native CAD north star, product boundaries, anti-goals, and v0.5 desktop robot arm kit direction
- update README.md so the front door differentiates kernelCAD from browser CAD clones and raw Replicad scripting

## Verification
- npm run typecheck

Live GitHub release v0.4.0 has already been updated with the standardized description.