### PR TITLE
feat(patterns): add grid pattern arrays

### DIFF
--- a/examples/patterns/servo-vented-plate.kcad.ts
+++ b/examples/patterns/servo-vented-plate.kcad.ts
@@ -1,0 +1,24 @@
+// Mechanical-core pattern example: a small servo mounting plate.
+//
+// The base plate uses feature-level holes for named bore refs, then adds a
+// grid-patterned vent insert as one editable repeated-feature record.
+
+const plate = box(70, 42, 4)
+  .holes('top', {
+    positions: [
+      { u: -27, v: -14 }, { u: 27, v: -14 },
+      { u: -27, v: 14 }, { u: 27, v: 14 },
+    ],
+    diameter: 3.2,
+    depth: 'through',
+    name: 'servoMounts',
+  });
+
+const ventBar = box(3, 18, 1.2)
+  .patternGrid({
+    x: { count: 5, direction: [1, 0, 0], spacing: 7 },
+    y: { count: 2, direction: [0, 1, 0], spacing: 11 },
+  })
+  .translate(-14, -5.5, 2.6);
+
+return plate.union(ventBar);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:audit": "npx tsx scripts/testQualityAudit.ts",
     "test:hygiene": "npm test -- scripts/repoHygieneAudit.test.ts",
     "test:package": "npx tsx scripts/packageReleaseAudit.ts",
-    "proof:foundation": "npm run typecheck && npm run test:audit && npm run test:hygiene && npm run test:package && npm test -- src/lib/constraints/solver.test.ts src/lib/constraints/advanced_constraints.test.ts tests/integration/diagnostics/hint-mandatory.test.ts scripts/lib/whatsNewTemplate.test.ts tests/integration/mcp/listApi.driftSentinel.test.ts tests/unit/skill/skillShapeMethodsDrift.test.ts tests/unit/patterns/patternCapture.test.ts tests/unit/backends/occt/patternLowerer.test.ts",
+    "proof:foundation": "npm run typecheck && npm run test:audit && npm run test:hygiene && npm run test:package && npm test -- src/lib/constraints/solver.test.ts src/lib/constraints/advanced_constraints.test.ts tests/integration/diagnostics/hint-mandatory.test.ts scripts/lib/whatsNewTemplate.test.ts tests/integration/mcp/listApi.driftSentinel.test.ts tests/unit/skill/skillShapeMethodsDrift.test.ts tests/unit/patterns/patternCapture.test.ts tests/unit/backends/occt/patternLowerer.test.ts tests/integration/examples/patternExamples.test.ts",
     "proof:assembly-contract": "npm run proof:foundation && npm test -- tests/unit/assemblies/assemblyCapture.test.ts tests/unit/backends/occt/assemblyLowerer.test.ts tests/unit/skill/skillGlobalsDrift.test.ts",
     "test:e2e": "playwright test",
     "site:dev": "npx tsx site/scripts/build-demo.ts && cd site && for f in public/*; do ln -sf \"$f\" \"$(basename \"$f\")\"; done && python3 -m http.server 8000",

--- a/src/backends/occt/occtLowerer.ts
+++ b/src/backends/occt/occtLowerer.ts
@@ -1144,6 +1144,21 @@ export class OcctLowerer implements FeatureLowerer {
         }
 
         shape = base.clone();
