### PR TITLE
feat(examples): parametric v0.21 donut demonstrating ParamRef arithmetic + fillet-on-revolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,17 @@ npm run dev
   underlying param is edited via `params.update`. Advertised through MCP
   `list_api` as a new `paramRefMethods` array.
 
+### Changed — example demonstrations
+
+- Rewrote `examples/v0.21/donut.kcad.ts` (the v0.21 hero artifact) to
+  exercise the just-shipped capabilities end-to-end: 7 of its 9 dimensions
+  are now declared via `param()`; glaze inner/outer radii derive from body
+  via `.add` / `.subtract`; body and glaze rings revolve and fillet via the
+  fillet-on-revolved fix. Body/glaze heights stay literal because
+  `.translate(x, y, z)` does not accept `ParamRef` today (sprinkle Z is
+  computed from those literals). Total: 13 features, builds clean from a
+  fresh evaluate.
+
 ### Fixed — tech debt
 
 - Rejected non-uniform `.scale(sx, sy, sz)` at capture time instead of silently

--- a/examples/v0.21/donut.kcad.ts
+++ b/examples/v0.21/donut.kcad.ts
@@ -1,58 +1,56 @@
-// v0.21 hero artifact: donut with glaze and sprinkles.
+// v0.21 hero artifact: parametric donut (body + glaze + sprinkles).
 //
-// Built using only v0.1/v0.2/v0.21-available primitives (no torus primitive
-// in current API). Body is a square-cross-section ring via revolveRect, then
-// .fillet() rounds every edge so it reads as a torus. Glaze is a thinner
-// ring sitting on top, slightly oversized for a "drip" silhouette. Sprinkles
-// are small extruded cylinders scattered on the glaze top.
+// Demonstrates the just-shipped capabilities:
+//   - `param()` for editable dimensions (params.update at runtime re-lowers)
+//   - ParamRef arithmetic (`.add`, `.subtract`) for derived dimensions
+//   - `.fillet()` on revolved geometry (filletable on `revolveRect` per
+//     `cylinder().fillet()` and friends now composing cleanly)
 //
-// Per memorable-builds policy spec §2 (v0.21 catalog entry).
+// Per the memorable-builds policy (see `kernelCAD-private/docs/process/`).
+//
+// Limitation worth flagging for agents: `.translate(x, y, z)` accepts plain
+// numbers only, not `ParamRef`. So the body/glaze HEIGHTS that feed sprinkle
+// Z position stay as literal numbers; everything else is parametric.
 
-const bodyInnerR = 12;
-const bodyOuterR = 35;
-const bodyHeight = 18;
-const bodyFillet = 7;
+const bodyInnerR = param('bodyInnerR', 12);
+const bodyOuterR = param('bodyOuterR', 35);
+const bodyHeightVal = 18;
+const bodyFilletR = param('bodyFilletR', 7);
 
-const glazeOverhang = 1;
-const glazeInset = 1;
-const glazeHeight = 5;
-const glazeFillet = 1.5;
+const glazeOverhang = param('glazeOverhang', 1);
+const glazeInset = param('glazeInset', 1);
+const glazeHeightVal = 5;
+const glazeFilletR = param('glazeFilletR', 1.5);
 
-const sprinkleR = 1;
-const sprinkleH = 3;
+const sprinkleR = param('sprinkleR', 1);
+const sprinkleH = param('sprinkleH', 3);
 
-const body = revolveRect(
-  bodyOuterR - bodyInnerR,
-  bodyHeight,
-  bodyInnerR,
-).fillet(bodyFillet);
+// Body: square cross-section ring of width = outerR - innerR.
+const bodyWidth = bodyOuterR.subtract(bodyInnerR);
+const body = revolveRect(bodyWidth, bodyHeightVal, bodyInnerR).fillet(bodyFilletR);
 
