### PR TITLE
chore(diagnostics): refresh MCP tool JSDoc to milestone-C codes

### DIFF
--- a/src/capture/captureSession.ts
+++ b/src/capture/captureSession.ts
@@ -585,7 +585,7 @@ function buildEdgeFeatureRef(
   }
   // Case 6: EdgeQuery — verify all keys are in the whitelist. If any keys are
   // unknown we still build a query ref so the lowerer can diagnose with the
-  // `feature.edge-feature.invalid-query` code; that keeps the error path on
+  // `feature.invalid-args` code; that keeps the error path on
   // the lowering side where diagnostics are aggregated.
   if (typeof selector === 'object' && selector !== null) {
     const keys = Object.keys(selector);
@@ -600,7 +600,7 @@ function buildEdgeFeatureRef(
       };
     }
     // Unknown shape — store as a query so the lowerer can diagnose
-    // `feature.edge-feature.invalid-query` against it.
+    // `feature.invalid-args` against it.
     return {
       key: 'edges',
       value: {

--- a/src/mcp/tools/getEdgesOf.ts
+++ b/src/mcp/tools/getEdgesOf.ts
@@ -26,7 +26,7 @@ export interface GetEdgesOfOutput {
   error?: string;
   /** Structured diagnostic code on `ok=false`. Set on both failure paths:
    *  (1) script-runtime exception → `KernelError` code or
-   *  `cli.script.exception` for non-kernel throws; (2) lowering-error path →
+   *  `cli.script-exception` for non-kernel throws; (2) lowering-error path →
    *  the first error diagnostic's `code`. */
   errorCode?: string;
 }

--- a/src/mcp/tools/getShapeInfo.ts
+++ b/src/mcp/tools/getShapeInfo.ts
@@ -24,9 +24,9 @@ export interface GetShapeInfoOutput {
   error?: string;
   /** Structured diagnostic code on `ok=false`. Set on both failure paths:
    *  (1) script-runtime exception → `KernelError` code (e.g.
-   *  `feature.path.duplicate-label`) or `cli.script.exception` for non-kernel
+   *  `feature.invalid-args`) or `cli.script-exception` for non-kernel
    *  throws; (2) lowering-error path → the first error diagnostic's `code`
-   *  (e.g. `feature.edge-feature.no-edges-match`). */
+   *  (e.g. `feature.selection.no-match`). */
   errorCode?: string;
 }
 

--- a/src/mcp/tools/listEdges.ts
+++ b/src/mcp/tools/listEdges.ts
@@ -23,7 +23,7 @@ export interface ListEdgesOutput {
   error?: string;
   /** Structured diagnostic code on `ok=false`. Set on both failure paths:
    *  (1) script-runtime exception → `KernelError` code or
-   *  `cli.script.exception` for non-kernel throws; (2) lowering-error path →
+   *  `cli.script-exception` for non-kernel throws; (2) lowering-error path →
    *  the first error diagnostic's `code`. */
   errorCode?: string;
 }

--- a/src/mcp/tools/listFaceLabels.ts
+++ b/src/mcp/tools/listFaceLabels.ts
@@ -40,8 +40,8 @@ export interface ListFaceLabelsOutput {
   labels?: LabelSummary[];
   error?: string;
   /** Structured diagnostic code on `ok=false`. Set on the script-runtime
-   *  exception path: `KernelError` code (e.g. `feature.path.duplicate-label`)
-   *  or `cli.script.exception` for non-kernel throws. (This tool walks records
+   *  exception path: `KernelError` code (e.g. `feature.invalid-args`)
+   *  or `cli.script-exception` for non-kernel throws. (This tool walks records
    *  without lowering, so there's no lowering-error path here.) */
   errorCode?: string;
 }

--- a/src/mcp/tools/listFaces.ts
+++ b/src/mcp/tools/listFaces.ts
@@ -31,7 +31,7 @@ export interface ListFacesOutput {
   error?: string;
   /** Structured diagnostic code on `ok=false`. Set on both failure paths:
    *  (1) script-runtime exception → `KernelError` code or
-   *  `cli.script.exception` for non-kernel throws; (2) lowering-error path →
+   *  `cli.script-exception` for non-kernel throws; (2) lowering-error path →
    *  the first error diagnostic's `code`. */
   errorCode?: string;
 }

--- a/src/mcp/tools/listFeatures.ts
+++ b/src/mcp/tools/listFeatures.ts
@@ -23,8 +23,8 @@ export interface ListFeaturesOutput {
   features: FeatureSummary[];
   error?: string;
   /** Structured diagnostic code on `ok=false`. Set on the script-runtime
-   *  exception path: `KernelError` code (e.g. `feature.path.duplicate-label`)
-   *  or `cli.script.exception` for non-kernel throws. (This tool walks records
+   *  exception path: `KernelError` code (e.g. `feature.invalid-args`)
+   *  or `cli.script-exception` for non-kernel throws. (This tool walks records
    *  without lowering, so there's no lowering-error path.) */
   errorCode?: string;
 }

--- a/src/mcp/tools/listTopology.ts
+++ b/src/mcp/tools/listTopology.ts
@@ -18,7 +18,7 @@ export interface ListTopologyOutput {
   error?: string;
   /** Structured diagnostic code on `ok=false`. Set on both failure paths:
    *  (1) script-runtime exception → `KernelError` code or
-   *  `cli.script.exception` for non-kernel throws; (2) lowering-error path →
+   *  `cli.script-exception` for non-kernel throws; (2) lowering-error path →
    *  the first error diagnostic's `code`. */
   errorCode?: string;
 }


### PR DESCRIPTION
## Summary

Closes the residual references to retired diagnostic codes that survived in JSDoc/comment text after milestone C's emission-site migration.

- 7 MCP tools (`listFaces`, `listFaceLabels`, `listFeatures`, `listEdges`, `listTopology`, `getEdgesOf`, `getShapeInfo`): `cli.script.exception` → `cli.script-exception`, plus folding `feature.path.duplicate-label` and `feature.edge-feature.no-edges-match` into the surviving `feature.invalid-args` / `feature.selection.no-match` codes.
- `src/capture/captureSession.ts`: two comments mentioning `feature.edge-feature.invalid-query` updated to `feature.invalid-args`.

Comment-only — no behaviour change. `tsc --noEmit` and `npm run lint` clean.

## Milestone C status

This finishes the milestone-C punch list. The slice is **effectively shipped** as of this PR. Acceptance criterion #3 (`SKILL.md ≤ 400 lines`) is **not met** (file is 557 lines, target ≤ 400) and is **explicitly deferred to milestone D** — the diagnostic-codes section already collapsed to its 8-line replacement; the unmet 157-line gap lives in `## API Surface` and adjacent sections, which the milestone-C spec itself flags as out of scope (arc constructors, `mirror`/`reflect` ergonomics, introspection-tool consolidation). All other acceptance criteria are met (verified end-to-end via regression check across all `examples/*.kcad.ts` and all `eval/tasks/*/solution-expert.kcad.ts`).

## Test Plan

- [x] `tsc --noEmit` green
- [x] `npm run lint` green
- [x] `grep -rn "cli\.script\.exception\|feature\.edge-feature\.\|feature\.face-feature\.\|capture\.faceLabels\." src/ --include='*.ts'` returns no matches outside `src/diagnostics/codes.ts`
- [x] Regression-verification subagent: 8/9 `examples/` build clean; 16/16 eval expert solutions build clean; deliberate-failure path emits new code (`feature.kernel-failed`) with mandatory `hint`, no `reachable`, no parallel `hints[]`
- [ ] CI green

## Pre-existing issues surfaced (NOT blockers, NOT introduced by this PR)

The verification subagent flagged three issues that pre-date this slice:

1. `tests/integration/cli-bundle/startup.test.ts` fails — CLI bundle reports `0.1.0` but `package.json` is `0.4.0`. Stale build artifact, unrelated.
2. `tests/integration/mcp/spawn.test.ts` fails — calls `solve_sketch` which is "Unknown tool". Looks like a tool removal/rename that left a test orphaned.
3. `examples/v0.21/donut.kcad.ts` emits 3 errors at runtime (verified at the donut-introducing commit `0966a87`). Pre-existing broken hero artifact.

Worth their own slices.