+        if (pattern.kind === 'grid') {
+          for (let x = 0; x < pattern.x.count; x++) {
+            for (let y = 0; y < pattern.y.count; y++) {
+              if (x === 0 && y === 0) continue;
+              const instance = base.clone().translate(
+                pattern.x.direction[0] * pattern.x.spacing * x + pattern.y.direction[0] * pattern.y.spacing * y,
+                pattern.x.direction[1] * pattern.x.spacing * x + pattern.y.direction[1] * pattern.y.spacing * y,
+                pattern.x.direction[2] * pattern.x.spacing * x + pattern.y.direction[2] * pattern.y.spacing * y,
+              );
+              shape = shape.union(instance);
+            }
+          }
+          break;
+        }
+
         for (let i = 1; i < pattern.count; i++) {
           let instance: OcctBackend;
           if (pattern.kind === 'linear') {

--- a/src/capture/proxy.ts
+++ b/src/capture/proxy.ts
@@ -178,6 +178,20 @@ export class Shape {
     return this.session.patternFeature(this, pattern);
   }
 
+  patternGrid(opts: {
+    x: { count: number; direction: [number, number, number]; spacing: number };
+    y: { count: number; direction: [number, number, number]; spacing: number };
+  }): Shape {
+    validateGridPatternAxis('patternGrid.x', opts.x, this.id);
+    validateGridPatternAxis('patternGrid.y', opts.y, this.id);
+    const pattern: PatternSpec = {
+      kind: 'grid',
+      x: opts.x,
+      y: opts.y,
+    };
+    return this.session.patternFeature(this, pattern);
+  }
+
   patternCircular(opts: { count: number; axis: [number, number, number]; angleDeg?: number }): Shape {
     if (!Number.isInteger(opts.count) || opts.count < 2) {
       throw new KernelError(
@@ -420,6 +434,37 @@ export class Shape {
     this._loweredAtRecordCount = records.length;
     this._loweredAtTransformCount = transformCount;
     return shape;
+  }
+}
+
+function validateGridPatternAxis(
+  label: 'patternGrid.x' | 'patternGrid.y',
+  axis: { count: number; direction: [number, number, number]; spacing: number },
+  featureId: FeatureId,
+): void {
+  if (!Number.isInteger(axis.count) || axis.count < 2) {
+    throw new KernelError(
+      'feature.invalid-args',
+      `${label} count must be an integer >= 2.`,
+      featureId,
+      'Pass count: 2 or greater for both grid axes.',
+    );
+  }
+  if (!isValidVec3(axis.direction)) {
+    throw new KernelError(
+      'feature.invalid-args',
+      `${label} direction must be a finite Vec3; got ${formatScalarForError(axis.direction)}.`,
+      featureId,
+      'Pass direction: [x, y, z] for both grid axes.',
+    );
+  }
+  if (typeof axis.spacing !== 'number' || !Number.isFinite(axis.spacing) || axis.spacing === 0) {
+    throw new KernelError(
+      'feature.invalid-args',
+      `${label} spacing must be a non-zero finite number; got ${formatScalarForError(axis.spacing)}.`,
+      featureId,
+      'Pass a non-zero finite spacing for both grid axes.',
+    );
   }
 }
 

--- a/src/intent/types.ts
+++ b/src/intent/types.ts
@@ -123,6 +123,18 @@ export interface LinearPatternSpec {
   spacing: number;
 }
 
+export interface GridPatternAxisSpec {
+  count: number;
+  direction: Vec3;
+  spacing: number;
+}
+
+export interface GridPatternSpec {
+  kind: 'grid';
+  x: GridPatternAxisSpec;
+  y: GridPatternAxisSpec;
+}
+
 export interface CircularPatternSpec {
   kind: 'circular';
   count: number;
@@ -130,7 +142,7 @@ export interface CircularPatternSpec {
   angleDeg: number;
 }
 
-export type PatternSpec = LinearPatternSpec | CircularPatternSpec;
+export type PatternSpec = LinearPatternSpec | CircularPatternSpec | GridPatternSpec;
 
 /**
  * Format a scalar value for inclusion in an error message.

--- a/src/mcp/tools/listApi.ts
+++ b/src/mcp/tools/listApi.ts
@@ -82,6 +82,7 @@ export const SHAPE_METHODS: ApiEntry[] = [
   { name: 'reflect', signature: `(plane: 'xy' | 'xz' | 'yz' | { plane: 'xy' | 'xz' | 'yz'; offset: number }) => Shape`, description: 'Reflect (pure rigid-body transformation) across a cardinal plane or an offset parallel plane. Volume is unchanged; handedness is flipped.' },
   { name: 'mirror', signature: `(plane: 'xy' | 'xz' | 'yz' | { plane: 'xy' | 'xz' | 'yz'; offset: number }) => Shape`, description: 'Boolean union of the source and its reflection across a cardinal plane. Produces a symmetric part. For pure reflection without union, use reflect().' },
   { name: 'patternLinear', signature: '({ count, direction, spacing }) => Shape', description: 'Repeat this shape in a linear array. `count` is >= 2, `direction` is a Vec3, and `spacing` is the distance between instances.' },
+  { name: 'patternGrid', signature: '({ x: { count, direction, spacing }, y: { count, direction, spacing } }) => Shape', description: 'Repeat this shape in a two-axis grid. Each axis count is >= 2; directions are Vec3s and spacing is the distance between neighbors on that axis.' },
   { name: 'patternCircular', signature: '({ count, axis, angleDeg? }) => Shape', description: 'Repeat this shape around an axis. `count` is >= 2 and `angleDeg` defaults to 360 degrees.' },
   { name: 'lower', signature: '() => Promise<OcctBackend>', description: 'Eagerly lower this Shape for inspection. Used internally by selectEdges; agents rarely call directly.' },
 ];

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -111,6 +111,7 @@ selectEdge(shape: Shape, query: EdgeQuery): Promise<EdgeSegment>;  // throws if 
 
 // Mechanical patterns:
 .patternLinear({ count, direction, spacing }: { count: number; direction: [number, number, number]; spacing: number }): Shape
+.patternGrid({ x, y }: { x: { count: number; direction: [number, number, number]; spacing: number }; y: { count: number; direction: [number, number, number]; spacing: number } }): Shape
 .patternCircular({ count, axis, angleDeg? }: { count: number; axis: [number, number, number]; angleDeg?: number }): Shape
 
 // Eager lowering (for inspection; rarely called by agents directly):

--- a/tests/integration/examples/patternExamples.test.ts
+++ b/tests/integration/examples/patternExamples.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateScript } from '../../../src/cli/commands/evaluate';
+
+describe('pattern examples', () => {
+  it('evaluates the servo vented plate grid-pattern example', async () => {
+    const result = await evaluateScript({ file: 'examples/patterns/servo-vented-plate.kcad.ts' });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.featureCount).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/tests/unit/backends/occt/patternLowerer.test.ts
+++ b/tests/unit/backends/occt/patternLowerer.test.ts
@@ -22,4 +22,39 @@ describe('OCCT pattern lowerer', () => {
     const bbox = pattern.boundingBox();
     expect(bbox.max[0] - bbox.min[0]).toBeGreaterThan(9);
   });
+
+  it('lowers a circular pattern into a fused repeated solid around an axis', async () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    kcad.box(2, 2, 2).translate(6, 0, 0).patternCircular({ count: 4, axis: [0, 0, 1] });
+
+    const result = await new RecomputeEngine(new OcctLowerer()).run(session.getRecords());
+
+    expect(result.diagnostics).toEqual([]);
+    const pattern = result.shapes.get('pattern_1');
+    expect(pattern).toBeDefined();
+    if (!pattern) throw new Error('pattern did not lower');
+    const bbox = pattern.boundingBox();
+    expect(bbox.max[0] - bbox.min[0]).toBeGreaterThan(12);
+    expect(bbox.max[1] - bbox.min[1]).toBeGreaterThan(12);
+  });
+
+  it('lowers a grid pattern into a fused 2D repeated solid', async () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    kcad.box(2, 2, 2).patternGrid({
+      x: { count: 3, direction: [1, 0, 0], spacing: 4 },
+      y: { count: 2, direction: [0, 1, 0], spacing: 5 },
+    });
+
+    const result = await new RecomputeEngine(new OcctLowerer()).run(session.getRecords());
+
+    expect(result.diagnostics).toEqual([]);
+    const pattern = result.shapes.get('pattern_1');
+    expect(pattern).toBeDefined();
+    if (!pattern) throw new Error('pattern did not lower');
+    const bbox = pattern.boundingBox();
+    expect(bbox.max[0] - bbox.min[0]).toBeGreaterThan(9);
+    expect(bbox.max[1] - bbox.min[1]).toBeGreaterThan(6);
+  });
 });

--- a/tests/unit/patterns/patternCapture.test.ts
+++ b/tests/unit/patterns/patternCapture.test.ts
@@ -34,4 +34,79 @@ describe('pattern capture contract', () => {
     expect(() => base.patternLinear({ count: 1, direction: [1, 0, 0], spacing: 12 }))
       .toThrow(/count must be an integer >= 2/);
   });
+
+  it('captures a circular pattern as one feature with axis metadata', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+
+    const base = kcad.cylinder(2, 1).translate(10, 0, 0);
+    const pattern = base.patternCircular({ count: 6, axis: [0, 0, 1], angleDeg: 180 });
+
+    const records = session.getRecords();
+    expect(pattern.id).toMatch(/^pattern_/);
+    expect(records.at(-1)).toMatchObject({
+      kind: 'pattern',
+      inputs: { base: { kind: 'feature', id: base.id } },
+      metadata: {
+        pattern: {
+          kind: 'circular',
+          count: 6,
+          axis: [0, 0, 1],
+          angleDeg: 180,
+        },
+      },
+    });
+  });
+
+  it('captures a grid pattern as one feature with x/y axes and counts', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+
+    const base = kcad.box(6, 3, 2);
+    const pattern = base.patternGrid({
+      x: { count: 3, direction: [1, 0, 0], spacing: 10 },
+      y: { count: 2, direction: [0, 1, 0], spacing: 8 },
+    });
+
+    const records = session.getRecords();
+    expect(pattern.id).toMatch(/^pattern_/);
+    expect(records.at(-1)).toMatchObject({
+      kind: 'pattern',
+      inputs: { base: { kind: 'feature', id: base.id } },
+      metadata: {
+        pattern: {
+          kind: 'grid',
+          x: { count: 3, direction: [1, 0, 0], spacing: 10 },
+          y: { count: 2, direction: [0, 1, 0], spacing: 8 },
+        },
+      },
+    });
+  });
+
+  it('rejects invalid grid axis counts before capture', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const base = kcad.box(10, 5, 2);
+
+    expect(() => base.patternGrid({
+      x: { count: 1, direction: [1, 0, 0], spacing: 10 },
+      y: { count: 2, direction: [0, 1, 0], spacing: 8 },
+    })).toThrow(/patternGrid.x count must be an integer >= 2/);
+  });
+
+  it('rejects invalid grid directions and spacing before capture', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const base = kcad.box(10, 5, 2);
+
+    expect(() => base.patternGrid({
+      x: { count: 2, direction: [1, 0, Number.NaN], spacing: 10 },
+      y: { count: 2, direction: [0, 1, 0], spacing: 8 },
+    })).toThrow(/patternGrid.x direction must be a finite Vec3/);
+
+    expect(() => base.patternGrid({
+      x: { count: 2, direction: [1, 0, 0], spacing: 10 },
+      y: { count: 2, direction: [0, 1, 0], spacing: 0 },
+    })).toThrow(/patternGrid.y spacing must be a non-zero finite number/);
+  });
 });


### PR DESCRIPTION
## Summary
- add `shape.patternGrid({ x, y })` using the existing captured `pattern` feature kind
- lower grid patterns to fused OCCT solids across two translation axes
- expose the method through `list_api`, `SKILL.md`, and drift-protected tests
- add a servo vented plate example that evaluates through the CLI path

## Verification
- `source ~/.nvm/nvm.sh && nvm use 22.22.0 >/dev/null && npm test -- tests/unit/patterns/patternCapture.test.ts tests/unit/backends/occt/patternLowerer.test.ts tests/integration/examples/patternExamples.test.ts tests/integration/mcp/listApi.driftSentinel.test.ts tests/unit/skill/skillShapeMethodsDrift.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 22.22.0 >/dev/null && npm run proof:foundation`

## Notes
This is the next mechanical-core slice: linear/circular patterns were already present on develop; this finishes the grid array path and protects it with an executable mechanical example.