### PR TITLE
fix(skill): align MCP edit tool signatures

### DIFF
--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -499,9 +499,9 @@ When you have `kernelcad mcp` available, use the MCP tools for dynamic introspec
 - `list_topology({ file? code?, feature_id? })` — canonical face names + edge count
 - `get_edges_of({ file? code?, feature_id?, face_name })` — boundary edges of a face (centroid, length, isClosed)
 - `why_did_this_fail({ file? code?, feature_id? })` — walk the upstream chain of a failing feature; returns each upstream feature's id/kind/health/diagnostics in topological order (per-code hints already inline on every diagnostic).
-- `set_param_value({ file? code?, param_name, value })` — override a param and recompute
-- `add_feature({ file? code?, kind, ... })` — append a new feature to the script's feature tree
-- `remove_feature({ file? code?, feature_id })` — suppress/remove a feature by id
+- `set_param_value({ code, param_name, new_value })` — edit a `param()` default value and return modified code plus diagnostics
+- `add_feature({ code, feature_code })` — insert one source line before the last top-level return and return modified code plus diagnostics
+- `remove_feature({ code, match })` — remove one uniquely matched non-return line and return modified code plus diagnostics
 - `list_edges({ file? code?, feature_id? })` — enumerate all edges (index, centroid, length, isClosed)
 - `list_faces({ file? code?, feature_id? })` — enumerate all faces with area and centroid
 - `list_face_labels({ file? code?, feature_id? })` — canonical face names resolvable on a feature

--- a/tests/unit/skill/skillMcpEditToolSignatures.test.ts
+++ b/tests/unit/skill/skillMcpEditToolSignatures.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve as resolvePath, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { TOOL_REGISTRY } from '../../../src/mcp/toolRegistry';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SKILL_MD = readFileSync(
+  resolvePath(__dirname, '../../../src/skill/SKILL.md'),
+  'utf8',
+);
+
+const editTools = [
+  {
+    name: 'set_param_value',
+    forbiddenParams: ['file', 'value'],
+  },
+  {
+    name: 'add_feature',
+    forbiddenParams: ['file', 'kind', '...'],
+  },
+  {
+    name: 'remove_feature',
+    forbiddenParams: ['file', 'feature_id'],
+  },
+];
+
+function documentedSignatureParams(toolName: string): string[] {
+  const signaturePattern = new RegExp(`- \`${toolName}\\(\\{([^}]*)\\}\\)\``);
+  const match = SKILL_MD.match(signaturePattern);
+
+  expect(match, `SKILL.md must document a signature bullet for ${toolName}`).not.toBeNull();
+
+  return match![1]
+    .split(',')
+    .map(param => param.trim().replace(/\?$/, ''))
+    .filter(Boolean);
+}
+
+describe('SKILL.md MCP edit tool signatures', () => {
+  it('match the required parameters exposed by the MCP registry', () => {
+    for (const tool of editTools) {
+      const registryEntry = TOOL_REGISTRY.find(entry => entry.definition.name === tool.name);
+      expect(registryEntry, `MCP registry must expose ${tool.name}`).toBeDefined();
+
+      const documentedParams = documentedSignatureParams(tool.name);
+      const requiredParams = registryEntry!.definition.inputSchema.required ?? [];
+
+      for (const requiredParam of requiredParams) {
+        expect(
+          documentedParams,
+          `${tool.name} docs must include required param ${requiredParam}`,
+        ).toContain(requiredParam);
+      }
+    }
+  });
+
+  it('do not advertise stale edit tool parameters', () => {
+    for (const tool of editTools) {
+      const documentedParams = documentedSignatureParams(tool.name);
+
+      for (const staleParam of tool.forbiddenParams) {
+        expect(
+          documentedParams,
+          `${tool.name} docs must not include stale param ${staleParam}`,
+        ).not.toContain(staleParam);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- align SKILL.md MCP edit tool bullets with the actual registry inputs
- add a sentinel test that checks edit-tool docs against required registry params and stale names

## Verification
- npm test -- tests/unit/skill/skillMcpEditToolSignatures.test.ts
- npm test -- tests/unit/skill/skillMcpEditToolSignatures.test.ts tests/unit/skill/skillToolCountDrift.test.ts tests/unit/skill/skillOutOfScopeTruth.test.ts tests/unit/mcp/tools/setParamValue.test.ts tests/unit/mcp/tools/addFeature.test.ts tests/unit/mcp/tools/removeFeature.test.ts tests/integration/mcp/spawn.test.ts
- npm run proof:foundation
- npm run lint