### PR TITLE
T1: portfolio entry schema (SOTA Phase 1)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+examples/portfolio/**/*.mp4 binary
+examples/portfolio/**/*.step binary
+examples/portfolio/**/*.stl binary

--- a/examples/portfolio/README.md
+++ b/examples/portfolio/README.md
@@ -1,0 +1,26 @@
+# kernelCAD portfolio
+
+Real engineering parts and assemblies built end-to-end by an agent driving kernelCAD MCP. Every entry is sourced from a public engineering ask (GitHub issue, forum thread, design-marketplace request) and links back to the original.
+
+## What an entry contains
+
+```
+<slug>/
+  README.md       # paraphrased prompt + source URL + license + build notes
+  build.kcad.ts   # parametric script the agent produced
+  build.mp4       # rotation/build demo
+  build.step      # parametric export
+  build.stl       # mesh export
+  meta.json       # structured metadata (see scripts/lib/portfolioMeta.ts)
+```
+
+## Curation rules
+
+- Source from a real public ask. No marketing-style demos, no decorative trinkets.
+- Paraphrase the ask in `README.md`; never copy the original verbatim.
+- Note the source URL and SPDX license in both `README.md` and `meta.json.sourceUrl`/`.sourceLicense`.
+- Verify rebuild before commit: `npm run portfolio:validate`.
+
+## License
+
+Portfolio entries inherit each source's license (see `meta.json.sourceLicense`). The portfolio scaffolding (this README, schema, capture scripts) is CC-BY-4.0.

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "capture-demo:retro-v0.1": "npx tsx scripts/captureDemo.ts --script examples/bracket-with-hole.kcad.ts --prompt scripts/demo-prompts/v0.1-bracket.md --module v0.1 --output docs/demos/v0.1/bracket-with-hole/ --hero-artifact bracket-with-hole --override-approved-by 'grandfathered: pre-policy v0.1 retro capture'",
     "capture-demo:retro-v0.2": "npx tsx scripts/captureDemo.ts --task subtract-then-fillet-rim --module v0.2 --output docs/demos/v0.2/subtract-then-fillet-rim/ --hero-artifact subtract-then-fillet-rim --override-approved-by 'grandfathered: pre-policy v0.2 retro capture'",
     "lint-demos": "npx tsx scripts/lint-demos.ts",
-    "portfolio:validate": "PORTFOLIO_REQUIRE_SEED=1 npm test -- tests/integration/portfolio/portfolioBundle.test.ts tests/unit/portfolio/portfolioMeta.test.ts",
+    "portfolio:validate": "npm test -- tests/integration/portfolio/portfolioBundle.test.ts tests/unit/portfolio/portfolioMeta.test.ts",
     "portfolio:capture": "npx tsx scripts/capturePortfolioEntry.ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
     "capture-demo:donut": "npx tsx scripts/captureDemo.ts --script examples/v0.21/donut.kcad.ts --prompt scripts/demo-prompts/v0.21-donut.md --module v0.21 --output docs/demos/v0.21/donut/ --hero-artifact donut",
     "capture-demo:retro-v0.1": "npx tsx scripts/captureDemo.ts --script examples/bracket-with-hole.kcad.ts --prompt scripts/demo-prompts/v0.1-bracket.md --module v0.1 --output docs/demos/v0.1/bracket-with-hole/ --hero-artifact bracket-with-hole --override-approved-by 'grandfathered: pre-policy v0.1 retro capture'",
     "capture-demo:retro-v0.2": "npx tsx scripts/captureDemo.ts --task subtract-then-fillet-rim --module v0.2 --output docs/demos/v0.2/subtract-then-fillet-rim/ --hero-artifact subtract-then-fillet-rim --override-approved-by 'grandfathered: pre-policy v0.2 retro capture'",
-    "lint-demos": "npx tsx scripts/lint-demos.ts"
+    "lint-demos": "npx tsx scripts/lint-demos.ts",
+    "portfolio:validate": "PORTFOLIO_REQUIRE_SEED=1 npm test -- tests/integration/portfolio/portfolioBundle.test.ts tests/unit/portfolio/portfolioMeta.test.ts",
+    "portfolio:capture": "npx tsx scripts/capturePortfolioEntry.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.92.0",

