### PR TITLE
feat: add assembly intent contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,9 +67,16 @@ npm run dev
 - Added the first Patterns contract with `.patternLinear(...)` and
   `.patternCircular(...)` shape methods, captured as canonical `.kcad.ts`
   model intent and advertised through MCP `list_api`.
+- Added the first v0.6 Assembly contract with `assembly(name).part(...)` and
+  `.revolute(...)` intent capture for named mechanical parts and joints.
+  Assembly records are executable geometry pass-throughs for now, so scripts
+  can preserve inspectable assembly metadata without implying a kinematic
+  solver exists yet.
 - Added a focused foundation proof script covering typecheck, test-quality
   audit, constraints, diagnostics, release-note template checks, MCP API drift,
   and pattern capture/lowering behavior.
+- Added `proof:assembly-contract` to verify foundation gates plus assembly
+  capture, assembly lowerer pass-through, and SKILL global discoverability.
 
 ### Added — v0.3 slice 3: symbolic params + edit-after-build replay
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test": "NODE_OPTIONS='--max-old-space-size=8192' vitest run",
     "test:audit": "npx tsx scripts/testQualityAudit.ts",
     "proof:foundation": "npm run typecheck && npm run test:audit && npm test -- src/lib/constraints/solver.test.ts src/lib/constraints/advanced_constraints.test.ts tests/integration/diagnostics/hint-mandatory.test.ts scripts/lib/whatsNewTemplate.test.ts tests/integration/mcp/listApi.driftSentinel.test.ts tests/unit/skill/skillShapeMethodsDrift.test.ts tests/unit/patterns/patternCapture.test.ts tests/unit/backends/occt/patternLowerer.test.ts",
+    "proof:assembly-contract": "npm run proof:foundation && npm test -- tests/unit/assemblies/assemblyCapture.test.ts tests/unit/backends/occt/assemblyLowerer.test.ts tests/unit/skill/skillGlobalsDrift.test.ts",
     "test:e2e": "playwright test",
     "site:dev": "npx tsx site/scripts/build-demo.ts && cd site && for f in public/*; do ln -sf \"$f\" \"$(basename \"$f\")\"; done && python3 -m http.server 8000",
     "site:build": "npx tsx site/scripts/build-demo.ts && node site/scripts/render-brand.mjs",

--- a/src/backends/occt/occtLowerer.ts
+++ b/src/backends/occt/occtLowerer.ts
@@ -247,6 +247,8 @@ export class OcctLowerer implements FeatureLowerer {
     'loft',      // NEW (v0.13.0-rc.10)
     'mirror',    // NEW (v0.13.0-rc.13)
     'pattern',
+    'assemblyPart',
+    'assemblyJoint',
   ]);
 
   async lower(r: FeatureRecord, inputs: ResolvedInputs): Promise<LowerResult> {
@@ -1154,6 +1156,46 @@ export class OcctLowerer implements FeatureLowerer {
           }
           shape = shape.union(instance);
         }
+        break;
+      }
+      case 'assemblyPart': {
+        const base = inputs.byKey.shape as OcctBackend | undefined;
+        if (!base) {
+          diagnostics.push({
+            target: this.target,
+            code: 'recompute.input.missing',
+            featureId: r.id,
+            severity: 'error',
+            message: `assembly part shape input is missing or failed.`,
+            hint: 'Assembly parts must wrap a successfully lowered source shape.',
+          });
+          return { shape: undefined as unknown as ShapeBackend, diagnostics };
+        }
+        shape = base.clone();
+        const at = (r.metadata as { at?: unknown } | undefined)?.at;
+        if (Array.isArray(at)) {
+          shape = shape.translate(
+            Number(at[0]),
+            Number(at[1]),
+            Number(at[2]),
+          );
+        }
+        break;
+      }
+      case 'assemblyJoint': {
+        const partA = inputs.byKey.a as OcctBackend | undefined;
+        if (!partA) {
+          diagnostics.push({
+            target: this.target,
+            code: 'recompute.input.missing',
+            featureId: r.id,
+            severity: 'error',
+            message: `assembly joint input 'a' is missing or failed.`,
+            hint: 'Assembly joints must reference successfully lowered assembly parts.',
+          });
+          return { shape: undefined as unknown as ShapeBackend, diagnostics };
+        }
+        shape = partA.clone();
         break;
       }
       default:

