### PR TITLE
chore(release): retag v0.5.0 → v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,9 @@ npm run dev
 
 ## [Unreleased]
 
-## [0.5.0] — 2026-05-08
+## [0.4.1] — 2026-05-08
+
+> **Versioning note (2026-05-08):** This release was originally tagged `v0.5.0`. The `v0.5.0` tag and GitHub release were withdrawn the same day to keep the `v0.5` minor reserved for the thin adaptive UI workstream per the gap-closure roadmap (Phase 4). The work itself — parametric authoring closure, fillet-on-revolved fix, diagnostic-vocab milestone C, Patterns + assembly contract foundations — ships unchanged as `v0.4.1`. No code changes between the withdrawn `v0.5.0` and this `v0.4.1`.
 
 ### Added — foundation + mechanical core preparation
 

--- a/docs/demos/v0.4.1/parametric-donut/meta.json
+++ b/docs/demos/v0.4.1/parametric-donut/meta.json
@@ -1,11 +1,11 @@
 {
   "taskId": "parametric-donut",
-  "module": "v0.5",
+  "module": "v0.4.1",
   "capturedAt": null,
   "durationMs": null,
   "truncated": false,
-  "gitSha": "602c6ba0ad715bf662f1a9546e4a1b691c679569",
+  "gitSha": null,
   "heroArtifact": "parametric-donut",
-  "catalogSource": "memorable-builds-policy/v0.5",
+  "catalogSource": null,
   "overrideApprovedBy": null
 }

--- a/docs/demos/v0.4.1/parametric-donut/whats-new.md
+++ b/docs/demos/v0.4.1/parametric-donut/whats-new.md
@@ -1,4 +1,4 @@
-# v0.5 — parametric authoring closure
+# v0.4.1 — parametric authoring closure
 
 ## Hero artifact
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kernelcad",
   "private": false,
-  "version": "0.5.0",
+  "version": "0.4.1",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/src/runtime/paramRef.ts
+++ b/src/runtime/paramRef.ts
@@ -6,7 +6,7 @@
 // `params` blob (via `Param.paramRef`); at lower time the dispatcher pre-resolves
 // the ref through the session's ParamTable.
 //
-// As of v0.5 ParamRef<number> exposes arithmetic methods (.add, .subtract,
+// As of v0.4.1 ParamRef<number> exposes arithmetic methods (.add, .subtract,
 // .multiply, .divide, .negate) that build a structured expression AST. The
 // expression is stored on `_expr` and resolved against the ParamTable at lower
 // time. This lets agents write `param('r', 5).divide(2)` instead of being

--- a/src/runtime/resolveParams.ts
+++ b/src/runtime/resolveParams.ts
@@ -10,7 +10,7 @@
 // `paramRef` name reached. Used at capture time to populate
 // `FeatureRecord.metadata.paramRefs` for the dependency index.
 //
-// As of v0.5 a Param's `paramRef` may be either a plain string (leaf-name
+// As of v0.4.1 a Param's `paramRef` may be either a plain string (leaf-name
 // shorthand for back-compat) or a structured `ParamRefExpr` AST produced by
 // the arithmetic methods on `ParamRef<number>`. Both shapes are walked here.
 //


### PR DESCRIPTION
## Summary

The `v0.5.0` tag and GitHub release published earlier today (PR #115, #116) have been withdrawn. The same code re-ships as `v0.4.1`.

**Why:** The gap-closure roadmap (Phase 4) reserves the `v0.5` minor for the thin adaptive UI workstream. The 2026-05-08 cut shipped parametric authoring closure + fillet-on-revolved fix + diagnostic-vocab milestone C + Patterns / assembly contract foundations — all good work, but not the adaptive-UI workstream. Tagging it `v0.5.0` collided with the planned minor and was being papered over with a retroactive README "version-label note." Cleaner to release it as a `v0.4` patch and keep the minor reserved.

**No code-behavior changes.** Pure version + metadata.

## Changes

- `package.json`: `0.5.0` → `0.4.1`
- `CHANGELOG.md`: relabel `[0.5.0]` → `[0.4.1]` with a versioning-note paragraph explaining the retag
- `docs/demos/v0.5/parametric-donut/` → `docs/demos/v0.4.1/parametric-donut/` (git mv, history preserved)
- `meta.json`: `module` v0.5 → v0.4.1; `gitSha` and `catalogSource` set to null (memorable-builds catalog applies to `v0.X.0` minors, not patches; new `gitSha` will be the merge commit on this PR)
- `whats-new.md`: title heading v0.5 → v0.4.1
- `src/runtime/paramRef.ts`, `src/runtime/resolveParams.ts`: comments "As of v0.5 ..." → "As of v0.4.1 ..." so the canonical version reference matches reality

## Already done outside this PR

- `gh release delete v0.5.0 --cleanup-tag` already executed: GitHub release page gone, remote tag `v0.5.0` deleted, local tag deleted. Verified `gh release list` and `git ls-remote --tags origin "v0.5*"` empty.
- `lint-demos: ok (4 modules checked)` locally.

## Follow-up after merge

1. Tag `v0.4.1` at the merge commit, push tag.
2. `gh release create v0.4.1` with reframed notes.
3. On `kernelCAD-private`: revert the README version-label note (Phase 4 keeps "v0.5 thin adaptive UI"), discard the v0.5 social drafts, write a brief postmortem.

## Test plan

- [ ] CI green on the PR
- [ ] After merge, `git tag v0.4.1 <merge-sha> && git push origin v0.4.1`
- [ ] `gh release create v0.4.1` with reframed notes succeeds
- [ ] `lint-demos` continues to pass with the new v0.4.1 tag