### PR TITLE
fix(skill): keep out-of-scope capabilities truthful

### DIFF
--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -521,8 +521,8 @@ These return errors today; do not generate code that uses them:
 
 - Tracked face/edge refs (only canonical refs and inline queries work) — deferred
 - Asymmetric chamfer (only symmetric 45° supported) — deferred
-- Hole / cut / draft as distinct features (use `subtract(cylinder)` etc.) — deferred
-- Assemblies / joints — deferred
+- Draft features — deferred
+- Dynamic assembly solving / motion simulation — deferred; static assembly parts, fixed connector placement, revolute joint metadata, and fused `assembly.model()` output are supported.
 - BOM, dimensions, BREP, multi-view PDF — deferred
 
 <!-- COOKBOOK:START -->

--- a/tests/unit/skill/skillOutOfScopeTruth.test.ts
+++ b/tests/unit/skill/skillOutOfScopeTruth.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve as resolvePath, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SKILL_MD = readFileSync(
+  resolvePath(__dirname, '../../../src/skill/SKILL.md'),
+  'utf8',
+);
+
+function outOfScopeSection(): string {
+  const match = SKILL_MD.match(/## Out of Scope\n([\s\S]*?)(?:\n## |\n<!-- COOKBOOK:START -->)/);
+  expect(match, 'SKILL.md must contain an Out of Scope section').not.toBeNull();
+  return match![1];
+}
+
+describe('SKILL.md Out of Scope truth sentinel', () => {
+  it('does not list shipped modeling capabilities as deferred', () => {
+    const outOfScope = outOfScopeSection();
+
+    const shippedCapabilityPatterns = [
+      /\bHole\b/i,
+      /\bcutout\b/i,
+      /\bAssemblies\b/i,
+      /\bjoints\b/i,
+    ];
+
+    for (const pattern of shippedCapabilityPatterns) {
+      expect(outOfScope, `Out of Scope still contains shipped capability pattern ${pattern}`).not.toMatch(pattern);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- remove shipped hole/cutout and static assembly support from SKILL.md Out of Scope
- clarify that only draft features and dynamic assembly solving remain deferred in that area
- add a sentinel test so shipped capabilities do not reappear as deferred

## Verification
- npm test -- tests/unit/skill/skillOutOfScopeTruth.test.ts tests/unit/skill/skillToolCountDrift.test.ts tests/unit/skill/skillGlobalsDrift.test.ts tests/unit/skill/skillShapeMethodsDrift.test.ts
- npm run proof:assembly-contract