--- a/src/capture/assembly.ts
+++ b/src/capture/assembly.ts
@@ -1,0 +1,91 @@
+import { KernelError } from '../intent/kernelError';
+import type { FeatureId, Vec3 } from '../intent/types';
+import { formatScalarForError, isValidVec3 } from '../intent/types';
+import type { CaptureSession } from './captureSession';
+import { Shape } from './proxy';
+
+export interface AssemblyPartRef {
+  id: FeatureId;
+  name: string;
+}
+
+export interface AssemblyJointRef {
+  id: FeatureId;
+  name: string;
+  kind: 'revolute';
+}
+
+export interface AssemblyPartOpts {
+  at?: Vec3;
+}
+
+export interface RevoluteJointOpts {
+  axis: Vec3;
+  origin: Vec3;
+  limitsDeg?: [number, number];
+}
+
+export class Assembly {
+  readonly name: string;
+  private readonly session: CaptureSession;
+
+  constructor(name: string, session: CaptureSession) {
+    this.name = name;
+    this.session = session;
+  }
+
+  part(name: string, shape: Shape, opts: AssemblyPartOpts = {}): AssemblyPartRef {
+    if (opts.at !== undefined && !isValidVec3(opts.at)) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `assembly part placement must be a finite Vec3; got ${formatScalarForError(opts.at)}.`,
+        shape.id,
+        'Pass at: [x, y, z], or omit it.',
+      );
+    }
+    const record = this.session.assemblyPart(this.name, name, shape, opts);
+    return { id: record.id, name };
+  }
+
+  revolute(name: string, a: AssemblyPartRef, b: AssemblyPartRef, opts: RevoluteJointOpts): AssemblyJointRef {
+    if (!isValidVec3(opts.axis)) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `revolute joint axis must be a finite Vec3; got ${formatScalarForError(opts.axis)}.`,
+        undefined,
+        'Pass axis: [x, y, z].',
+      );
+    }
+    if (!isValidVec3(opts.origin)) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `revolute joint origin must be a finite Vec3; got ${formatScalarForError(opts.origin)}.`,
+        undefined,
+        'Pass origin: [x, y, z].',
+      );
+    }
+    if (opts.limitsDeg !== undefined && !isValidJointLimits(opts.limitsDeg)) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `revolute joint limitsDeg must be [minDeg, maxDeg] finite numbers with min < max; got ${formatScalarForError(opts.limitsDeg)}.`,
+        undefined,
+        'Pass limitsDeg: [minDeg, maxDeg], or omit it.',
+      );
+    }
+    const record = this.session.assemblyJoint(this.name, name, 'revolute', a, b, opts);
+    return { id: record.id, name, kind: 'revolute' };
+  }
+}
+
+export function makeAssembly(name: string | undefined, session: CaptureSession): Assembly {
+  return new Assembly(name?.trim() || 'assembly', session);
+}
+
+function isValidJointLimits(value: [number, number]): boolean {
+  return (
+    Array.isArray(value) &&
+    value.length === 2 &&
+    value.every((n) => typeof n === 'number' && Number.isFinite(n)) &&
+    value[0] < value[1]
+  );
+}

--- a/src/capture/captureSession.ts
+++ b/src/capture/captureSession.ts
@@ -3,6 +3,7 @@ import type { FeatureRecord, ShapeTransform } from '../intent/featureRecord';
 import type { FeatureKind, FeatureRef, Param, PatternSpec, PlaneSpec } from '../intent/types';
 import { Shape } from './proxy';
 import { Sketch } from './sketch';
+import type { AssemblyPartOpts, AssemblyPartRef, RevoluteJointOpts } from './assembly';
 import { EDGE_QUERY_KEYS as EDGE_QUERY_KEYS_ARR } from '../backends/occt/queryKeys';
 import { ParamTable, type SerializedParamTable } from '../runtime/paramTable';
 import type { SoftWarning } from '../runtime/softWarning';