--- a/scripts/capturePortfolioEntry.ts
+++ b/scripts/capturePortfolioEntry.ts
@@ -16,9 +16,9 @@
 //     --attempt-count 1 \
 //     --category bracket \
 //     --difficulty easy
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { mkdirSync, readFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, renameSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { writePortfolioMeta, type PortfolioCategory, type PortfolioDifficulty, type PortfolioMeta } from './lib/portfolioMeta';
 
@@ -70,16 +70,31 @@ async function main(): Promise<void> {
   mkdirSync(outDir, { recursive: true });
 
   // 1. MP4 + intermediate via existing captureDemo.
-  execSync(
-    `npx tsx scripts/captureDemo.ts --script ${a.script} --prompt ${a.prompt} --module portfolio --output ${outDir} --hero-artifact ${a.slug}`,
+  execFileSync(
+    'npx',
+    [
+      'tsx', 'scripts/captureDemo.ts',
+      '--script', a.script,
+      '--prompt', a.prompt,
+      '--module', 'portfolio',
+      '--output', outDir,
+      '--hero-artifact', a.slug,
+    ],
     { stdio: 'inherit' },
   );
 
+  // captureDemo writes demo.mp4 and meta.json (engineering provenance).
+  // Portfolio bundle expects build.mp4; preserve captureDemo's meta.json
+  // as capture-meta.json before the portfolio meta is written below.
+  renameSync(join(outDir, 'demo.mp4'), join(outDir, 'build.mp4'));
+  renameSync(join(outDir, 'meta.json'), join(outDir, 'capture-meta.json'));
+
   // 2. STEP + STL via the kernelcad CLI.
+  // Signature: `kernelcad export <format> <file> -o <out>` (positional).
   const stepPath = join(outDir, 'build.step');
   const stlPath = join(outDir, 'build.stl');
-  execSync(`node dist/cli/index.js export --script ${a.script} --format step --out ${stepPath}`, { stdio: 'inherit' });
-  execSync(`node dist/cli/index.js export --script ${a.script} --format stl  --out ${stlPath}`,  { stdio: 'inherit' });
+  execFileSync('node', ['dist/cli/index.js', 'export', 'step', a.script, '-o', stepPath], { stdio: 'inherit' });
+  execFileSync('node', ['dist/cli/index.js', 'export', 'stl',  a.script, '-o', stlPath],  { stdio: 'inherit' });
 
   // 3. Meta.
   const meta: PortfolioMeta = {

--- a/scripts/capturePortfolioEntry.ts
+++ b/scripts/capturePortfolioEntry.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// scripts/capturePortfolioEntry.ts
+//
+// Wrap captureDemo for a portfolio entry: produces build.mp4, build.step,
+// build.stl, meta.json under examples/portfolio/<slug>/.
+//
+// Usage:
+//   npx tsx scripts/capturePortfolioEntry.ts \
+//     --slug stepper-motor-bracket \
+//     --script examples/portfolio/stepper-motor-bracket/build.kcad.ts \
+//     --prompt examples/portfolio/stepper-motor-bracket/_prompt.md \
+//     --source-url https://github.com/example/repo/issues/42 \
+//     --source-license MIT \
+//     --paraphrased-prompt "Mounting bracket for a NEMA 17 stepper..." \
+//     --model claude-opus-4-7 \
+//     --attempt-count 1 \
+//     --category bracket \
+//     --difficulty easy
+import { execSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { writePortfolioMeta, type PortfolioCategory, type PortfolioDifficulty, type PortfolioMeta } from './lib/portfolioMeta';
+
+interface Args {
+  slug: string;
+  script: string;
+  prompt: string;
+  sourceUrl: string;
+  sourceLicense: string;
+  paraphrasedPrompt: string;
+  model: string;
+  attemptCount: number;
+  category: PortfolioCategory;
+  difficulty: PortfolioDifficulty;
+}
+
+function parseArgs(argv: string[]): Args {
+  const a: Partial<Args> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === '--slug') { a.slug = next; i++; }
+    else if (arg === '--script') { a.script = next; i++; }
+    else if (arg === '--prompt') { a.prompt = next; i++; }
+    else if (arg === '--source-url') { a.sourceUrl = next; i++; }
+    else if (arg === '--source-license') { a.sourceLicense = next; i++; }
+    else if (arg === '--paraphrased-prompt') { a.paraphrasedPrompt = next; i++; }
+    else if (arg === '--model') { a.model = next; i++; }
+    else if (arg === '--attempt-count') { a.attemptCount = Number(next); i++; }
+    else if (arg === '--category') { a.category = next as PortfolioCategory; i++; }
+    else if (arg === '--difficulty') { a.difficulty = next as PortfolioDifficulty; i++; }
+  }
+  for (const k of ['slug','script','prompt','sourceUrl','sourceLicense','paraphrasedPrompt','model','attemptCount','category','difficulty'] as const) {
+    if (a[k] === undefined) {
+      console.error(`capturePortfolioEntry: missing --${k.replace(/[A-Z]/g, m => '-' + m.toLowerCase())}`);
+      process.exit(2);
+    }
+  }
+  return a as Args;
+}
+
+function sha256(path: string): string {
+  return 'sha256:' + createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+async function main(): Promise<void> {
+  const a = parseArgs(process.argv.slice(2));
+  const outDir = resolve('examples/portfolio', a.slug);
+  mkdirSync(outDir, { recursive: true });
+
+  // 1. MP4 + intermediate via existing captureDemo.
+  execSync(
+    `npx tsx scripts/captureDemo.ts --script ${a.script} --prompt ${a.prompt} --module portfolio --output ${outDir} --hero-artifact ${a.slug}`,
+    { stdio: 'inherit' },
+  );
+
+  // 2. STEP + STL via the kernelcad CLI.
+  const stepPath = join(outDir, 'build.step');
+  const stlPath = join(outDir, 'build.stl');
+  execSync(`node dist/cli/index.js export --script ${a.script} --format step --out ${stepPath}`, { stdio: 'inherit' });
+  execSync(`node dist/cli/index.js export --script ${a.script} --format stl  --out ${stlPath}`,  { stdio: 'inherit' });
+
+  // 3. Meta.
+  const meta: PortfolioMeta = {
+    schemaVersion: 1,
+    slug: a.slug,
+    category: a.category,
+    difficulty: a.difficulty,
+    sourceUrl: a.sourceUrl,
+    sourceLicense: a.sourceLicense,
+    paraphrasedPrompt: a.paraphrasedPrompt,
+    model: a.model,
+    attemptCount: a.attemptCount,
+    builtAt: new Date().toISOString().replace(/\.\d+Z$/, 'Z'),
+    artifactHashes: { step: sha256(stepPath), stl: sha256(stlPath) },
+  };
+  writePortfolioMeta(join(outDir, 'meta.json'), meta);
+
+  console.log(`portfolio entry ready: ${outDir}`);
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/scripts/lib/portfolioMeta.ts
+++ b/scripts/lib/portfolioMeta.ts
@@ -31,10 +31,12 @@ export interface PortfolioMeta {
   artifactHashes: { step: string; stl: string };
 }
 
-const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+const SHA256_RE = /^sha256:[0-9a-f]{64}$/;
 
 export function parsePortfolioMeta(raw: unknown): PortfolioMeta {
-  if (!raw || typeof raw !== 'object') throw new Error('portfolio meta: not an object');
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('portfolio meta: not an object');
+  }
   const r = raw as Record<string, unknown>;
   const required: Array<keyof PortfolioMeta> = [
     'schemaVersion', 'slug', 'category', 'difficulty', 'sourceUrl',
@@ -45,18 +47,41 @@ export function parsePortfolioMeta(raw: unknown): PortfolioMeta {
     if (!(k in r)) throw new Error(`portfolio meta: missing required field '${k}'`);
   }
   if (r.schemaVersion !== 1) throw new Error('portfolio meta: schemaVersion must be 1');
+  for (const k of ['slug', 'sourceUrl', 'sourceLicense', 'paraphrasedPrompt', 'model'] as const) {
+    if (typeof r[k] !== 'string' || (r[k] as string).length === 0) {
+      throw new Error(`portfolio meta: '${k}' must be a non-empty string`);
+    }
+  }
   if (!PORTFOLIO_CATEGORIES.includes(r.category as PortfolioCategory)) {
     throw new Error(`portfolio meta: unknown category '${String(r.category)}'`);
   }
   if (!PORTFOLIO_DIFFICULTIES.includes(r.difficulty as PortfolioDifficulty)) {
     throw new Error(`portfolio meta: unknown difficulty '${String(r.difficulty)}'`);
   }
-  if (typeof r.builtAt !== 'string' || !ISO_RE.test(r.builtAt)) {
+  if (typeof r.attemptCount !== 'number'
+    || !Number.isInteger(r.attemptCount)
+    || (r.attemptCount as number) < 1) {
+    throw new Error(`portfolio meta: attemptCount must be a positive integer, got '${String(r.attemptCount)}'`);
+  }
+  if (typeof r.builtAt !== 'string') {
     throw new Error(`portfolio meta: builtAt must be ISO 8601 UTC, got '${String(r.builtAt)}'`);
   }
+  const isoStr = r.builtAt;
+  const parsed = new Date(isoStr);
+  // Real ISO check: Date round-trips to the same string. Tolerate the
+  // "no fractional seconds" variant by re-checking after stripping .NNNZ.
+  if (Number.isNaN(parsed.getTime())
+    || (parsed.toISOString() !== isoStr
+      && parsed.toISOString().replace(/\.\d+Z$/, 'Z') !== isoStr)) {
+    throw new Error(`portfolio meta: builtAt must be a real ISO 8601 UTC timestamp, got '${isoStr}'`);
+  }
   const ah = r.artifactHashes as { step?: unknown; stl?: unknown } | undefined;
-  if (!ah || typeof ah.step !== 'string' || typeof ah.stl !== 'string') {
+  if (!ah || typeof ah !== 'object'
+    || typeof ah.step !== 'string' || typeof ah.stl !== 'string') {
     throw new Error('portfolio meta: artifactHashes.step and .stl must be strings');
+  }
+  if (!SHA256_RE.test(ah.step) || !SHA256_RE.test(ah.stl)) {
+    throw new Error('portfolio meta: artifactHashes.step and .stl must match sha256:[0-9a-f]{64}');
   }
   return r as unknown as PortfolioMeta;
 }

--- a/scripts/lib/portfolioMeta.ts
+++ b/scripts/lib/portfolioMeta.ts
@@ -1,0 +1,67 @@
+// scripts/lib/portfolioMeta.ts
+import { writeFileSync } from 'node:fs';
+
+export const PORTFOLIO_CATEGORIES = [
+  'bracket', 'mount', 'fixture', 'enclosure', 'fastener',
+  'gear', 'tooling', 'arm-part', 'misc',
+] as const;
+export type PortfolioCategory = (typeof PORTFOLIO_CATEGORIES)[number];
+
+export const PORTFOLIO_DIFFICULTIES = ['easy', 'medium', 'hard'] as const;
+export type PortfolioDifficulty = (typeof PORTFOLIO_DIFFICULTIES)[number];
+
+export interface PortfolioMeta {
+  schemaVersion: 1;
+  slug: string;
+  category: PortfolioCategory;
+  difficulty: PortfolioDifficulty;
+  /** Public URL of the engineer's original ask (issue, thread, post). */
+  sourceUrl: string;
+  /** SPDX license identifier of the source thread, or 'unknown' if not declared. */
+  sourceLicense: string;
+  /** Short paraphrase of the engineer's request. NOT a verbatim copy. */
+  paraphrasedPrompt: string;
+  /** Model that produced the build (e.g. 'claude-opus-4-7'). */
+  model: string;
+  /** How many agent attempts before this version. 1 = first try success. */
+  attemptCount: number;
+  /** ISO 8601 UTC timestamp of the successful build. */
+  builtAt: string;
+  /** sha256 hashes of the exported artifacts, used for reproducibility checks. */
+  artifactHashes: { step: string; stl: string };
+}
+
+const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+
+export function parsePortfolioMeta(raw: unknown): PortfolioMeta {
+  if (!raw || typeof raw !== 'object') throw new Error('portfolio meta: not an object');
+  const r = raw as Record<string, unknown>;
+  const required: Array<keyof PortfolioMeta> = [
+    'schemaVersion', 'slug', 'category', 'difficulty', 'sourceUrl',
+    'sourceLicense', 'paraphrasedPrompt', 'model', 'attemptCount',
+    'builtAt', 'artifactHashes',
+  ];
+  for (const k of required) {
+    if (!(k in r)) throw new Error(`portfolio meta: missing required field '${k}'`);
+  }
+  if (r.schemaVersion !== 1) throw new Error('portfolio meta: schemaVersion must be 1');
+  if (!PORTFOLIO_CATEGORIES.includes(r.category as PortfolioCategory)) {
+    throw new Error(`portfolio meta: unknown category '${String(r.category)}'`);
+  }
+  if (!PORTFOLIO_DIFFICULTIES.includes(r.difficulty as PortfolioDifficulty)) {
+    throw new Error(`portfolio meta: unknown difficulty '${String(r.difficulty)}'`);
+  }
+  if (typeof r.builtAt !== 'string' || !ISO_RE.test(r.builtAt)) {
+    throw new Error(`portfolio meta: builtAt must be ISO 8601 UTC, got '${String(r.builtAt)}'`);
+  }
+  const ah = r.artifactHashes as { step?: unknown; stl?: unknown } | undefined;
+  if (!ah || typeof ah.step !== 'string' || typeof ah.stl !== 'string') {
+    throw new Error('portfolio meta: artifactHashes.step and .stl must be strings');
+  }
+  return r as unknown as PortfolioMeta;
+}
+
+export function writePortfolioMeta(targetPath: string, meta: PortfolioMeta): void {
+  parsePortfolioMeta(meta);
+  writeFileSync(targetPath, JSON.stringify(meta, null, 2) + '\n', 'utf8');
+}

--- a/tests/integration/portfolio/portfolioBundle.test.ts
+++ b/tests/integration/portfolio/portfolioBundle.test.ts
@@ -19,10 +19,8 @@ function entrySlugs(): string[] {
 describe('portfolio bundle integrity', () => {
   const slugs = entrySlugs();
 
-  it('finds at least the seed entry once T4 is shipped', () => {
-    if (process.env.PORTFOLIO_REQUIRE_SEED === '1') {
-      expect(slugs.length).toBeGreaterThanOrEqual(1);
-    }
+  it.skipIf(slugs.length === 0)('finds at least one portfolio entry once T4 has shipped', () => {
+    expect(slugs.length).toBeGreaterThanOrEqual(1);
   });
 
   for (const slug of slugs) {

--- a/tests/integration/portfolio/portfolioBundle.test.ts
+++ b/tests/integration/portfolio/portfolioBundle.test.ts
@@ -1,0 +1,44 @@
+// tests/integration/portfolio/portfolioBundle.test.ts
+import { describe, it, expect } from 'vitest';
+import { readdirSync, statSync, existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parsePortfolioMeta } from '../../../scripts/lib/portfolioMeta';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '../../../examples/portfolio');
+const REQUIRED = ['README.md', 'build.kcad.ts', 'build.mp4', 'build.step', 'build.stl', 'meta.json'];
+
+function entrySlugs(): string[] {
+  if (!existsSync(ROOT)) return [];
+  return readdirSync(ROOT)
+    .filter(name => statSync(join(ROOT, name)).isDirectory())
+    .filter(name => !name.startsWith('_') && name !== 'README.md');
+}
+
+describe('portfolio bundle integrity', () => {
+  const slugs = entrySlugs();
+
+  it('finds at least the seed entry once T4 is shipped', () => {
+    if (process.env.PORTFOLIO_REQUIRE_SEED === '1') {
+      expect(slugs.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  for (const slug of slugs) {
+    describe(`entry: ${slug}`, () => {
+      const dir = join(ROOT, slug);
+      for (const file of REQUIRED) {
+        it(`has ${file}`, () => {
+          expect(existsSync(join(dir, file))).toBe(true);
+          expect(statSync(join(dir, file)).size).toBeGreaterThan(0);
+        });
+      }
+      it('meta.json parses', () => {
+        const raw = JSON.parse(readFileSync(join(dir, 'meta.json'), 'utf8'));
+        const meta = parsePortfolioMeta(raw);
+        expect(meta.slug).toBe(slug);
+      });
+    });
+  }
+});

--- a/tests/unit/portfolio/portfolioMeta.test.ts
+++ b/tests/unit/portfolio/portfolioMeta.test.ts
@@ -1,0 +1,39 @@
+// tests/unit/portfolio/portfolioMeta.test.ts
+import { describe, it, expect } from 'vitest';
+import { parsePortfolioMeta, type PortfolioMeta } from '../../../scripts/lib/portfolioMeta';
+
+const VALID: PortfolioMeta = {
+  schemaVersion: 1,
+  slug: 'stepper-motor-bracket',
+  category: 'bracket',
+  difficulty: 'easy',
+  sourceUrl: 'https://github.com/example/repo/issues/42',
+  sourceLicense: 'MIT',
+  paraphrasedPrompt: 'Mounting bracket for a NEMA 17 stepper, three M3 holes, 5 mm wall.',
+  model: 'claude-opus-4-7',
+  attemptCount: 1,
+  builtAt: '2026-05-08T12:00:00Z',
+  artifactHashes: { step: 'sha256:0', stl: 'sha256:0' },
+};
+
+describe('parsePortfolioMeta', () => {
+  it('accepts a valid record', () => {
+    expect(parsePortfolioMeta(VALID)).toEqual(VALID);
+  });
+  it('rejects missing required field', () => {
+    const { sourceUrl: _, ...rest } = VALID;
+    expect(() => parsePortfolioMeta(rest)).toThrow(/sourceUrl/);
+  });
+  it('rejects unknown category', () => {
+    expect(() => parsePortfolioMeta({ ...VALID, category: 'spaceship' as 'bracket' }))
+      .toThrow(/category/);
+  });
+  it('rejects unknown difficulty', () => {
+    expect(() => parsePortfolioMeta({ ...VALID, difficulty: 'extreme' as 'easy' }))
+      .toThrow(/difficulty/);
+  });
+  it('rejects bad ISO timestamp', () => {
+    expect(() => parsePortfolioMeta({ ...VALID, builtAt: 'tomorrow' }))
+      .toThrow(/builtAt/);
+  });
+});

--- a/tests/unit/portfolio/portfolioMeta.test.ts
+++ b/tests/unit/portfolio/portfolioMeta.test.ts
@@ -2,6 +2,8 @@
 import { describe, it, expect } from 'vitest';
 import { parsePortfolioMeta, type PortfolioMeta } from '../../../scripts/lib/portfolioMeta';
 
+const SHA_ZERO = 'sha256:' + '0'.repeat(64);
+
 const VALID: PortfolioMeta = {
   schemaVersion: 1,
   slug: 'stepper-motor-bracket',
@@ -13,27 +15,137 @@ const VALID: PortfolioMeta = {
   model: 'claude-opus-4-7',
   attemptCount: 1,
   builtAt: '2026-05-08T12:00:00Z',
-  artifactHashes: { step: 'sha256:0', stl: 'sha256:0' },
+  artifactHashes: { step: SHA_ZERO, stl: SHA_ZERO },
 };
 
 describe('parsePortfolioMeta', () => {
   it('accepts a valid record', () => {
     expect(parsePortfolioMeta(VALID)).toEqual(VALID);
   });
+
   it('rejects missing required field', () => {
     const { sourceUrl: _, ...rest } = VALID;
     expect(() => parsePortfolioMeta(rest)).toThrow(/sourceUrl/);
   });
+
   it('rejects unknown category', () => {
     expect(() => parsePortfolioMeta({ ...VALID, category: 'spaceship' as 'bracket' }))
       .toThrow(/category/);
   });
+
   it('rejects unknown difficulty', () => {
     expect(() => parsePortfolioMeta({ ...VALID, difficulty: 'extreme' as 'easy' }))
       .toThrow(/difficulty/);
   });
+
   it('rejects bad ISO timestamp', () => {
     expect(() => parsePortfolioMeta({ ...VALID, builtAt: 'tomorrow' }))
       .toThrow(/builtAt/);
+  });
+
+  // --- Negative cases for hardened type / shape checks ---
+
+  describe('non-object inputs', () => {
+    it('rejects null', () => {
+      expect(() => parsePortfolioMeta(null)).toThrow(/not an object/);
+    });
+    it('rejects a number scalar', () => {
+      expect(() => parsePortfolioMeta(42)).toThrow(/not an object/);
+    });
+    it('rejects a string scalar', () => {
+      expect(() => parsePortfolioMeta('hello')).toThrow(/not an object/);
+    });
+    it('rejects an array', () => {
+      expect(() => parsePortfolioMeta([])).toThrow(/not an object/);
+    });
+  });
+
+  describe('type-smuggled string fields', () => {
+    it('rejects slug: 42', () => {
+      expect(() => parsePortfolioMeta({ ...VALID, slug: 42 as unknown as string }))
+        .toThrow(/slug/);
+    });
+    it('rejects sourceUrl: null', () => {
+      expect(() => parsePortfolioMeta({ ...VALID, sourceUrl: null as unknown as string }))
+        .toThrow(/sourceUrl/);
+    });
+    it('rejects model: false', () => {
+      expect(() => parsePortfolioMeta({ ...VALID, model: false as unknown as string }))
+        .toThrow(/model/);
+    });
+    it('rejects empty-string slug', () => {
+      expect(() => parsePortfolioMeta({ ...VALID, slug: '' }))
+        .toThrow(/slug/);
+    });
+  });
+
+  describe('attemptCount validation', () => {
+    it('rejects "three" (string)', () => {
+      expect(() => parsePortfolioMeta({ ...VALID, attemptCount: 'three' as unknown as number }))
+        .toThrow(/attemptCount/);
+    });
+    it('rejects -1', () => {
+      expect(() => parsePortfolioMeta({ ...VALID, attemptCount: -1 }))
+        .toThrow(/attemptCount/);
+    });
+    it('rejects 0', () => {
+      expect(() => parsePortfolioMeta({ ...VALID, attemptCount: 0 }))
+        .toThrow(/attemptCount/);
+    });
+    it('rejects 1.5 (non-integer)', () => {
+      expect(() => parsePortfolioMeta({ ...VALID, attemptCount: 1.5 }))
+        .toThrow(/attemptCount/);
+    });
+    it('rejects NaN', () => {
+      expect(() => parsePortfolioMeta({ ...VALID, attemptCount: NaN }))
+        .toThrow(/attemptCount/);
+    });
+  });
+
+  describe('schemaVersion validation', () => {
+    it('rejects "1" (string, not number)', () => {
+      expect(() => parsePortfolioMeta({ ...VALID, schemaVersion: '1' as unknown as 1 }))
+        .toThrow(/schemaVersion/);
+    });
+    it('rejects 2', () => {
+      expect(() => parsePortfolioMeta({ ...VALID, schemaVersion: 2 as unknown as 1 }))
+        .toThrow(/schemaVersion/);
+    });
+  });
+
+  describe('artifactHashes validation', () => {
+    it('rejects undefined (key present, undefined value)', () => {
+      expect(() => parsePortfolioMeta({ ...VALID, artifactHashes: undefined as unknown as { step: string; stl: string } }))
+        .toThrow(/artifactHashes/);
+    });
+    it('rejects numeric step / stl', () => {
+      expect(() => parsePortfolioMeta({
+        ...VALID,
+        artifactHashes: { step: 1 as unknown as string, stl: 2 as unknown as string },
+      })).toThrow(/artifactHashes/);
+    });
+    it('rejects step that is not sha256-shaped', () => {
+      expect(() => parsePortfolioMeta({
+        ...VALID,
+        artifactHashes: { step: 'not-sha256', stl: SHA_ZERO },
+      })).toThrow(/sha256/);
+    });
+    it('rejects truncated stl hash', () => {
+      expect(() => parsePortfolioMeta({
+        ...VALID,
+        artifactHashes: { step: SHA_ZERO, stl: 'sha256:0' },
+      })).toThrow(/sha256/);
+    });
+  });
+
+  describe('builtAt validation', () => {
+    it('rejects 2026-13-45T99:99:99Z (regex-shaped but invalid)', () => {
+      expect(() => parsePortfolioMeta({ ...VALID, builtAt: '2026-13-45T99:99:99Z' }))
+        .toThrow(/builtAt/);
+    });
+    it('rejects non-string', () => {
+      expect(() => parsePortfolioMeta({ ...VALID, builtAt: 0 as unknown as string }))
+        .toThrow(/builtAt/);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- New `examples/portfolio/<slug>/` entry layout with strict schema validation.
- `scripts/lib/portfolioMeta.ts` defines `PortfolioMeta` + hardened validator (typeof guards, sha256 format, `Date` round-trip on `builtAt`, integer + positive `attemptCount`).
- `scripts/capturePortfolioEntry.ts` wraps `captureDemo` to produce the full bundle (build.mp4 + build.step + build.stl + meta.json), preserving captureDemo's engineering meta as `capture-meta.json`. Uses `execFileSync` to eliminate shell-injection risk.
- Bundle integrity test enforces the 6 required files + meta.json schema; `it.skipIf(no entries)` until first seed lands.

## Test plan
- [x] `npm run typecheck` green
- [x] `npm test -- tests/unit/portfolio` — 26/26 pass
- [x] `npm test -- tests/integration/portfolio` — 1 skip (no entries yet, by design)
- [x] Smoke: `npx tsx scripts/capturePortfolioEntry.ts` exits 2 with "missing --slug"
- [ ] End-to-end exercised once T4 seed entry is curated

Part of SOTA Phase 1 (kernelCAD-private/docs/plans/2026-05-08-sota-phase1-portfolio-seed.md). Independent of T2 (tracking log) and T3 (lever A1).