### PR TITLE
feat(api): ParamRef arithmetic methods (add/subtract/multiply/divide/negate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,14 @@ npm run dev
   and pattern capture/lowering behavior.
 - Added `proof:assembly-contract` to verify foundation gates plus assembly
   capture, static assembly model lowering, and SKILL global discoverability.
+- Added arithmetic methods on `ParamRef<number>` — `.add`, `.subtract`,
+  `.multiply`, `.divide`, and `.negate` — so agents can derive editable
+  dimensions like `param('r', 5).divide(2)` instead of falling back to plain
+  JS numbers (which silently `NaN`-coerce the branded ParamRef object). Each
+  method builds a structured expression that the dispatcher resolves against
+  the live ParamTable at lower time, so derived values stay reactive when the
+  underlying param is edited via `params.update`. Advertised through MCP
+  `list_api` as a new `paramRefMethods` array.
 
 ### Fixed — tech debt
 

--- a/src/compute/recomputeEngine.ts
+++ b/src/compute/recomputeEngine.ts
@@ -17,7 +17,7 @@ function normalizeBooleanOp(expr: string | undefined): 'subtract' | 'union' | 'i
   return undefined;
 }
 
-function isParamLike(v: unknown): v is { evaluated: number; paramRef?: string } {
+function isParamLike(v: unknown): v is { evaluated: number; paramRef?: unknown } {
   return (
     typeof v === 'object' &&
     v !== null &&
@@ -27,7 +27,11 @@ function isParamLike(v: unknown): v is { evaluated: number; paramRef?: string } 
 
 function enabledGateParamName(record: FeatureRecord): string | undefined {
   const enabled = (record.metadata as { enabled?: unknown } | undefined)?.enabled;
-  return isParamLike(enabled) ? enabled.paramRef : undefined;
+  if (!isParamLike(enabled)) return undefined;
+  // Boolean ParamRefs are leaves only (not composable per design); a string
+  // paramRef yields the gate name. Composed AST shapes carry no single name
+  // and don't apply to boolean gates.
+  return typeof enabled.paramRef === 'string' ? enabled.paramRef : undefined;
 }
 
 function isEnabledFalse(record: FeatureRecord): boolean {

--- a/src/intent/types.ts
+++ b/src/intent/types.ts
@@ -20,10 +20,12 @@ export interface Param {
   /**
    * Slice-3: when set, this Param is a symbolic reference into the session's
    * ParamTable. The dispatcher pre-resolves at lower time and refreshes
-   * `evaluated` from `paramTable.get(paramRef).value`. Lowerers never see this
-   * field set — they always operate on resolved Params.
+   * `evaluated` from the table. Plain string is the leaf-name shorthand
+   * (back-compat); a ParamRefExpr is the full AST for derived expressions
+   * like `param('r', 5).divide(2)`. Lowerers never see this field set — they
+   * always operate on resolved Params.
    */
-  paramRef?: string;
+  paramRef?: string | import('../runtime/paramRef').ParamRefExpr;
 }
 
 // Single source of truth for the six axis-aligned canonical face names.

--- a/src/mcp/tools/listApi.ts
+++ b/src/mcp/tools/listApi.ts
@@ -38,6 +38,7 @@ export interface ListApiOutput {
   shapeMethods?: ApiEntry[];
   sketchMethods?: ApiEntry[];
   pathBuilderMethods?: ApiEntry[];
+  paramRefMethods?: ApiEntry[];
   edgeQueryKeys?: readonly string[];
   faceQueryKeys?: readonly string[];
   /** Per-kind faceLabels support: which global functions accept opts.faceLabels and what values are valid. */
@@ -95,6 +96,14 @@ export const SKETCH_METHODS: ApiEntry[] = [
   { name: 'reflect', signature: `(axis: 'x' | 'y' | { axis: 'x' | 'y'; offset: number }) => Sketch`, description: "Reflect this sketch's path across an axis, returning a new Sketch. 'x' negates y-coords; 'y' negates x-coords; { axis, offset } reflects across the parallel axis at the given offset. Arc winding (signed sagitta/bulge/radius) is inverted automatically. Labels are preserved." },
 ];
 
+export const PARAM_REF_METHODS: ApiEntry[] = [
+  { name: 'add', signature: '(other: number | ParamRef<number>) => ParamRef<number>', description: 'Build a ParamRef whose value equals this ParamRef plus `other`. Use this instead of JS `+` (which would NaN-coerce the branded object).' },
+  { name: 'subtract', signature: '(other: number | ParamRef<number>) => ParamRef<number>', description: 'Build a ParamRef whose value equals this ParamRef minus `other`. Use this instead of JS `-`.' },
+  { name: 'multiply', signature: '(other: number | ParamRef<number>) => ParamRef<number>', description: 'Build a ParamRef whose value equals this ParamRef times `other`. Use this instead of JS `*`.' },
+  { name: 'divide', signature: '(other: number | ParamRef<number>) => ParamRef<number>', description: 'Build a ParamRef whose value equals this ParamRef divided by `other`. Division by zero throws at lower time, not at chain time. Use this instead of JS `/`.' },
+  { name: 'negate', signature: '() => ParamRef<number>', description: 'Build a ParamRef whose value equals the unary negation of this ParamRef. Use this instead of JS unary `-`.' },
+];
+
 export const PATH_BUILDER_METHODS: ApiEntry[] = [
   { name: 'moveTo', signature: '(x, y) => PathBuilder', description: 'Start the path at (x, y). Required first call.' },
   { name: 'lineTo', signature: '(x, y) => PathBuilder', description: 'Add a straight line segment to (x, y).' },
@@ -141,6 +150,7 @@ export async function listApiTool(input: ListApiInput = {}): Promise<ListApiOutp
     shapeMethods: SHAPE_METHODS,
     sketchMethods: SKETCH_METHODS,
     pathBuilderMethods: PATH_BUILDER_METHODS,
+    paramRefMethods: PARAM_REF_METHODS,
     edgeQueryKeys: EDGE_QUERY_KEYS,
     faceQueryKeys: FACE_QUERY_KEYS,
     featureKindFaceLabels: FEATURE_KIND_FACE_LABELS,

--- a/src/runtime/editableHelpers.ts
+++ b/src/runtime/editableHelpers.ts
@@ -2,19 +2,31 @@
 // records / numeric validation views. See spec §E.1, §E.3.
 
 import type { Param, Unit } from '../intent/types';
-import { isParamRef, type Editable } from './paramRef';
+import { isParamRef, paramExprToDebugString, type Editable } from './paramRef';
 import type { ParamTable } from './paramTable';
+import { resolveExpr } from './resolveParams';
 
 /** Build a Param from an `Editable<number>` value. When the input is a
  *  ParamRef, the resulting Param carries `paramRef` so the dispatcher
- *  pre-resolve substitutes it at lower time. */
+ *  pre-resolve substitutes it at lower time. Leaf ParamRefs store the bare
+ *  name string (back-compat with v0.4 captures); composed ParamRefs store
+ *  the structured AST so the resolver can walk it. */
 export function toParam(value: Editable<number>, unit: Unit): Param {
   if (isParamRef(value)) {
+    const expr = value._expr;
+    if (expr.kind === 'param') {
+      return {
+        expression: `{$param:${expr.name}}`,
+        unit,
+        evaluated: 0,
+        paramRef: expr.name,
+      };
+    }
     return {
-      expression: `{$param:${value.$param}}`,
+      expression: `{$paramExpr:${paramExprToDebugString(expr)}}`,
       unit,
       evaluated: 0,
-      paramRef: value.$param,
+      paramRef: expr,
     };
   }
   return { expression: String(value), unit, evaluated: value };
@@ -22,11 +34,12 @@ export function toParam(value: Editable<number>, unit: Unit): Param {
 
 /** Resolve an Editable<number> to its current numeric value at capture time
  *  (looking up the param table when symbolic). Used for validation, which
- *  needs concrete numbers for bounds / mutual-exclusion checks. */
+ *  needs concrete numbers for bounds / mutual-exclusion checks. Composed
+ *  ParamRefs are evaluated against the table via the same expression walker
+ *  the dispatcher uses at lower time. */
 export function currentValue(value: Editable<number>, table: ParamTable): number {
   if (!isParamRef(value)) return value;
-  const entry = table.get(value.$param);
-  return entry.value as number;
+  return resolveExpr(value._expr, table);
 }
 
 /** Same for Editable<boolean>. */
@@ -38,7 +51,9 @@ export function currentBool(value: Editable<boolean>, table: ParamTable): boolea
 
 /** Build a Param from an Editable<boolean>. Encodes booleans as
  *  evaluated 0|1 (unitless). Slice-3 stores `enabled` opts via this helper
- *  so the dispatcher's pre-resolve substitutes paramRefs uniformly. */
+ *  so the dispatcher's pre-resolve substitutes paramRefs uniformly. Boolean
+ *  ParamRefs are leaves only (not composable per design), so the stored
+ *  paramRef is always a bare name string. */
 export function toBoolParam(value: Editable<boolean>): Param {
   if (isParamRef(value)) {
     return {

--- a/src/runtime/paramRef.ts
+++ b/src/runtime/paramRef.ts
@@ -5,13 +5,135 @@
 // at capture time the proxy stores the symbolic ref in the FeatureRecord's
 // `params` blob (via `Param.paramRef`); at lower time the dispatcher pre-resolves
 // the ref through the session's ParamTable.
+//
+// As of v0.5 ParamRef<number> exposes arithmetic methods (.add, .subtract,
+// .multiply, .divide, .negate) that build a structured expression AST. The
+// expression is stored on `_expr` and resolved against the ParamTable at lower
+// time. This lets agents write `param('r', 5).divide(2)` instead of being
+// forced to use plain JS numbers (which would NaN-coerce the branded object).
+
+import { KernelError } from '../intent/kernelError';
 
 const PARAM_REF_BRAND = 'ParamRef' as const;
 
-export interface ParamRef<T extends number | boolean = number | boolean> {
+/** Structured expression AST for a ParamRef<number>. Four node kinds:
+ *  param leaf, numeric literal, binary op, and negation. Walk via the resolver
+ *  in `src/runtime/resolveParams.ts` to get a concrete number against a
+ *  ParamTable. Boolean ParamRefs always have `kind: 'param'`. */
+export type ParamRefExpr =
+  | { kind: 'param'; name: string }
+  | { kind: 'lit'; value: number }
+  | { kind: 'binop'; op: '+' | '-' | '*' | '/'; left: ParamRefExpr; right: ParamRefExpr }
+  | { kind: 'neg'; expr: ParamRefExpr };
+
+/** Build a debug-friendly string for an expression — used to populate
+ *  `ParamRef.$param` so that diagnostic messages and serialized blobs that
+ *  reference the ref read sensibly. Matches a leaf's bare name and parenthesizes
+ *  composed expressions, e.g. `(x / 2)`. */
+export function paramExprToDebugString(expr: ParamRefExpr): string {
+  switch (expr.kind) {
+    case 'param':
+      return expr.name;
+    case 'lit':
+      return String(expr.value);
+    case 'binop':
+      return `(${paramExprToDebugString(expr.left)} ${expr.op} ${paramExprToDebugString(expr.right)})`;
+    case 'neg':
+      return `(-${paramExprToDebugString(expr.expr)})`;
+  }
+}
+
+export class ParamRef<T extends number | boolean = number | boolean> {
   readonly $param: string;
-  readonly _brand: typeof PARAM_REF_BRAND;
+  readonly _brand: typeof PARAM_REF_BRAND = PARAM_REF_BRAND;
   readonly _type: T extends number ? 'number' : 'boolean';
+  readonly _expr: ParamRefExpr;
+
+  constructor(expr: ParamRefExpr, type: T extends number ? 'number' : 'boolean') {
+    this._expr = expr;
+    this._type = type;
+    this.$param = paramExprToDebugString(expr);
+    Object.freeze(this);
+  }
+
+  add(this: ParamRef<number>, other: number | ParamRef<number>): ParamRef<number> {
+    assertNumericReceiver(this, 'add');
+    return new ParamRef<number>(
+      { kind: 'binop', op: '+', left: this._expr, right: operandExpr(other, 'add') },
+      'number',
+    );
+  }
+
+  subtract(this: ParamRef<number>, other: number | ParamRef<number>): ParamRef<number> {
+    assertNumericReceiver(this, 'subtract');
+    return new ParamRef<number>(
+      { kind: 'binop', op: '-', left: this._expr, right: operandExpr(other, 'subtract') },
+      'number',
+    );
+  }
+
+  multiply(this: ParamRef<number>, other: number | ParamRef<number>): ParamRef<number> {
+    assertNumericReceiver(this, 'multiply');
+    return new ParamRef<number>(
+      { kind: 'binop', op: '*', left: this._expr, right: operandExpr(other, 'multiply') },
+      'number',
+    );
+  }
+
+  divide(this: ParamRef<number>, other: number | ParamRef<number>): ParamRef<number> {
+    assertNumericReceiver(this, 'divide');
+    return new ParamRef<number>(
+      { kind: 'binop', op: '/', left: this._expr, right: operandExpr(other, 'divide') },
+      'number',
+    );
+  }
+
+  negate(this: ParamRef<number>): ParamRef<number> {
+    assertNumericReceiver(this, 'negate');
+    return new ParamRef<number>({ kind: 'neg', expr: this._expr }, 'number');
+  }
+}
+
+function assertNumericReceiver(ref: ParamRef, method: string): void {
+  if (ref._type !== 'number') {
+    throw new KernelError(
+      'feature.invalid-args',
+      `ParamRef.${method}() requires a numeric ParamRef; got '${ref._type}' ParamRef '${ref.$param}'.`,
+      undefined,
+      `invalid-args.param.type-mismatch — ParamRef.${method}() requires a numeric ParamRef; got '${ref._type}' ParamRef '${ref.$param}'.`,
+    );
+  }
+}
+
+function operandExpr(other: number | ParamRef<number>, method: string): ParamRefExpr {
+  if (typeof other === 'number') {
+    if (!Number.isFinite(other)) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `ParamRef.${method}() operand must be a finite number; got ${other}.`,
+        undefined,
+        `invalid-args.param.invalid-args — ParamRef.${method}() operand must be a finite number; got ${other}.`,
+      );
+    }
+    return { kind: 'lit', value: other };
+  }
+  if (isParamRef(other)) {
+    if (other._type !== 'number') {
+      throw new KernelError(
+        'feature.invalid-args',
+        `ParamRef.${method}() operand must be a numeric ParamRef; got '${other._type}' ParamRef '${other.$param}'.`,
+        undefined,
+        `invalid-args.param.type-mismatch — ParamRef.${method}() operand must be a numeric ParamRef; got '${other._type}' ParamRef '${other.$param}'.`,
+      );
+    }
+    return other._expr;
+  }
+  throw new KernelError(
+    'feature.invalid-args',
+    `ParamRef.${method}() operand must be a number or numeric ParamRef.`,
+    undefined,
+    `invalid-args.param.invalid-args — ParamRef.${method}() operand must be a number or numeric ParamRef.`,
+  );
 }
 
 export type Editable<T extends number | boolean> = T | ParamRef<T>;
@@ -29,9 +151,5 @@ export function makeParamRef<T extends number | boolean>(
   name: string,
   type: T extends number ? 'number' : 'boolean',
 ): ParamRef<T> {
-  return Object.freeze({
-    $param: name,
-    _brand: PARAM_REF_BRAND,
-    _type: type,
-  }) as ParamRef<T>;
+  return new ParamRef<T>({ kind: 'param', name }, type);
 }

--- a/src/runtime/resolveParams.ts
+++ b/src/runtime/resolveParams.ts
@@ -10,11 +10,17 @@
 // `paramRef` name reached. Used at capture time to populate
 // `FeatureRecord.metadata.paramRefs` for the dependency index.
 //
+// As of v0.5 a Param's `paramRef` may be either a plain string (leaf-name
+// shorthand for back-compat) or a structured `ParamRefExpr` AST produced by
+// the arithmetic methods on `ParamRef<number>`. Both shapes are walked here.
+//
 // Lowerers never call these helpers — the dispatcher pre-resolves before
 // invoking the lowerer (lowerer signatures stay slice-2-stable).
 
 import type { Param } from '../intent/types';
+import { KernelError } from '../intent/kernelError';
 import type { ParamTable } from './paramTable';
+import type { ParamRefExpr } from './paramRef';
 
 function isParam(v: unknown): v is Param {
   return (
@@ -24,6 +30,68 @@ function isParam(v: unknown): v is Param {
     typeof (v as Param).unit === 'string' &&
     typeof (v as Param).evaluated === 'number'
   );
+}
+
+/** Walk a ParamRefExpr against the ParamTable and return the concrete number.
+ *  Looks up leaf `{ kind: 'param' }` nodes (booleans coerce to 0|1 to match the
+ *  numeric-Param shape that resolveParams produces). Throws on division by
+ *  zero with `feature.invalid-args`. */
+export function resolveExpr(expr: ParamRefExpr, table: ParamTable): number {
+  switch (expr.kind) {
+    case 'lit':
+      return expr.value;
+    case 'param': {
+      const entry = table.get(expr.name);
+      if (entry.type === 'boolean') return entry.value ? 1 : 0;
+      return entry.value as number;
+    }
+    case 'binop': {
+      const l = resolveExpr(expr.left, table);
+      const r = resolveExpr(expr.right, table);
+      switch (expr.op) {
+        case '+': return l + r;
+        case '-': return l - r;
+        case '*': return l * r;
+        case '/':
+          if (r === 0) {
+            throw new KernelError(
+              'feature.invalid-args',
+              'division by zero in ParamRef expression',
+              undefined,
+              `invalid-args.param.invalid-args — division by zero in ParamRef expression`,
+            );
+          }
+          return l / r;
+      }
+      // Exhaustiveness: `op` is a closed union, but a defensive throw keeps
+      // strict-mode compilers happy if the union grows.
+      throw new KernelError(
+        'feature.invalid-args',
+        `unknown ParamRef binop '${(expr as { op: string }).op}'`,
+        undefined,
+        `invalid-args.param.invalid-args — unknown ParamRef binop`,
+      );
+    }
+    case 'neg':
+      return -resolveExpr(expr.expr, table);
+  }
+}
+
+function collectExprNames(expr: ParamRefExpr, refs: Set<string>): void {
+  switch (expr.kind) {
+    case 'param':
+      refs.add(expr.name);
+      return;
+    case 'lit':
+      return;
+    case 'binop':
+      collectExprNames(expr.left, refs);
+      collectExprNames(expr.right, refs);
+      return;
+    case 'neg':
+      collectExprNames(expr.expr, refs);
+      return;
+  }
 }
 
 export function resolveParams<T>(blob: T, table: ParamTable): T {
@@ -45,17 +113,22 @@ function walkResolve(node: unknown, table: ParamTable): unknown {
   if (typeof node !== 'object') return node;
   if (isParam(node)) {
     if (!node.paramRef) return node;
-    const entry = table.get(node.paramRef);
-    if (entry.type === 'boolean') {
-      // Boolean Params: encode as evaluated 0|1 to stay number-typed; consumers
-      // (lowerer dispatcher's `enabled` check) will read entry.value directly
-      // through a parallel resolveBooleanParam path. For numeric-shape Params,
-      // this branch shouldn't be reached because boolean values are stored as
-      // their own field on the record (see capture proxy). Defensive: pass
-      // through as 0/1.
-      return { ...node, evaluated: entry.value ? 1 : 0 };
+    if (typeof node.paramRef === 'string') {
+      const entry = table.get(node.paramRef);
+      if (entry.type === 'boolean') {
+        // Boolean Params: encode as evaluated 0|1 to stay number-typed; consumers
+        // (lowerer dispatcher's `enabled` check) will read entry.value directly
+        // through a parallel resolveBooleanParam path. For numeric-shape Params,
+        // this branch shouldn't be reached because boolean values are stored as
+        // their own field on the record (see capture proxy). Defensive: pass
+        // through as 0/1.
+        return { ...node, evaluated: entry.value ? 1 : 0 };
+      }
+      return { ...node, evaluated: entry.value as number };
     }
-    return { ...node, evaluated: entry.value as number };
+    // Structured AST: walk the expression tree against the table.
+    const evaluated = resolveExpr(node.paramRef, table);
+    return { ...node, evaluated };
   }
   // Plain object: walk its entries.
   const obj = node as Record<string, unknown>;
@@ -83,7 +156,12 @@ function walkCollect(node: unknown, refs: Set<string>): void {
   }
   if (typeof node !== 'object') return;
   if (isParam(node)) {
-    if (node.paramRef) refs.add(node.paramRef);
+    if (!node.paramRef) return;
+    if (typeof node.paramRef === 'string') {
+      refs.add(node.paramRef);
+    } else {
+      collectExprNames(node.paramRef, refs);
+    }
     return;
   }
   const obj = node as Record<string, unknown>;

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -294,7 +294,7 @@ Resolution rule when names collide with canonical face names: created refs alway
 
 ## Editable parameters
 
-Use `param()` for values the user may want to tweak after the first build; use literals for incidental dimensions. A param returns a symbolic `ParamRef`, not a number, so do not do JS arithmetic with it. If a derived value should be editable, declare it as its own param. If it is incidental, compute it from literals before the chain.
+Use `param()` for values the user may want to tweak after the first build; use literals for incidental dimensions. A param returns a symbolic `ParamRef`, not a number, so do not do JS arithmetic with it (`paramRef / 2` will NaN-coerce the branded object). For derived dimensions, chain the arithmetic methods on the ParamRef itself: `.add`, `.subtract`, `.multiply`, `.divide`, `.negate` each return a new ParamRef built on a structured expression that re-evaluates whenever the underlying param changes — e.g. `param('r', 5).divide(2)` for a half-radius, or `param('w', 80).subtract(param('margin', 5).multiply(2))` for a derived inset width.
 
 ```typescript
 const boltDia = param('boltDia', 5, { min: 3, max: 10, description: 'bolt hole diameter' });

--- a/tests/unit/runtime/paramRefArithmetic.test.ts
+++ b/tests/unit/runtime/paramRefArithmetic.test.ts
@@ -1,0 +1,203 @@
+// tests/unit/runtime/paramRefArithmetic.test.ts
+//
+// Regression tests for the ParamRef arithmetic methods (.add, .subtract,
+// .multiply, .divide, .negate). Verifies AST construction, AST-walk
+// resolution against a ParamTable, table-update reactivity, cross-type
+// rejection, and dependency-collection over composed expressions.
+
+import { describe, it, expect } from 'vitest';
+import { makeParamRef, isParamRef, type ParamRefExpr } from '../../../src/runtime/paramRef';
+import { ParamTable } from '../../../src/runtime/paramTable';
+import { resolveExpr, resolveParams, collectParamRefs } from '../../../src/runtime/resolveParams';
+import { toParam } from '../../../src/runtime/editableHelpers';
+
+function declared(table: ParamTable, name: string, value: number): void {
+  table.declare(name, 'number', value);
+}
+
+describe('ParamRef arithmetic methods', () => {
+  it('.add(number) builds a binop AST and resolves correctly', () => {
+    const t = new ParamTable();
+    declared(t, 'x', 10);
+    const x = makeParamRef<number>('x', 'number');
+    const expr = x.add(5);
+    expect(isParamRef(expr)).toBe(true);
+    expect(expr._expr.kind).toBe('binop');
+    expect(resolveExpr(expr._expr, t)).toBe(15);
+  });
+
+  it('.subtract(number) resolves correctly', () => {
+    const t = new ParamTable();
+    declared(t, 'x', 10);
+    const x = makeParamRef<number>('x', 'number');
+    expect(resolveExpr(x.subtract(3)._expr, t)).toBe(7);
+  });
+
+  it('.multiply(number) resolves correctly', () => {
+    const t = new ParamTable();
+    declared(t, 'r', 5);
+    const r = makeParamRef<number>('r', 'number');
+    expect(resolveExpr(r.multiply(2)._expr, t)).toBe(10);
+  });
+
+  it('.divide(number) resolves correctly', () => {
+    const t = new ParamTable();
+    declared(t, 'r', 10);
+    const r = makeParamRef<number>('r', 'number');
+    expect(resolveExpr(r.divide(2)._expr, t)).toBe(5);
+  });
+
+  it('.negate() resolves correctly', () => {
+    const t = new ParamTable();
+    declared(t, 'x', 7);
+    const x = makeParamRef<number>('x', 'number');
+    expect(resolveExpr(x.negate()._expr, t)).toBe(-7);
+  });
+
+  it('chained .add(5).divide(2) builds nested AST and resolves correctly', () => {
+    const t = new ParamTable();
+    declared(t, 'x', 10);
+    const x = makeParamRef<number>('x', 'number');
+    const y = x.add(5).divide(2);
+    expect(resolveExpr(y._expr, t)).toBe(7.5);
+    // Outer node should be the divide.
+    expect(y._expr.kind).toBe('binop');
+    if (y._expr.kind === 'binop') {
+      expect(y._expr.op).toBe('/');
+      expect(y._expr.left.kind).toBe('binop');
+    }
+  });
+
+  it('mixed operands (paramRef + paramRef) resolve against the table', () => {
+    const t = new ParamTable();
+    declared(t, 'a', 4);
+    declared(t, 'b', 3);
+    const a = makeParamRef<number>('a', 'number');
+    const b = makeParamRef<number>('b', 'number');
+    expect(resolveExpr(a.add(b)._expr, t)).toBe(7);
+    expect(resolveExpr(a.multiply(b)._expr, t)).toBe(12);
+    expect(resolveExpr(a.subtract(b)._expr, t)).toBe(1);
+    expect(resolveExpr(a.divide(b)._expr, t)).toBeCloseTo(4 / 3, 10);
+  });
+
+  it('debug $param string reflects the composed expression', () => {
+    const x = makeParamRef<number>('x', 'number');
+    expect(x.$param).toBe('x');
+    expect(x.divide(2).$param).toBe('(x / 2)');
+    expect(x.add(5).divide(2).$param).toBe('((x + 5) / 2)');
+    expect(x.negate().$param).toBe('(-x)');
+  });
+
+  it('arithmetic on a boolean ParamRef throws feature.invalid-args', () => {
+    const flag = makeParamRef<boolean>('flag', 'boolean');
+    // Cast: TypeScript narrows .add to the numeric overload via `this`-typing,
+    // but we want to verify the runtime guard for callers that bypass the
+    // type system (e.g. .kcad.ts authored without strict types).
+    const bogus = flag as unknown as ReturnType<typeof makeParamRef<number>>;
+    expect(() => bogus.add(1)).toThrow(/numeric ParamRef/);
+    expect(() => bogus.divide(2)).toThrow(/numeric ParamRef/);
+    expect(() => bogus.negate()).toThrow(/numeric ParamRef/);
+  });
+
+  it('numeric receiver rejects boolean ParamRef as operand', () => {
+    const x = makeParamRef<number>('x', 'number');
+    const flag = makeParamRef<boolean>('flag', 'boolean');
+    const bogus = flag as unknown as ReturnType<typeof makeParamRef<number>>;
+    expect(() => x.add(bogus)).toThrow(/numeric ParamRef/);
+    expect(() => x.multiply(bogus)).toThrow(/numeric ParamRef/);
+  });
+
+  it('numeric literal operand must be finite', () => {
+    const x = makeParamRef<number>('x', 'number');
+    expect(() => x.add(Number.NaN)).toThrow(/finite number/);
+    expect(() => x.multiply(Number.POSITIVE_INFINITY)).toThrow(/finite number/);
+  });
+
+  it('division by literal 0 builds valid AST but throws at evaluation', () => {
+    const t = new ParamTable();
+    declared(t, 'x', 10);
+    const x = makeParamRef<number>('x', 'number');
+    const y = x.divide(0);
+    // AST construction succeeds — no eager arithmetic in capture.
+    expect(y._expr.kind).toBe('binop');
+    expect(() => resolveExpr(y._expr, t)).toThrow(/division by zero/);
+  });
+
+  it('division by zero through table-resolved param throws at evaluation', () => {
+    const t = new ParamTable();
+    declared(t, 'x', 10);
+    declared(t, 'd', 0);
+    const x = makeParamRef<number>('x', 'number');
+    const d = makeParamRef<number>('d', 'number');
+    const y = x.divide(d);
+    expect(() => resolveExpr(y._expr, t)).toThrow(/division by zero/);
+  });
+
+  it('table updates reflow through composed expressions', () => {
+    const t = new ParamTable();
+    declared(t, 'x', 10);
+    const x = makeParamRef<number>('x', 'number');
+    const half = x.divide(2);
+    expect(resolveExpr(half._expr, t)).toBe(5);
+    t.set('x', 20);
+    expect(resolveExpr(half._expr, t)).toBe(10);
+  });
+
+  it('toParam stores AST for composed ParamRefs and resolveParams refreshes evaluated', () => {
+    const t = new ParamTable();
+    declared(t, 'r', 10);
+    const r = makeParamRef<number>('r', 'number');
+    const half = r.divide(2);
+    const param = toParam(half, 'mm');
+    // AST is stored, not a string.
+    expect(typeof param.paramRef).toBe('object');
+    const expr = param.paramRef as ParamRefExpr;
+    expect(expr.kind).toBe('binop');
+
+    const resolved = resolveParams({ radius: param }, t) as { radius: { evaluated: number } };
+    expect(resolved.radius.evaluated).toBe(5);
+
+    // Update the table; resolveParams reflects the change.
+    t.set('r', 30);
+    const resolved2 = resolveParams({ radius: param }, t) as { radius: { evaluated: number } };
+    expect(resolved2.radius.evaluated).toBe(15);
+  });
+
+  it('toParam keeps leaf ParamRef as bare-name string (back-compat)', () => {
+    const r = makeParamRef<number>('r', 'number');
+    const param = toParam(r, 'mm');
+    expect(typeof param.paramRef).toBe('string');
+    expect(param.paramRef).toBe('r');
+  });
+
+  it('collectParamRefs walks the AST and returns all leaf names', () => {
+    const t = new ParamTable();
+    declared(t, 'a', 1);
+    declared(t, 'b', 2);
+    declared(t, 'c', 3);
+    const a = makeParamRef<number>('a', 'number');
+    const b = makeParamRef<number>('b', 'number');
+    const c = makeParamRef<number>('c', 'number');
+    // Expression: ((a + b) * c) - a    →  leaves {a, b, c} (a appears twice).
+    const expr = a.add(b).multiply(c).subtract(a);
+    const blob = { x: toParam(expr, 'mm') };
+    const refs = collectParamRefs(blob);
+    expect(refs.size).toBe(3);
+    expect(refs.has('a')).toBe(true);
+    expect(refs.has('b')).toBe(true);
+    expect(refs.has('c')).toBe(true);
+  });
+
+  it('collectParamRefs unions string-shorthand and AST-shaped paramRefs', () => {
+    const x = makeParamRef<number>('x', 'number');
+    const y = makeParamRef<number>('y', 'number');
+    const blob = {
+      a: toParam(x, 'mm'),                 // leaf: paramRef is 'x' string
+      b: toParam(y.add(1), 'mm'),          // composed: paramRef is AST
+    };
+    const refs = collectParamRefs(blob);
+    expect(refs.size).toBe(2);
+    expect(refs.has('x')).toBe(true);
+    expect(refs.has('y')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds five arithmetic methods to `ParamRef<number>` so agents can write `param('r', 5).divide(2)` instead of being forced into plain JS numbers. Closes the only entry on `kernelCAD-private/docs/process/api-ergonomic-gaps.md` (logged 2026-05-08 from the robotArmKit demotion slice — that PR had to drop all 11 `param()` calls because `screwSpacingX / 2` silently produced `NaN`).

Each method:
- accepts `number | ParamRef<number>` as operand
- returns a new `ParamRef<number>` whose value composes the receiver with the operand
- evaluates against the live `ParamTable` at lower time, so derived values stay reactive on `params.update`

```ts
const r = param('r', 5);
const h = param('h', 10);
return cylinder(r.multiply(2), h).fillet(r.divide(5));   // works clean
```

## Architecture

- `ParamRef` becomes a class (still structurally branded — `isParamRef` unchanged). Internal state grows a `_expr: ParamRefExpr` field — a small AST with 4 node kinds (`param`, `lit`, `binop`, `neg`).
- Methods build new ASTs and return new `ParamRef` instances.
- `Param.paramRef` widens from `string` to `string | ParamRefExpr`. Existing leaf storage (string) keeps working — backward compatible.
- `resolveParams` (and `collectParamRefs`) discriminate on `typeof`: string → existing table-lookup path; object → walk the AST recursively.
- No new dependencies. Custom evaluator is ~30 lines.
- Boolean ParamRefs unchanged — arithmetic methods reject boolean operands at the call site with `feature.invalid-args`.

## Commits

1. `feat(runtime): refactor ParamRef to class with arithmetic methods` — `7301372`
2. `feat(runtime): walk ParamRef AST in resolveParams + collectParamRefs` — `2b38321`
3. `feat(capture): store AST for non-leaf ParamRef in Param.paramRef` — `9c44c06`
4. `test(runtime): regression tests for ParamRef arithmetic methods` — `4054f15`
5. `feat(api): advertise ParamRef arithmetic methods + CHANGELOG` — `6197152`

## Test Plan

- [x] `tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `tests/unit/runtime/`: 79/79 pass (61 pre-existing + 18 new in `paramRefArithmetic.test.ts`)
- [x] `tests/unit/capture/`: 164/164 pass
- [x] Drift sentinels (`tests/unit/skill/`, `tests/integration/mcp/listApi*.test.ts`): 22/22 pass
- [x] `npm test` full: **1364 passed**, 17 pre-existing skipped, no new failures
- [x] Smoke probe: `cylinder(r.multiply(2), h).fillet(r.divide(5))` → 2 features, OK
- [ ] CI green

## Test coverage

New `tests/unit/runtime/paramRefArithmetic.test.ts` covers:
- Each of the 5 methods individually
- Chained `.add(5).divide(2)` expressions
- Mixed operands (paramRef + paramRef)
- Cross-type rejection (boolean ParamRef in arithmetic → `feature.invalid-args` thrown synchronously)
- Division by literal 0 builds a valid AST, throws at evaluation (matches every other symbolic-math system)
- Change-table-and-re-resolve: declare `x=10`, build `x.divide(2)` → 5; update `x` to 20, resolve again → 10
- `collectParamRefs` walks the AST and accumulates all leaf names

## Out of scope (deferred)

- Rewriting the robot-arm desktop-3axis example to restore parametric authoring. Separate slice if/when worth demonstrating.
- Donut as a parametric example. Same.
- Boolean composition methods (`.and()`, `.or()`, `.not()`) — different domain.
- Comparison operators — different domain.
- Aliases (`.times()`, `.half()`) — five methods is the lean surface.

## Spec + plan

In `kernelCAD-private`: `docs/specs/2026-05-08-paramref-arithmetic-methods-design.md`, `docs/plans/2026-05-08-paramref-arithmetic-methods.md`.

## Implementer notes (small deviations from plan)

- `currentBool` (`src/runtime/editableHelpers.ts`) intentionally kept its `value.$param` lookup since boolean ParamRefs are leaves only (per design); for leaves, `$param === name`, so the path is correct.
- One ancillary edit in `src/compute/recomputeEngine.ts` widened `isParamLike`'s type guard for the new `paramRef?: string | ParamRefExpr` shape; narrows via `typeof === 'string'` for the `enabledGateParamName` path. No behavior change.
- `SKILL.md` "Editable parameters" subsection rewritten in place rather than appended — replaced the old "do not do JS arithmetic" prohibition with positive examples of `.divide` / `.multiply` so agents see the method-chaining path immediately.