### PR TITLE
feat(api): demote revolveRect; PathBuilder accepts Editable<number>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,12 @@ npm run dev
   `bulgeArc` factor wraps as `'unitless'`; everything else is `'mm'`.
   Advertised through `list_api`'s `pathBuilderMethods` and SKILL.md.
 
+  Limitation: `Sketch.reflect(axis)` collapses any symbolic ParamRef coords
+  to their current numeric values at reflect time. The reflected sketch
+  does not track param edits for the reflected coords. Author the reflected
+  path directly when you need full param tracking on both halves. Tracked
+  in the api-ergonomic-gaps backlog.
+
 ### Changed — example demonstrations
 
 - Rewrote `examples/v0.21/donut.kcad.ts` (the v0.21 hero artifact) to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,16 +92,29 @@ npm run dev
   underlying param is edited via `params.update`. Advertised through MCP
   `list_api` as a new `paramRefMethods` array.
 
+### Changed — PathBuilder accepts editable parameters
+
+- Widened every `PathBuilder` method (`moveTo`, `lineTo`, `tangentArc`,
+  `threePointsArc`, `sagittaArc`, `bulgeArc`, `radiusArc`) so coords and
+  scalar arguments accept `Editable<number>` (`number | ParamRef<number>`).
+  `SketchCommand` now stores `Param` objects on those positions instead
+  of bare numbers; the dispatcher's pre-resolve substitutes any symbolic
+  ParamRef at lower time, so a `path()...close().revolve()` profile is
+  fully parametric and reactive to `params.update`. The
+  `bulgeArc` factor wraps as `'unitless'`; everything else is `'mm'`.
+  Advertised through `list_api`'s `pathBuilderMethods` and SKILL.md.
+
 ### Changed — example demonstrations
 
 - Rewrote `examples/v0.21/donut.kcad.ts` (the v0.21 hero artifact) to
   exercise the just-shipped capabilities end-to-end: 7 of its 9 dimensions
   are now declared via `param()`; glaze inner/outer radii derive from body
-  via `.add` / `.subtract`; body and glaze rings revolve and fillet via the
-  fillet-on-revolved fix. Body/glaze heights stay literal because
-  `.translate(x, y, z)` does not accept `ParamRef` today (sprinkle Z is
-  computed from those literals). Total: 13 features, builds clean from a
-  fresh evaluate.
+  via `.add` / `.subtract`; body and glaze profiles authored via
+  `path()...close().revolve()` so every revolution coord is a ParamRef.
+  Body and glaze fillets compose via the fillet-on-revolved fix.
+  Body/glaze heights stay literal because `.translate(x, y, z)` does not
+  accept `ParamRef` today (sprinkle Z is computed from those literals).
+  Total: 15 features, builds clean from a fresh evaluate.
 
 ### Fixed — tech debt
 
@@ -142,6 +155,18 @@ npm run dev
   generic primitives, assemblies, and revolute joints. Use it via
   `lookup_cookbook("multi-part mechanical assembly")` or
   `evaluate_script({ file: "examples/robot-arm/desktop-3axis.kcad.ts" })`.
+
+### Removed — duplicative revolved-rect helper
+
+- Removed `revolveRect(w, h, offsetX, angleDeg?, opts?)` from the script
+  global surface, `OcctBackend.revolveRect`, the `list_api` /
+  `SKILL.md` / `featureKindFaceLabels` advertisements, and the
+  `revolve` lowerer's profileKind dispatch. The helper had zero unique
+  capability over `path().moveTo(...).lineTo(...).close().revolve()` —
+  the same washer/donut-body geometry, but every coord is now an
+  `Editable<number>` so authoring stays parametric end-to-end.
+  Pre-1.0; consistent with the `robotArmKit` precedent (no deprecation
+  alias).
 
 ### Added — v0.3 slice 3: symbolic params + edit-after-build replay
 

--- a/cookbook/snippets/revolve-rectangular-profile.md
+++ b/cookbook/snippets/revolve-rectangular-profile.md
@@ -1,14 +1,20 @@
 ---
 id: revolve-rectangular-profile
-title: Cylindrical wall or ring via revolveRect with offset
-tags: [revolve, primitive]
+title: Cylindrical wall or ring via path + revolve
+tags: [revolve, sketch, primitive]
 keywords:
   - thin cylindrical wall
   - ring or tube
   - revolve a rectangle offset from the axis
-when_to_use: You want a thin cylindrical wall, ring, or tube — revolve a rectangle around Z with an offset from the axis equal to the inner radius.
+when_to_use: You want a thin cylindrical wall, ring, or tube — author the rectangular profile via path() with the inner radius as the x offset, then call .revolve() to sweep it around Z.
 ---
 
 ```typescript
-return revolveRect(2, 20, 15, 360);
+return path()
+  .moveTo(15, 0)
+  .lineTo(17, 0)
+  .lineTo(17, 20)
+  .lineTo(15, 20)
+  .close()
+  .revolve();
 ```

--- a/examples/v0.21/donut.kcad.ts
+++ b/examples/v0.21/donut.kcad.ts
@@ -3,14 +3,14 @@
 // Demonstrates the just-shipped capabilities:
 //   - `param()` for editable dimensions (params.update at runtime re-lowers)
 //   - ParamRef arithmetic (`.add`, `.subtract`) for derived dimensions
-//   - `.fillet()` on revolved geometry (filletable on `revolveRect` per
-//     `cylinder().fillet()` and friends now composing cleanly)
+//   - `path()...close().revolve().fillet()` end-to-end parametric — every
+//     coord on the revolution profile is a ParamRef
 //
 // Per the memorable-builds policy (see `kernelCAD-private/docs/process/`).
 //
 // Limitation worth flagging for agents: `.translate(x, y, z)` accepts plain
 // numbers only, not `ParamRef`. So the body/glaze HEIGHTS that feed sprinkle
-// Z position stay as literal numbers; everything else is parametric.
+// Z position stay as literal numbers; PathBuilder is now fully parametric.
 
 const bodyInnerR = param('bodyInnerR', 12);
 const bodyOuterR = param('bodyOuterR', 35);
@@ -25,17 +25,29 @@ const glazeFilletR = param('glazeFilletR', 1.5);
 const sprinkleR = param('sprinkleR', 1);
 const sprinkleH = param('sprinkleH', 3);
 
-// Body: square cross-section ring of width = outerR - innerR.
-const bodyWidth = bodyOuterR.subtract(bodyInnerR);
-const body = revolveRect(bodyWidth, bodyHeightVal, bodyInnerR).fillet(bodyFilletR);
+// Body: rectangular cross-section ring revolved around Z. Coords on the
+// revolution profile are ParamRefs so dimensions stay editable end-to-end.
+const body = path()
+  .moveTo(bodyInnerR, 0)
+  .lineTo(bodyOuterR, 0)
+  .lineTo(bodyOuterR, bodyHeightVal)
+  .lineTo(bodyInnerR, bodyHeightVal)
+  .close()
+  .revolve()
+  .fillet(bodyFilletR);
 
 // Glaze: thinner ring sitting on top of the body, slightly oversized for a
 // "drip" silhouette. Inner/outer radii derive from the body via ParamRef
 // arithmetic so the glaze tracks the body when params edit.
 const glazeOuterR = bodyOuterR.add(glazeOverhang);
 const glazeInnerR = bodyInnerR.add(glazeInset);
-const glazeWidth = glazeOuterR.subtract(glazeInnerR);
-const glaze = revolveRect(glazeWidth, glazeHeightVal, glazeInnerR)
+const glaze = path()
+  .moveTo(glazeInnerR, 0)
+  .lineTo(glazeOuterR, 0)
+  .lineTo(glazeOuterR, glazeHeightVal)
+  .lineTo(glazeInnerR, glazeHeightVal)
+  .close()
+  .revolve()
   .translate(0, 0, bodyHeightVal)
   .fillet(glazeFilletR);
 

--- a/scripts/demo-prompts/v0.21-donut.md
+++ b/scripts/demo-prompts/v0.21-donut.md
@@ -4,6 +4,6 @@ Build a recognizable donut: a torus-shaped body with a smaller glaze ring sittin
 
 The donut body should read as a classic ring shape (rounded edges, hole through the middle, height comfortable to the eye). The glaze should overhang slightly on the outside and inset slightly into the hole, giving a soft "drip" silhouette. Sprinkles should be cylindrical pieces, irregularly placed across the glaze top.
 
-Constraints: build using only primitives + booleans + fillets available at v0.21 (no `torus` primitive — use `revolveRect` + `fillet` to approximate). All distances in mm.
+Constraints: build using only primitives + sketches + booleans + fillets available at v0.21 (no `torus` primitive — author rectangular profiles via `path()...close().revolve()` and `.fillet()` to approximate). All distances in mm.
 
 Parameters: hole radius, outer radius, body height, body fillet, glaze overhang, glaze inset, glaze height, glaze fillet, sprinkle radius, sprinkle height.

--- a/src/backends/occt/cutoutLowerer.ts
+++ b/src/backends/occt/cutoutLowerer.ts
@@ -79,7 +79,7 @@ function profileBboxRadius(commands: readonly SketchCommand[]): number {
   let maxR = 0;
   for (const c of commands) {
     if ('x' in c && 'y' in c) {
-      const r = Math.hypot(c.x, c.y);
+      const r = Math.hypot(c.x.evaluated, c.y.evaluated);
       if (r > maxR) maxR = r;
     }
   }
@@ -95,23 +95,26 @@ function drawingFromCommands(commands: readonly SketchCommand[]): replicad.Drawi
   const first = commands[0];
   if (first.kind !== 'moveTo') throw new Error('cutoutLowerer.drawingFromCommands: first command must be moveTo');
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let pen: any = replicad.draw([first.x, first.y]);
+  let pen: any = replicad.draw([first.x.evaluated, first.y.evaluated]);
   for (let i = 1; i < closeIdx; i++) {
     const c = commands[i];
-    if (c.kind === 'lineTo') pen = pen.lineTo([c.x, c.y]);
-    else if (c.kind === 'tangentArc') pen = pen.tangentArcTo([c.x, c.y]);
-    else if (c.kind === 'threePointsArc') pen = pen.threePointsArcTo([c.x, c.y], [c.midX, c.midY]);
-    else if (c.kind === 'sagittaArc') pen = pen.sagittaArcTo([c.x, c.y], c.sagitta);
-    else if (c.kind === 'bulgeArc') pen = pen.bulgeArcTo([c.x, c.y], c.bulge);
+    if (c.kind === 'lineTo') pen = pen.lineTo([c.x.evaluated, c.y.evaluated]);
+    else if (c.kind === 'tangentArc') pen = pen.tangentArcTo([c.x.evaluated, c.y.evaluated]);
+    else if (c.kind === 'threePointsArc') pen = pen.threePointsArcTo([c.x.evaluated, c.y.evaluated], [c.midX.evaluated, c.midY.evaluated]);
+    else if (c.kind === 'sagittaArc') pen = pen.sagittaArcTo([c.x.evaluated, c.y.evaluated], c.sagitta.evaluated);
+    else if (c.kind === 'bulgeArc') pen = pen.bulgeArcTo([c.x.evaluated, c.y.evaluated], c.bulge.evaluated);
     else if (c.kind === 'radiusArc') {
       // radius → sagitta conversion (positive bulges left of chord)
-      const dx = c.x - first.x, dy = c.y - first.y;
+      const cx = c.x.evaluated;
+      const cy = c.y.evaluated;
+      const cr = c.radius.evaluated;
+      const dx = cx - first.x.evaluated, dy = cy - first.y.evaluated;
       const chord = Math.hypot(dx, dy);
       const halfChord = chord / 2;
-      const r = Math.abs(c.radius);
+      const r = Math.abs(cr);
       if (r < halfChord) throw new Error(`cutoutLowerer: radiusArc |radius|=${r} < chord/2=${halfChord}`);
-      const sagitta = (c.radius >= 0 ? 1 : -1) * (r - Math.sqrt(r * r - halfChord * halfChord));
-      pen = pen.sagittaArcTo([c.x, c.y], sagitta);
+      const sagitta = (cr >= 0 ? 1 : -1) * (r - Math.sqrt(r * r - halfChord * halfChord));
+      pen = pen.sagittaArcTo([cx, cy], sagitta);
     }
   }
   return pen.close();

--- a/src/backends/occt/edgeSelection.ts
+++ b/src/backends/occt/edgeSelection.ts
@@ -865,7 +865,7 @@ function labelToEdgeQuery(
     };
   }
 
