### PR TITLE
refactor(mcp): centralize script loading

### DIFF
--- a/src/mcp/runMcpScript.ts
+++ b/src/mcp/runMcpScript.ts
@@ -1,0 +1,72 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { initOcct } from '../backends/occt/occtBackend';
+import { kernelErrorToDiagnostic } from '../script-runtime/kernelErrorToDiagnostic';
+import { runScript, type RunScriptResult } from '../script-runtime/runScript';
+
+export interface McpScriptInput {
+  file?: string;
+  code?: string;
+}
+
+export type RunMcpScriptResult =
+  | {
+      ok: true;
+      run: RunScriptResult;
+      fileName: string;
+    }
+  | {
+      ok: false;
+      error: string;
+      errorCode?: string;
+    };
+
+export async function runMcpScript(input: McpScriptInput): Promise<RunMcpScriptResult> {
+  await initOcct();
+
+  const source = await loadMcpScriptSource(input);
+  if (!source.ok) return source;
+
+  try {
+    return {
+      ok: true,
+      fileName: source.fileName,
+      run: await runScript({ code: source.code, fileName: source.fileName }),
+    };
+  } catch (e) {
+    const diag = kernelErrorToDiagnostic(e);
+    return { ok: false, error: diag.message, errorCode: diag.code };
+  }
+}
+
+export type LoadMcpScriptSourceResult =
+  | { ok: true; code: string; fileName: string }
+  | { ok: false; error: string };
+
+export async function loadMcpScriptSource(input: McpScriptInput): Promise<LoadMcpScriptSourceResult> {
+  if (input.code !== undefined) {
+    return {
+      ok: true,
+      code: input.code,
+      fileName: input.file ?? '<inline>',
+    };
+  }
+
+  if (input.file === undefined) {
+    return { ok: false, error: 'Must provide either { file } or { code }.' };
+  }
+
+  const filePath = resolve(input.file);
+  try {
+    return {
+      ok: true,
+      code: await readFile(filePath, 'utf8'),
+      fileName: filePath,
+    };
+  } catch (e) {
+    return {
+      ok: false,
+      error: `Cannot read file: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+}

--- a/src/mcp/tools/exportStl.ts
+++ b/src/mcp/tools/exportStl.ts
@@ -1,10 +1,11 @@
 // src/mcp/tools/exportStl.ts
-import { writeFile, mkdir, readFile as readFileFs } from 'node:fs/promises';
-import { dirname, isAbsolute, resolve as resolvePath } from 'node:path';
+import { writeFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
 import { initOcct } from '../../backends/occt/occtBackend';
 import { runAndExport } from '../../script-runtime/export';
 import type { CompilerDiagnostic } from '../../diagnostics/diagnostic';
 import { validateOutputPath } from '../../script-runtime/safeOutputPath';
+import { loadMcpScriptSource } from '../runMcpScript';
 
 export interface ExportStlInput {
   file?: string;
@@ -36,38 +37,25 @@ export interface ExportStlOutput {
  * Returns a JSON receipt: `{ ok, output_path, byte_count, feature_count, diagnostics }`.
  */
 export async function exportStlTool(input: ExportStlInput): Promise<ExportStlOutput> {
-  const { file, code, output_path, feature_id } = input;
+  const { output_path, feature_id } = input;
 
   if (!output_path || typeof output_path !== 'string') {
     return { ok: false, error: 'Required: output_path' };
   }
 
-  let scriptCode: string;
-  let fileName: string;
-
-  if (code !== undefined) {
-    scriptCode = code;
-    fileName = file ?? '<inline>';
-  } else if (file !== undefined) {
-    const filePath = isAbsolute(file) ? file : resolvePath(file);
-    fileName = filePath;
-    try {
-      scriptCode = await readFileFs(filePath, 'utf8');
-    } catch (e) {
-      return {
-        ok: false,
-        error: `Cannot read file: ${e instanceof Error ? e.message : String(e)}`,
-      };
-    }
-  } else {
-    return { ok: false, error: 'Must provide either { file } or { code }.' };
-  }
+  const source = await loadMcpScriptSource(input);
+  if (!source.ok) return source;
 
   await initOcct();
 
   let result;
   try {
-    result = await runAndExport({ code: scriptCode, fileName, format: 'stl', feature_id });
+    result = await runAndExport({
+      code: source.code,
+      fileName: source.fileName,
+      format: 'stl',
+      feature_id,
+    });
   } catch (e) {
     return {
       ok: false,

--- a/src/mcp/tools/getEdgesOf.ts
+++ b/src/mcp/tools/getEdgesOf.ts
@@ -1,13 +1,10 @@
 // src/mcp/tools/getEdgesOf.ts
-import { runScript } from '../../script-runtime/runScript';
 import { RecomputeEngine } from '../../compute/recomputeEngine';
 import { OcctLowerer } from '../../backends/occt/occtLowerer';
-import { initOcct, OcctBackend } from '../../backends/occt/occtBackend';
+import { OcctBackend } from '../../backends/occt/occtBackend';
 import { pickEdges } from '../../backends/occt/edgeSelection';
-import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
 import type { FeatureRecord } from '../../intent/featureRecord';
-import { kernelErrorToDiagnostic } from '../../script-runtime/kernelErrorToDiagnostic';
+import { runMcpScript } from '../runMcpScript';
 
 export interface GetEdgesOfInput {
   file?: string;
@@ -35,36 +32,13 @@ export interface GetEdgesOfOutput {
 }
 
 export async function getEdgesOfTool(input: GetEdgesOfInput): Promise<GetEdgesOfOutput> {
-  await initOcct();
-
   if (!input.face_name) {
     return { ok: false, error: 'face_name is required.' };
   }
 
-  let code: string;
-  let fileName: string;
-  if (input.code !== undefined) {
-    code = input.code;
-    fileName = input.file ?? '<inline>';
-  } else if (input.file !== undefined) {
-    const filePath = resolve(input.file);
-    fileName = filePath;
-    try {
-      code = await readFile(filePath, 'utf8');
-    } catch (e) {
-      return { ok: false, error: `Cannot read file: ${e instanceof Error ? e.message : String(e)}` };
-    }
-  } else {
-    return { ok: false, error: 'Must provide either { file } or { code }.' };
-  }
-
-  let run;
-  try {
-    run = await runScript({ code, fileName });
-  } catch (e) {
-    const diag = kernelErrorToDiagnostic(e);
-    return { ok: false, error: diag.message, errorCode: diag.code };
-  }
+  const script = await runMcpScript(input);
+  if (!script.ok) return script;
+  const { run } = script;
 
   if (run.records.length === 0) return { ok: false, error: 'Script produced no features.' };
   const targetId = input.feature_id ?? run.records[run.records.length - 1].id;

--- a/src/mcp/tools/getShapeInfo.ts
+++ b/src/mcp/tools/getShapeInfo.ts
@@ -1,12 +1,8 @@
 // src/mcp/tools/getShapeInfo.ts
-import { runScript } from '../../script-runtime/runScript';
 import { RecomputeEngine } from '../../compute/recomputeEngine';
 import { OcctLowerer } from '../../backends/occt/occtLowerer';
-import { initOcct } from '../../backends/occt/occtBackend';
-import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
 import type { FeatureKind } from '../../intent/types';
-import { kernelErrorToDiagnostic } from '../../script-runtime/kernelErrorToDiagnostic';
+import { runMcpScript } from '../runMcpScript';
 
 export interface GetShapeInfoInput {
   file?: string;
@@ -37,33 +33,9 @@ export interface GetShapeInfoOutput {
 export async function getShapeInfoTool(
   input: GetShapeInfoInput,
 ): Promise<GetShapeInfoOutput> {
-  await initOcct();
-
-  let code: string;
-  let fileName: string;
-
-  if (input.code !== undefined) {
-    code = input.code;
-    fileName = input.file ?? '<inline>';
-  } else if (input.file !== undefined) {
-    const filePath = resolve(input.file);
-    fileName = filePath;
-    try {
-      code = await readFile(filePath, 'utf8');
-    } catch (e) {
-      return { ok: false, error: `Cannot read file: ${e instanceof Error ? e.message : String(e)}` };
-    }
-  } else {
-    return { ok: false, error: 'Must provide either { file } or { code }.' };
-  }
-
-  let run;
-  try {
-    run = await runScript({ code, fileName });
-  } catch (e) {
-    const diag = kernelErrorToDiagnostic(e);
-    return { ok: false, error: diag.message, errorCode: diag.code };
-  }
+  const script = await runMcpScript(input);
+  if (!script.ok) return script;
+  const { run } = script;
 
   if (run.records.length === 0) {
     return { ok: false, error: 'Script produced no features.' };

--- a/src/mcp/tools/listAssemblies.ts
+++ b/src/mcp/tools/listAssemblies.ts
@@ -1,10 +1,6 @@
-import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
-import { initOcct } from '../../backends/occt/occtBackend';
 import type { FeatureRecord } from '../../intent/featureRecord';
 import type { FeatureId, FeatureRef } from '../../intent/types';
-import { kernelErrorToDiagnostic } from '../../script-runtime/kernelErrorToDiagnostic';
-import { runScript } from '../../script-runtime/runScript';
+import { runMcpScript } from '../runMcpScript';
 
 export interface ListAssembliesInput {
   file?: string;
@@ -62,38 +58,10 @@ export interface ListAssembliesOutput {
 export async function listAssembliesTool(
   input: ListAssembliesInput,
 ): Promise<ListAssembliesOutput> {
-  await initOcct();
-  let code: string;
-  let fileName: string;
+  const result = await runMcpScript(input);
+  if (!result.ok) return { ok: false, assemblies: [], error: result.error, errorCode: result.errorCode };
 
-  if (input.code !== undefined) {
-    code = input.code;
-    fileName = input.file ?? '<inline>';
-  } else if (input.file !== undefined) {
-    const filePath = resolve(input.file);
-    fileName = filePath;
-    try {
-      code = await readFile(filePath, 'utf8');
-    } catch (e) {
-      return {
-        ok: false,
-        assemblies: [],
-        error: `Cannot read file: ${e instanceof Error ? e.message : String(e)}`,
-      };
-    }
-  } else {
-    return { ok: false, assemblies: [], error: 'Must provide either { file } or { code }.' };
-  }
-
-  let run;
-  try {
-    run = await runScript({ code, fileName });
-  } catch (e) {
-    const diag = kernelErrorToDiagnostic(e);
-    return { ok: false, assemblies: [], error: diag.message, errorCode: diag.code };
-  }
-
-  return { assemblies: summarizeAssemblies(run.records) };
+  return { assemblies: summarizeAssemblies(result.run.records) };
 }
 
 function summarizeAssemblies(records: readonly FeatureRecord[]): AssemblySummary[] {

--- a/src/mcp/tools/listEdges.ts
+++ b/src/mcp/tools/listEdges.ts
@@ -4,14 +4,11 @@
 // Lets agents introspect any shape (primitives, booleans, transformed solids,
 // imported geometry) before running fillet/chamfer.
 
-import { runScript } from '../../script-runtime/runScript';
 import { RecomputeEngine } from '../../compute/recomputeEngine';
 import { OcctLowerer } from '../../backends/occt/occtLowerer';
-import { initOcct, OcctBackend } from '../../backends/occt/occtBackend';
+import { OcctBackend } from '../../backends/occt/occtBackend';
 import { selectEdges, type EdgeQuery, type EdgeSegment } from '../../backends/occt/edgeQueries';
-import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
-import { kernelErrorToDiagnostic } from '../../script-runtime/kernelErrorToDiagnostic';
+import { runMcpScript } from '../runMcpScript';
 
 export interface ListEdgesInput {
   file?: string;
@@ -32,32 +29,9 @@ export interface ListEdgesOutput {
 }
 
 export async function listEdgesTool(input: ListEdgesInput): Promise<ListEdgesOutput> {
-  await initOcct();
-
-  let code: string;
-  let fileName: string;
-  if (input.code !== undefined) {
-    code = input.code;
-    fileName = input.file ?? '<inline>';
-  } else if (input.file !== undefined) {
-    const filePath = resolve(input.file);
-    fileName = filePath;
-    try {
-      code = await readFile(filePath, 'utf8');
-    } catch (e) {
-      return { ok: false, error: `Cannot read file: ${e instanceof Error ? e.message : String(e)}` };
-    }
-  } else {
-    return { ok: false, error: 'Must provide either { file } or { code }.' };
-  }
-
-  let run;
-  try {
-    run = await runScript({ code, fileName });
-  } catch (e) {
-    const diag = kernelErrorToDiagnostic(e);
-    return { ok: false, error: diag.message, errorCode: diag.code };
-  }
+  const script = await runMcpScript(input);
+  if (!script.ok) return script;
+  const { run } = script;
   if (run.records.length === 0) {
     return { ok: false, error: 'Script returned no features.' };
   }

--- a/src/mcp/tools/listFaceLabels.ts
+++ b/src/mcp/tools/listFaceLabels.ts
@@ -6,13 +6,10 @@
 // so agents can disambiguate. Lets agents discover the label vocabulary on a
 // shape before referencing labels in fillet/chamfer/shell.
 
-import { runScript } from '../../script-runtime/runScript';
-import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
-import { kernelErrorToDiagnostic } from '../../script-runtime/kernelErrorToDiagnostic';
 import type { CanonicalFace } from '../../intent/types';
 import type { FaceQuery } from '../../backends/occt/edgeQueries';
 import type { FaceLabelsMap } from '../../intent/featureRecord';
+import { runMcpScript } from '../runMcpScript';
 
 export interface ListFaceLabelsInput {
   file?: string;
@@ -50,30 +47,9 @@ export interface ListFaceLabelsOutput {
 }
 
 export async function listFaceLabelsTool(input: ListFaceLabelsInput): Promise<ListFaceLabelsOutput> {
-  let code: string;
-  let fileName: string;
-  if (input.code !== undefined) {
-    code = input.code;
-    fileName = input.file ?? '<inline>';
-  } else if (input.file !== undefined) {
-    const filePath = resolve(input.file);
-    fileName = filePath;
-    try {
-      code = await readFile(filePath, 'utf8');
-    } catch (e) {
-      return { ok: false, error: `Cannot read file: ${e instanceof Error ? e.message : String(e)}` };
-    }
-  } else {
-    return { ok: false, error: 'Must provide either { file } or { code }.' };
-  }
-
-  let run;
-  try {
-    run = await runScript({ code, fileName });
-  } catch (e) {
-    const diag = kernelErrorToDiagnostic(e);
-    return { ok: false, error: diag.message, errorCode: diag.code };
-  }
+  const result = await runMcpScript(input);
+  if (!result.ok) return result;
+  const { run } = result;
 
   const labels: LabelSummary[] = [];
 

--- a/src/mcp/tools/listFaces.ts
+++ b/src/mcp/tools/listFaces.ts
@@ -2,15 +2,12 @@
 //
 // MCP tool: list faces of a kernelCAD shape with optional FaceQuery filter.
 
-import { runScript } from '../../script-runtime/runScript';
 import { RecomputeEngine } from '../../compute/recomputeEngine';
 import { OcctLowerer } from '../../backends/occt/occtLowerer';
-import { initOcct, OcctBackend } from '../../backends/occt/occtBackend';
+import { OcctBackend } from '../../backends/occt/occtBackend';
 import { resolveFaceQuery, type FaceQuery } from '../../backends/occt/edgeQueries';
-import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
 import type { Face } from 'replicad';
-import { kernelErrorToDiagnostic } from '../../script-runtime/kernelErrorToDiagnostic';
+import { runMcpScript } from '../runMcpScript';
 
 export interface ListFacesInput {
   file?: string;
@@ -40,32 +37,9 @@ export interface ListFacesOutput {
 }
 
 export async function listFacesTool(input: ListFacesInput): Promise<ListFacesOutput> {
-  await initOcct();
-
-  let code: string;
-  let fileName: string;
-  if (input.code !== undefined) {
-    code = input.code;
-    fileName = input.file ?? '<inline>';
-  } else if (input.file !== undefined) {
-    const filePath = resolve(input.file);
-    fileName = filePath;
-    try {
-      code = await readFile(filePath, 'utf8');
-    } catch (e) {
-      return { ok: false, error: `Cannot read file: ${e instanceof Error ? e.message : String(e)}` };
-    }
-  } else {
-    return { ok: false, error: 'Must provide either { file } or { code }.' };
-  }
-
-  let run;
-  try {
-    run = await runScript({ code, fileName });
-  } catch (e) {
-    const diag = kernelErrorToDiagnostic(e);
-    return { ok: false, error: diag.message, errorCode: diag.code };
-  }
+  const script = await runMcpScript(input);
+  if (!script.ok) return script;
+  const { run } = script;
   if (run.records.length === 0) {
     return { ok: false, error: 'Script returned no features.' };
   }

--- a/src/mcp/tools/listFeatures.ts
+++ b/src/mcp/tools/listFeatures.ts
@@ -1,10 +1,5 @@
-// src/mcp/tools/listFeatures.ts
-import { runScript } from '../../script-runtime/runScript';
-import { initOcct } from '../../backends/occt/occtBackend';
-import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
 import type { FeatureKind, Param } from '../../intent/types';
-import { kernelErrorToDiagnostic } from '../../script-runtime/kernelErrorToDiagnostic';
+import { runMcpScript } from '../runMcpScript';
 
 export interface ListFeaturesInput {
   file?: string;
@@ -37,36 +32,9 @@ export interface ListFeaturesOutput {
 export async function listFeaturesTool(
   input: ListFeaturesInput,
 ): Promise<ListFeaturesOutput> {
-  await initOcct();
-  let code: string;
-  let fileName: string;
-
-  if (input.code !== undefined) {
-    code = input.code;
-    fileName = input.file ?? '<inline>';
-  } else if (input.file !== undefined) {
-    const filePath = resolve(input.file);
-    fileName = filePath;
-    try {
-      code = await readFile(filePath, 'utf8');
-    } catch (e) {
-      return {
-        ok: false,
-        features: [],
-        error: `Cannot read file: ${e instanceof Error ? e.message : String(e)}`,
-      };
-    }
-  } else {
-    return { ok: false, features: [], error: 'Must provide either { file } or { code }.' };
-  }
-
-  let run;
-  try {
-    run = await runScript({ code, fileName });
-  } catch (e) {
-    const diag = kernelErrorToDiagnostic(e);
-    return { ok: false, features: [], error: diag.message, errorCode: diag.code };
-  }
+  const result = await runMcpScript(input);
+  if (!result.ok) return { ok: false, features: [], error: result.error, errorCode: result.errorCode };
+  const { run } = result;
 
   const features: FeatureSummary[] = run.records.map(r => ({
     id: r.id,

--- a/src/mcp/tools/listTopology.ts
+++ b/src/mcp/tools/listTopology.ts
@@ -1,11 +1,8 @@
 // src/mcp/tools/listTopology.ts
-import { runScript } from '../../script-runtime/runScript';
 import { RecomputeEngine } from '../../compute/recomputeEngine';
 import { OcctLowerer } from '../../backends/occt/occtLowerer';
-import { initOcct, OcctBackend } from '../../backends/occt/occtBackend';
-import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
-import { kernelErrorToDiagnostic } from '../../script-runtime/kernelErrorToDiagnostic';
+import { OcctBackend } from '../../backends/occt/occtBackend';
+import { runMcpScript } from '../runMcpScript';
 
 export interface ListTopologyInput {
   file?: string;
@@ -30,33 +27,9 @@ const BOX_FACES = ['top', 'bottom', 'left', 'right', 'front', 'back'] as const;
 const CYLINDER_FACES = ['top', 'bottom'] as const;
 
 export async function listTopologyTool(input: ListTopologyInput): Promise<ListTopologyOutput> {
-  await initOcct();
-
-  let code: string;
-  let fileName: string;
-
-  if (input.code !== undefined) {
-    code = input.code;
-    fileName = input.file ?? '<inline>';
-  } else if (input.file !== undefined) {
-    const filePath = resolve(input.file);
-    fileName = filePath;
-    try {
-      code = await readFile(filePath, 'utf8');
-    } catch (e) {
-      return { ok: false, error: `Cannot read file: ${e instanceof Error ? e.message : String(e)}` };
-    }
-  } else {
-    return { ok: false, error: 'Must provide either { file } or { code }.' };
-  }
-
-  let run;
-  try {
-    run = await runScript({ code, fileName });
-  } catch (e) {
-    const diag = kernelErrorToDiagnostic(e);
-    return { ok: false, error: diag.message, errorCode: diag.code };
-  }
+  const script = await runMcpScript(input);
+  if (!script.ok) return script;
+  const { run } = script;
 
   if (run.records.length === 0) return { ok: false, error: 'Script produced no features.' };
 

--- a/src/mcp/tools/whyDidThisFail.ts
+++ b/src/mcp/tools/whyDidThisFail.ts
@@ -8,15 +8,11 @@
 // vocabulary collapse), so this tool no longer carries an HINTS map.
 // Agents can call list_diagnostic_codes for the full catalogue.
 
-import { runScript } from '../../script-runtime/runScript';
 import { RecomputeEngine } from '../../compute/recomputeEngine';
 import { OcctLowerer } from '../../backends/occt/occtLowerer';
-import { initOcct } from '../../backends/occt/occtBackend';
-import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
 import type { FeatureKind } from '../../intent/types';
 import type { CompilerDiagnostic } from '../../diagnostics/diagnostic';
-import { kernelErrorToDiagnostic } from '../../script-runtime/kernelErrorToDiagnostic';
+import { runMcpScript } from '../runMcpScript';
 
 export interface WhyDidThisFailInput {
   file?: string;
@@ -51,32 +47,9 @@ export interface WhyDidThisFailOutput {
 }
 
 export async function whyDidThisFailTool(input: WhyDidThisFailInput): Promise<WhyDidThisFailOutput> {
-  await initOcct();
-
-  let code: string;
-  let fileName: string;
-  if (input.code !== undefined) {
-    code = input.code;
-    fileName = input.file ?? '<inline>';
-  } else if (input.file !== undefined) {
-    const filePath = resolve(input.file);
-    fileName = filePath;
-    try {
-      code = await readFile(filePath, 'utf8');
-    } catch (e) {
-      return { ok: false, error: `Cannot read file: ${e instanceof Error ? e.message : String(e)}` };
-    }
-  } else {
-    return { ok: false, error: 'Must provide either { file } or { code }.' };
-  }
-
-  let run;
-  try {
-    run = await runScript({ code, fileName });
-  } catch (e) {
-    const diag = kernelErrorToDiagnostic(e);
-    return { ok: false, error: diag.message, errorCode: diag.code };
-  }
+  const script = await runMcpScript(input);
+  if (!script.ok) return script;
+  const { run } = script;
 
   if (run.records.length === 0) return { ok: false, error: 'Script produced no features.' };
 

--- a/tests/unit/mcp/runMcpScript.test.ts
+++ b/tests/unit/mcp/runMcpScript.test.ts
@@ -1,0 +1,65 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { runMcpScript } from '../../../src/mcp/runMcpScript';
+
+describe('runMcpScript', () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  it('runs inline code and uses <inline> as the file name by default', async () => {
+    const result = await runMcpScript({ code: `return box(10, 10, 10);` });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.run.records).toHaveLength(1);
+    expect(result.fileName).toBe('<inline>');
+  });
+
+  it('runs code loaded from a file and reports the resolved file name', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'kernelcad-mcp-runner-'));
+    const file = join(tempDir, 'part.kcad.ts');
+    await writeFile(file, `return cylinder(5, 10);`, 'utf8');
+
+    const result = await runMcpScript({ file });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.run.records.map(record => record.kind)).toEqual(['cylinder']);
+    expect(result.fileName).toBe(file);
+  });
+
+  it('returns a uniform missing-input error', async () => {
+    const result = await runMcpScript({});
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Must provide either { file } or { code }.',
+    });
+  });
+
+  it('returns a uniform file-read error', async () => {
+    const result = await runMcpScript({ file: '/tmp/kernelcad-missing-script.kcad.ts' });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.error).toMatch(/^Cannot read file:/);
+  });
+
+  it('returns structured script diagnostics', async () => {
+    const result = await runMcpScript({ code: `throw new Error('boom');` });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'boom',
+      errorCode: 'cli.script-exception',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared MCP script source/runner helper for { file | code } tools
- migrate MCP inspection/export tools away from duplicated file loading and script diagnostic boilerplate
- add helper coverage for inline/file execution, missing input, unreadable file, and script exceptions

## Verification
- npm test -- tests/unit/mcp/runMcpScript.test.ts tests/integration/mcp/exportStl.test.ts tests/unit/mcp/tools/listFeatures.test.ts tests/unit/mcp/tools/listAssemblies.test.ts tests/unit/mcp/tools/listFaceLabels.test.ts tests/unit/mcp/tools/getShapeInfo.test.ts tests/unit/mcp/tools/listTopology.test.ts tests/integration/mcp/listEdges.test.ts tests/unit/mcp/tools/getEdgesOf.test.ts tests/unit/mcp/tools/whyDidThisFail.test.ts tests/integration/mcp/serverToolDispatch.test.ts tests/integration/mcp/errorCode.test.ts
- npm run proof:assembly-contract
- npm run lint
- npm run build:cli
- npm test
- npm run build