-const glaze = revolveRect(
-  (bodyOuterR + glazeOverhang) - (bodyInnerR + glazeInset),
-  glazeHeight,
-  bodyInnerR + glazeInset,
-)
-  .translate(0, 0, bodyHeight)
-  .fillet(glazeFillet);
+// Glaze: thinner ring sitting on top of the body, slightly oversized for a
+// "drip" silhouette. Inner/outer radii derive from the body via ParamRef
+// arithmetic so the glaze tracks the body when params edit.
+const glazeOuterR = bodyOuterR.add(glazeOverhang);
+const glazeInnerR = bodyInnerR.add(glazeInset);
+const glazeWidth = glazeOuterR.subtract(glazeInnerR);
+const glaze = revolveRect(glazeWidth, glazeHeightVal, glazeInnerR)
+  .translate(0, 0, bodyHeightVal)
+  .fillet(glazeFilletR);
 
-const sprinkleZ = bodyHeight + glazeHeight;
-
+// Sprinkles scattered around the glaze top. Positions are JS-computed (polar
+// → Cartesian); only the sprinkle dimensions are parametric.
+const sprinkleZ = bodyHeightVal + glazeHeightVal;
 const sprinklePolar: Array<[number, number]> = [
-  [22, 15],
-  [18, 60],
-  [25, 105],
-  [20, 150],
-  [23, 200],
-  [19, 245],
-  [22, 290],
-  [21, 335],
+  [22, 15], [18, 60], [25, 105], [20, 150],
+  [23, 200], [19, 245], [22, 290], [21, 335],
 ];
-
-const sprinkles = sprinklePolar.map(([r, deg]) => {
+const sprinkles = sprinklePolar.map(([radius, deg]) => {
   const rad = (deg * Math.PI) / 180;
   return cylinder(sprinkleH, sprinkleR).translate(
-    r * Math.cos(rad),
-    r * Math.sin(rad),
+    radius * Math.cos(rad),
+    radius * Math.sin(rad),
     sprinkleZ,
   );
 });


### PR DESCRIPTION
## Summary

Closes the loop on today's two marquee capabilities — ParamRef arithmetic methods (#110) and fillet-on-revolved-shapes (#109) — by rewriting the v0.21 hero artifact (`examples/v0.21/donut.kcad.ts`) to actually exercise them end-to-end. Per the memorable-builds policy, the hero artifact must visibly demonstrate the milestone's marquee capabilities; before this PR the donut was filleting via the now-fixed path but used plain JS numbers throughout.

## What changed

- 7 of 9 dimensions declared via `param()`: `bodyInnerR`, `bodyOuterR`, `bodyFilletR`, `glazeOverhang`, `glazeInset`, `glazeFilletR`, `sprinkleR`, `sprinkleH`.
- Derived dimensions via ParamRef arithmetic:
  - `bodyWidth = bodyOuterR.subtract(bodyInnerR)`
  - `glazeOuterR = bodyOuterR.add(glazeOverhang)`
  - `glazeInnerR = bodyInnerR.add(glazeInset)`
  - `glazeWidth = glazeOuterR.subtract(glazeInnerR)`
- Body and glaze still use `revolveRect(...).fillet(...)` — both now compose cleanly post-#109.
- `bodyHeightVal` and `glazeHeightVal` stay literal because `.translate(x, y, z)` does not accept `ParamRef` today; sprinkle Z is computed from those literals. The comment in the file flags this limitation explicitly so agents reading the example see the rough edge.

## Test plan

- [x] `npx tsx src/cli/index.ts evaluate examples/v0.21/donut.kcad.ts` → 13 features, OK
- [x] `tsc --noEmit` clean
- [x] `npm run lint` clean
- [ ] CI green

## Out of scope

- Extending `path()` / `.translate(...)` to accept `Editable<number>` so body/glaze heights can also be parametric. Bigger surface change; would invalidate the current `.translate` signature. Worth its own slice if the limitation matters more than the demonstration.
- `revolveRect` demotion. Coming up next as a separate slice — the donut will need a second rewrite then to use `path()` + `Sketch.revolve()`.