### PR TITLE
feat(api): .translate + .rotate accept Editable<number> (full parametric closure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,17 +110,33 @@ npm run dev
   path directly when you need full param tracking on both halves. Tracked
   in the api-ergonomic-gaps backlog.
 
+### Changed — Shape transforms accept editable parameters
+
+- Widened `Shape.translate(x, y, z)` and `Shape.rotate(axis, degrees, pivot?)`
+  so every coordinate, axis component, the rotation angle, and every pivot
+  component accepts `Editable<number>` (`number | ParamRef<number>`).
+  `ShapeTransform` now stores `Param` objects (with `mm` units for
+  translations and pivots, `deg` for rotation angle, `unitless` for axis
+  direction components) instead of bare numbers, and the OCCT lowerer
+  reads `.evaluated` after the dispatcher's pre-resolve substitutes any
+  symbolic ParamRef. After this slice, every editable dimension in the
+  public surface accepts `ParamRef<number>`. Advertised through
+  `list_api`'s `SHAPE_METHODS` and SKILL.md.
+- `CaptureSession.appendTransform` now merges any ParamRefs found in
+  the transform body into `record.metadata.paramRefs`, so
+  `params.update`'s first-affected scan correctly invalidates records
+  whose only param dependency lives in transforms (e.g. a translated
+  glaze whose Z follows a `bodyHeight` param).
+
 ### Changed — example demonstrations
 
-- Rewrote `examples/v0.21/donut.kcad.ts` (the v0.21 hero artifact) to
-  exercise the just-shipped capabilities end-to-end: 7 of its 9 dimensions
-  are now declared via `param()`; glaze inner/outer radii derive from body
-  via `.add` / `.subtract`; body and glaze profiles authored via
-  `path()...close().revolve()` so every revolution coord is a ParamRef.
-  Body and glaze fillets compose via the fillet-on-revolved fix.
-  Body/glaze heights stay literal because `.translate(x, y, z)` does not
-  accept `ParamRef` today (sprinkle Z is computed from those literals).
-  Total: 15 features, builds clean from a fresh evaluate.
+- `examples/v0.21/donut.kcad.ts` is now fully parametric end-to-end: every
+  editable dimension is a `param()`. Body/glaze profiles use ParamRef
+  coords through `path()...close().revolve()`; glaze radii derive from
+  body via `.add` / `.subtract`; glaze Z is `bodyHeight` directly; sprinkle
+  Z is `bodyHeight.add(glazeHeight)` (composed ParamRef). Editing any
+  param via `params.update` re-lowers the chain and the donut tracks the
+  edit live. Total: 15 features, builds clean from a fresh evaluate.
 
 ### Fixed — tech debt
 

--- a/examples/v0.21/donut.kcad.ts
+++ b/examples/v0.21/donut.kcad.ts
@@ -1,25 +1,26 @@
 // v0.21 hero artifact: parametric donut (body + glaze + sprinkles).
 //
-// Demonstrates the just-shipped capabilities:
+// Demonstrates the full parametric closure of the public surface:
 //   - `param()` for editable dimensions (params.update at runtime re-lowers)
 //   - ParamRef arithmetic (`.add`, `.subtract`) for derived dimensions
-//   - `path()...close().revolve().fillet()` end-to-end parametric — every
+//   - `path()...close().revolve()...fillet()` end-to-end parametric — every
 //     coord on the revolution profile is a ParamRef
+//   - `.translate(x, y, z)` accepts ParamRef on every coord, so derived
+//     positions (sprinkleZ = bodyHeight + glazeHeight) stay editable too
+//
+// After this slice, every editable dimension in this file is a param —
+// no literal numbers feed downstream geometry.
 //
 // Per the memorable-builds policy (see `kernelCAD-private/docs/process/`).
-//
-// Limitation worth flagging for agents: `.translate(x, y, z)` accepts plain
-// numbers only, not `ParamRef`. So the body/glaze HEIGHTS that feed sprinkle
-// Z position stay as literal numbers; PathBuilder is now fully parametric.
 
 const bodyInnerR = param('bodyInnerR', 12);
 const bodyOuterR = param('bodyOuterR', 35);
-const bodyHeightVal = 18;
+const bodyHeight = param('bodyHeight', 18);
 const bodyFilletR = param('bodyFilletR', 7);
 
 const glazeOverhang = param('glazeOverhang', 1);
 const glazeInset = param('glazeInset', 1);
-const glazeHeightVal = 5;
+const glazeHeight = param('glazeHeight', 5);
 const glazeFilletR = param('glazeFilletR', 1.5);
 
 const sprinkleR = param('sprinkleR', 1);
@@ -30,30 +31,33 @@ const sprinkleH = param('sprinkleH', 3);
 const body = path()
   .moveTo(bodyInnerR, 0)
   .lineTo(bodyOuterR, 0)
-  .lineTo(bodyOuterR, bodyHeightVal)
-  .lineTo(bodyInnerR, bodyHeightVal)
+  .lineTo(bodyOuterR, bodyHeight)
+  .lineTo(bodyInnerR, bodyHeight)
   .close()
   .revolve()
   .fillet(bodyFilletR);
 
 // Glaze: thinner ring sitting on top of the body, slightly oversized for a
 // "drip" silhouette. Inner/outer radii derive from the body via ParamRef
-// arithmetic so the glaze tracks the body when params edit.
+// arithmetic so the glaze tracks the body when params edit. The translate
+// Z is `bodyHeight` itself — a ParamRef — so it tracks edits live.
 const glazeOuterR = bodyOuterR.add(glazeOverhang);
 const glazeInnerR = bodyInnerR.add(glazeInset);
 const glaze = path()
   .moveTo(glazeInnerR, 0)
   .lineTo(glazeOuterR, 0)
-  .lineTo(glazeOuterR, glazeHeightVal)
-  .lineTo(glazeInnerR, glazeHeightVal)
+  .lineTo(glazeOuterR, glazeHeight)
+  .lineTo(glazeInnerR, glazeHeight)
   .close()
   .revolve()
-  .translate(0, 0, bodyHeightVal)
+  .translate(0, 0, bodyHeight)
   .fillet(glazeFilletR);
 
 // Sprinkles scattered around the glaze top. Positions are JS-computed (polar
-// → Cartesian); only the sprinkle dimensions are parametric.
-const sprinkleZ = bodyHeightVal + glazeHeightVal;
+// → Cartesian); only the sprinkle dimensions and Z are parametric. The Z
+// position is `bodyHeight + glazeHeight` — a composed ParamRef — so the
+// sprinkles ride on top of the glaze even after live param edits.
+const sprinkleZ = bodyHeight.add(glazeHeight);
 const sprinklePolar: Array<[number, number]> = [
   [22, 15], [18, 60], [25, 105], [20, 150],
   [23, 200], [19, 245], [22, 290], [21, 335],

--- a/src/backends/occt/occtLowerer.ts
+++ b/src/backends/occt/occtLowerer.ts
@@ -6,7 +6,7 @@ import type {
   ShapeBackend,
 } from '../backend';
 import type { FeatureRecord } from '../../intent/featureRecord';
-import type { FeatureKind, PatternSpec, PlaneSpec } from '../../intent/types';
+import type { FeatureKind, PatternSpec, PlaneSpec, Vec3 } from '../../intent/types';
 import { isValidPlaneSpec } from '../../intent/types';
 import type { CompilerDiagnostic } from '../../diagnostics/diagnostic';
 import { OcctBackend } from './occtBackend';
@@ -1281,11 +1281,16 @@ export class OcctLowerer implements FeatureLowerer {
       const inputMap = inputBackend.historyMap;
       switch (t.op) {
         case 'translate':
-          shape = shape.translate(t.x, t.y, t.z);
+          shape = shape.translate(t.x.evaluated, t.y.evaluated, t.z.evaluated);
           break;
-        case 'rotateAxis':
-          shape = shape.rotate(t.axis, t.degrees, t.pivot);
+        case 'rotateAxis': {
+          const ax: Vec3 = [t.axis[0].evaluated, t.axis[1].evaluated, t.axis[2].evaluated];
+          const pv: Vec3 | undefined = t.pivot
+            ? [t.pivot[0].evaluated, t.pivot[1].evaluated, t.pivot[2].evaluated]
+            : undefined;
+          shape = shape.rotate(ax, t.degrees.evaluated, pv);
           break;
+        }
         case 'scale':
           shape = shape.scale([t.sx, t.sy, t.sz]);
           break;

--- a/src/capture/captureSession.ts
+++ b/src/capture/captureSession.ts
@@ -145,6 +145,16 @@ export class CaptureSession {
     const r = this.records.find(x => x.id === id);
     if (!r) throw new Error(`Feature '${id}' not registered`);
     r.transforms.push(t);
+    // Slice-5: Param-typed translate/rotateAxis transforms can carry ParamRefs.
+    // Merge any new refs into metadata.paramRefs so `params.update`'s
+    // first-affected scan invalidates this record when the named param edits.
+    const newRefs = collectParamRefs(t);
+    if (newRefs.size > 0) {
+      const existing = (r.metadata as { paramRefs?: string[] } | undefined)?.paramRefs ?? [];
+      const merged = new Set<string>(existing);
+      for (const name of newRefs) merged.add(name);
+      r.metadata = { ...(r.metadata ?? {}), paramRefs: Array.from(merged) };
+    }
   }
 
   boolean(op: 'union' | 'difference' | 'intersection', base: Shape, cutters: Shape[]): Shape {

--- a/src/capture/proxy.ts
+++ b/src/capture/proxy.ts
@@ -15,6 +15,7 @@ import {
   type EditableCutoutOpts,
 } from '../intent/cutoutValidation';
 import { isParamRef, type Editable } from '../runtime/paramRef';
+import { toParam } from '../runtime/editableHelpers';
 
 type CanonicalFace = 'top' | 'bottom' | 'left' | 'right' | 'front' | 'back';
 
@@ -56,21 +57,28 @@ export class Shape {
     this.session = session;
   }
 
-  translate(x: number, y: number, z: number): Shape {
-    if (!isValidVec3([x, y, z])) {
+  translate(x: Editable<number>, y: Editable<number>, z: Editable<number>): Shape {
+    const px = toParam(x, 'mm');
+    const py = toParam(y, 'mm');
+    const pz = toParam(z, 'mm');
+    if (!isValidVec3([px.evaluated, py.evaluated, pz.evaluated])) {
       throw new KernelError(
         'feature.invalid-args',
-        `Translate vector must be three finite numbers; got [${x}, ${y}, ${z}].`,
+        `Translate vector must be three finite numbers; got [${px.evaluated}, ${py.evaluated}, ${pz.evaluated}].`,
         this.id,
         'Pass three finite numbers (x, y, z) to .translate().',
       );
     }
-    this.session.appendTransform(this.id, { op: 'translate', x, y, z });
+    this.session.appendTransform(this.id, { op: 'translate', x: px, y: py, z: pz });
     return this;
   }
 
-  rotate(axis: [number, number, number], degrees: number, pivot?: [number, number, number]): Shape {
-    if (!isValidVec3(axis) || typeof degrees !== 'number' || !Number.isFinite(degrees)) {
+  rotate(
+    axis: [Editable<number>, Editable<number>, Editable<number>],
+    degrees: Editable<number>,
+    pivot?: [Editable<number>, Editable<number>, Editable<number>],
+  ): Shape {
+    if (!Array.isArray(axis) || axis.length !== 3) {
       throw new KernelError(
         'feature.invalid-args',
         `Rotate axis must be a finite Vec3 and degrees must be a finite number; got axis=${formatScalarForError(axis)}, degrees=${formatScalarForError(degrees)}.`,
@@ -78,15 +86,47 @@ export class Shape {
         'Pass a finite Vec3 axis and a finite number of degrees to .rotate(axis, degrees, pivot?).',
       );
     }
-    if (pivot !== undefined && !isValidVec3(pivot)) {
+    const ax = toParam(axis[0], 'unitless');
+    const ay = toParam(axis[1], 'unitless');
+    const az = toParam(axis[2], 'unitless');
+    const deg = toParam(degrees, 'deg');
+    if (!isValidVec3([ax.evaluated, ay.evaluated, az.evaluated]) || !Number.isFinite(deg.evaluated)) {
       throw new KernelError(
         'feature.invalid-args',
-        `Rotate pivot (when provided) must be a finite Vec3; got ${formatScalarForError(pivot)}.`,
+        `Rotate axis must be a finite Vec3 and degrees must be a finite number; got axis=${formatScalarForError(axis)}, degrees=${formatScalarForError(degrees)}.`,
         this.id,
-        'Pass a finite Vec3 as the pivot, or omit it.',
+        'Pass a finite Vec3 axis and a finite number of degrees to .rotate(axis, degrees, pivot?).',
       );
     }
-    this.session.appendTransform(this.id, { op: 'rotateAxis', axis, degrees, pivot });
+    let pivotParams: [import('../intent/types').Param, import('../intent/types').Param, import('../intent/types').Param] | undefined;
+    if (pivot !== undefined) {
+      if (!Array.isArray(pivot) || pivot.length !== 3) {
+        throw new KernelError(
+          'feature.invalid-args',
+          `Rotate pivot (when provided) must be a finite Vec3; got ${formatScalarForError(pivot)}.`,
+          this.id,
+          'Pass a finite Vec3 as the pivot, or omit it.',
+        );
+      }
+      const px = toParam(pivot[0], 'mm');
+      const py = toParam(pivot[1], 'mm');
+      const pz = toParam(pivot[2], 'mm');
+      if (!isValidVec3([px.evaluated, py.evaluated, pz.evaluated])) {
+        throw new KernelError(
+          'feature.invalid-args',
+          `Rotate pivot (when provided) must be a finite Vec3; got ${formatScalarForError(pivot)}.`,
+          this.id,
+          'Pass a finite Vec3 as the pivot, or omit it.',
+        );
+      }
+      pivotParams = [px, py, pz];
+    }
+    this.session.appendTransform(this.id, {
+      op: 'rotateAxis',
+      axis: [ax, ay, az],
+      degrees: deg,
+      pivot: pivotParams,
+    });
     return this;
   }
 

--- a/src/intent/featureRecord.ts
+++ b/src/intent/featureRecord.ts
@@ -1,14 +1,13 @@
 import type {
   CanonicalFace, FeatureId, FeatureKind, FeatureRef, Param, PlaneSpec, ScriptLocation,
-  Vec3,
 } from './types';
 // Re-export so consumers can import CanonicalFace from the same module as FaceLabelsMap.
 export type { CanonicalFace };
 import type { FaceQuery } from '../backends/occt/edgeQueries';
 
 export type ShapeTransform =
-  | { op: 'translate'; x: number; y: number; z: number }
-  | { op: 'rotateAxis'; axis: Vec3; degrees: number; pivot?: Vec3 }
+  | { op: 'translate'; x: Param; y: Param; z: Param }
+  | { op: 'rotateAxis'; axis: [Param, Param, Param]; degrees: Param; pivot?: [Param, Param, Param] }
   | { op: 'scale'; sx: number; sy: number; sz: number }
   | { op: 'reflect'; plane: PlaneSpec };
 

--- a/src/mcp/tools/listApi.ts
+++ b/src/mcp/tools/listApi.ts
@@ -67,8 +67,8 @@ export const GLOBALS: ApiEntry[] = [
 ];
 
 export const SHAPE_METHODS: ApiEntry[] = [
-  { name: 'translate', signature: '(x, y, z) => Shape', description: 'Translate by (x, y, z).' },
-  { name: 'rotate', signature: '(axis, degrees, pivot?) => Shape', description: 'Rotate `degrees` around `axis` (vector); pivot defaults to origin.' },
+  { name: 'translate', signature: '(x: Editable<number>, y: Editable<number>, z: Editable<number>) => Shape', description: 'Translate by (x, y, z). Each coordinate accepts a number or a `ParamRef<number>` so translations stay editable post-build.' },
+  { name: 'rotate', signature: '(axis: [Editable<number>, Editable<number>, Editable<number>], degrees: Editable<number>, pivot?: [Editable<number>, Editable<number>, Editable<number>]) => Shape', description: 'Rotate `degrees` around `axis` (vector); pivot defaults to origin. Axis components, degrees, and pivot all accept `ParamRef<number>`.' },
   { name: 'scale', signature: '(s) => Shape', description: 'Scale uniformly by one positive finite factor. Passing sy/sz is accepted only when all three factors are equal; non-uniform scale is rejected because the OCCT backend cannot honor it yet.' },
   { name: 'union', signature: '(...others) => Shape', description: 'Boolean union with one or more shapes.' },
   { name: 'subtract', signature: '(...others) => Shape', description: 'Boolean difference (this minus others).' },

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -81,8 +81,12 @@ selectEdge(shape: Shape, query: EdgeQuery): Promise<EdgeSegment>;  // throws if 
 
 ```typescript
 // Transforms (mutate-then-return-this; chain freely):
-.translate(x: number, y: number, z: number): Shape
-.rotate(axis: [number, number, number], degrees: number, pivot?: [number, number, number]): Shape
+.translate(x: Editable<number>, y: Editable<number>, z: Editable<number>): Shape
+.rotate(
+  axis: [Editable<number>, Editable<number>, Editable<number>],
+  degrees: Editable<number>,
+  pivot?: [Editable<number>, Editable<number>, Editable<number>],
+): Shape
 .scale(s: number): Shape  // uniform only; non-uniform sx/sy/sz is rejected
 
 // Booleans (each returns a NEW Shape that captures a 'boolean' feature record):

--- a/tests/unit/backends/occt/occtLowerer.test.ts
+++ b/tests/unit/backends/occt/occtLowerer.test.ts
@@ -38,7 +38,7 @@ describe('OcctLowerer', () => {
       id: 'box_1', kind: 'box',
       params: { x: mm(10), y: mm(10), z: mm(10), centered: ul(0) },
       inputs: {},
-      transforms: [{ op: 'translate', x: 5, y: 0, z: 0 }],
+      transforms: [{ op: 'translate', x: mm(5), y: mm(0), z: mm(0) }],
       suppressed: false,
     };
     const lowerer = new OcctLowerer();
@@ -57,7 +57,7 @@ describe('OcctLowerer', () => {
       id: 'cyl_1', kind: 'cylinder',
       params: { h: mm(20), r: mm(5) },
       inputs: {},
-      transforms: [{ op: 'translate', x: 10, y: 10, z: 0 }],
+      transforms: [{ op: 'translate', x: mm(10), y: mm(10), z: mm(0) }],
       suppressed: false,
     };
     const baseRes = await lowerer.lower(baseRec, { byKey: {} });

--- a/tests/unit/capture/captureSession.test.ts
+++ b/tests/unit/capture/captureSession.test.ts
@@ -47,7 +47,12 @@ describe('CaptureSession', () => {
     shape.translate(5, 0, 0);
     const records = s.getRecords();
     expect(records[0].transforms).toEqual([
-      { op: 'translate', x: 5, y: 0, z: 0 },
+      {
+        op: 'translate',
+        x: { expression: '5', unit: 'mm', evaluated: 5 },
+        y: { expression: '0', unit: 'mm', evaluated: 0 },
+        z: { expression: '0', unit: 'mm', evaluated: 0 },
+      },
     ]);
   });
 

--- a/tests/unit/compute/recomputeEngine.test.ts
+++ b/tests/unit/compute/recomputeEngine.test.ts
@@ -31,7 +31,7 @@ describe('RecomputeEngine', () => {
       { id: 'cyl_1', kind: 'cylinder',
         params: { h: mm(20), r: mm(5) },
         inputs: {},
-        transforms: [{ op: 'translate', x: 10, y: 10, z: 0 }],
+        transforms: [{ op: 'translate', x: mm(10), y: mm(10), z: mm(0) }],
         suppressed: false },
       { id: 'bool_1', kind: 'boolean',
         params: { op: { expression: "'difference'", unit: 'unitless', evaluated: 0 } },

--- a/tests/unit/runtime/translateRotateEditable.test.ts
+++ b/tests/unit/runtime/translateRotateEditable.test.ts
@@ -1,0 +1,123 @@
+// tests/unit/runtime/translateRotateEditable.test.ts
+//
+// Regression suite for Shape.translate / Shape.rotate Editable<number>
+// extension.
+//
+// Three case categories:
+//   1. Per-method capture: each transform variant accepts a ParamRef and
+//      stores a Param whose paramRef field is set on the corresponding
+//      coordinate / scalar / pivot component.
+//   2. Pivot acceptance: rotate's optional pivot accepts ParamRef coords.
+//   3. Parametric reactivity: building a translated box, editing the param
+//      via session.params.update, observing the shape's bbox center moved.
+//
+// Spec: kernelCAD-private/docs/specs/2026-05-08-translate-rotate-editable-design.md
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOcct } from '../../../src/backends/occt/occtBackend';
+import { CaptureSession } from '../../../src/capture/captureSession';
+import { createApi } from '../../../src/modules/api';
+import type { ShapeTransform } from '../../../src/intent/featureRecord';
+
+beforeAll(async () => { await initOcct(); });
+
+// ---------------------------------------------------------------------------
+// 1. Per-method capture: a leaf ParamRef survives onto the stored Param via
+//    Param.paramRef.
+
+function transformsOf(session: CaptureSession): ShapeTransform[] {
+  const records = session.getRecords();
+  if (records.length === 0) throw new Error('no records found');
+  return records[records.length - 1].transforms;
+}
+
+describe('Shape.translate accepts Editable<number> — per-coord capture', () => {
+  it('translate stores ParamRef on x', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    const x = api.param('x', 5);
+    api.box(10, 10, 10).translate(x, 0, 0);
+    const ts = transformsOf(session);
+    expect(ts).toHaveLength(1);
+    const t = ts[0] as Extract<ShapeTransform, { op: 'translate' }>;
+    expect(t.op).toBe('translate');
+    expect(t.x.paramRef).toBe('x');
+    expect(t.y.paramRef).toBeUndefined();
+    expect(t.z.paramRef).toBeUndefined();
+    expect(t.x.unit).toBe('mm');
+  });
+
+  it('translate stores ParamRef on y and z too', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    const y = api.param('y', 7);
+    const z = api.param('z', 9);
+    api.box(10, 10, 10).translate(0, y, z);
+    const ts = transformsOf(session);
+    const t = ts[0] as Extract<ShapeTransform, { op: 'translate' }>;
+    expect(t.y.paramRef).toBe('y');
+    expect(t.z.paramRef).toBe('z');
+  });
+});
+
+describe('Shape.rotate accepts Editable<number> — per-component capture', () => {
+  it('rotate stores ParamRef on degrees', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    const deg = api.param('deg', 45);
+    api.box(10, 10, 10).rotate([0, 0, 1], deg);
+    const ts = transformsOf(session);
+    expect(ts).toHaveLength(1);
+    const t = ts[0] as Extract<ShapeTransform, { op: 'rotateAxis' }>;
+    expect(t.op).toBe('rotateAxis');
+    expect(t.degrees.paramRef).toBe('deg');
+    expect(t.degrees.unit).toBe('deg');
+  });
+
+  it('rotate axis components accept ParamRef (unitless)', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    const az = api.param('az', 1);
+    api.box(10, 10, 10).rotate([0, 0, az], 45);
+    const ts = transformsOf(session);
+    const t = ts[0] as Extract<ShapeTransform, { op: 'rotateAxis' }>;
+    expect(t.axis[2].paramRef).toBe('az');
+    expect(t.axis[2].unit).toBe('unitless');
+  });
+
+  it('rotate pivot accepts ParamRef on each component (mm)', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    const px = api.param('px', 5);
+    api.box(10, 10, 10).rotate([0, 0, 1], 45, [px, 0, 0]);
+    const ts = transformsOf(session);
+    const t = ts[0] as Extract<ShapeTransform, { op: 'rotateAxis' }>;
+    expect(t.pivot).toBeDefined();
+    expect(t.pivot![0].paramRef).toBe('px');
+    expect(t.pivot![0].unit).toBe('mm');
+    expect(t.pivot![1].paramRef).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. End-to-end: translated box lowers and the param edit is observable.
+
+describe('Shape.translate Editable — params.update reactivity', () => {
+  it('updating x translates the box; bbox center shifts by the delta', async () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    const x = api.param('x', 5);
+    const shape = api.box(10, 10, 10).translate(x, 0, 0);
+
+    const initial = await shape.lower();
+    const initialBox = initial.boundingBox();
+    const initialCenterX = (initialBox.min[0] + initialBox.max[0]) / 2;
+
+    // Edit x: 5 → 25. bbox center should move +20 mm in x.
+    const updated = await session.params.update([{ name: 'x', value: 25 }]);
+    const updatedBox = updated.shape.boundingBox();
+    const updatedCenterX = (updatedBox.min[0] + updatedBox.max[0]) / 2;
+
+    expect(updatedCenterX - initialCenterX).toBeCloseTo(20, 5);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the parametric authoring arc started by **PR #110** (`ParamRef` arithmetic methods), continued by **PR #112** (`PathBuilder` Editable extension), and finished here. After this slice, **every editable dimension on the public agent surface accepts `ParamRef<number>`**.

The donut hero artifact (`examples/v0.21/donut.kcad.ts`) is now fully parametric — every dimension declared via `param()` and reactive to `params.update`.

## What changed

1. **`Shape.translate(x, y, z)` and `Shape.rotate(axis, degrees, pivot?)`** widen to accept `Editable<number>` for every coord/angle/axis/pivot component. Numeric callers continue to work unchanged.
2. **`ShapeTransform` storage migrates** — `translate.x` and `rotateAxis.{axis,degrees,pivot}` change from `number` to `Param`. Same pattern as PR #112's `SketchCommand` migration.
3. **`OcctLowerer`'s transform switch** reads `.evaluated` for translate/rotateAxis. `scale` and `reflect` arms unchanged.
4. **`CaptureSession.appendTransform`** now merges any ParamRefs found in the transform body into `record.metadata.paramRefs`. Required for `params.update`'s first-affected scan to invalidate records whose only param dependency lives in transforms (e.g., a translated glaze whose Z follows `bodyHeight`).
5. **Donut full parametric closure** — body/glaze heights become `param()`s; `sprinkleZ = bodyHeight.add(glazeHeight)` (composed ParamRef).

## Commits

1. `feat(intent): ShapeTransform stores Param for translate/rotateAxis coords` — `9c693c1`
2. `feat(capture): Shape.translate/.rotate accept Editable<number>` — `c44bb9f`
3. `feat(lowerer): consume Param-typed transform fields` — `7321f03`
4. `feat(api): advertise translate/rotate Editable signatures` — `e9e0017`
5. `feat(examples): donut fully parametric; regression tests for translate/rotate Editable` — `48142b5`
6. `docs(changelog): record .translate/.rotate Editable extension + donut closure` — `cd9f84d`

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run qc:build` clean (typecheck + build:cli + cookbook:build + drift check + cookbook:evaluate; pre-empts slice B's drift miss)
- [x] `npm test`: **1376/1393 passing**, 17 pre-existing skipped, no new failures (+6 vs PR #112 — new regression suite)
- [x] Donut probe: 15 features, OK
- [x] Translate-with-ParamRef probe: `box(10,10,10).translate(param("x",5), 0, 0)` → 1 feature, OK
- [x] New regression suite: `tests/unit/runtime/translateRotateEditable.test.ts` (6 cases including parametric reactivity)
- [ ] CI green

## Implementer-flagged scope deviation

**`CaptureSession.appendTransform` paramRefs index merge.** The spec didn't anticipate this. Pre-this-slice, transforms held no ParamRefs so this code path didn't matter; post-this-slice, a `box.translate(param('x', 5), 0, 0)` whose only param dependency is in the transform was being skipped by `params.update`'s first-affected scan. Fix: `appendTransform` runs `collectParamRefs(t)` and merges names into `record.metadata.paramRefs`. Documented in CHANGELOG.

## Out of scope

- `.scale` Editable extension. Uniform scale takes a single number; non-uniform was already rejected. Not capability-adding.
- `.reflect` offset Editable. Plane is categorical; offset is the only numeric param worth widening. Defer.
- Slider joint type / Phase 2 mechanical core — separate slice.
- Headless build boundary — slice D in the planned series.

## Spec + plan

In `kernelCAD-private`: `docs/specs/2026-05-08-translate-rotate-editable-design.md`, `docs/plans/2026-05-08-translate-rotate-editable.md`.

## What this finishes

The 5-PR parametric authoring arc:
- **#110**: arithmetic on `ParamRef<number>` (`.add`, `.subtract`, `.multiply`, `.divide`, `.negate`)
- **#111**: parametric donut demonstration (revolveRect path, slice A)
- **#112**: `PathBuilder` Editable extension + revolveRect demotion + donut rewritten to `path()+revolve()`
- **THIS PR**: `.translate` + `.rotate` Editable extension; donut every-dim-parametric

Every public-surface dimensional argument now accepts `ParamRef<number>` (with the documented exception of `Sketch.reflect` which collapses to numeric — backlog entry in `kernelCAD-private/docs/process/api-ergonomic-gaps.md`).