### PR TITLE
feat(mcp): add assembly inspection tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ npm run dev
 - Added v0.6 assembly connector frames: parts can declare named local connector
   origins, place a new part by aligning one connector to another, and capture
   fixed `assemblyConnect` records for later agent inspection.
+- Added MCP `list_assemblies` so agents can query captured assembly parts,
+  connector frames, fixed connections, joints, and aggregate models from a
+  `.kcad.ts` script.
 - Added a focused foundation proof script covering typecheck, test-quality
   audit, constraints, diagnostics, release-note template checks, MCP API drift,
   and pattern capture/lowering behavior.

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -2,6 +2,7 @@
 export { createMcpServer } from './server';
 export { evaluateScriptTool, type EvaluateScriptInput, type EvaluateScriptOutput } from './tools/evaluateScript';
 export { listFeaturesTool, type ListFeaturesInput, type ListFeaturesOutput } from './tools/listFeatures';
+export { listAssembliesTool, type ListAssembliesInput, type ListAssembliesOutput } from './tools/listAssemblies';
 export { getShapeInfoTool, type GetShapeInfoInput, type GetShapeInfoOutput } from './tools/getShapeInfo';
 export { listTopologyTool, type ListTopologyInput, type ListTopologyOutput } from './tools/listTopology';
 export { getEdgesOfTool, type GetEdgesOfInput, type GetEdgesOfOutput } from './tools/getEdgesOf';

--- a/src/mcp/toolRegistry.ts
+++ b/src/mcp/toolRegistry.ts
@@ -8,6 +8,7 @@ import { listApiTool } from './tools/listApi';
 import { listDiagnosticCodesTool } from './tools/listDiagnosticCodes';
 import { listEdgesTool } from './tools/listEdges';
 import { listFaceLabelsTool } from './tools/listFaceLabels';
+import { listAssembliesTool } from './tools/listAssemblies';
 import { listFacesTool } from './tools/listFaces';
 import { listFeaturesTool } from './tools/listFeatures';
 import { listTopologyTool } from './tools/listTopology';
@@ -67,6 +68,22 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
       },
     },
     handler: input => listFeaturesTool(input as Parameters<typeof listFeaturesTool>[0]),
