### PR TITLE
fix(release): guard npm package build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "npm": ">=10.0.0"
   },
   "bin": {
-    "kernelcad": "./dist/cli/index.js"
+    "kernelcad": "dist/cli/index.js"
   },
   "files": [
     "dist/cli",
@@ -27,9 +27,11 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "release": "npx tsx scripts/release.ts",
+    "prepack": "npm run build:cli",
     "test": "NODE_OPTIONS='--max-old-space-size=8192' vitest run",
     "test:audit": "npx tsx scripts/testQualityAudit.ts",
-    "proof:foundation": "npm run typecheck && npm run test:audit && npm test -- src/lib/constraints/solver.test.ts src/lib/constraints/advanced_constraints.test.ts tests/integration/diagnostics/hint-mandatory.test.ts scripts/lib/whatsNewTemplate.test.ts tests/integration/mcp/listApi.driftSentinel.test.ts tests/unit/skill/skillShapeMethodsDrift.test.ts tests/unit/patterns/patternCapture.test.ts tests/unit/backends/occt/patternLowerer.test.ts",
+    "test:package": "npx tsx scripts/packageReleaseAudit.ts",
+    "proof:foundation": "npm run typecheck && npm run test:audit && npm run test:package && npm test -- src/lib/constraints/solver.test.ts src/lib/constraints/advanced_constraints.test.ts tests/integration/diagnostics/hint-mandatory.test.ts scripts/lib/whatsNewTemplate.test.ts tests/integration/mcp/listApi.driftSentinel.test.ts tests/unit/skill/skillShapeMethodsDrift.test.ts tests/unit/patterns/patternCapture.test.ts tests/unit/backends/occt/patternLowerer.test.ts",
     "proof:assembly-contract": "npm run proof:foundation && npm test -- tests/unit/assemblies/assemblyCapture.test.ts tests/unit/backends/occt/assemblyLowerer.test.ts tests/unit/skill/skillGlobalsDrift.test.ts",
     "test:e2e": "playwright test",
     "site:dev": "npx tsx site/scripts/build-demo.ts && cd site && for f in public/*; do ln -sf \"$f\" \"$(basename \"$f\")\"; done && python3 -m http.server 8000",

--- a/scripts/packageReleaseAudit.test.ts
+++ b/scripts/packageReleaseAudit.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { auditPackageJsonText, formatPackageAuditReport } from './packageReleaseAudit';
+
+describe('packageReleaseAudit', () => {
+  it('requires prepack to build the CLI bundle before npm pack or publish', () => {
+    const result = auditPackageJsonText(JSON.stringify({
+      bin: { kernelcad: 'dist/cli/index.js' },
+      files: ['dist/cli', 'README.md', 'LICENSE'],
+      scripts: {},
+    }));
+
+    expect(result.blockers).toContainEqual({
+      kind: 'missing-prepack-build',
+      message: 'package.json scripts.prepack must run npm run build:cli',
+    });
+    expect(formatPackageAuditReport(result)).toContain('missing-prepack-build');
+  });
+
+  it('accepts a package that builds the CLI and includes the bin path', () => {
+    const result = auditPackageJsonText(JSON.stringify({
+      bin: { kernelcad: 'dist/cli/index.js' },
+      files: ['dist/cli', 'README.md', 'LICENSE'],
+      scripts: { prepack: 'npm run build:cli' },
+    }));
+
+    expect(result.blockers).toEqual([]);
+  });
+});

--- a/scripts/packageReleaseAudit.ts
+++ b/scripts/packageReleaseAudit.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+export type PackageAuditKind = 'missing-prepack-build' | 'missing-bin-file-entry';
+
+export interface PackageAuditFinding {
+  kind: PackageAuditKind;
+  message: string;
+}
+
+export interface PackageAuditResult {
+  blockers: PackageAuditFinding[];
+}
+
+interface PackageJsonShape {
+  bin?: Record<string, string> | string;
+  files?: string[];
+  scripts?: Record<string, string>;
+}
+
+function binPaths(pkg: PackageJsonShape): string[] {
+  if (typeof pkg.bin === 'string') return [pkg.bin];
+  if (pkg.bin && typeof pkg.bin === 'object') return Object.values(pkg.bin);
+  return [];
+}
+
+function fileEntryIncludesPath(files: string[], path: string): boolean {
+  const normalizedPath = path.replace(/^\.\//, '');
+  return files.some(entry => {
+    const normalizedEntry = entry.replace(/^\.\//, '').replace(/\/$/, '');
+    return normalizedPath === normalizedEntry || normalizedPath.startsWith(`${normalizedEntry}/`);
+  });
+}
+
+export function auditPackageJsonText(text: string): PackageAuditResult {
+  const pkg = JSON.parse(text) as PackageJsonShape;
+  const blockers: PackageAuditFinding[] = [];
+
+  if (pkg.scripts?.prepack !== 'npm run build:cli') {
+    blockers.push({
+      kind: 'missing-prepack-build',
+      message: 'package.json scripts.prepack must run npm run build:cli',
+    });
+  }
+
+  const files = pkg.files ?? [];
+  for (const binPath of binPaths(pkg)) {
+    if (!fileEntryIncludesPath(files, binPath)) {
+      blockers.push({
+        kind: 'missing-bin-file-entry',
+        message: `package.json files must include bin path ${binPath}`,
+      });
+    }
+  }
+
+  return { blockers };
+}
+
+export function formatPackageAuditReport(result: PackageAuditResult): string {
+  return result.blockers.map(finding => `${finding.kind}: ${finding.message}`).join('\n');
+}
+
+function main(): void {
+  const result = auditPackageJsonText(readFileSync('package.json', 'utf8'));
+  const report = formatPackageAuditReport(result);
+  if (report) console.error(report);
+  if (result.blockers.length > 0) {
+    process.exit(1);
+  }
+}
+
+const invoked = process.argv[1] === fileURLToPath(import.meta.url);
+if (invoked) main();


### PR DESCRIPTION
## Summary
- add a package release audit that blocks package configs where npm pack/publish would omit the CLI bundle
- wire npm prepack to run build:cli so clean checkout packaging includes dist/cli
- include the package audit in proof:foundation

## Verification
- npm test -- scripts/packageReleaseAudit.test.ts
- npm run test:package
- npm pack --dry-run --json
- npm run proof:foundation