@@ -193,6 +194,56 @@ export class CaptureSession {
         base: { kind: 'feature', id: base.id },
       },
       metadata: { pattern },
+    });
+  }
+
+  assemblyPart(assemblyName: string, partName: string, shape: Shape, opts: AssemblyPartOpts = {}): FeatureRecord {
+    if (!this.records.some(r => r.id === shape.id)) {
+      throw new Error(`assembly.part: shape '${shape.id}' is not from this CaptureSession`);
+    }
+    return this.register({
+      kind: 'assemblyPart',
+      params: {},
+      inputs: {
+        shape: { kind: 'feature', id: shape.id },
+      },
+      metadata: {
+        assemblyName,
+        partName,
+        ...(opts.at !== undefined ? { at: opts.at } : {}),
+      },
+    });
+  }
+
+  assemblyJoint(
+    assemblyName: string,
+    jointName: string,
+    jointKind: 'revolute',
+    a: AssemblyPartRef,
+    b: AssemblyPartRef,
+    opts: RevoluteJointOpts,
+  ): FeatureRecord {
+    for (const part of [a, b]) {
+      const record = this.records.find(r => r.id === part.id);
+      if (!record || record.kind !== 'assemblyPart') {
+        throw new Error(`assembly.${jointKind}: part '${part.id}' is not an assembly part in this CaptureSession`);
+      }
+    }
+    return this.register({
+      kind: 'assemblyJoint',
+      params: {},
+      inputs: {
+        a: { kind: 'feature', id: a.id },
+        b: { kind: 'feature', id: b.id },
+      },
+      metadata: {
+        assemblyName,
+        jointName,
+        jointKind,
+        axis: opts.axis,
+        origin: opts.origin,
+        ...(opts.limitsDeg !== undefined ? { limitsDeg: opts.limitsDeg } : {}),
+      },
     });
   }
 