-  const commands = (upstreamSketch.metadata as { commands?: Array<{ kind: string; x?: number; y?: number; label?: string }> } | undefined)?.commands;
+  const commands = (upstreamSketch.metadata as { commands?: Array<{ kind: string; x?: { evaluated: number }; y?: { evaluated: number }; label?: string }> } | undefined)?.commands;
   if (!commands) {
     return {
       error: {
@@ -910,6 +910,10 @@ function labelToEdgeQuery(
       },
     };
   }
+  const prevX = prev.x.evaluated;
+  const prevY = prev.y.evaluated;
+  const segX = segment.x.evaluated;
+  const segY = segment.y.evaluated;
 
   const depth = extractExtrudeDepth(records, record);
   if (depth === null) {
@@ -932,10 +936,10 @@ function labelToEdgeQuery(
   // these four edges' midpoints — collapsed in any axis where the segment is
   // axis-parallel, expanded by `tol` to absorb floating-point noise.
   const tol = 1e-3;
-  const xMin = Math.min(prev.x, segment.x) - tol;
-  const xMax = Math.max(prev.x, segment.x) + tol;
-  const yMin = Math.min(prev.y, segment.y) - tol;
-  const yMax = Math.max(prev.y, segment.y) + tol;
+  const xMin = Math.min(prevX, segX) - tol;
+  const xMax = Math.max(prevX, segX) + tol;
+  const yMin = Math.min(prevY, segY) - tol;
+  const yMax = Math.max(prevY, segY) + tol;
   return {
     query: {
       within: {

--- a/src/backends/occt/occtBackend.ts
+++ b/src/backends/occt/occtBackend.ts
@@ -167,10 +167,10 @@ export class OcctBackend implements ShapeBackend {
 
     const ccw = ensureCCW(points);
 
-    // Build a 2D drawing using replicad's DrawingPen API — the same pattern
-    // used by revolveRect. draw(start).lineTo(p1)...lineTo(pn-1).close()
-    // returns a Drawing; sketchOnPlane('XY') promotes it to a Sketch; extrude
-    // lifts it to a 3D solid.
+    // Build a 2D drawing using replicad's DrawingPen API:
+    // draw(start).lineTo(p1)...lineTo(pn-1).close() returns a Drawing;
+    // sketchOnPlane('XY') promotes it to a Sketch; extrude lifts it to a
+    // 3D solid.
     let pen = replicad.draw(ccw[0]);
     for (let i = 1; i < ccw.length; i++) {
       pen = pen.lineTo(ccw[i]) as typeof pen;
@@ -202,36 +202,6 @@ export class OcctBackend implements ShapeBackend {
     const sketch = drawing.sketchOnPlane('XY');
     const single = sketch as unknown as { extrude: (d: number) => ReplicadShape3D };
     return new OcctBackend(single.extrude(depth));
-  }
-
-  /**
-   * Revolve an axis-aligned rectangular profile around the Z axis.
-   * The rect is placed in the XZ plane with its corner at `(offsetX, 0)`,
-   * extends `w` in radial X and `h` in axial Z. With `angleDeg = 360`, the
-   * result is a washer: inner radius `offsetX`, outer radius `offsetX + w`,
-   * height `h`.
-   *
-   * NOTE: `angleDeg` is currently informational — Replicad's `Sketch.revolve`
-   * always sweeps a full turn. Partial revolutions are deferred to v0.2.
-   */
-  static revolveRect(
-    w: number,
-    h: number,
-    offsetX: number,
-    _angleDeg: number, // eslint-disable-line @typescript-eslint/no-unused-vars
-  ): OcctBackend {
-    if (!initialized) throw new Error('OCCT not initialized — call initOcct() first');
-    const drawing = replicad
-      .draw([offsetX, 0])
-      .hLine(w)
-      .vLine(h)
-      .hLine(-w)
-      .close();
-    const sketch = drawing.sketchOnPlane('XZ');
-    const single = sketch as unknown as {
-      revolve: (axis?: [number, number, number]) => ReplicadShape3D;
-    };
-    return new OcctBackend(single.revolve([0, 0, 1]));
   }
 
   /**

--- a/src/backends/occt/occtBackend.ts
+++ b/src/backends/occt/occtBackend.ts
@@ -255,38 +255,41 @@ export class OcctBackend implements ShapeBackend {
     if (first.kind !== 'moveTo') {
       throw new Error('OcctBackend.fromSketchCommands: first command must be moveTo.');
     }
-    let pen = replicad.draw([first.x, first.y]);
-    let currentX = first.x;
-    let currentY = first.y;
+    let pen = replicad.draw([first.x.evaluated, first.y.evaluated]);
+    let currentX = first.x.evaluated;
+    let currentY = first.y.evaluated;
     for (let i = 1; i < closeIdx; i++) {
       const c = commands[i];
       if (c.kind === 'lineTo') {
-        pen = pen.lineTo([c.x, c.y]) as typeof pen;
+        pen = pen.lineTo([c.x.evaluated, c.y.evaluated]) as typeof pen;
       } else if (c.kind === 'tangentArc') {
-        pen = pen.tangentArcTo([c.x, c.y]) as typeof pen;
+        pen = pen.tangentArcTo([c.x.evaluated, c.y.evaluated]) as typeof pen;
       } else if (c.kind === 'threePointsArc') {
-        pen = pen.threePointsArcTo([c.x, c.y], [c.midX, c.midY]) as typeof pen;
+        pen = pen.threePointsArcTo([c.x.evaluated, c.y.evaluated], [c.midX.evaluated, c.midY.evaluated]) as typeof pen;
       } else if (c.kind === 'sagittaArc') {
-        pen = pen.sagittaArcTo([c.x, c.y], c.sagitta) as typeof pen;
+        pen = pen.sagittaArcTo([c.x.evaluated, c.y.evaluated], c.sagitta.evaluated) as typeof pen;
       } else if (c.kind === 'bulgeArc') {
-        pen = pen.bulgeArcTo([c.x, c.y], c.bulge) as typeof pen;
+        pen = pen.bulgeArcTo([c.x.evaluated, c.y.evaluated], c.bulge.evaluated) as typeof pen;
       } else if (c.kind === 'radiusArc') {
-        const chord = Math.hypot(c.x - currentX, c.y - currentY);
+        const cx = c.x.evaluated;
+        const cy = c.y.evaluated;
+        const cr = c.radius.evaluated;
+        const chord = Math.hypot(cx - currentX, cy - currentY);
         if (chord < 1e-9) {
-          throw new Error(`radiusArc: degenerate chord (start ≈ end) at point (${c.x}, ${c.y})`);
+          throw new Error(`radiusArc: degenerate chord (start ≈ end) at point (${cx}, ${cy})`);
         }
-        if (Math.abs(c.radius) < chord / 2) {
-          throw new Error(`radiusArc: radius (${c.radius}) too small for chord length ${chord.toFixed(3)} — needs |radius| >= chord/2`);
+        if (Math.abs(cr) < chord / 2) {
+          throw new Error(`radiusArc: radius (${cr}) too small for chord length ${chord.toFixed(3)} — needs |radius| >= chord/2`);
         }
         const halfChord = chord / 2;
-        const sagittaMagnitude = Math.abs(c.radius) - Math.sqrt(c.radius * c.radius - halfChord * halfChord);
-        const signedSagitta = Math.sign(c.radius) * sagittaMagnitude;
-        pen = pen.sagittaArcTo([c.x, c.y], signedSagitta) as typeof pen;
+        const sagittaMagnitude = Math.abs(cr) - Math.sqrt(cr * cr - halfChord * halfChord);
+        const signedSagitta = Math.sign(cr) * sagittaMagnitude;
+        pen = pen.sagittaArcTo([cx, cy], signedSagitta) as typeof pen;
       }
       // Update position after every non-close command (all have explicit x/y endpoint)
       if ('x' in c && 'y' in c) {
-        currentX = c.x;
-        currentY = c.y;
+        currentX = c.x.evaluated;
+        currentY = c.y.evaluated;
       }
     }
     const drawing = pen.close();

--- a/src/backends/occt/occtLowerer.ts
+++ b/src/backends/occt/occtLowerer.ts
@@ -462,95 +462,72 @@ export class OcctLowerer implements FeatureLowerer {
         break;
       }
       case 'revolve': {
-        const profileKind = String(r.params.profileKind.expression).replace(/'/g, '');
-        if (profileKind === 'rect') {
-          shape = OcctBackend.revolveRect(
-            r.params.w.evaluated,
-            r.params.h.evaluated,
-            r.params.offsetX.evaluated,
-            r.params.angleDeg.evaluated,
-          );
-        } else if (profileKind === 'sketch') {
-          const sketchInput = inputs.byKey.sketch as OcctBackend | undefined;
-          if (!sketchInput) {
-            diagnostics.push({
-              target: 'export-occt',
-              code: 'feature.invalid-args',
-              featureId: r.id,
-              severity: 'error',
-              message: `revolve with profile='sketch' requires an input named 'sketch'.`,
-              hint: 'Chain revolve from a path()...close() sketch.',
-            });
-            return { shape: undefined as unknown as ShapeBackend, diagnostics };
-          }
-          const commands = sketchInput.getSketchCommands();
-          if (!commands) {
-            diagnostics.push({
-              target: 'export-occt',
-              code: 'feature.invalid-args',
-              featureId: r.id,
-              severity: 'error',
-              message: `revolve sketch input has no command history.`,
-              hint: 'Chain revolve from a path()...close() sketch (the sketch must carry its command history).',
-            });
-            return { shape: undefined as unknown as ShapeBackend, diagnostics };
-          }
-          // Empty profile: only moveTo + close (or even less). No segments means
-          // no area to revolve.
-          const segmentCount = commands.filter(c => c.kind === 'lineTo' || c.kind === 'tangentArc').length;
-          if (segmentCount === 0) {
-            diagnostics.push({
-              target: 'export-occt',
-              code: 'feature.invalid-args',
-              featureId: r.id,
-              severity: 'error',
-              message: `revolve profile has no line/arc segments — area is zero.`,
-              hint: 'Add at least one lineTo or arc segment to the path before close.',
-            });
-            return { shape: undefined as unknown as ShapeBackend, diagnostics };
-          }
-          // Axis-cross check: any point with x < 0 means the profile spans the
-          // rotation axis, which yields a self-intersecting revolve.
-          const crossing = commands.find(c => (c.kind === 'moveTo' || c.kind === 'lineTo' || c.kind === 'tangentArc') && c.x < 0);
-          if (crossing) {
-            diagnostics.push({
-              target: 'export-occt',
-              code: 'feature.revolve.crosses-axis',
-              featureId: r.id,
-              severity: 'error',
-              message: `revolve profile point (x=${(crossing as { x: number }).x}) crosses rotation axis. All points must satisfy x >= 0.`,
-              hint: 'A revolve profile must stay on one side of the rotation axis. Clamp all path coordinates to x >= 0.',
-            });
-            return { shape: undefined as unknown as ShapeBackend, diagnostics };
-          }
-          try {
-            shape = OcctBackend.revolveFromSketch(sketchInput);
-          } catch (e) {
-            const msg = e instanceof Error ? e.message : String(e);
-            diagnostics.push({
-              target: 'export-occt',
-              code: 'feature.kernel-failed',
-              featureId: r.id,
-              severity: 'error',
-              message: `OCCT revolve failed: ${msg}`,
-              hint: 'OCCT could not revolve — the profile may self-intersect or be degenerate.',
-            });
-            return { shape: undefined as unknown as ShapeBackend, diagnostics };
-          }
-        } else {
-          return {
-            shape: undefined as unknown as ShapeBackend,
-            diagnostics: [
-              {
-                target: this.target,
-                code: 'feature.invalid-args',
-                featureId: r.id,
-                severity: 'error',
-                message: `revolve profile kind '${profileKind}' not supported. Use 'rect' or 'sketch'.`,
-                hint: "Use a supported revolve profile kind: 'rect' or 'sketch'.",
-              },
-            ],
-          };
+        const sketchInput = inputs.byKey.sketch as OcctBackend | undefined;
+        if (!sketchInput) {
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.invalid-args',
+            featureId: r.id,
+            severity: 'error',
+            message: `revolve requires an input named 'sketch'.`,
+            hint: 'Chain revolve from a path()...close() sketch.',
+          });
+          return { shape: undefined as unknown as ShapeBackend, diagnostics };
+        }
+        const commands = sketchInput.getSketchCommands();
+        if (!commands) {
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.invalid-args',
+            featureId: r.id,
+            severity: 'error',
+            message: `revolve sketch input has no command history.`,
+            hint: 'Chain revolve from a path()...close() sketch (the sketch must carry its command history).',
+          });
+          return { shape: undefined as unknown as ShapeBackend, diagnostics };
+        }
+        // Empty profile: only moveTo + close (or even less). No segments means
+        // no area to revolve.
+        const segmentCount = commands.filter(c => c.kind === 'lineTo' || c.kind === 'tangentArc').length;
+        if (segmentCount === 0) {
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.invalid-args',
+            featureId: r.id,
+            severity: 'error',
+            message: `revolve profile has no line/arc segments — area is zero.`,
+            hint: 'Add at least one lineTo or arc segment to the path before close.',
+          });
+          return { shape: undefined as unknown as ShapeBackend, diagnostics };
+        }
+        // Axis-cross check: any point with x < 0 means the profile spans the
+        // rotation axis, which yields a self-intersecting revolve.
+        const crossing = commands.find(c => (c.kind === 'moveTo' || c.kind === 'lineTo' || c.kind === 'tangentArc') && c.x.evaluated < 0);
+        if (crossing) {
+          const xv = (crossing as { x: { evaluated: number } }).x.evaluated;
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.revolve.crosses-axis',
+            featureId: r.id,
+            severity: 'error',
+            message: `revolve profile point (x=${xv}) crosses rotation axis. All points must satisfy x >= 0.`,
+            hint: 'A revolve profile must stay on one side of the rotation axis. Clamp all path coordinates to x >= 0.',
+          });
+          return { shape: undefined as unknown as ShapeBackend, diagnostics };
+        }
+        try {
+          shape = OcctBackend.revolveFromSketch(sketchInput);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.kernel-failed',
+            featureId: r.id,
+            severity: 'error',
+            message: `OCCT revolve failed: ${msg}`,
+            hint: 'OCCT could not revolve — the profile may self-intersect or be degenerate.',
+          });
+          return { shape: undefined as unknown as ShapeBackend, diagnostics };
         }
         break;
       }

--- a/src/capture/sketch.ts
+++ b/src/capture/sketch.ts
@@ -1,20 +1,22 @@
 // src/capture/sketch.ts
-import type { FeatureId, FeatureRef, Vec3, AxisSpec } from '../intent/types';
+import type { FeatureId, FeatureRef, Vec3, AxisSpec, Param } from '../intent/types';
 import { isValidAxisSpec } from '../intent/types';
 import type { CaptureSession } from './captureSession';
 import { validateFaceLabels } from './faceLabels';
 import { Shape } from './proxy';
 import { KernelError } from '../intent/kernelError';
 import type { FaceLabelsMap } from '../intent/featureRecord';
+import { type Editable } from '../runtime/paramRef';
+import { toParam } from '../runtime/editableHelpers';
 
 export type SketchCommand =
-  | { kind: 'moveTo'; x: number; y: number }
-  | { kind: 'lineTo'; x: number; y: number }
-  | { kind: 'tangentArc'; x: number; y: number }
-  | { kind: 'threePointsArc'; x: number; y: number; midX: number; midY: number }
-  | { kind: 'sagittaArc'; x: number; y: number; sagitta: number }
-  | { kind: 'bulgeArc'; x: number; y: number; bulge: number }
-  | { kind: 'radiusArc'; x: number; y: number; radius: number }
+  | { kind: 'moveTo'; x: Param; y: Param }
+  | { kind: 'lineTo'; x: Param; y: Param }
+  | { kind: 'tangentArc'; x: Param; y: Param }
+  | { kind: 'threePointsArc'; x: Param; y: Param; midX: Param; midY: Param }
+  | { kind: 'sagittaArc'; x: Param; y: Param; sagitta: Param }
+  | { kind: 'bulgeArc'; x: Param; y: Param; bulge: Param }
+  | { kind: 'radiusArc'; x: Param; y: Param; radius: Param }
   | { kind: 'close' };
 
 /**
@@ -208,13 +210,31 @@ export class Sketch {
     // Normalize -0 to 0 so reflected coordinates are well-formed.
     const norm = (n: number): number => n === 0 ? 0 : n;
 
-    const reflectXY = (x: number, y: number): [number, number] => {
-      if (axis === 'x') return [norm(x), norm(-y)];
-      if (axis === 'y') return [norm(-x), norm(y)];
-      const off = axis.offset ?? 0;
-      if (axis.axis === 'x') return [norm(x), norm(2 * off - y)];
-      return [norm(2 * off - x), norm(y)]; // axis.axis === 'y'
+    // Reflection collapses any symbolic ParamRef into its current numeric value:
+    // the reflected coordinate depends on the axis offset and the source coord,
+    // and there's no symbolic-arithmetic path that preserves both. The inputs
+    // are read via `.evaluated` (concrete) and re-wrapped as numeric Params.
+    const reflectXY = (x: Param, y: Param): [Param, Param] => {
+      const xv = x.evaluated;
+      const yv = y.evaluated;
+      let nx: number;
+      let ny: number;
+      if (axis === 'x') {
+        nx = norm(xv); ny = norm(-yv);
+      } else if (axis === 'y') {
+        nx = norm(-xv); ny = norm(yv);
+      } else {
+        const off = axis.offset ?? 0;
+        if (axis.axis === 'x') {
+          nx = norm(xv); ny = norm(2 * off - yv);
+        } else { // axis.axis === 'y'
+          nx = norm(2 * off - xv); ny = norm(yv);
+        }
+      }
+      return [toParam(nx, 'mm'), toParam(ny, 'mm')];
     };
+
+    const negateScalar = (p: Param): Param => toParam(-p.evaluated, p.unit);
 
     // Arc sign-flip: reflection inverts winding. For arcs whose direction is
     // encoded as a sign on a scalar (sagitta, bulge, radius), negate the sign.
@@ -245,15 +265,15 @@ export class Sketch {
         }
         case 'sagittaArc': {
           const [x, y] = reflectXY(cmd.x, cmd.y);
-          return { ...cmd, x, y, sagitta: -cmd.sagitta };
+          return { ...cmd, x, y, sagitta: negateScalar(cmd.sagitta) };
         }
         case 'bulgeArc': {
           const [x, y] = reflectXY(cmd.x, cmd.y);
-          return { ...cmd, x, y, bulge: -cmd.bulge };
+          return { ...cmd, x, y, bulge: negateScalar(cmd.bulge) };
         }
         case 'radiusArc': {
           const [x, y] = reflectXY(cmd.x, cmd.y);
-          return { ...cmd, x, y, radius: -cmd.radius };
+          return { ...cmd, x, y, radius: negateScalar(cmd.radius) };
         }
         case 'close':
           return cmd;
@@ -299,13 +319,13 @@ export class PathBuilder {
     this.session = session;
   }
 
-  moveTo(x: number, y: number): PathBuilder {
-    this.commands.push({ kind: 'moveTo', x, y });
+  moveTo(x: Editable<number>, y: Editable<number>): PathBuilder {
+    this.commands.push({ kind: 'moveTo', x: toParam(x, 'mm'), y: toParam(y, 'mm') });
     return this;
   }
 
-  lineTo(x: number, y: number): PathBuilder {
-    this.commands.push({ kind: 'lineTo', x, y });
+  lineTo(x: Editable<number>, y: Editable<number>): PathBuilder {
+    this.commands.push({ kind: 'lineTo', x: toParam(x, 'mm'), y: toParam(y, 'mm') });
     return this;
   }
 
@@ -317,8 +337,8 @@ export class PathBuilder {
    * Throws at lowering time (via `feature.sketch.failed` diagnostic) if
    * called as the first command — there's no prior tangent to consume.
    */
-  tangentArc(x: number, y: number): PathBuilder {
-    this.commands.push({ kind: 'tangentArc', x, y });
+  tangentArc(x: Editable<number>, y: Editable<number>): PathBuilder {
+    this.commands.push({ kind: 'tangentArc', x: toParam(x, 'mm'), y: toParam(y, 'mm') });
     return this;
   }
 
@@ -336,8 +356,14 @@ export class PathBuilder {
    * @param midX midpoint X (any point the arc passes through, not on the chord)
    * @param midY midpoint Y
    */
-  threePointsArc(x: number, y: number, midX: number, midY: number): PathBuilder {
-    this.commands.push({ kind: 'threePointsArc', x, y, midX, midY });
+  threePointsArc(x: Editable<number>, y: Editable<number>, midX: Editable<number>, midY: Editable<number>): PathBuilder {
+    this.commands.push({
+      kind: 'threePointsArc',
+      x: toParam(x, 'mm'),
+      y: toParam(y, 'mm'),
+      midX: toParam(midX, 'mm'),
+      midY: toParam(midY, 'mm'),
+    });
     return this;
   }
 
@@ -355,8 +381,13 @@ export class PathBuilder {
    * @param y endpoint Y
    * @param sagitta perpendicular bulge height (signed)
    */
-  sagittaArc(x: number, y: number, sagitta: number): PathBuilder {
-    this.commands.push({ kind: 'sagittaArc', x, y, sagitta });
+  sagittaArc(x: Editable<number>, y: Editable<number>, sagitta: Editable<number>): PathBuilder {
+    this.commands.push({
+      kind: 'sagittaArc',
+      x: toParam(x, 'mm'),
+      y: toParam(y, 'mm'),
+      sagitta: toParam(sagitta, 'mm'),
+    });
     return this;
   }
 
@@ -374,8 +405,13 @@ export class PathBuilder {
    * @param y endpoint Y
    * @param bulge DXF bulge factor (signed)
    */
-  bulgeArc(x: number, y: number, bulge: number): PathBuilder {
-    this.commands.push({ kind: 'bulgeArc', x, y, bulge });
+  bulgeArc(x: Editable<number>, y: Editable<number>, bulge: Editable<number>): PathBuilder {
+    this.commands.push({
+      kind: 'bulgeArc',
+      x: toParam(x, 'mm'),
+      y: toParam(y, 'mm'),
+      bulge: toParam(bulge, 'unitless'),
+    });
     return this;
   }
 
@@ -398,8 +434,13 @@ export class PathBuilder {
    * @param y endpoint Y
    * @param radius arc radius (signed)
    */
-  radiusArc(x: number, y: number, radius: number): PathBuilder {
-    this.commands.push({ kind: 'radiusArc', x, y, radius });
+  radiusArc(x: Editable<number>, y: Editable<number>, radius: Editable<number>): PathBuilder {
+    this.commands.push({
+      kind: 'radiusArc',
+      x: toParam(x, 'mm'),
+      y: toParam(y, 'mm'),
+      radius: toParam(radius, 'mm'),
+    });
     return this;
   }
 

--- a/src/intent/cutoutValidation.ts
+++ b/src/intent/cutoutValidation.ts
@@ -66,7 +66,7 @@ function hasStraightSelfIntersection(commands: readonly SketchCommand[]): boolea
   const pts: Array<[number, number]> = [];
   for (const c of commands) {
     if (c.kind === 'close') break;
-    if ('x' in c && 'y' in c) pts.push([c.x, c.y]);
+    if ('x' in c && 'y' in c) pts.push([c.x.evaluated, c.y.evaluated]);
   }
   // Segments are pts[i] → pts[i+1]; closure adds pts[last] → pts[0].
   if (pts.length < 4) return false;

--- a/src/mcp/toolRegistry.ts
+++ b/src/mcp/toolRegistry.ts
@@ -171,7 +171,7 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
   {
     definition: {
       name: 'add_feature',
-      description: 'Insert a new feature line into a kernelCAD script before the last top-level return statement. Returns the modified code as text plus diagnostics from re-evaluating the result. Side-effect-free. Primitives that accept faceLabels (box, cylinder, extrudeRect, extrudeCircle, extrudePolygon, extrudeRoundedRect, revolveRect) can receive `opts.faceLabels` in the inserted code — use `list_api` to see `featureKindFaceLabels` for the full value schema.',
+      description: 'Insert a new feature line into a kernelCAD script before the last top-level return statement. Returns the modified code as text plus diagnostics from re-evaluating the result. Side-effect-free. Primitives that accept faceLabels (box, cylinder, extrudeRect, extrudeCircle, extrudePolygon, extrudeRoundedRect) can receive `opts.faceLabels` in the inserted code — use `list_api` to see `featureKindFaceLabels` for the full value schema.',
       inputSchema: {
         type: 'object',
         properties: {

--- a/src/mcp/tools/listApi.ts
+++ b/src/mcp/tools/listApi.ts
@@ -56,7 +56,6 @@ export const GLOBALS: ApiEntry[] = [
   { name: 'extrudeCircle', signature: '(r, height, opts?) => Shape', description: 'Extrude a radius-r circle (XY) by `height` along Z. `opts.faceLabels` maps user label names to canonical face names (top/bottom) or FaceQuery descriptors.' },
   { name: 'extrudePolygon', signature: '(points, depth, opts?) => Shape', description: 'Extrude a 2D polygon (array of [x, y] points) by `depth` along Z. `opts.faceLabels` maps user label names to canonical face names or FaceQuery descriptors.' },
   { name: 'extrudeRoundedRect', signature: '(width, height, radius, depth, opts?) => Shape', description: 'Extrude a rounded rectangle (corner radius) by `depth` along Z. `opts.faceLabels` maps user label names to canonical face names (top/bottom/left/right/front/back) or FaceQuery descriptors.' },
-  { name: 'revolveRect', signature: '(w, h, offsetX, angleDeg?, opts?) => Shape', description: 'Revolve a w-by-h rectangle around Z, offset by `offsetX` from the axis. Default 360 degrees. `opts.faceLabels` maps user label names to canonical face names (top/bottom) or FaceQuery descriptors.' },
   { name: 'path', signature: '() => PathBuilder', description: 'Start a 2D path: chain moveTo / lineTo / arcs / .close() to get a Sketch.' },
   { name: 'param', signature: "(name, defaultValue, meta?) => ParamRef", description: 'Declare a symbolic editable parameter. Returns a ParamRef the chain ops accept anywhere a number is expected. Edit post-build via `kcad.params.update`. `meta?: { min?, max?, description? }`.' },
   { name: 'params', signature: "(decl) => { [name]: ParamRef }", description: 'Batched form of `param()` — declare many params at once. Returns an object of ParamRefs keyed by name.' },
@@ -105,14 +104,14 @@ export const PARAM_REF_METHODS: ApiEntry[] = [
 ];
 
 export const PATH_BUILDER_METHODS: ApiEntry[] = [
-  { name: 'moveTo', signature: '(x, y) => PathBuilder', description: 'Start the path at (x, y). Required first call.' },
-  { name: 'lineTo', signature: '(x, y) => PathBuilder', description: 'Add a straight line segment to (x, y).' },
-  { name: 'tangentArc', signature: '(x, y) => PathBuilder', description: 'Arc continuing tangent from the previous segment to (x, y). Requires a prior segment.' },
-  { name: 'threePointsArc', signature: '(x, y, midX, midY) => PathBuilder', description: 'Arc through start, midpoint, and end. No prior tangent required.' },
-  { name: 'sagittaArc', signature: '(x, y, sagitta) => PathBuilder', description: 'Arc by chord + perpendicular bulge height. Sign chooses bulge side.' },
-  { name: 'bulgeArc', signature: '(x, y, bulge) => PathBuilder', description: 'Arc by chord + DXF bulge factor (tan(angle/4)).' },
-  { name: 'radiusArc', signature: '(x, y, radius) => PathBuilder', description: 'Arc by chord + explicit radius. Always minor arc; sign chooses bulge side.' },
-  { name: 'label', signature: '(name) => PathBuilder', description: 'Tag the previous segment so it can be referenced later in fillet/chamfer/shell as `{face: name}`.' },
+  { name: 'moveTo', signature: '(x: Editable<number>, y: Editable<number>) => PathBuilder', description: 'Start the path at (x, y). Required first call. Coords accept ParamRef for parametric authoring.' },
+  { name: 'lineTo', signature: '(x: Editable<number>, y: Editable<number>) => PathBuilder', description: 'Add a straight line segment to (x, y). Coords accept ParamRef for parametric authoring.' },
+  { name: 'tangentArc', signature: '(x: Editable<number>, y: Editable<number>) => PathBuilder', description: 'Arc continuing tangent from the previous segment to (x, y). Requires a prior segment. Coords accept ParamRef for parametric authoring.' },
+  { name: 'threePointsArc', signature: '(x: Editable<number>, y: Editable<number>, midX: Editable<number>, midY: Editable<number>) => PathBuilder', description: 'Arc through start, midpoint, and end. No prior tangent required. Coords accept ParamRef for parametric authoring.' },
+  { name: 'sagittaArc', signature: '(x: Editable<number>, y: Editable<number>, sagitta: Editable<number>) => PathBuilder', description: 'Arc by chord + perpendicular bulge height. Sign chooses bulge side. All scalars accept ParamRef for parametric authoring.' },
+  { name: 'bulgeArc', signature: '(x: Editable<number>, y: Editable<number>, bulge: Editable<number>) => PathBuilder', description: 'Arc by chord + DXF bulge factor (tan(angle/4)). All scalars accept ParamRef for parametric authoring.' },
+  { name: 'radiusArc', signature: '(x: Editable<number>, y: Editable<number>, radius: Editable<number>) => PathBuilder', description: 'Arc by chord + explicit radius. Always minor arc; sign chooses bulge side. All scalars accept ParamRef for parametric authoring.' },
+  { name: 'label', signature: '(name: string) => PathBuilder', description: 'Tag the previous segment so it can be referenced later in fillet/chamfer/shell as `{face: name}`.' },
   { name: 'close', signature: '() => Sketch', description: 'Close the path; returns a Sketch that can be extruded/revolved/swept.' },
 ];
 
@@ -126,7 +125,6 @@ export const FEATURE_KIND_FACE_LABELS: FeatureKindFaceLabels = {
     'extrudeCircle',
     'extrudePolygon',
     'extrudeRoundedRect',
-    'revolveRect',
   ] as const,
   description:
     'Pass `opts.faceLabels` as a plain object map from user-chosen label name to either a canonical face name ' +

--- a/src/mcp/tools/listFaceLabels.ts
+++ b/src/mcp/tools/listFaceLabels.ts
@@ -57,7 +57,7 @@ export async function listFaceLabelsTool(input: ListFaceLabelsInput): Promise<Li
   for (const rec of run.records) {
     if (rec.kind !== 'sketch') continue;
     if (input.feature_id && rec.id !== input.feature_id) continue;
-    const commands = (rec.metadata as { commands?: Array<{ kind: string; x?: number; y?: number; label?: string }> } | undefined)?.commands;
+    const commands = (rec.metadata as { commands?: Array<{ kind: string; x?: { evaluated: number }; y?: { evaluated: number }; label?: string }> } | undefined)?.commands;
     if (!commands) continue;
     for (let i = 0; i < commands.length; i++) {
       const c = commands[i];
@@ -69,10 +69,10 @@ export async function listFaceLabelsTool(input: ListFaceLabelsInput): Promise<Li
         sketchId: rec.id,
         segmentKind: c.kind,
         chord: {
-          startX: prev?.x ?? 0,
-          startY: prev?.y ?? 0,
-          endX: c.x ?? 0,
-          endY: c.y ?? 0,
+          startX: prev?.x?.evaluated ?? 0,
+          startY: prev?.y?.evaluated ?? 0,
+          endX: c.x?.evaluated ?? 0,
+          endY: c.y?.evaluated ?? 0,
         },
       });
     }

--- a/src/modules/api.ts
+++ b/src/modules/api.ts
@@ -33,7 +33,6 @@ export interface KernelCadApi {
   extrudeCircle(r: Editable<number>, height: Editable<number>, opts?: FaceLabelOpts): Shape;
   extrudePolygon(points: [number, number][], depth: Editable<number>, opts?: FaceLabelOpts): Shape;
   extrudeRoundedRect(width: Editable<number>, height: Editable<number>, radius: Editable<number>, depth: Editable<number>, opts?: FaceLabelOpts): Shape;
-  revolveRect(w: Editable<number>, h: Editable<number>, offsetX: Editable<number>, angleDeg?: Editable<number>, opts?: FaceLabelOpts): Shape;
   union(...shapes: Shape[]): Shape;
   assembly(name?: string): Assembly;
 
@@ -50,7 +49,6 @@ export interface KernelCadApi {
 
 const mm = (n: Editable<number>): Param => toParam(n, 'mm');
 const ul = (n: Editable<number>): Param => toParam(n, 'unitless');
-const deg = (n: Editable<number>): Param => toParam(n, 'deg');
 
 export function createApi(ctx: ApiContext): KernelCadApi {
   const { session } = ctx;
@@ -135,20 +133,6 @@ export function createApi(ctx: ApiContext): KernelCadApi {
           profileKind: { expression: "'rounded-rect'", unit: 'unitless', evaluated: 0 },
           width: mm(width), height: mm(height), radius: mm(radius), depth: mm(depth),
         },
-        metadata: faceLabels ? { faceLabels } : undefined,
-      });
-    },
-    revolveRect(w, h, offsetX, angleDeg = 360, opts) {
-      const faceLabels = validateFaceLabels(opts?.faceLabels, 'revolve');
-      return session.createShape({
-        kind: 'revolve',
-        params: {
-          profileKind: { expression: "'rect'", unit: 'unitless', evaluated: 0 },
-          w: mm(w), h: mm(h),
-          offsetX: mm(offsetX),
-          angleDeg: deg(angleDeg),
-        },
-        inputs: {},
         metadata: faceLabels ? { faceLabels } : undefined,
       });
     },

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -57,10 +57,9 @@ extrudeCircle(r: number, height: number, opts?: { faceLabels?: Record<string, Ca
 extrudePolygon(points: [number, number][], depth: number, opts?: { faceLabels?: Record<string, CanonicalFace | FaceQuery> }): Shape;
 extrudeRoundedRect(width: number, height: number, radius: number, depth: number, opts?: { faceLabels?: Record<string, CanonicalFace | FaceQuery> }): Shape;
 
-// Revolve helper — rectangular profile revolved around Z (offset from axis by offsetX).
-revolveRect(w: number, h: number, offsetX: number, angleDeg?: number, opts?: { faceLabels?: Record<string, CanonicalFace | FaceQuery> }): Shape;
-
-// Path builder — chain moveTo / lineTo / arcs / .close() to get a Sketch.
+// Path builder — chain moveTo / lineTo / arcs / .close() to get a Sketch. For
+// revolved geometry (washers, donut bodies, mug profiles, etc.) build a profile
+// via path() and call .revolve() on the resulting Sketch.
 path(): PathBuilder;
 
 // Boolean union of two or more shapes (top-level alternative to .union()).
@@ -203,16 +202,18 @@ A `Sketch` is produced by `path()...close()`. All Sketch methods return a `Shape
 `path()` returns a `PathBuilder`. Chain these calls; finish with `.close()` to get a `Sketch`.
 
 ```typescript
-.moveTo(x: number, y: number): PathBuilder      // Required first call — sets the start point.
-.lineTo(x: number, y: number): PathBuilder      // Straight segment to (x, y).
-.tangentArc(x: number, y: number): PathBuilder  // Arc continuing tangent from prior segment.
-.threePointsArc(x: number, y: number, midX: number, midY: number): PathBuilder  // Arc through start, mid, end.
-.sagittaArc(x: number, y: number, sagitta: number): PathBuilder  // Arc by chord + perpendicular bulge. Sign chooses side.
-.bulgeArc(x: number, y: number, bulge: number): PathBuilder      // Arc by chord + DXF bulge factor (tan(angle/4)).
-.radiusArc(x: number, y: number, radius: number): PathBuilder    // Arc by chord + explicit radius; sign chooses side.
+.moveTo(x: Editable<number>, y: Editable<number>): PathBuilder      // Required first call — sets the start point.
+.lineTo(x: Editable<number>, y: Editable<number>): PathBuilder      // Straight segment to (x, y).
+.tangentArc(x: Editable<number>, y: Editable<number>): PathBuilder  // Arc continuing tangent from prior segment.
+.threePointsArc(x: Editable<number>, y: Editable<number>, midX: Editable<number>, midY: Editable<number>): PathBuilder  // Arc through start, mid, end.
+.sagittaArc(x: Editable<number>, y: Editable<number>, sagitta: Editable<number>): PathBuilder  // Arc by chord + perpendicular bulge. Sign chooses side.
+.bulgeArc(x: Editable<number>, y: Editable<number>, bulge: Editable<number>): PathBuilder      // Arc by chord + DXF bulge factor (tan(angle/4)).
+.radiusArc(x: Editable<number>, y: Editable<number>, radius: Editable<number>): PathBuilder    // Arc by chord + explicit radius; sign chooses side.
 .label(name: string): PathBuilder               // Tag the prior segment for fillet/chamfer/shell by name.
 .close(): Sketch                                // Close path; returns a Sketch.
 ```
+
+Every PathBuilder coord and scalar accepts `Editable<number>` (`number | ParamRef<number>`), so symbolic params survive into capture and the dispatcher's pre-resolve substitutes them at lower time. Build derived dimensions with the ParamRef arithmetic methods (`.add`, `.subtract`, `.multiply`, `.divide`, `.negate`).
 
 ### Constrained sketches (v0.4 MCP)
 

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -546,7 +546,7 @@ When you need a canonical pattern, call MCP tool `lookup_cookbook(query, k?)` to
 | mirror-half-part | The part is symmetric across a cardinal plane; build only one half and call mirror to produce the complete symmetric part. |
 | non-overlapping-l-bracket | You're building two perpendicular plates joined at a right angle; both plates have the same thickness; volumes must not overlap at the joint. |
 | parametric-bolt-pattern-skeleton | You want a compact bolt-hole part with an editable bolt-diameter parameter that can be changed later. |
-| revolve-rectangular-profile | You want a thin cylindrical wall, ring, or tube — revolve a rectangle around Z with an offset from the axis equal to the inner radius. |
+| revolve-rectangular-profile | You want a thin cylindrical wall, ring, or tube — author the rectangular profile via path() with the inner radius as the x offset, then call .revolve() to sweep it around Z. |
 | subtract-then-fillet-rim | You want a parametric plate, drill a through-hole, and round the rim where the hole meets the top face. |
 | union-of-stacked-primitives | You want to compose multiple primitives into one part by translating each into place and unioning them, without volume overlap. |
 

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -194,6 +194,10 @@ A `Sketch` is produced by `path()...close()`. All Sketch methods return a `Shape
 // Reflect this sketch's path across an axis, returning a new Sketch.
 // 'x' negates y-coords; 'y' negates x-coords; { axis, offset } reflects across a parallel axis.
 // Arc winding is inverted automatically. Labels are preserved.
+// Limitation: any ParamRef coords in the source path are resolved to numeric
+// values at reflect time, so the reflected sketch does not track param edits
+// for the reflected coords. Author the reflected path directly (or split into
+// halves and union them) when you need full param tracking on both halves.
 .reflect(axis: 'x' | 'y' | { axis: 'x' | 'y'; offset: number }): Sketch
 ```
 

--- a/tests/integration/mcp/listApi.test.ts
+++ b/tests/integration/mcp/listApi.test.ts
@@ -47,7 +47,7 @@ describe('list_api MCP tool', () => {
   });
 
   it('globals signatures for faceLabels-accepting kinds mention opts and faceLabels', () => {
-    const FACE_LABEL_KINDS = ['box', 'cylinder', 'extrudeRect', 'extrudeCircle', 'extrudePolygon', 'extrudeRoundedRect', 'revolveRect'];
+    const FACE_LABEL_KINDS = ['box', 'cylinder', 'extrudeRect', 'extrudeCircle', 'extrudePolygon', 'extrudeRoundedRect'];
     for (const kind of FACE_LABEL_KINDS) {
       const entry = GLOBALS.find(g => g.name === kind);
       expect(entry, `GLOBALS entry for ${kind} should exist`).toBeDefined();
@@ -67,8 +67,8 @@ describe('list_api MCP tool', () => {
     expect(r.featureKindFaceLabels).toBeDefined();
     const fkfl = r.featureKindFaceLabels!;
 
-    // All seven accepting kinds present
-    const acceptingKinds = ['box', 'cylinder', 'extrudeRect', 'extrudeCircle', 'extrudePolygon', 'extrudeRoundedRect', 'revolveRect'];
+    // All accepting kinds present
+    const acceptingKinds = ['box', 'cylinder', 'extrudeRect', 'extrudeCircle', 'extrudePolygon', 'extrudeRoundedRect'];
     for (const kind of acceptingKinds) {
       expect(fkfl.acceptingKinds, `acceptingKinds should include ${kind}`).toContain(kind);
     }

--- a/tests/unit/backends/occt/filletRevolvedShapes.test.ts
+++ b/tests/unit/backends/occt/filletRevolvedShapes.test.ts
@@ -5,9 +5,9 @@
 // Standard_Failure (raw WASM pointer) on cylinder cap edge midpoints (which
 // sit exactly on the parametric U-seam of a CYLINDRE/CONE/SPHERE face).
 //
-// Before the fix, all four cases below produced a useless raw-pointer
+// Before the fix, the cases below produced a useless raw-pointer
 // diagnostic (e.g., `OCCT fillet failed: 8479736`). After the fix, fillets
-// on cylinder/extrudeCircle/revolveRect-built shapes succeed.
+// on cylinder/extrudeCircle-built shapes succeed.
 import { describe, it, expect, beforeAll } from 'vitest';
 import { OcctLowerer } from '../../../../src/backends/occt/occtLowerer';
 import { OcctBackend, initOcct } from '../../../../src/backends/occt/occtBackend';
@@ -56,21 +56,6 @@ describe('OcctLowerer fillet on revolved/cylindrical shapes', () => {
     const v = result.shape.volume();
     expect(v).toBeLessThan(baselineVolume);
     expect(v).toBeGreaterThan(baselineVolume * 0.9);
-  });
-
-  it('lowers an all-edges fillet on revolveRect (washer)', async () => {
-    // Washer: inner radius 5, outer radius 15, height 6 — has inner+outer
-    // cylindrical faces and top/bottom annular faces (8 circular cap edges).
-    const base = OcctBackend.revolveRect(10, 6, 5, 360);
-    const baselineVolume = base.volume();
-    const result = await new OcctLowerer().lower(
-      filletRecord('fillet_revrect', 1),
-      { byKey: { base } },
-    );
-    expect(result.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0);
-    const v = result.shape.volume();
-    expect(v).toBeLessThan(baselineVolume);
-    expect(v).toBeGreaterThan(baselineVolume * 0.85);
   });
 
   it('still lowers an all-edges fillet on a box (regression check on prismatic shapes)', async () => {

--- a/tests/unit/backends/occt/loftFromSketches.test.ts
+++ b/tests/unit/backends/occt/loftFromSketches.test.ts
@@ -2,28 +2,31 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { OcctBackend, initOcct } from '../../../../src/backends/occt/occtBackend';
 import type { SketchCommand } from '../../../../src/capture/sketch';
+import { toParam } from '../../../../src/runtime/editableHelpers';
+
+const mm = (n: number) => toParam(n, 'mm');
 
 const square2x2: SketchCommand[] = [
-  { kind: 'moveTo', x: -1, y: -1 },
-  { kind: 'lineTo', x: 1, y: -1 },
-  { kind: 'lineTo', x: 1, y: 1 },
-  { kind: 'lineTo', x: -1, y: 1 },
+  { kind: 'moveTo', x: mm(-1), y: mm(-1) },
+  { kind: 'lineTo', x: mm(1), y: mm(-1) },
+  { kind: 'lineTo', x: mm(1), y: mm(1) },
+  { kind: 'lineTo', x: mm(-1), y: mm(1) },
   { kind: 'close' },
 ];
 
 const square4x4: SketchCommand[] = [
-  { kind: 'moveTo', x: -2, y: -2 },
-  { kind: 'lineTo', x: 2, y: -2 },
-  { kind: 'lineTo', x: 2, y: 2 },
-  { kind: 'lineTo', x: -2, y: 2 },
+  { kind: 'moveTo', x: mm(-2), y: mm(-2) },
+  { kind: 'lineTo', x: mm(2), y: mm(-2) },
+  { kind: 'lineTo', x: mm(2), y: mm(2) },
+  { kind: 'lineTo', x: mm(-2), y: mm(2) },
   { kind: 'close' },
 ];
 
 const square6x6: SketchCommand[] = [
-  { kind: 'moveTo', x: -3, y: -3 },
-  { kind: 'lineTo', x: 3, y: -3 },
-  { kind: 'lineTo', x: 3, y: 3 },
-  { kind: 'lineTo', x: -3, y: 3 },
+  { kind: 'moveTo', x: mm(-3), y: mm(-3) },
+  { kind: 'lineTo', x: mm(3), y: mm(-3) },
+  { kind: 'lineTo', x: mm(3), y: mm(3) },
+  { kind: 'lineTo', x: mm(-3), y: mm(3) },
   { kind: 'close' },
 ];
 

--- a/tests/unit/backends/occt/occtBackend.revolveSketch.test.ts
+++ b/tests/unit/backends/occt/occtBackend.revolveSketch.test.ts
@@ -2,6 +2,9 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { OcctBackend, initOcct } from '../../../../src/backends/occt/occtBackend';
 import type { SketchCommand } from '../../../../src/capture/sketch';
+import { toParam } from '../../../../src/runtime/editableHelpers';
+
+const mm = (n: number) => toParam(n, 'mm');
 
 describe('OcctBackend.revolveFromSketch', () => {
   beforeAll(async () => { await initOcct(); });
@@ -10,10 +13,10 @@ describe('OcctBackend.revolveFromSketch', () => {
     // Washer: inner radius 10, outer radius 20, height 5
     // Volume = π × (20² − 10²) × 5 = 1500π ≈ 4712.39
     const commands: SketchCommand[] = [
-      { kind: 'moveTo', x: 10, y: 0 },
-      { kind: 'lineTo', x: 20, y: 0 },
-      { kind: 'lineTo', x: 20, y: 5 },
-      { kind: 'lineTo', x: 10, y: 5 },
+      { kind: 'moveTo', x: mm(10), y: mm(0) },
+      { kind: 'lineTo', x: mm(20), y: mm(0) },
+      { kind: 'lineTo', x: mm(20), y: mm(5) },
+      { kind: 'lineTo', x: mm(10), y: mm(5) },
       { kind: 'close' },
     ];
     const sketch = OcctBackend.fromSketchCommands(commands);
@@ -28,10 +31,10 @@ describe('OcctBackend.revolveFromSketch', () => {
     // Solid cylinder: radius 10, height 20
     // Volume = π × 10² × 20 = 2000π ≈ 6283.19
     const commands: SketchCommand[] = [
-      { kind: 'moveTo', x: 0, y: 0 },
-      { kind: 'lineTo', x: 10, y: 0 },
-      { kind: 'lineTo', x: 10, y: 20 },
-      { kind: 'lineTo', x: 0, y: 20 },
+      { kind: 'moveTo', x: mm(0), y: mm(0) },
+      { kind: 'lineTo', x: mm(10), y: mm(0) },
+      { kind: 'lineTo', x: mm(10), y: mm(20) },
+      { kind: 'lineTo', x: mm(0), y: mm(20) },
       { kind: 'close' },
     ];
     const sketch = OcctBackend.fromSketchCommands(commands);
@@ -43,11 +46,11 @@ describe('OcctBackend.revolveFromSketch', () => {
 
   it('revolves a tangentArc profile (mug body) into a positive-volume solid', () => {
     const commands: SketchCommand[] = [
-      { kind: 'moveTo', x: 20, y: 0 },
-      { kind: 'lineTo', x: 20, y: 60 },
-      { kind: 'tangentArc', x: 25, y: 80 },
-      { kind: 'lineTo', x: 0, y: 80 },
-      { kind: 'lineTo', x: 0, y: 0 },
+      { kind: 'moveTo', x: mm(20), y: mm(0) },
+      { kind: 'lineTo', x: mm(20), y: mm(60) },
+      { kind: 'tangentArc', x: mm(25), y: mm(80) },
+      { kind: 'lineTo', x: mm(0), y: mm(80) },
+      { kind: 'lineTo', x: mm(0), y: mm(0) },
       { kind: 'close' },
     ];
     const sketch = OcctBackend.fromSketchCommands(commands);
@@ -62,9 +65,9 @@ describe('OcctBackend.revolveFromSketch', () => {
 
   it('exposes the original commands on a sketch-tagged backend', () => {
     const commands: SketchCommand[] = [
-      { kind: 'moveTo', x: 0, y: 0 },
-      { kind: 'lineTo', x: 5, y: 0 },
-      { kind: 'lineTo', x: 5, y: 5 },
+      { kind: 'moveTo', x: mm(0), y: mm(0) },
+      { kind: 'lineTo', x: mm(5), y: mm(0) },
+      { kind: 'lineTo', x: mm(5), y: mm(5) },
       { kind: 'close' },
     ];
     const sketch = OcctBackend.fromSketchCommands(commands);

--- a/tests/unit/backends/occt/occtBackend.sketchExtrude.test.ts
+++ b/tests/unit/backends/occt/occtBackend.sketchExtrude.test.ts
@@ -2,16 +2,20 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { OcctBackend, initOcct } from '../../../../src/backends/occt/occtBackend';
 import type { SketchCommand } from '../../../../src/capture/sketch';
+import { toParam } from '../../../../src/runtime/editableHelpers';
+
+const mm = (n: number) => toParam(n, 'mm');
+const ul = (n: number) => toParam(n, 'unitless');
 
 describe('OcctBackend sketch + extrudeSketch', () => {
   beforeAll(async () => { await initOcct(); });
 
   it('builds a sketch shape from line commands and extrudes it', () => {
     const commands: SketchCommand[] = [
-      { kind: 'moveTo', x: 0, y: 0 },
-      { kind: 'lineTo', x: 10, y: 0 },
-      { kind: 'lineTo', x: 10, y: 10 },
-      { kind: 'lineTo', x: 0, y: 10 },
+      { kind: 'moveTo', x: mm(0), y: mm(0) },
+      { kind: 'lineTo', x: mm(10), y: mm(0) },
+      { kind: 'lineTo', x: mm(10), y: mm(10) },
+      { kind: 'lineTo', x: mm(0), y: mm(10) },
       { kind: 'close' },
     ];
     const sketch = OcctBackend.fromSketchCommands(commands);
@@ -27,16 +31,16 @@ describe('OcctBackend sketch + extrudeSketch', () => {
 
   it('throws when no close command is present', () => {
     const commands: SketchCommand[] = [
-      { kind: 'moveTo', x: 0, y: 0 },
-      { kind: 'lineTo', x: 10, y: 0 },
+      { kind: 'moveTo', x: mm(0), y: mm(0) },
+      { kind: 'lineTo', x: mm(10), y: mm(0) },
     ];
     expect(() => OcctBackend.fromSketchCommands(commands)).toThrow(/close/);
   });
 
   it('throws on extrudeFromSketch with non-positive depth', () => {
     const commands: SketchCommand[] = [
-      { kind: 'moveTo', x: 0, y: 0 }, { kind: 'lineTo', x: 1, y: 0 },
-      { kind: 'lineTo', x: 1, y: 1 }, { kind: 'close' },
+      { kind: 'moveTo', x: mm(0), y: mm(0) }, { kind: 'lineTo', x: mm(1), y: mm(0) },
+      { kind: 'lineTo', x: mm(1), y: mm(1) }, { kind: 'close' },
     ];
     const sketch = OcctBackend.fromSketchCommands(commands);
     expect(() => OcctBackend.extrudeFromSketch(sketch, 0)).toThrow(/positive/);
@@ -44,13 +48,13 @@ describe('OcctBackend sketch + extrudeSketch', () => {
 
   it('builds and extrudes a sketch with a tangentArc segment', () => {
     const commands: SketchCommand[] = [
-      { kind: 'moveTo', x: 0, y: 0 },
-      { kind: 'lineTo', x: 20, y: 0 },
-      { kind: 'lineTo', x: 20, y: 10 },
-      { kind: 'tangentArc', x: 15, y: 15 },
-      { kind: 'lineTo', x: 10, y: 15 },
-      { kind: 'lineTo', x: 10, y: 20 },
-      { kind: 'lineTo', x: 0, y: 20 },
+      { kind: 'moveTo', x: mm(0), y: mm(0) },
+      { kind: 'lineTo', x: mm(20), y: mm(0) },
+      { kind: 'lineTo', x: mm(20), y: mm(10) },
+      { kind: 'tangentArc', x: mm(15), y: mm(15) },
+      { kind: 'lineTo', x: mm(10), y: mm(15) },
+      { kind: 'lineTo', x: mm(10), y: mm(20) },
+      { kind: 'lineTo', x: mm(0), y: mm(20) },
       { kind: 'close' },
     ];
     const sketch = OcctBackend.fromSketchCommands(commands);
@@ -65,8 +69,8 @@ describe('OcctBackend sketch + extrudeSketch', () => {
 
   it('threePointsArc produces a non-zero-area extrusion', () => {
     const commands: SketchCommand[] = [
-      { kind: 'moveTo', x: 0, y: 0 },
-      { kind: 'threePointsArc', x: 20, y: 0, midX: 10, midY: 5 },
+      { kind: 'moveTo', x: mm(0), y: mm(0) },
+      { kind: 'threePointsArc', x: mm(20), y: mm(0), midX: mm(10), midY: mm(5) },
       { kind: 'close' },
     ];
     const sketch = OcctBackend.fromSketchCommands(commands);
@@ -78,13 +82,13 @@ describe('OcctBackend sketch + extrudeSketch', () => {
 
   it('sagittaArc with positive vs negative sagitta produces equal-magnitude volumes (sign = bulge side)', () => {
     const cmdsPos: SketchCommand[] = [
-      { kind: 'moveTo', x: 0, y: 0 },
-      { kind: 'sagittaArc', x: 20, y: 0, sagitta: 5 },
+      { kind: 'moveTo', x: mm(0), y: mm(0) },
+      { kind: 'sagittaArc', x: mm(20), y: mm(0), sagitta: mm(5) },
       { kind: 'close' },
     ];
     const cmdsNeg: SketchCommand[] = [
-      { kind: 'moveTo', x: 0, y: 0 },
-      { kind: 'sagittaArc', x: 20, y: 0, sagitta: -5 },
+      { kind: 'moveTo', x: mm(0), y: mm(0) },
+      { kind: 'sagittaArc', x: mm(20), y: mm(0), sagitta: mm(-5) },
       { kind: 'close' },
     ];
     const vPos = OcctBackend.extrudeFromSketch(OcctBackend.fromSketchCommands(cmdsPos), 1).volume();
@@ -96,13 +100,13 @@ describe('OcctBackend sketch + extrudeSketch', () => {
   it('bulgeArc and sagittaArc produce equivalent shapes when sagitta = bulge × halfChord (within 5%)', () => {
     // Replicad bulge = tan(theta/4); for chord 20 / sagitta 5, expected bulge ≈ 0.5.
     const cmdsSag: SketchCommand[] = [
-      { kind: 'moveTo', x: 0, y: 0 },
-      { kind: 'sagittaArc', x: 20, y: 0, sagitta: 5 },
+      { kind: 'moveTo', x: mm(0), y: mm(0) },
+      { kind: 'sagittaArc', x: mm(20), y: mm(0), sagitta: mm(5) },
       { kind: 'close' },
     ];
     const cmdsBulge: SketchCommand[] = [
-      { kind: 'moveTo', x: 0, y: 0 },
-      { kind: 'bulgeArc', x: 20, y: 0, bulge: 0.5 },
+      { kind: 'moveTo', x: mm(0), y: mm(0) },
+      { kind: 'bulgeArc', x: mm(20), y: mm(0), bulge: ul(0.5) },
       { kind: 'close' },
     ];
     const vSag = OcctBackend.extrudeFromSketch(OcctBackend.fromSketchCommands(cmdsSag), 1).volume();
@@ -116,8 +120,8 @@ describe('OcctBackend sketch + extrudeSketch', () => {
     // chord 20, radius 15 → theta = 2·asin(2/3) ≈ 1.4595 rad
     // segment area = R²(theta − sin theta)/2 ≈ 225 × (1.4595 − 0.9938)/2 ≈ 52.4
     const commands: SketchCommand[] = [
-      { kind: 'moveTo', x: 0, y: 0 },
-      { kind: 'radiusArc', x: 20, y: 0, radius: 15 },
+      { kind: 'moveTo', x: mm(0), y: mm(0) },
+      { kind: 'radiusArc', x: mm(20), y: mm(0), radius: mm(15) },
       { kind: 'close' },
     ];
     const sketch = OcctBackend.fromSketchCommands(commands);
@@ -128,8 +132,8 @@ describe('OcctBackend sketch + extrudeSketch', () => {
 
   it('radiusArc throws when |radius| < chord/2', () => {
     const commands: SketchCommand[] = [
-      { kind: 'moveTo', x: 0, y: 0 },
-      { kind: 'radiusArc', x: 20, y: 0, radius: 9 },
+      { kind: 'moveTo', x: mm(0), y: mm(0) },
+      { kind: 'radiusArc', x: mm(20), y: mm(0), radius: mm(9) },
       { kind: 'close' },
     ];
     expect(() => OcctBackend.fromSketchCommands(commands))
@@ -138,8 +142,8 @@ describe('OcctBackend sketch + extrudeSketch', () => {
 
   it('radiusArc throws when chord is degenerate (start ≈ end)', () => {
     const commands: SketchCommand[] = [
-      { kind: 'moveTo', x: 5, y: 5 },
-      { kind: 'radiusArc', x: 5, y: 5, radius: 10 },
+      { kind: 'moveTo', x: mm(5), y: mm(5) },
+      { kind: 'radiusArc', x: mm(5), y: mm(5), radius: mm(10) },
       { kind: 'close' },
     ];
     expect(() => OcctBackend.fromSketchCommands(commands))
@@ -148,13 +152,13 @@ describe('OcctBackend sketch + extrudeSketch', () => {
 
   it('radiusArc with positive vs negative radius produces equal-magnitude volumes (sign = bulge side)', () => {
     const cmdsPos: SketchCommand[] = [
-      { kind: 'moveTo', x: 0, y: 0 },
-      { kind: 'radiusArc', x: 20, y: 0, radius: 15 },
+      { kind: 'moveTo', x: mm(0), y: mm(0) },
+      { kind: 'radiusArc', x: mm(20), y: mm(0), radius: mm(15) },
       { kind: 'close' },
     ];
     const cmdsNeg: SketchCommand[] = [
-      { kind: 'moveTo', x: 0, y: 0 },
-      { kind: 'radiusArc', x: 20, y: 0, radius: -15 },
+      { kind: 'moveTo', x: mm(0), y: mm(0) },
+      { kind: 'radiusArc', x: mm(20), y: mm(0), radius: mm(-15) },
       { kind: 'close' },
     ];
     const vPos = OcctBackend.extrudeFromSketch(OcctBackend.fromSketchCommands(cmdsPos), 1).volume();

--- a/tests/unit/backends/occt/occtLowerer.extrude.test.ts
+++ b/tests/unit/backends/occt/occtLowerer.extrude.test.ts
@@ -23,20 +23,8 @@ describe('OcctLowerer — extrude/revolve', () => {
     expect(res.shape.volume()).toBeCloseTo(6000, 0);
   });
 
-  it('revolves a rect profile around Y axis', async () => {
-    const r: FeatureRecord = {
-      id: 'revolve_1', kind: 'revolve',
-      params: {
-        profileKind: { expression: "'rect'", unit: 'unitless', evaluated: 0 },
-        w: mm(5), h: mm(10),
-        offsetX: mm(5),
-        angleDeg: { expression: '360', unit: 'deg', evaluated: 360 },
-      },
-      inputs: {}, transforms: [], suppressed: false,
-    };
-    const res = await new OcctLowerer().lower(r, { byKey: {} });
-    // washer: outer cylinder (r=10, h=10) - inner cylinder (r=5, h=10)
-    const expected = Math.PI * (100 - 25) * 10;
-    expect(res.shape.volume()).toBeCloseTo(expected, 0);
-  });
+  // Revolve from a rect profileKind has been demoted; revolve now requires a
+  // path()...close() sketch input. End-to-end revolve coverage lives in
+  // tests/unit/backends/occt/occtBackend.revolveSketch.test.ts and
+  // tests/unit/capture/sketch.test.ts.
 });

--- a/tests/unit/backends/occt/occtLowerer.sketch.test.ts
+++ b/tests/unit/backends/occt/occtLowerer.sketch.test.ts
@@ -14,9 +14,9 @@ describe('OcctLowerer sketch + extrude-from-sketch', () => {
 
   it('lowers a sketch record into an OcctBackend with kind=sketch', async () => {
     const commands: SketchCommand[] = [
-      { kind: 'moveTo', x: 0, y: 0 },
-      { kind: 'lineTo', x: 10, y: 0 },
-      { kind: 'lineTo', x: 10, y: 10 },
+      { kind: 'moveTo', x: mm(0), y: mm(0) },
+      { kind: 'lineTo', x: mm(10), y: mm(0) },
+      { kind: 'lineTo', x: mm(10), y: mm(10) },
       { kind: 'close' },
     ];
     const r: FeatureRecord = {
@@ -31,10 +31,10 @@ describe('OcctLowerer sketch + extrude-from-sketch', () => {
 
   it('lowers an extrude with profile=sketch using the upstream sketch', async () => {
     const commands: SketchCommand[] = [
-      { kind: 'moveTo', x: 0, y: 0 },
-      { kind: 'lineTo', x: 10, y: 0 },
-      { kind: 'lineTo', x: 10, y: 10 },
-      { kind: 'lineTo', x: 0, y: 10 },
+      { kind: 'moveTo', x: mm(0), y: mm(0) },
+      { kind: 'lineTo', x: mm(10), y: mm(0) },
+      { kind: 'lineTo', x: mm(10), y: mm(10) },
+      { kind: 'lineTo', x: mm(0), y: mm(10) },
       { kind: 'close' },
     ];
     const sketch = OcctBackend.fromSketchCommands(commands);

--- a/tests/unit/backends/occt/sweepFromSketch.test.ts
+++ b/tests/unit/backends/occt/sweepFromSketch.test.ts
@@ -3,12 +3,14 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { OcctBackend, initOcct } from '../../../../src/backends/occt/occtBackend';
 import type { SketchCommand } from '../../../../src/capture/sketch';
 import { helix } from '../../../../src/modules/helix';
+import { toParam } from '../../../../src/runtime/editableHelpers';
 
+const mm = (n: number) => toParam(n, 'mm');
 const square2x2: SketchCommand[] = [
-  { kind: 'moveTo', x: -1, y: -1 },
-  { kind: 'lineTo', x: 1, y: -1 },
-  { kind: 'lineTo', x: 1, y: 1 },
-  { kind: 'lineTo', x: -1, y: 1 },
+  { kind: 'moveTo', x: mm(-1), y: mm(-1) },
+  { kind: 'lineTo', x: mm(1), y: mm(-1) },
+  { kind: 'lineTo', x: mm(1), y: mm(1) },
+  { kind: 'lineTo', x: mm(-1), y: mm(1) },
   { kind: 'close' },
 ];
 

--- a/tests/unit/capture/captureSession.test.ts
+++ b/tests/unit/capture/captureSession.test.ts
@@ -123,13 +123,6 @@ describe('faceLabels capture-time validation and persistence', () => {
     expect((rec.metadata as { faceLabels?: unknown }).faceLabels).toEqual({ roof: 'top' });
   });
 
-  it('persists faceLabels on revolveRect', () => {
-    const { session, api } = makeApi();
-    api.revolveRect(5, 10, 2, 360, { faceLabels: { rim: 'right' } });
-    const rec = session.getRecords()[0];
-    expect((rec.metadata as { faceLabels?: unknown }).faceLabels).toEqual({ rim: 'right' });
-  });
-
   it('persists query-based faceLabels on extrude (Sketch.extrude)', () => {
     const { session, api } = makeApi();
     const sketch = api.path().moveTo(0,0).lineTo(10,0).lineTo(10,5).lineTo(0,5).close();

--- a/tests/unit/capture/sketch.test.ts
+++ b/tests/unit/capture/sketch.test.ts
@@ -23,11 +23,16 @@ describe('path() builder + Sketch capture', () => {
     const result = await runScript({ code, fileName: 'test.kcad.ts' });
     const sketchRec = result.records.find(r => r.kind === 'sketch')!;
     const commands = (sketchRec.metadata as { commands: unknown[] }).commands;
-    expect(commands).toEqual([
-      { kind: 'moveTo', x: 0, y: 0 },
-      { kind: 'lineTo', x: 10, y: 0 },
-      { kind: 'close' },
-    ]);
+    // Coords are stored as Param objects so symbolic ParamRefs survive into
+    // lower time. Compare via .evaluated for the numeric view.
+    expect(commands).toHaveLength(3);
+    expect(commands[0]).toMatchObject({ kind: 'moveTo' });
+    expect((commands[0] as { x: { evaluated: number }; y: { evaluated: number } }).x.evaluated).toBe(0);
+    expect((commands[0] as { x: { evaluated: number }; y: { evaluated: number } }).y.evaluated).toBe(0);
+    expect(commands[1]).toMatchObject({ kind: 'lineTo' });
+    expect((commands[1] as { x: { evaluated: number }; y: { evaluated: number } }).x.evaluated).toBe(10);
+    expect((commands[1] as { x: { evaluated: number }; y: { evaluated: number } }).y.evaluated).toBe(0);
+    expect(commands[2]).toEqual({ kind: 'close' });
   });
 
   it('extrude record references the sketch via inputs.sketch', async () => {
@@ -96,7 +101,11 @@ describe('path() builder + Sketch capture', () => {
     const result = await runScript({ code, fileName: 'test.kcad.ts' });
     const sketchRec = result.records.find(r => r.kind === 'sketch')!;
     const commands = (sketchRec.metadata as { commands: unknown[] }).commands;
-    expect(commands).toContainEqual({ kind: 'tangentArc', x: 15, y: 5 });
+    expect(commands).toContainEqual({
+      kind: 'tangentArc',
+      x: { expression: '15', unit: 'mm', evaluated: 15 },
+      y: { expression: '5', unit: 'mm', evaluated: 5 },
+    });
   });
 
   it('rejects tangentArc as the first command (would have no prior tangent)', async () => {
@@ -138,7 +147,11 @@ describe('path() builder + Sketch capture', () => {
     const result = await runScript({ code, fileName: 'test.kcad.ts' });
     const sketchRec = result.records.find(r => r.kind === 'sketch')!;
     const commands = (sketchRec.metadata as { commands: unknown[] }).commands;
-    expect(commands).toContainEqual({ kind: 'tangentArc', x: 25, y: 80 });
+    expect(commands).toContainEqual({
+      kind: 'tangentArc',
+      x: { expression: '25', unit: 'mm', evaluated: 25 },
+      y: { expression: '80', unit: 'mm', evaluated: 80 },
+    });
     expect(result.records.find(r => r.kind === 'revolve')).toBeDefined();
   });
 
@@ -206,7 +219,13 @@ describe('path() builder + Sketch capture', () => {
     const result = await runScript({ code, fileName: 'test.kcad.ts' });
     const sketchRec = result.records.find(r => r.kind === 'sketch')!;
     const commands = (sketchRec.metadata as { commands: unknown[] }).commands;
-    expect(commands).toContainEqual({ kind: 'threePointsArc', x: 20, y: 0, midX: 10, midY: 5 });
+    expect(commands).toContainEqual({
+      kind: 'threePointsArc',
+      x: { expression: '20', unit: 'mm', evaluated: 20 },
+      y: { expression: '0', unit: 'mm', evaluated: 0 },
+      midX: { expression: '10', unit: 'mm', evaluated: 10 },
+      midY: { expression: '5', unit: 'mm', evaluated: 5 },
+    });
   });
 
   it('captures sagittaArc with chord endpoint and bulge', async () => {
@@ -214,7 +233,12 @@ describe('path() builder + Sketch capture', () => {
     const result = await runScript({ code, fileName: 'test.kcad.ts' });
     const sketchRec = result.records.find(r => r.kind === 'sketch')!;
     const commands = (sketchRec.metadata as { commands: unknown[] }).commands;
-    expect(commands).toContainEqual({ kind: 'sagittaArc', x: 20, y: 0, sagitta: 5 });
+    expect(commands).toContainEqual({
+      kind: 'sagittaArc',
+      x: { expression: '20', unit: 'mm', evaluated: 20 },
+      y: { expression: '0', unit: 'mm', evaluated: 0 },
+      sagitta: { expression: '5', unit: 'mm', evaluated: 5 },
+    });
   });
 
   it('captures bulgeArc with chord endpoint and DXF bulge factor', async () => {
@@ -222,7 +246,12 @@ describe('path() builder + Sketch capture', () => {
     const result = await runScript({ code, fileName: 'test.kcad.ts' });
     const sketchRec = result.records.find(r => r.kind === 'sketch')!;
     const commands = (sketchRec.metadata as { commands: unknown[] }).commands;
-    expect(commands).toContainEqual({ kind: 'bulgeArc', x: 20, y: 0, bulge: 0.5 });
+    expect(commands).toContainEqual({
+      kind: 'bulgeArc',
+      x: { expression: '20', unit: 'mm', evaluated: 20 },
+      y: { expression: '0', unit: 'mm', evaluated: 0 },
+      bulge: { expression: '0.5', unit: 'unitless', evaluated: 0.5 },
+    });
   });
 
   it('captures radiusArc with chord endpoint and radius', async () => {
@@ -230,7 +259,12 @@ describe('path() builder + Sketch capture', () => {
     const result = await runScript({ code, fileName: 'test.kcad.ts' });
     const sketchRec = result.records.find(r => r.kind === 'sketch')!;
     const commands = (sketchRec.metadata as { commands: unknown[] }).commands;
-    expect(commands).toContainEqual({ kind: 'radiusArc', x: 20, y: 0, radius: 15 });
+    expect(commands).toContainEqual({
+      kind: 'radiusArc',
+      x: { expression: '20', unit: 'mm', evaluated: 20 },
+      y: { expression: '0', unit: 'mm', evaluated: 0 },
+      radius: { expression: '15', unit: 'mm', evaluated: 15 },
+    });
   });
 
   it('emits feature.sketch.degenerate-arc when radiusArc has invalid radius', async () => {
@@ -907,11 +941,12 @@ describe('path() builder + Sketch capture', () => {
       const sketches = result.records.filter(r => r.kind === 'sketch');
       expect(sketches).toHaveLength(2);
       const reflectedSketch = sketches[1];
-      const cmds = (reflectedSketch.metadata as { commands: Array<{ kind: string; x?: number; y?: number }> }).commands;
-      expect(cmds[0]).toMatchObject({ kind: 'moveTo', x: 0, y: 0 });
-      expect(cmds[1]).toMatchObject({ kind: 'lineTo', x: 10, y: 0 });
-      expect(cmds[2]).toMatchObject({ kind: 'lineTo', x: 10, y: -5 });
-      expect(cmds[3]).toMatchObject({ kind: 'lineTo', x: 0, y: -5 });
+      const cmds = (reflectedSketch.metadata as { commands: Array<{ kind: string; x?: { evaluated: number }; y?: { evaluated: number } }> }).commands;
+      const xy = (i: number): [number | undefined, number | undefined] => [cmds[i].x?.evaluated, cmds[i].y?.evaluated];
+      expect(cmds[0].kind).toBe('moveTo'); expect(xy(0)).toEqual([0, 0]);
+      expect(cmds[1].kind).toBe('lineTo'); expect(xy(1)).toEqual([10, 0]);
+      expect(cmds[2].kind).toBe('lineTo'); expect(xy(2)).toEqual([10, -5]);
+      expect(cmds[3].kind).toBe('lineTo'); expect(xy(3)).toEqual([0, -5]);
     });
 
     it('reflects across the y-axis with offset', async () => {
@@ -923,9 +958,11 @@ describe('path() builder + Sketch capture', () => {
       const result = await runScript({ code, fileName: 'test.kcad.ts' });
       const sketches = result.records.filter(r => r.kind === 'sketch');
       const reflectedSketch = sketches[1];
-      const cmds = (reflectedSketch.metadata as { commands: Array<{ kind: string; x?: number; y?: number }> }).commands;
-      expect(cmds[0]).toMatchObject({ kind: 'moveTo', x: 2, y: 0 });
-      expect(cmds[1]).toMatchObject({ kind: 'lineTo', x: -3, y: 5 });
+      const cmds = (reflectedSketch.metadata as { commands: Array<{ kind: string; x?: { evaluated: number }; y?: { evaluated: number } }> }).commands;
+      expect(cmds[0].kind).toBe('moveTo');
+      expect([cmds[0].x?.evaluated, cmds[0].y?.evaluated]).toEqual([2, 0]);
+      expect(cmds[1].kind).toBe('lineTo');
+      expect([cmds[1].x?.evaluated, cmds[1].y?.evaluated]).toEqual([-3, 5]);
     });
 
     it('negates sagitta sign on sagittaArc (winding inversion)', async () => {
@@ -936,10 +973,10 @@ describe('path() builder + Sketch capture', () => {
       const result = await runScript({ code, fileName: 'test.kcad.ts' });
       const sketches = result.records.filter(r => r.kind === 'sketch');
       const reflectedSketch = sketches[1];
-      const cmds = (reflectedSketch.metadata as { commands: Array<{ kind: string; sagitta?: number }> }).commands;
+      const cmds = (reflectedSketch.metadata as { commands: Array<{ kind: string; sagitta?: { evaluated: number } }> }).commands;
       const arcCmd = cmds.find(c => c.kind === 'sagittaArc');
       expect(arcCmd).toBeDefined();
-      expect(arcCmd!.sagitta).toBe(-5);
+      expect(arcCmd!.sagitta?.evaluated).toBe(-5);
     });
 
     it('negates radius sign on radiusArc (winding inversion)', async () => {
@@ -950,10 +987,10 @@ describe('path() builder + Sketch capture', () => {
       const result = await runScript({ code, fileName: 'test.kcad.ts' });
       const sketches = result.records.filter(r => r.kind === 'sketch');
       const reflectedSketch = sketches[1];
-      const cmds = (reflectedSketch.metadata as { commands: Array<{ kind: string; radius?: number }> }).commands;
+      const cmds = (reflectedSketch.metadata as { commands: Array<{ kind: string; radius?: { evaluated: number } }> }).commands;
       const arcCmd = cmds.find(c => c.kind === 'radiusArc');
       expect(arcCmd).toBeDefined();
-      expect(arcCmd!.radius).toBe(-15);
+      expect(arcCmd!.radius?.evaluated).toBe(-15);
     });
 
     it('preserves labels on their corresponding segments', async () => {

--- a/tests/unit/runtime/pathBuilderEditable.test.ts
+++ b/tests/unit/runtime/pathBuilderEditable.test.ts
@@ -1,0 +1,165 @@
+// tests/unit/runtime/pathBuilderEditable.test.ts
+//
+// Regression suite for PathBuilder Editable<number> coords / scalars.
+//
+// Three case categories:
+//   1. Per-method capture: each PathBuilder method (moveTo/lineTo/tangentArc/
+//      threePointsArc/sagittaArc/bulgeArc/radiusArc) accepts a ParamRef and
+//      stores a Param whose paramRef field is set.
+//   2. End-to-end build: a fully-parametric path with leaf and composed
+//      ParamRefs lowers cleanly through OcctLowerer.
+//   3. Parametric reactivity: editing the param via session.params.update
+//      changes the lowered shape's volume.
+//
+// Spec: kernelCAD-private/docs/specs/2026-05-08-revolverect-demotion-and-pathbuilder-editable-design.md
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOcct } from '../../../src/backends/occt/occtBackend';
+import { CaptureSession } from '../../../src/capture/captureSession';
+import { createApi } from '../../../src/modules/api';
+import type { SketchCommand } from '../../../src/capture/sketch';
+
+beforeAll(async () => { await initOcct(); });
+
+// ---------------------------------------------------------------------------
+// 1. Per-method capture: a leaf ParamRef survives onto the stored Param via
+//    Param.paramRef.
+
+function getCommands(session: CaptureSession): SketchCommand[] {
+  const sketchRec = session.getRecords().find(r => r.kind === 'sketch');
+  if (!sketchRec) throw new Error('no sketch record found');
+  return ((sketchRec.metadata as { commands?: SketchCommand[] } | undefined)?.commands) ?? [];
+}
+
+describe('PathBuilder accepts Editable<number> — per-method capture', () => {
+  it('moveTo stores ParamRef on x and y', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    const r = api.param('r', 5);
+    api.path().moveTo(r, 0).lineTo(10, 0).close();
+    const cmds = getCommands(session);
+    const move = cmds[0] as { kind: 'moveTo'; x: { paramRef?: unknown }; y: { paramRef?: unknown } };
+    expect(move.kind).toBe('moveTo');
+    expect(move.x.paramRef).toBe('r');
+  });
+
+  it('lineTo stores ParamRef on x and y', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    const r = api.param('r', 5);
+    api.path().moveTo(0, 0).lineTo(r, 0).close();
+    const cmds = getCommands(session);
+    const line = cmds[1] as { kind: 'lineTo'; x: { paramRef?: unknown } };
+    expect(line.kind).toBe('lineTo');
+    expect(line.x.paramRef).toBe('r');
+  });
+
+  it('tangentArc stores ParamRef on x and y', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    const r = api.param('r', 5);
+    api.path().moveTo(0, 0).lineTo(10, 0).tangentArc(r, 5).close();
+    const cmds = getCommands(session);
+    const arc = cmds.find(c => c.kind === 'tangentArc') as { x: { paramRef?: unknown } } | undefined;
+    expect(arc).toBeDefined();
+    expect(arc!.x.paramRef).toBe('r');
+  });
+
+  it('threePointsArc stores ParamRef on midX', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    const m = api.param('m', 10);
+    api.path().moveTo(0, 0).threePointsArc(20, 0, m, 5).close();
+    const cmds = getCommands(session);
+    const arc = cmds.find(c => c.kind === 'threePointsArc') as { midX: { paramRef?: unknown } } | undefined;
+    expect(arc).toBeDefined();
+    expect(arc!.midX.paramRef).toBe('m');
+  });
+
+  it('sagittaArc stores ParamRef on sagitta', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    const s = api.param('s', 5);
+    api.path().moveTo(0, 0).sagittaArc(20, 0, s).close();
+    const cmds = getCommands(session);
+    const arc = cmds.find(c => c.kind === 'sagittaArc') as { sagitta: { paramRef?: unknown } } | undefined;
+    expect(arc).toBeDefined();
+    expect(arc!.sagitta.paramRef).toBe('s');
+  });
+
+  it('bulgeArc stores ParamRef on bulge (unitless)', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    const b = api.param('b', 0.5);
+    api.path().moveTo(0, 0).bulgeArc(20, 0, b).close();
+    const cmds = getCommands(session);
+    const arc = cmds.find(c => c.kind === 'bulgeArc') as { bulge: { paramRef?: unknown; unit: string } } | undefined;
+    expect(arc).toBeDefined();
+    expect(arc!.bulge.paramRef).toBe('b');
+    expect(arc!.bulge.unit).toBe('unitless');
+  });
+
+  it('radiusArc stores ParamRef on radius', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    const radius = api.param('radius', 15);
+    api.path().moveTo(0, 0).radiusArc(20, 0, radius).close();
+    const cmds = getCommands(session);
+    const arc = cmds.find(c => c.kind === 'radiusArc') as { radius: { paramRef?: unknown } } | undefined;
+    expect(arc).toBeDefined();
+    expect(arc!.radius.paramRef).toBe('radius');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. End-to-end: leaf and composed ParamRefs survive into a successful lower.
+
+describe('PathBuilder Editable — end-to-end lowering', () => {
+  it('builds and lowers a parametric path with leaf + composed ParamRefs', async () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    const r = api.param('r', 5);
+    const shape = api.path()
+      .moveTo(r, 0)
+      .lineTo(r.add(10), 0)
+      .lineTo(r.add(10), 5)
+      .lineTo(r, 5)
+      .close()
+      .extrude(3);
+    const lowered = await shape.lower();
+    expect(lowered.volume()).toBeCloseTo(150, 0); // 10 × 5 × 3
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Parametric reactivity: editing the param via session.params.update
+//    re-lowers the shape with the new value, observable in the volume.
+
+describe('PathBuilder Editable — params.update reactivity', () => {
+  it('updating r changes the revolved shape volume', async () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    const r = api.param('r', 5);
+    // Washer profile: inner radius r, outer radius r+10, height 5.
+    const shape = api.path()
+      .moveTo(r, 0)
+      .lineTo(r.add(10), 0)
+      .lineTo(r.add(10), 5)
+      .lineTo(r, 5)
+      .close()
+      .revolve();
+
+    const initial = await shape.lower();
+    const v1 = initial.volume();
+    expect(v1).toBeGreaterThan(0);
+
+    // Edit r 5 → 8. Outer radius grows from 15 to 18; inner radius from 5 to 8.
+    // Volume = π * (outer² - inner²) * h:
+    //   v1 = π * (15² - 5²) * 5 = π * 200 * 5 = 1000π ≈ 3141.6
+    //   v2 = π * (18² - 8²) * 5 = π * 260 * 5 = 1300π ≈ 4084.1
+    const updated = await session.params.update([{ name: 'r', value: 8 }]);
+    const v2 = updated.shape.volume();
+    expect(v2).toBeGreaterThan(v1);
+    expect(Math.abs(v2 - v1)).toBeGreaterThan(50);
+  });
+});


### PR DESCRIPTION
## Summary

Bundled slice — same shape as the `robotArmKit` demotion (commit `353f8c5` on develop) for the demotion half:

1. **Demote `revolveRect`.** Zero unique capability over `path()...close().revolve()`. Removed from `KernelCadApi`, `OcctBackend`, the lowerer's `'revolve'` arm dispatch, `list_api`, `toolRegistry`'s `addFeature` description, `SKILL.md`, and 3 test sites.
2. **Extend `PathBuilder` to accept `Editable<number>`** for every coord/scalar parameter. Without this, the substitution path (`revolveRect` → `path()+revolve`) would lose the parametric authoring just gained in PR #111. `SketchCommand` storage migrates from `{ x: number }` to `{ x: Param }` across all 7 command kinds.
3. **Donut rewrite.** `examples/v0.21/donut.kcad.ts` now authors body and glaze via `path()...close().revolve()` with ParamRef coords throughout.

## Why bundled

Splitting demotion from the PathBuilder extension would transiently regress slice A (PR #111) — the donut's parametric demonstration would flip back to numeric coords until a follow-up landed. Bundled keeps the substitution coherent.

## Commits

1. `feat(sketch): PathBuilder accepts Editable<number>; SketchCommand stores Param` — `0addaec`
2. `feat(lowerer): consume Param-typed sketch coords; drop rect-revolve dispatch` — `30c0a98`
3. `feat(api): remove revolveRect from public API + OcctBackend` — `f1019dc`
4. `feat(api): drop revolveRect from list_api/SKILL.md/tests; widen PathBuilder signatures` — `8aa0391`
5. `feat(examples): rewrite donut to path()+Sketch.revolve(); regression tests for PathBuilder Editable` — `f6d43ae`
6. `docs(changelog): record revolveRect demotion + PathBuilder Editable extension` — `e27e06e`
7. `docs: surface Sketch.reflect parametric-collapse deviation` — `65013c7`

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.app.json` clean
- [x] `npm run lint` clean
- [x] `npm test` full: **1370/1387 passing**, 17 pre-existing skipped, no new failures
- [x] Donut probe: `examples/v0.21/donut.kcad.ts` → 15 features, OK (was 13 with `revolveRect`; rewrite produces 15 features because `path()...revolve()` is multiple records)
- [x] Parametric path probe: `path().moveTo(r, 0).lineTo(r.add(10), 0).lineTo(r.add(10), 5).lineTo(r, 5).close().revolve()` with `r = param('r', 5)` → OK
- [x] New regression suite at `tests/unit/runtime/pathBuilderEditable.test.ts`
- [ ] CI green

## Implementer scope deviations (all transparent in commits)

- **`Sketch.reflect(axis)` collapses symbolic ParamRef coords to numeric values at reflect time.** Preserving symbolic ASTs through reflection arithmetic wasn't viable in this slice. Documented in SKILL.md (`.reflect` section), CHANGELOG (PathBuilder Editable subsection), and the api-ergonomic-gaps backlog (kernelCAD-private). Workaround: author both halves explicitly.
- **Lowerer migration extended beyond `occtLowerer.ts`** — `edgeSelection.ts`, `cutoutLowerer.ts`, `cutoutValidation.ts`, `listFaceLabels.ts`, and `Sketch.reflect` itself all read coord/scalar fields from `SketchCommand` as numbers. All migrated to `.evaluated`.
- **Dropped `profileKind` discriminant from the revolve arm entirely** — the only remaining value was `'sketch'` after revolveRect's `'rect'` branch removed.
- **Dropped `tests/unit/backends/occt/occtLowerer.extrude.test.ts:'revolves a rect profile around Y axis'`** test — necessary follow-on of the dispatch removal; coverage retained by `occtBackend.revolveSketch.test.ts` and the new path-builder Editable tests.

## Out of scope

- Arc constructor sprawl trim (`tangentArc`/`threePointsArc`/`sagittaArc`/`bulgeArc`/`radiusArc` → 2-3) — milestone D.
- `mirror`/`reflect` ergonomics — milestone D.
- `extrudeRect`/`extrudeCircle`/`extrudePolygon`/`extrudeRoundedRect` demotion — separate slices.
- `.translate(x, y, z)` Editable extension — separate slice if needed.
- Preserving symbolic ParamRefs through `Sketch.reflect()` — backlog entry.

## Spec + plan

In `kernelCAD-private`: `docs/specs/2026-05-08-revolverect-demotion-and-pathbuilder-editable-design.md`, `docs/plans/2026-05-08-revolverect-demotion-and-pathbuilder-editable.md`. Backlog entry: `docs/process/api-ergonomic-gaps.md`.