### PR TITLE
chore(release): close v0.5.0 release-completion gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1463,11 +1463,11 @@ npm run dev
 Found a bug? [Open an issue](https://github.com/w1ne/kernelCAD/issues)
 
 
-# Changelog
+# Legacy changelog (pre-reset)
 
-All notable changes to this project will be documented in this file.
- 
-## [Unreleased]
+This section preserves a separate kernelCAD changelog from before the 2026-05 versioning reset. Entries below describe an earlier prototyping line that ran 0.0.1 → 0.10.0 in Jan-Feb 2026 with a different scope; the canonical project changelog above starts at the 2026-05 cut. Kept here for historical reference; nothing below applies to the current version line.
+
+## [Legacy Unreleased]
 ### Added - Visibility & Selection System
 - **Visibility Persistence**:
     - Implemented `localStorage` persistence for `hiddenIds`.
@@ -1649,7 +1649,7 @@ All notable changes to this project will be documented in this file.
 - **Performance**: 60fps in all modes, no memory leaks on mode switching
 - **Edge Threshold**: 15° for sharp geometric features only
 
-## [0.2.1] - 2026-01-26
+## [Legacy 0.2.1] - 2026-01-26
 ### Fixed
 - **Default Template Array Return**: Changed default template from `return filleted.cut(cyl);` to `return [filleted.cut(cyl)];` to enable AST auto-update of return statements.
 - **Shape Visibility**: Box/Cylinder insertions now correctly appear in 3D view after insertion.

--- a/docs/demos/v0.5/parametric-donut/meta.json
+++ b/docs/demos/v0.5/parametric-donut/meta.json
@@ -1,10 +1,10 @@
 {
   "taskId": "parametric-donut",
   "module": "v0.5",
-  "capturedAt": "2026-05-08T13:30:00.000Z",
+  "capturedAt": null,
   "durationMs": null,
   "truncated": false,
-  "gitSha": null,
+  "gitSha": "602c6ba0ad715bf662f1a9546e4a1b691c679569",
   "heroArtifact": "parametric-donut",
   "catalogSource": "memorable-builds-policy/v0.5",
   "overrideApprovedBy": null

--- a/docs/demos/v0.5/parametric-donut/whats-new.md
+++ b/docs/demos/v0.5/parametric-donut/whats-new.md
@@ -22,4 +22,4 @@ This release closes the parametric authoring arc. Every editable dimensional arg
 
 Plus the donut hero artifact rewritten in two passes (#111, #112, #113) to demonstrate the surface end-to-end.
 
-![Demo](./demo.mp4)
+> **Note:** A captured `demo.mp4` for this artifact is forthcoming via the v0.21 synchronized live-build pipeline. Reproduce the build locally with `npx tsx src/cli/index.ts evaluate examples/v0.21/donut.kcad.ts` (15 features, OK).


### PR DESCRIPTION
## Summary

Closes the immediate release-completion gaps surfaced after v0.5.0 tag was cut (#115).

## What changed

| File | Change |
|---|---|
| `docs/demos/v0.5/parametric-donut/whats-new.md` | Removed the broken `![Demo](./demo.mp4)` link (no MP4 captured yet) and replaced with a "captured demo forthcoming" note + reproduction command. Honours the never-ship-broken-videos discipline. |
| `docs/demos/v0.5/parametric-donut/meta.json` | `gitSha`: filled with `602c6ba` (the v0.5.0 release squash commit). `capturedAt`: null (honest — no capture has happened yet). |
| `CHANGELOG.md` | Deconflicted the duplicate `[Unreleased]` and `[0.2.1]` sections by relabelling the legacy concatenated section as "Legacy changelog (pre-reset)" with an explanatory note. The canonical project changelog remains the upper section starting at `[Unreleased]` / `[0.5.0]`. |

## Test plan

- [x] `npm run lint` clean
- [x] `npm run qc:build` clean
- [x] `npm test`: 1376/1393 passing, 17 pre-existing skipped, no new failures
- [ ] CI green

## Out of scope

- **Capturing a real `demo.mp4` for v0.5** — needs the v0.21 synchronized live-build pipeline; a separate slice when the pipeline is ready to run for v0.5.
- **Private-repo follow-ups** — kernel-cut post drafts, social-post-ledger entry, README roadmap fix (Phase 4 v0.5 conflict). Will land in `kernelCAD-private` commits.
- **npm publish for v0.5.0** — pending explicit approval.