--- a/src/mcp/tools/listApi.ts
+++ b/src/mcp/tools/listApi.ts
@@ -60,6 +60,7 @@ export const GLOBALS: ApiEntry[] = [
   { name: 'param', signature: "(name, defaultValue, meta?) => ParamRef", description: 'Declare a symbolic editable parameter. Returns a ParamRef the chain ops accept anywhere a number is expected. Edit post-build via `kcad.params.update`. `meta?: { min?, max?, description? }`.' },
   { name: 'params', signature: "(decl) => { [name]: ParamRef }", description: 'Batched form of `param()` — declare many params at once. Returns an object of ParamRefs keyed by name.' },
   { name: 'union', signature: '(...shapes) => Shape', description: 'Boolean union of two or more shapes.' },
+  { name: 'assembly', signature: '(name?) => Assembly', description: 'Start an inspectable mechanical assembly. Use `.part(name, shape, { at? })` to wrap modeled solids and `.revolute(name, a, b, { axis, origin, limitsDeg? })` to capture joint intent. v0.6 records are executable geometry pass-throughs; full kinematic solving is not implied.' },
   { name: 'helix', signature: '({ radius, pitch, turns, axis?, pointsPerTurn?, startAngle? }) => [number, number, number][]', description: 'Polyline helix rail for `Sketch.sweep`. Default axis Z, 32 points per turn.' },
   { name: 'selectEdges', signature: '(shape, query?) => Promise<EdgeSegment[]>', description: 'Pre-select edges by EdgeQuery. Awaitable; lowers the shape lazily.' },
   { name: 'selectEdge', signature: '(shape, query) => Promise<EdgeSegment>', description: 'Like selectEdges but throws if zero or multiple edges match. Use for unambiguous single-edge selection.' },

--- a/src/modules/api.ts
+++ b/src/modules/api.ts
@@ -1,5 +1,6 @@
 import type { CaptureSession } from '../capture/captureSession';
 import { validateFaceLabels } from '../capture/faceLabels';
+import { makeAssembly, type Assembly } from '../capture/assembly';
 import { Shape } from '../capture/proxy';
 import { makePath, type PathBuilder } from '../capture/sketch';
 import type { Param } from '../intent/types';
@@ -34,6 +35,7 @@ export interface KernelCadApi {
   extrudeRoundedRect(width: Editable<number>, height: Editable<number>, radius: Editable<number>, depth: Editable<number>, opts?: FaceLabelOpts): Shape;
   revolveRect(w: Editable<number>, h: Editable<number>, offsetX: Editable<number>, angleDeg?: Editable<number>, opts?: FaceLabelOpts): Shape;
   union(...shapes: Shape[]): Shape;
+  assembly(name?: string): Assembly;
 
   // Slice-3 symbolic params (replaces slice-1's number-returning param()).
   // See spec §E.1, §E.2.
@@ -154,6 +156,9 @@ export function createApi(ctx: ApiContext): KernelCadApi {
       if (shapes.length < 2) throw new Error('union() requires at least 2 shapes');
       const [first, ...rest] = shapes;
       return first.union(...rest);
+    },
+    assembly(name) {
+      return makeAssembly(name, session);
     },
     param(name, defaultValue, meta) {
       // Prevent re-wrapping if the agent accidentally passes a ParamRef

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -66,6 +66,10 @@ path(): PathBuilder;
 // Boolean union of two or more shapes (top-level alternative to .union()).
 union(...shapes: Shape[]): Shape;
 
+// Inspectable mechanical assembly intent. Captures parts and joints as records;
+// v0.6 assembly records lower as geometry pass-throughs, not as a kinematic solver.
+assembly(name?: string): Assembly;
+
 // Polyline helix rail for Sketch.sweep.
 helix({ radius, pitch, turns, axis?, pointsPerTurn?, startAngle? }): [number, number, number][];
 
@@ -116,6 +120,33 @@ selectEdge(shape: Shape, query: EdgeQuery): Promise<EdgeSegment>;  // throws if 
 `EdgeSelector = EdgeQuery | EdgeSegment[] | { face: string | FaceQuery } | undefined`
 `FaceSelector = CanonicalFace | string (label) | FaceQuery`
 `CanonicalFace = 'top' | 'bottom' | 'left' | 'right' | 'front' | 'back'`
+
+### Assembly intent
+
+Use `assembly()` when the model needs named mechanical parts and joint metadata that a human or agent can inspect later. Keep returning/exporting real Shape geometry separately; assembly records are part/joint intent, not a full motion solve yet.
+
+```typescript
+const arm = assembly('two-link arm');
+const base = arm.part('base', box(30, 30, 8), { at: [0, 0, 0] });
+const link = arm.part('link', box(80, 12, 8), { at: [0, 0, 8] });
+
+arm.revolute('shoulder', base, link, {
+  axis: [0, 0, 1],
+  origin: [0, 0, 8],
+  limitsDeg: [-90, 90],
+});
+```
+
+```typescript
+interface Assembly {
+  part(name: string, shape: Shape, opts?: { at?: [number, number, number] }): AssemblyPartRef;
+  revolute(name: string, a: AssemblyPartRef, b: AssemblyPartRef, opts: {
+    axis: [number, number, number];
+    origin: [number, number, number];
+    limitsDeg?: [number, number];
+  }): AssemblyJointRef;
+}
+```
 
 ### Sketch methods
 

--- a/tests/unit/assemblies/assemblyCapture.test.ts
+++ b/tests/unit/assemblies/assemblyCapture.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { CaptureSession } from '../../../src/capture/captureSession';
+import { createApi } from '../../../src/modules/api';
+
+describe('assembly capture contract', () => {
+  it('captures named parts and a revolute joint as inspectable intent records', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+
+    const arm = kcad.assembly('two-link arm');
+    const baseShape = kcad.box(30, 30, 8);
+    const linkShape = kcad.box(80, 12, 8).translate(40, 0, 8);
+
+    const base = arm.part('base', baseShape, { at: [0, 0, 0] });
+    const link = arm.part('link', linkShape, { at: [0, 0, 8] });
+    const shoulder = arm.revolute('shoulder', base, link, {
+      axis: [0, 0, 1],
+      origin: [0, 0, 8],
+      limitsDeg: [-90, 90],
+    });
+
+    expect(base.id).toMatch(/^assemblyPart_/);
+    expect(link.id).toMatch(/^assemblyPart_/);
+    expect(shoulder.id).toMatch(/^assemblyJoint_/);
+
+    const records = session.getRecords();
+    expect(records.find(r => r.id === base.id)).toMatchObject({
+      kind: 'assemblyPart',
+      inputs: { shape: { kind: 'feature', id: baseShape.id } },
+      metadata: {
+        assemblyName: 'two-link arm',
+        partName: 'base',
+        at: [0, 0, 0],
+      },
+    });
+    expect(records.find(r => r.id === link.id)).toMatchObject({
+      kind: 'assemblyPart',
+      inputs: { shape: { kind: 'feature', id: linkShape.id } },
+      metadata: {
+        assemblyName: 'two-link arm',
+        partName: 'link',
+        at: [0, 0, 8],
+      },
+    });
+    expect(records.find(r => r.id === shoulder.id)).toMatchObject({
+      kind: 'assemblyJoint',
+      inputs: {
+        a: { kind: 'feature', id: base.id },
+        b: { kind: 'feature', id: link.id },
+      },
+      metadata: {
+        assemblyName: 'two-link arm',
+        jointName: 'shoulder',
+        jointKind: 'revolute',
+        axis: [0, 0, 1],
+        origin: [0, 0, 8],
+        limitsDeg: [-90, 90],
+      },
+    });
+  });
+
+  it('rejects invalid revolute joint axes before capture', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('invalid joint');
+    const a = arm.part('a', kcad.box(10, 10, 10));
+    const b = arm.part('b', kcad.box(10, 10, 10));
+
+    expect(() => arm.revolute('bad', a, b, {
+      axis: [0, Number.NaN, 1],
+      origin: [0, 0, 0],
+    })).toThrow(/revolute joint axis must be a finite Vec3/);
+  });
+});

--- a/tests/unit/backends/occt/assemblyLowerer.test.ts
+++ b/tests/unit/backends/occt/assemblyLowerer.test.ts
@@ -1,0 +1,31 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { CaptureSession } from '../../../../src/capture/captureSession';
+import { RecomputeEngine } from '../../../../src/compute/recomputeEngine';
+import { OcctLowerer } from '../../../../src/backends/occt/occtLowerer';
+import { initOcct } from '../../../../src/backends/occt/occtBackend';
+import { createApi } from '../../../../src/modules/api';
+
+describe('OCCT assembly lowerer', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('keeps assembly part and joint records executable as geometry passthroughs', async () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('two-link arm');
+    const base = arm.part('base', kcad.box(20, 20, 6), { at: [0, 0, 0] });
+    const link = arm.part('link', kcad.box(80, 10, 6), { at: [30, 0, 6] });
+    const shoulder = arm.revolute('shoulder', base, link, {
+      axis: [0, 0, 1],
+      origin: [0, 0, 6],
+      limitsDeg: [-90, 90],
+    });
+
+    const result = await new RecomputeEngine(new OcctLowerer()).run(session.getRecords());
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.shapes.get(base.id)).toBeDefined();
+    expect(result.shapes.get(link.id)).toBeDefined();
+    expect(result.shapes.get(shoulder.id)).toBeDefined();
+    expect(result.shapes.get(link.id)?.boundingBox().min[0]).toBeGreaterThan(20);
+  });
+});


### PR DESCRIPTION
## Summary
- add top-level assembly(name) API with named part and revolute joint capture
- lower assembly part/joint records as executable geometry pass-throughs while preserving intent metadata
- advertise the assembly workflow through list_api and SKILL.md, with a focused proof script

## Verification
- npm run proof:assembly-contract
- npm run lint
- npm test (fails only before CLI bundle exists: tests/integration/cli-bundle/startup.test.ts expects dist/cli/index.js)
- npm run build:cli && npm test -- tests/integration/cli-bundle/startup.test.ts