### PR TITLE
T2: portfolio attempts tracking log (SOTA Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ site/public/brand/
 site/public/og-image.png
 site/og-image.png
 site/brand
+
+# Portfolio attempt log (append-only, not source-controlled)
+eval/portfolio-attempts.jsonl

--- a/eval/lib.ts
+++ b/eval/lib.ts
@@ -32,7 +32,7 @@ export function formatDiagnostics(diagnostics: Diagnostic[]): string {
 
 export function computeScore(
   result: HarnessResult,
-  meta: { attempts: number; tokens_in: number; tokens_out: number; time_ms: number },
+  meta: { attempts: number; tokens_in: number; tokens_out: number; time_ms: number; firstFailureCode?: string },
 ): Score {
   const gateValues = Object.values(result.gates);
   const gate_pass = gateValues.every((v) => v);
@@ -51,7 +51,7 @@ export function computeScore(
     }
   }
 
-  return {
+  const out: Score = {
     gates: result.gates,
     scored: result.scored,
     gate_pass,
@@ -60,6 +60,8 @@ export function computeScore(
     tokens: { input: meta.tokens_in, output: meta.tokens_out, total: meta.tokens_in + meta.tokens_out },
     time_ms: meta.time_ms,
   };
+  if (meta.firstFailureCode !== undefined) out.firstFailureCode = meta.firstFailureCode;
+  return out;
 }
 
 export interface RenderTranscriptArgs {

--- a/eval/portfolio/_tasks/README.md
+++ b/eval/portfolio/_tasks/README.md
@@ -1,0 +1,13 @@
+# eval/portfolio/_tasks
+
+One subdirectory per portfolio entry, mirroring the slug under `examples/portfolio/`.
+
+```
+eval/portfolio/_tasks/<slug>/
+  prompt.md     # the same paraphrased prompt used in the portfolio entry README
+  harness.ts    # gates that the agent's output must pass to count as "built"
+```
+
+The portfolio attempt runner (`scripts/portfolioAttempt.ts`) reads from these paths and writes score data into `eval/runs/portfolio-<slug>-<timestamp>/`.
+
+Harness contracts mirror the `eval/tasks/` shape — see `eval/runner.ts:runTask`.

--- a/eval/portfolio/failureMode.ts
+++ b/eval/portfolio/failureMode.ts
@@ -1,0 +1,29 @@
+// eval/portfolio/failureMode.ts
+import { DIAGNOSTIC_CODES, type DiagnosticCode } from '../../src/diagnostics/codes';
+
+/** Locked taxonomy per spec Open Item #7. */
+export type FailureMode =
+  | { kind: 'diagnostic'; code: DiagnosticCode }
+  | { kind: 'retrieval_miss' }
+  | { kind: 'tool_gap'; tool?: string }
+  | { kind: 'model_limit' }
+  | { kind: 'out_of_scope' };
+
+/** String representation used in the JSONL log. */
+export type FailureModeTag = `diagnostic_${DiagnosticCode}` | 'retrieval_miss' | 'tool_gap' | 'model_limit' | 'out_of_scope';
+
+export function failureModeToTag(m: FailureMode): FailureModeTag {
+  switch (m.kind) {
+    case 'diagnostic': return `diagnostic_${m.code}`;
+    case 'retrieval_miss': return 'retrieval_miss';
+    case 'tool_gap': return 'tool_gap';
+    case 'model_limit': return 'model_limit';
+    case 'out_of_scope': return 'out_of_scope';
+  }
+}
+
+export function isFailureModeTag(s: string): s is FailureModeTag {
+  if (s === 'retrieval_miss' || s === 'tool_gap' || s === 'model_limit' || s === 'out_of_scope') return true;
+  if (!s.startsWith('diagnostic_')) return false;
+  return (DIAGNOSTIC_CODES as readonly string[]).includes(s.slice('diagnostic_'.length));
+}

--- a/eval/portfolio/portfolioAttemptsLog.ts
+++ b/eval/portfolio/portfolioAttemptsLog.ts
@@ -1,0 +1,50 @@
+// eval/portfolio/portfolioAttemptsLog.ts
+import { appendFileSync, existsSync, readFileSync } from 'node:fs';
+import { isFailureModeTag, type FailureModeTag } from './failureMode';
+import { DIAGNOSTIC_CODES, type DiagnosticCode } from '../../src/diagnostics/codes';
+
+export type PortfolioAttemptStatus = 'built' | 'failed' | 'abandoned';
+
+export interface PortfolioAttempt {
+  schemaVersion: 1;
+  slug: string;
+  attemptN: number;
+  status: PortfolioAttemptStatus;
+  failureMode: FailureModeTag | null;
+  diagnosticCode: DiagnosticCode | null;
+  model: string;
+  date: string;
+  notes: string;
+}
+
+const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+
+function validate(a: PortfolioAttempt): void {
+  if (a.schemaVersion !== 1) throw new Error('portfolioAttempt: schemaVersion must be 1');
+  if (!a.slug) throw new Error('portfolioAttempt: slug required');
+  if (!Number.isInteger(a.attemptN) || a.attemptN < 1) throw new Error('portfolioAttempt: attemptN must be a positive int');
+  if (!['built', 'failed', 'abandoned'].includes(a.status)) throw new Error('portfolioAttempt: bad status');
+  if (a.status === 'built' && a.failureMode !== null) throw new Error("portfolioAttempt: status='built' requires failureMode=null");
+  if (a.status !== 'built' && a.failureMode === null) throw new Error(`portfolioAttempt: status='${a.status}' requires non-null failureMode`);
+  if (a.failureMode !== null && !isFailureModeTag(a.failureMode)) throw new Error(`portfolioAttempt: bad failureMode '${a.failureMode}'`);
+  if (a.diagnosticCode !== null && !(DIAGNOSTIC_CODES as readonly string[]).includes(a.diagnosticCode)) {
+    throw new Error(`portfolioAttempt: bad diagnosticCode '${a.diagnosticCode}'`);
+  }
+  if (!ISO_RE.test(a.date)) throw new Error(`portfolioAttempt: date must be ISO 8601 UTC, got '${a.date}'`);
+}
+
+export function appendPortfolioAttempt(logPath: string, a: PortfolioAttempt): void {
+  validate(a);
+  appendFileSync(logPath, JSON.stringify(a) + '\n', 'utf8');
+}
+
+export function readPortfolioAttempts(logPath: string): PortfolioAttempt[] {
+  if (!existsSync(logPath)) return [];
+  return readFileSync(logPath, 'utf8')
+    .split('\n')
+    .filter(line => line.trim().length > 0)
+    .map((line, i) => {
+      try { return JSON.parse(line) as PortfolioAttempt; }
+      catch (e) { throw new Error(`portfolioAttempt: bad JSON on line ${i + 1}: ${(e as Error).message}`); }
+    });
+}

--- a/eval/portfolio/portfolioAttemptsLog.ts
+++ b/eval/portfolio/portfolioAttemptsLog.ts
@@ -30,6 +30,14 @@ function validate(a: PortfolioAttempt): void {
   if (a.diagnosticCode !== null && !(DIAGNOSTIC_CODES as readonly string[]).includes(a.diagnosticCode)) {
     throw new Error(`portfolioAttempt: bad diagnosticCode '${a.diagnosticCode}'`);
   }
+  if (a.failureMode !== null && a.failureMode.startsWith('diagnostic_')) {
+    const expected = a.failureMode.slice('diagnostic_'.length);
+    if (a.diagnosticCode !== expected) {
+      throw new Error(`portfolioAttempt: failureMode '${a.failureMode}' implies diagnosticCode '${expected}', got '${a.diagnosticCode}'`);
+    }
+  } else if (a.failureMode !== null && a.diagnosticCode !== null) {
+    throw new Error(`portfolioAttempt: non-diagnostic failureMode '${a.failureMode}' requires diagnosticCode=null`);
+  }
   if (!ISO_RE.test(a.date)) throw new Error(`portfolioAttempt: date must be ISO 8601 UTC, got '${a.date}'`);
 }
 

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -85,6 +85,24 @@ function loadFixture(fixturePath: string): AgentResponse[] {
   return data.responses;
 }
 
+/**
+ * Construct an agent client for the given model. When ANTHROPIC_API_KEY is
+ * set in the environment, returns a real Anthropic client; otherwise throws.
+ *
+ * Exported so other entrypoints (e.g. scripts/portfolioAttempt.ts) can build
+ * an agent without re-running this file's CLI `main()`. The model arg is
+ * accepted for symmetry with future per-model dispatch but is not currently
+ * used to vary client construction — the model is passed through to
+ * `runTask` separately.
+ */
+export function makeAgent(_model: string): AgentClient {
+  void _model;
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new Error('makeAgent: ANTHROPIC_API_KEY is required to construct a real agent client.');
+  }
+  return new AnthropicAgentClient(process.env.ANTHROPIC_API_KEY);
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const isMock = args.includes('--mock');
@@ -183,7 +201,22 @@ async function main(): Promise<void> {
   process.exit(allInfra ? 1 : 0);
 }
 
-main().catch((err) => {
-  console.error('Fatal:', err);
-  process.exit(1);
-});
+// Only run the CLI when this module is the entrypoint. Importing it from
+// another script (e.g. scripts/portfolioAttempt.ts using `makeAgent`) must
+// not trigger a full eval run.
+const isEntrypoint = (() => {
+  if (!process.argv[1]) return false;
+  try {
+    const invokedUrl = new URL(`file://${process.argv[1]}`).href;
+    return import.meta.url === invokedUrl;
+  } catch {
+    return false;
+  }
+})();
+
+if (isEntrypoint) {
+  main().catch((err) => {
+    console.error('Fatal:', err);
+    process.exit(1);
+  });
+}

--- a/eval/runner.ts
+++ b/eval/runner.ts
@@ -48,6 +48,10 @@ export async function runTask(args: RunTaskArgs): Promise<TaskResult> {
   let totalOut = 0;
   let lastEvaluateOk = false;
   let finalScript: string | null = null;
+  // First non-OK diagnostic code observed across the loop. Set once, never
+  // overwritten — downstream classifiers (portfolio attempt logger) use this
+  // to tag a failed run with the diagnostic that surfaced first.
+  let firstFailureCode: string | undefined;
 
   const start = Date.now();
 
@@ -100,6 +104,10 @@ export async function runTask(args: RunTaskArgs): Promise<TaskResult> {
     const ev = await evaluateScript(outputScriptPath);
     events.push({ kind: 'evaluate', attempt, ok: ev.ok, diagnostics: ev.diagnostics });
 
+    if (!ev.ok && firstFailureCode === undefined && ev.diagnostics.length > 0) {
+      firstFailureCode = ev.diagnostics[0].code;
+    }
+
     if (ev.ok) {
       lastEvaluateOk = true;
       break;
@@ -141,6 +149,7 @@ export async function runTask(args: RunTaskArgs): Promise<TaskResult> {
     tokens_in: totalIn,
     tokens_out: totalOut,
     time_ms: Date.now() - start,
+    firstFailureCode,
   });
 
   writeFileSync(scorePath, JSON.stringify(score, null, 2));

--- a/eval/types.ts
+++ b/eval/types.ts
@@ -37,6 +37,14 @@ export interface Score {
   attempts: number; // 1..3
   tokens: { input: number; output: number; total: number };
   time_ms: number;
+  /**
+   * First non-OK diagnostic code observed during the agent loop, if any.
+   * Used by downstream tooling (e.g. portfolio attempt classifier) to
+   * tag a failed run with the diagnostic that surfaced first. `undefined`
+   * when the run never produced a diagnostic (e.g. clean pass, or only
+   * synthetic `eval.no-script-extracted` fallbacks).
+   */
+  firstFailureCode?: string;
 }
 
 // Transcript events — captured during a run, rendered to markdown afterward.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build:cli": "tsc --noEmit -p tsconfig.cli.json && node -e \"const b=require('./node_modules/esbuild/lib/main.js');b.build({entryPoints:['src/cli/index.ts'],bundle:true,platform:'node',format:'esm',target:'node20',outfile:'dist/cli/index.js',external:['commander','typescript','replicad'],banner:{js:[\\\"#!/usr/bin/env node\\\",\\\"import{createRequire as __bcr}from'node:module';\\\",\\\"const require=__bcr(import.meta.url);\\\",\\\"const __filename=new URL(import.meta.url).pathname;\\\",\\\"const __dirname=new URL('.',import.meta.url).pathname;\\\"].join('\\\\n')}}).then(()=>{require('fs').copyFileSync('node_modules/replicad-opencascadejs/src/replicad_single.wasm','dist/cli/replicad_single.wasm');require('fs').copyFileSync('src/skill/SKILL.md','dist/cli/SKILL.md');console.log('dist/cli/index.js built')}).catch(e=>{console.error(e);process.exit(1)})\"",
     "eval": "npx tsx eval/run.ts",
     "eval:ab": "npx tsx scripts/evalAb.ts",
+    "portfolio:attempt": "npx tsx scripts/portfolioAttempt.ts",
     "cookbook:validate": "npx tsx scripts/cookbookValidate.ts",
     "cookbook:evaluate": "npx tsx scripts/cookbookEvaluate.ts",
     "cookbook:build": "npx tsx scripts/buildCookbookIndex.ts",

--- a/scripts/portfolioAttempt.ts
+++ b/scripts/portfolioAttempt.ts
@@ -3,6 +3,9 @@
 //
 // Run one agent attempt against a portfolio entry's prompt and append
 // a single line to eval/portfolio-attempts.jsonl with the outcome.
+//
+// Usage: portfolioAttempt --slug <slug> --model <model> [--notes <notes>]
+// The prompt and harness are read from eval/portfolio/_tasks/<slug>/.
 import { resolve } from 'node:path';
 import { existsSync, readFileSync } from 'node:fs';
 import { runTask } from '../eval/runner';
@@ -10,19 +13,19 @@ import { appendPortfolioAttempt } from '../eval/portfolio/portfolioAttemptsLog';
 import type { PortfolioAttempt, PortfolioAttemptStatus } from '../eval/portfolio/portfolioAttemptsLog';
 import type { FailureModeTag } from '../eval/portfolio/failureMode';
 import type { DiagnosticCode } from '../src/diagnostics/codes';
+import { makeAgent } from '../eval/run';
 
-interface Args { slug: string; prompt: string; model: string; notes: string; }
+interface Args { slug: string; model: string; notes: string; }
 
 function parseArgs(argv: string[]): Args {
   const a: Partial<Args> = { notes: '' };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i], next = argv[i + 1];
     if (arg === '--slug') { a.slug = next; i++; }
-    else if (arg === '--prompt') { a.prompt = next; i++; }
     else if (arg === '--model') { a.model = next; i++; }
     else if (arg === '--notes') { a.notes = next; i++; }
   }
-  for (const k of ['slug','prompt','model'] as const) {
+  for (const k of ['slug','model'] as const) {
     if (!a[k]) { console.error(`portfolioAttempt: missing --${k}`); process.exit(2); }
   }
   return a as Args;
@@ -32,7 +35,12 @@ function classify(score: { gate_pass: boolean; firstFailureCode?: string }): { s
   if (score.gate_pass) return { status: 'built', failureMode: null, diagnosticCode: null };
   const code = score.firstFailureCode;
   if (code) return { status: 'failed', failureMode: `diagnostic_${code}` as FailureModeTag, diagnosticCode: code as DiagnosticCode };
-  return { status: 'failed', failureMode: 'tool_gap', diagnosticCode: null };
+  // Ambiguous: harness gate failed without a kernel diagnostic. Default to
+  // out_of_scope (most common cause: kernel can't express the part) and warn
+  // so the operator can post-edit failureMode in the JSONL line if a
+  // different category fits better (e.g. model_limit when no script extracted).
+  console.warn('portfolioAttempt: ambiguous failure (no firstFailureCode); tagging as out_of_scope. Re-tag the JSONL line manually if model_limit / tool_gap fits better.');
+  return { status: 'failed', failureMode: 'out_of_scope', diagnosticCode: null };
 }
 
 async function main(): Promise<void> {
@@ -44,7 +52,6 @@ async function main(): Promise<void> {
   if (!existsSync(taskDir)) { console.error(`portfolioAttempt: task dir missing: ${taskDir}. Create with prompt.md + harness.ts first.`); process.exit(2); }
   const runDir = resolve('eval/runs', `portfolio-${a.slug}-${startedAt}`);
 
-  const { makeAgent } = await import('../eval/run');
   const agent = makeAgent(a.model);
   const skillMd = readFileSync(resolve('src/skill/SKILL.md'), 'utf8');
 

--- a/scripts/portfolioAttempt.ts
+++ b/scripts/portfolioAttempt.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// scripts/portfolioAttempt.ts
+//
+// Run one agent attempt against a portfolio entry's prompt and append
+// a single line to eval/portfolio-attempts.jsonl with the outcome.
+import { resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { runTask } from '../eval/runner';
+import { appendPortfolioAttempt } from '../eval/portfolio/portfolioAttemptsLog';
+import type { PortfolioAttempt, PortfolioAttemptStatus } from '../eval/portfolio/portfolioAttemptsLog';
+import type { FailureModeTag } from '../eval/portfolio/failureMode';
+import type { DiagnosticCode } from '../src/diagnostics/codes';
+
+interface Args { slug: string; prompt: string; model: string; notes: string; }
+
+function parseArgs(argv: string[]): Args {
+  const a: Partial<Args> = { notes: '' };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i], next = argv[i + 1];
+    if (arg === '--slug') { a.slug = next; i++; }
+    else if (arg === '--prompt') { a.prompt = next; i++; }
+    else if (arg === '--model') { a.model = next; i++; }
+    else if (arg === '--notes') { a.notes = next; i++; }
+  }
+  for (const k of ['slug','prompt','model'] as const) {
+    if (!a[k]) { console.error(`portfolioAttempt: missing --${k}`); process.exit(2); }
+  }
+  return a as Args;
+}
+
+function classify(score: { gate_pass: boolean; firstFailureCode?: string }): { status: PortfolioAttemptStatus; failureMode: FailureModeTag | null; diagnosticCode: DiagnosticCode | null } {
+  if (score.gate_pass) return { status: 'built', failureMode: null, diagnosticCode: null };
+  const code = score.firstFailureCode;
+  if (code) return { status: 'failed', failureMode: `diagnostic_${code}` as FailureModeTag, diagnosticCode: code as DiagnosticCode };
+  return { status: 'failed', failureMode: 'tool_gap', diagnosticCode: null };
+}
+
+async function main(): Promise<void> {
+  const a = parseArgs(process.argv.slice(2));
+  const logPath = resolve('eval/portfolio-attempts.jsonl');
+
+  const startedAt = new Date().toISOString().replace(/[:.]/g, '-').replace('Z', '');
+  const taskDir = resolve('eval/portfolio/_tasks', a.slug);
+  if (!existsSync(taskDir)) { console.error(`portfolioAttempt: task dir missing: ${taskDir}. Create with prompt.md + harness.ts first.`); process.exit(2); }
+  const runDir = resolve('eval/runs', `portfolio-${a.slug}-${startedAt}`);
+
+  const { makeAgent } = await import('../eval/run');
+  const agent = makeAgent(a.model);
+  const skillMd = readFileSync(resolve('src/skill/SKILL.md'), 'utf8');
+
+  // runTask writes score.json + transcript.md into runDir; we read score.json
+  // back to classify the attempt rather than relying on the in-memory return
+  // value (the disk artifact is the canonical record).
+  await runTask({ taskDir, runDir, agent, model: a.model, skillMd, startedAt });
+
+  const score = JSON.parse(readFileSync(resolve(runDir, 'score.json'), 'utf8')) as {
+    gate_pass: boolean;
+    firstFailureCode?: string;
+    attempts: number;
+  };
+  const { status, failureMode, diagnosticCode } = classify(score);
+
+  const attempt: PortfolioAttempt = {
+    schemaVersion: 1,
+    slug: a.slug,
+    attemptN: score.attempts,
+    status,
+    failureMode,
+    diagnosticCode,
+    model: a.model,
+    date: new Date().toISOString().replace(/\.\d+Z$/, 'Z'),
+    notes: a.notes,
+  };
+  appendPortfolioAttempt(logPath, attempt);
+  console.log(`appended: ${a.slug} attempt #${attempt.attemptN} → ${status}${failureMode ? ' / ' + failureMode : ''}`);
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/tests/unit/eval/portfolioAttemptsLog.test.ts
+++ b/tests/unit/eval/portfolioAttemptsLog.test.ts
@@ -51,4 +51,16 @@ describe('portfolioAttemptsLog', () => {
     const bad = { schemaVersion: 1, slug: 's', attemptN: 1, status: 'built', failureMode: 'tool_gap', diagnosticCode: null, model: 'm', date: '2026-05-08T12:00:00Z', notes: '' };
     expect(() => appendPortfolioAttempt(log, bad as unknown as PortfolioAttempt)).toThrow(/built.*failureMode/);
   });
+
+  it('rejects mismatched diagnostic-tag and diagnosticCode', () => {
+    const log = join(dir, 'attempts.jsonl');
+    const bad = { schemaVersion: 1, slug: 's', attemptN: 1, status: 'failed', failureMode: 'diagnostic_feature.kernel-failed', diagnosticCode: 'cli.invalid-args', model: 'm', date: '2026-05-08T12:00:00Z', notes: '' };
+    expect(() => appendPortfolioAttempt(log, bad as PortfolioAttempt)).toThrow(/implies diagnosticCode/);
+  });
+
+  it('rejects non-diagnostic failureMode with non-null diagnosticCode', () => {
+    const log = join(dir, 'attempts.jsonl');
+    const bad = { schemaVersion: 1, slug: 's', attemptN: 1, status: 'failed', failureMode: 'tool_gap', diagnosticCode: 'feature.kernel-failed', model: 'm', date: '2026-05-08T12:00:00Z', notes: '' };
+    expect(() => appendPortfolioAttempt(log, bad as PortfolioAttempt)).toThrow(/non-diagnostic failureMode/);
+  });
 });

--- a/tests/unit/eval/portfolioAttemptsLog.test.ts
+++ b/tests/unit/eval/portfolioAttemptsLog.test.ts
@@ -1,0 +1,54 @@
+// tests/unit/eval/portfolioAttemptsLog.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  appendPortfolioAttempt,
+  readPortfolioAttempts,
+  type PortfolioAttempt,
+} from '../../../eval/portfolio/portfolioAttemptsLog';
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'pa-')); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+describe('portfolioAttemptsLog', () => {
+  it('appends and reads a built attempt', () => {
+    const log = join(dir, 'attempts.jsonl');
+    const a: PortfolioAttempt = {
+      schemaVersion: 1,
+      slug: 'stepper-motor-bracket',
+      attemptN: 1,
+      status: 'built',
+      failureMode: null,
+      diagnosticCode: null,
+      model: 'claude-opus-4-7',
+      date: '2026-05-08T12:00:00Z',
+      notes: 'first attempt — clean revolve + holes',
+    };
+    appendPortfolioAttempt(log, a);
+    expect(readPortfolioAttempts(log)).toEqual([a]);
+  });
+
+  it('appends multiple lines preserving order', () => {
+    const log = join(dir, 'attempts.jsonl');
+    const a1: PortfolioAttempt = { schemaVersion: 1, slug: 's', attemptN: 1, status: 'failed', failureMode: 'diagnostic_feature.kernel-failed', diagnosticCode: 'feature.kernel-failed', model: 'm', date: '2026-05-08T12:00:00Z', notes: '' };
+    const a2: PortfolioAttempt = { ...a1, attemptN: 2, status: 'built', failureMode: null, diagnosticCode: null };
+    appendPortfolioAttempt(log, a1);
+    appendPortfolioAttempt(log, a2);
+    expect(readPortfolioAttempts(log).map(a => a.attemptN)).toEqual([1, 2]);
+  });
+
+  it('rejects bad failure mode at write time', () => {
+    const log = join(dir, 'attempts.jsonl');
+    const bad = { schemaVersion: 1, slug: 's', attemptN: 1, status: 'failed', failureMode: 'wat', diagnosticCode: null, model: 'm', date: '2026-05-08T12:00:00Z', notes: '' };
+    expect(() => appendPortfolioAttempt(log, bad as PortfolioAttempt)).toThrow(/failureMode/);
+  });
+
+  it('rejects status=built with non-null failureMode', () => {
+    const log = join(dir, 'attempts.jsonl');
+    const bad = { schemaVersion: 1, slug: 's', attemptN: 1, status: 'built', failureMode: 'tool_gap', diagnosticCode: null, model: 'm', date: '2026-05-08T12:00:00Z', notes: '' };
+    expect(() => appendPortfolioAttempt(log, bad as unknown as PortfolioAttempt)).toThrow(/built.*failureMode/);
+  });
+});


### PR DESCRIPTION
## Summary
- Append-only JSONL log at `eval/portfolio-attempts.jsonl` (gitignored) recording one row per agent attempt against a portfolio entry.
- Locked failure-mode taxonomy: `diagnostic_<code>` | `retrieval_miss` | `tool_gap` | `model_limit` | `out_of_scope`. `built` status requires `failureMode === null`. Validator enforces failureMode↔diagnosticCode consistency.
- `scripts/portfolioAttempt.ts` runs `eval/runner.ts` against `eval/portfolio/_tasks/<slug>/{prompt.md,harness.ts}` and appends the outcome. Default for ambiguous failures is `out_of_scope` with stderr operator-triage hint.
- Pre-step refactors: `Score.firstFailureCode` (set-once-from-first-error semantics) and `eval/run.ts:makeAgent` exposed via static export with `import.meta.url` entrypoint guard.

## Test plan
- [x] `npm run typecheck` green
- [x] `npm test -- tests/unit/eval/portfolioAttemptsLog.test.ts` — 6/6 pass (round-trip, ordering, failureMode rejection, status-coupling, diagnostic-tag↔code consistency)
- [x] No regression on `eval/lib.test.ts` (22) + `eval/runner.test.ts` (3)

Part of SOTA Phase 1. Independent of T1 (portfolio schema) and T3 (lever A1).