+  },
+  {
+    definition: {
+      name: 'list_assemblies',
+      description:
+        'List assembly intent captured by a kernelCAD script: assemblies, parts, named connectors, ' +
+        'fixed connections, joints, and aggregate assembly models. Pass either { file } or { code }.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          file: { type: 'string', description: 'Path to a .kcad.ts script file.' },
+          code: { type: 'string', description: 'Inline kernelCAD script source.' },
+        },
+      },
+    },
+    handler: input => listAssembliesTool(input as Parameters<typeof listAssembliesTool>[0]),
   },
   {
     definition: {

--- a/src/mcp/tools/listAssemblies.ts
+++ b/src/mcp/tools/listAssemblies.ts
@@ -1,0 +1,204 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { initOcct } from '../../backends/occt/occtBackend';
+import type { FeatureRecord } from '../../intent/featureRecord';
+import type { FeatureId, FeatureRef } from '../../intent/types';
+import { kernelErrorToDiagnostic } from '../../script-runtime/kernelErrorToDiagnostic';
+import { runScript } from '../../script-runtime/runScript';
+
+export interface ListAssembliesInput {
+  file?: string;
+  code?: string;
+}
+
+export interface AssemblyPartSummary {
+  id: FeatureId;
+  name: string;
+  shapeId?: FeatureId;
+  at?: unknown;
+  connectors: Record<string, unknown>;
+  placedBy?: unknown;
+}
+
+export interface AssemblyJointSummary {
+  id: FeatureId;
+  name: string;
+  kind: string;
+  partIds: { a?: FeatureId; b?: FeatureId };
+  axis?: unknown;
+  origin?: unknown;
+  limitsDeg?: unknown;
+}
+
+export interface AssemblyConnectionSummary {
+  id: FeatureId;
+  name: string;
+  kind: string;
+  partIds: { a?: FeatureId; b?: FeatureId };
+  a?: unknown;
+  b?: unknown;
+}
+
+export interface AssemblyModelSummary {
+  id: FeatureId;
+  partIds: FeatureId[];
+}
+
+export interface AssemblySummary {
+  name: string;
+  parts: AssemblyPartSummary[];
+  joints: AssemblyJointSummary[];
+  connections: AssemblyConnectionSummary[];
+  models: AssemblyModelSummary[];
+}
+
+export interface ListAssembliesOutput {
+  ok?: boolean;
+  assemblies: AssemblySummary[];
+  error?: string;
+  errorCode?: string;
+}
+
+export async function listAssembliesTool(
+  input: ListAssembliesInput,
+): Promise<ListAssembliesOutput> {
+  await initOcct();
+  let code: string;
+  let fileName: string;
+
+  if (input.code !== undefined) {
+    code = input.code;
+    fileName = input.file ?? '<inline>';
+  } else if (input.file !== undefined) {
+    const filePath = resolve(input.file);
+    fileName = filePath;
+    try {
+      code = await readFile(filePath, 'utf8');
+    } catch (e) {
+      return {
+        ok: false,
+        assemblies: [],
+        error: `Cannot read file: ${e instanceof Error ? e.message : String(e)}`,
+      };
+    }
+  } else {
+    return { ok: false, assemblies: [], error: 'Must provide either { file } or { code }.' };
+  }
+
+  let run;
+  try {
+    run = await runScript({ code, fileName });
+  } catch (e) {
+    const diag = kernelErrorToDiagnostic(e);
+    return { ok: false, assemblies: [], error: diag.message, errorCode: diag.code };
+  }
+
+  return { assemblies: summarizeAssemblies(run.records) };
+}
+
+function summarizeAssemblies(records: readonly FeatureRecord[]): AssemblySummary[] {
+  const assemblies = new Map<string, AssemblySummary>();
+
+  for (const record of records) {
+    if (!isAssemblyRecord(record)) continue;
+    const metadata = record.metadata ?? {};
+    const assemblyName = typeof metadata.assemblyName === 'string'
+      ? metadata.assemblyName
+      : 'assembly';
+    const assembly = getOrCreateAssembly(assemblies, assemblyName);
+
+    if (record.kind === 'assemblyPart') {
+      assembly.parts.push({
+        id: record.id,
+        name: stringMetadata(metadata.partName, record.id),
+        shapeId: featureInputId(record.inputs.shape),
+        at: metadata.at,
+        connectors: objectMetadata(metadata.connectors),
+        ...(metadata.placedBy !== undefined ? { placedBy: metadata.placedBy } : {}),
+      });
+    }
+
+    if (record.kind === 'assemblyJoint') {
+      assembly.joints.push({
+        id: record.id,
+        name: stringMetadata(metadata.jointName, record.id),
+        kind: stringMetadata(metadata.jointKind, 'joint'),
+        partIds: {
+          a: featureInputId(record.inputs.a),
+          b: featureInputId(record.inputs.b),
+        },
+        ...(metadata.axis !== undefined ? { axis: metadata.axis } : {}),
+        ...(metadata.origin !== undefined ? { origin: metadata.origin } : {}),
+        ...(metadata.limitsDeg !== undefined ? { limitsDeg: metadata.limitsDeg } : {}),
+      });
+    }
+
+    if (record.kind === 'assemblyConnect') {
+      assembly.connections.push({
+        id: record.id,
+        name: stringMetadata(metadata.connectName, record.id),
+        kind: stringMetadata(metadata.kind, 'fixed'),
+        partIds: {
+          a: featureInputId(record.inputs.a),
+          b: featureInputId(record.inputs.b),
+        },
+        ...(metadata.a !== undefined ? { a: metadata.a } : {}),
+        ...(metadata.b !== undefined ? { b: metadata.b } : {}),
+      });
+    }
+
+    if (record.kind === 'assemblyModel') {
+      assembly.models.push({
+        id: record.id,
+        partIds: Array.isArray(metadata.partIds)
+          ? metadata.partIds.filter((partId): partId is FeatureId => typeof partId === 'string')
+          : Object.entries(record.inputs)
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([, ref]) => featureInputId(ref))
+            .filter((partId): partId is FeatureId => partId !== undefined),
+      });
+    }
+  }
+
+  return [...assemblies.values()];
+}
+
+function getOrCreateAssembly(
+  assemblies: Map<string, AssemblySummary>,
+  name: string,
+): AssemblySummary {
+  const existing = assemblies.get(name);
+  if (existing) return existing;
+  const assembly: AssemblySummary = {
+    name,
+    parts: [],
+    joints: [],
+    connections: [],
+    models: [],
+  };
+  assemblies.set(name, assembly);
+  return assembly;
+}
+
+function isAssemblyRecord(record: FeatureRecord): boolean {
+  return (
+    record.kind === 'assemblyPart' ||
+    record.kind === 'assemblyJoint' ||
+    record.kind === 'assemblyConnect' ||
+    record.kind === 'assemblyModel'
+  );
+}
+
+function featureInputId(ref: FeatureRef | undefined): FeatureId | undefined {
+  return ref?.kind === 'feature' ? ref.id : undefined;
+}
+
+function stringMetadata(value: unknown, fallback: string): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function objectMetadata(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -124,7 +124,7 @@ selectEdge(shape: Shape, query: EdgeQuery): Promise<EdgeSegment>;  // throws if 
 
 ### Assembly intent
 
-Use `assembly()` when the model needs named mechanical parts, connector frames, and joint metadata that a human or agent can inspect later. Call `.model()` after adding parts to return one fused/exportable `Shape` containing every placed part. Connector and joint records remain metadata for now; `.model()` does not solve motion.
+Use `assembly()` when the model needs named mechanical parts, connector frames, and joint metadata that a human or agent can inspect later. Call `.model()` after adding parts to return one fused/exportable `Shape` containing every placed part. Connector and joint records remain metadata for now; `.model()` does not solve motion. Use MCP `list_assemblies({ file? code? })` to inspect the captured assembly intent without recomputing topology.
 
 ```typescript
 const arm = assembly('two-link arm');
@@ -490,10 +490,11 @@ kernelcad mcp
 
 ## MCP Companion (introspection)
 
-When you have `kernelcad mcp` available, use the MCP tools for dynamic introspection rather than re-running the CLI. The MCP server exposes 21 tools:
+When you have `kernelcad mcp` available, use the MCP tools for dynamic introspection rather than re-running the CLI. The MCP server exposes 22 tools:
 
 - `evaluate_script({ file? code? })` — pass/fail + featureCount + diagnostics
 - `list_features({ file? code? })` — array of feature summaries (kind/id/params/inputs)
+- `list_assemblies({ file? code? })` — captured assembly intent: assemblies, parts, named connectors, fixed connections, joints, and aggregate models
 - `get_shape_info({ file? code?, feature_id? })` — volume/surfaceArea/bbox of a feature (default: last)
 - `list_topology({ file? code?, feature_id? })` — canonical face names + edge count
 - `get_edges_of({ file? code?, feature_id?, face_name })` — boundary edges of a face (centroid, length, isClosed)

--- a/tests/integration/mcp/serverToolDispatch.test.ts
+++ b/tests/integration/mcp/serverToolDispatch.test.ts
@@ -19,6 +19,28 @@ describe('MCP server tool registry', () => {
     });
   });
 
+  it('dispatches assembly inspection through the advertised registry', async () => {
+    await expect(callMcpTool('list_assemblies', {
+      code: `
+        const hinge = assembly('registry hinge');
+        hinge.part('leafA', box(20, 8, 2));
+        hinge.part('leafB', box(20, 8, 2), { at: [20, 0, 0] });
+        return hinge.model();
+      `,
+    })).resolves.toMatchObject({
+      assemblies: [
+        {
+          name: 'registry hinge',
+          parts: [
+            expect.objectContaining({ name: 'leafA' }),
+            expect.objectContaining({ name: 'leafB' }),
+          ],
+          models: [expect.objectContaining({ partIds: expect.any(Array) })],
+        },
+      ],
+    });
+  });
+
   it('keeps unknown tool errors explicit', async () => {
     await expect(callMcpTool('missing_tool', {})).rejects.toThrow('Unknown tool: missing_tool');
   });

--- a/tests/unit/mcp/tools/listAssemblies.test.ts
+++ b/tests/unit/mcp/tools/listAssemblies.test.ts
@@ -1,0 +1,111 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { initOcct } from '../../../../src/backends/occt/occtBackend';
+import { listAssembliesTool } from '../../../../src/mcp/tools/listAssemblies';
+
+describe('listAssembliesTool', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('lists assembly parts, connectors, fixed connections, joints, and models from inline code', async () => {
+    const result = await listAssembliesTool({
+      code: `
+        const arm = assembly('inspection arm');
+        const base = arm.part('base', box(30, 30, 8), {
+          at: [0, 0, 0],
+          connectors: {
+            shoulder: { origin: [15, 15, 8], axis: [0, 0, 1] },
+          },
+        });
+        const link = arm.part('link', box(80, 10, 6), {
+          connectors: {
+            root: { origin: [0, 5, 3], axis: [0, 0, 1] },
+            wrist: { origin: [80, 5, 3], axis: [0, 0, 1] },
+          },
+          connect: {
+            connector: 'root',
+            to: base.connector('shoulder'),
+            name: 'shoulder-fixed',
+          },
+        });
+        arm.revolute('shoulder', base, link, {
+          axis: [0, 0, 1],
+          origin: [15, 15, 8],
+          limitsDeg: [-90, 90],
+        });
+        return arm.model();
+      `,
+    });
+
+    expect(result.ok).toBeUndefined();
+    expect(result.assemblies).toHaveLength(1);
+
+    const assembly = result.assemblies[0];
+    expect(assembly.name).toBe('inspection arm');
+    expect(assembly.parts.map(part => part.name)).toEqual(['base', 'link']);
+    expect(assembly.parts[0]).toMatchObject({
+      name: 'base',
+      shapeId: expect.stringMatching(/^box_/),
+      at: [0, 0, 0],
+      connectors: {
+        shoulder: { origin: [15, 15, 8], axis: [0, 0, 1] },
+      },
+    });
+    expect(assembly.parts[1]).toMatchObject({
+      name: 'link',
+      shapeId: expect.stringMatching(/^box_/),
+      at: [15, 10, 5],
+      connectors: {
+        root: { origin: [0, 5, 3], axis: [0, 0, 1] },
+        wrist: { origin: [80, 5, 3], axis: [0, 0, 1] },
+      },
+      placedBy: {
+        connector: 'root',
+        to: {
+          partId: assembly.parts[0].id,
+          partName: 'base',
+          connector: 'shoulder',
+        },
+      },
+    });
+    expect(assembly.connections).toEqual([
+      expect.objectContaining({
+        name: 'shoulder-fixed',
+        kind: 'fixed',
+        partIds: { a: assembly.parts[0].id, b: assembly.parts[1].id },
+        a: expect.objectContaining({ partName: 'base', connector: 'shoulder' }),
+        b: expect.objectContaining({ partName: 'link', connector: 'root' }),
+      }),
+    ]);
+    expect(assembly.joints).toEqual([
+      expect.objectContaining({
+        name: 'shoulder',
+        kind: 'revolute',
+        partIds: { a: assembly.parts[0].id, b: assembly.parts[1].id },
+        axis: [0, 0, 1],
+        origin: [15, 15, 8],
+        limitsDeg: [-90, 90],
+      }),
+    ]);
+    expect(assembly.models).toEqual([
+      expect.objectContaining({
+        partIds: [assembly.parts[0].id, assembly.parts[1].id],
+      }),
+    ]);
+  });
+
+  it('returns an empty assembly list when the script has no assembly records', async () => {
+    const result = await listAssembliesTool({ code: `return box(10, 10, 10);` });
+
+    expect(result).toEqual({ assemblies: [] });
+  });
+
+  it('returns structured diagnostics when the script fails', async () => {
+    const result = await listAssembliesTool({ code: `throw new Error('boom');` });
+
+    expect(result).toMatchObject({
+      ok: false,
+      assemblies: [],
+      error: 'boom',
+      errorCode: 'cli.script-exception',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add MCP list_assemblies for captured assembly intent
- expose parts, connectors, fixed connections, joints, and aggregate assembly models
- document the tool in SKILL.md and changelog, with registry dispatch coverage

## Verification
- npm test -- tests/unit/mcp/tools/listAssemblies.test.ts tests/integration/mcp/serverToolDispatch.test.ts tests/unit/skill/skillToolCountDrift.test.ts
- npm run proof:assembly-contract
- npm run lint
- npm run build:cli
- npm test -- tests/integration/cli-bundle/startup.test.ts
- npm test
- npm run build