### PR TITLE
chore(intent): relocate queryKeys.ts from backends/occt/ to intent/

### DIFF
--- a/src/backends/occt/edgeSelection.ts
+++ b/src/backends/occt/edgeSelection.ts
@@ -6,7 +6,7 @@ import type { CanonicalFace, EdgeRef } from '../../intent/types';
 import { OcctBackend } from './occtBackend';
 import { resolveEdgeQuery, resolveFaceQuery, computeDihedralPublic } from './edgeQueries';
 import type { FaceQuery } from './edgeQueries';
-import { EDGE_QUERY_KEYS } from './queryKeys';
+import { EDGE_QUERY_KEYS } from '../../intent/queryKeys';
 import { resolveFaceRef } from '../../naming/resolveFaceRef';
 import {
   parseFaceSelector,

--- a/src/capture/captureSession.ts
+++ b/src/capture/captureSession.ts
@@ -9,7 +9,7 @@ import type {
   AssemblyPartRef,
   RevoluteJointOpts,
 } from './assembly';
-import { EDGE_QUERY_KEYS as EDGE_QUERY_KEYS_ARR } from '../backends/occt/queryKeys';
+import { EDGE_QUERY_KEYS as EDGE_QUERY_KEYS_ARR } from '../intent/queryKeys';
 import { ParamTable, type SerializedParamTable } from '../runtime/paramTable';
 import type { SoftWarning } from '../runtime/softWarning';
 import { collectParamRefs } from '../runtime/resolveParams';

--- a/src/intent/queryKeys.ts
+++ b/src/intent/queryKeys.ts
@@ -1,15 +1,20 @@
-// src/backends/occt/queryKeys.ts
+// src/intent/queryKeys.ts
 //
 // Single source of truth for the legal keys of `EdgeQuery` and `FaceQuery`.
 // All consumers (capture-side dispatch, lowerer-side validation, MCP
 // `list_api`) import from here so a future addition to `EdgeQuery` /
 // `FaceQuery` only requires updating these arrays once.
 //
+// Lives under `src/intent/` (vocabulary), not `src/backends/occt/`, so that
+// agent-facing layers (capture, MCP) don't import OCCT-backend modules
+// directly. The `EdgeQuery` / `FaceQuery` TYPES still live with the OCCT
+// implementation; only the key arrays move with this slice.
+//
 // The arrays are typed `ReadonlyArray<keyof EdgeQuery>` (etc) so an INVALID
 // key in the array fails at compile time. The Exclude-extends-never check
 // below also catches the REVERSE direction: a key added to the type but
 // missing from the array (rc.9 review I1).
-import type { EdgeQuery, FaceQuery } from './edgeQueries';
+import type { EdgeQuery, FaceQuery } from '../backends/occt/edgeQueries';
 
 export const EDGE_QUERY_KEYS: ReadonlyArray<keyof EdgeQuery> = [
   'atZ', 'atX', 'atY', 'near', 'within', 'parallel', 'perpendicular',

--- a/src/mcp/tools/listApi.ts
+++ b/src/mcp/tools/listApi.ts
@@ -6,7 +6,7 @@
 // API addition (this file is the single source of truth for "what can a
 // .kcad.ts script call?").
 
-import { EDGE_QUERY_KEYS, FACE_QUERY_KEYS } from '../../backends/occt/queryKeys';
+import { EDGE_QUERY_KEYS, FACE_QUERY_KEYS } from '../../intent/queryKeys';
 import { SUPPORTED_CONSTRAINT_TYPES } from './constraints';
 import type { ConstraintType } from '../../lib/constraints/types';
 

--- a/tests/unit/intent/queryKeys.test.ts
+++ b/tests/unit/intent/queryKeys.test.ts
@@ -1,6 +1,6 @@
-// tests/unit/backends/occt/queryKeys.test.ts
+// tests/unit/intent/queryKeys.test.ts
 import { describe, it, expect } from 'vitest';
-import { EDGE_QUERY_KEYS, FACE_QUERY_KEYS } from '../../../../src/backends/occt/queryKeys';
+import { EDGE_QUERY_KEYS, FACE_QUERY_KEYS } from '../../../src/intent/queryKeys';
 
 describe('queryKeys (single source of truth)', () => {
   it('EDGE_QUERY_KEYS is the canonical key list (compile-time exhaustiveness in queryKeys.ts)', () => {
@@ -26,9 +26,9 @@ describe('queryKeys (single source of truth)', () => {
   it('all consumers import from the same source (modules load cleanly)', async () => {
     // The compile-time `keyof` checks above are the actual drift guard.
     // This test just ensures all 3 consumer files load without import errors.
-    const fromCaptureSession = await import('../../../../src/capture/captureSession');
-    const fromEdgeSelection = await import('../../../../src/backends/occt/edgeSelection');
-    const fromListApi = await import('../../../../src/mcp/tools/listApi');
+    const fromCaptureSession = await import('../../../src/capture/captureSession');
+    const fromEdgeSelection = await import('../../../src/backends/occt/edgeSelection');
+    const fromListApi = await import('../../../src/mcp/tools/listApi');
     expect(fromCaptureSession).toBeDefined();
     expect(fromEdgeSelection).toBeDefined();
     expect(fromListApi).toBeDefined();


### PR DESCRIPTION
## Summary

Closes the architectural-purity gap surfaced in the slice-D audit (headless build boundary). After today's PRs #109-#113, `CaptureSession` no longer instantiates `RecomputeEngine` and the canonical build path lives in `src/kernel/buildModel.ts` — but `CaptureSession` still had a value import from `src/backends/occt/queryKeys.ts` (the `EDGE_QUERY_KEYS_ARR` constant). That counts as an "OCCT backend module" import per the headless build boundary spec.

## What changed

- Renamed `src/backends/occt/queryKeys.ts` → `src/intent/queryKeys.ts`. Vocabulary constants (the legal keys of `EdgeQuery` / `FaceQuery`) belong in `src/intent/`.
- The `EdgeQuery` / `FaceQuery` TYPES stay where they are (`src/backends/occt/edgeQueries.ts`) — they describe an OCCT-backed query DSL with backend-specific semantics. Only the key arrays move.
- 3 importer paths updated: `src/capture/captureSession.ts`, `src/backends/occt/edgeSelection.ts`, `src/mcp/tools/listApi.ts`.
- Test file moved to mirror: `tests/unit/intent/queryKeys.test.ts`.

## Test plan

- [x] `npm test`: 1376/1393 passing, 17 pre-existing skipped, no new failures
- [x] `tsc --noEmit` clean
- [x] `npm run qc:build` clean (typecheck + build:cli + cookbook + drift check)
- [x] `npm run lint` clean
- [ ] CI green

## Behavior change

None. Pure file move + import path update.

## Slice context

This is the polish closing the slice-D audit findings (headless build boundary). The main migration (`buildModel`, `updateModelParams`, `CaptureSession` no longer creating `RecomputeEngine`) was already shipped in earlier work. After this PR, `CaptureSession` does not import from `src/backends/occt/` at all.

`src/kernel/HeadlessKernel.ts` is left in place — it's a separate abstraction (code-mutation context for agents, used by `src/agent/AgentAPI.ts`), not redundant with `buildModel.ts`.