### PR TITLE
feat(scripts): selectHeroDemo honors patch-version dir

### DIFF
--- a/scripts/lib/selectHeroDemo.test.ts
+++ b/scripts/lib/selectHeroDemo.test.ts
@@ -174,6 +174,103 @@ test('multiple catalog matches — throws ambiguity', () => {
   rmSync(root, { recursive: true, force: true });
 });
 
+test('patch dir takes precedence over minor dir when both exist', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'demos-'));
+
+  // Minor dir has the v0.4 rocket-keychain (override-approved)
+  mkdirSync(path.join(root, 'v0.4', 'rocket-keychain'), { recursive: true });
+  writeFileSync(
+    path.join(root, 'v0.4', 'rocket-keychain', 'meta.json'),
+    JSON.stringify({
+      heroArtifact: 'rocket-keychain',
+      overrideApprovedBy: 'pre-policy v0.4 retro',
+    }),
+  );
+  writeFileSync(path.join(root, 'v0.4', 'rocket-keychain', 'demo.mp4'), 'fake');
+
+  // Patch dir has a refresh hero
+  mkdirSync(path.join(root, 'v0.4.1', 'donut'), { recursive: true });
+  writeFileSync(
+    path.join(root, 'v0.4.1', 'donut', 'meta.json'),
+    JSON.stringify({
+      heroArtifact: 'donut',
+      overrideApprovedBy: 'controller: parametric closure refresh',
+    }),
+  );
+  writeFileSync(path.join(root, 'v0.4.1', 'donut', 'demo.mp4'), 'fake');
+
+  const result = selectHeroDemo({ packageVersion: '0.4.1', demosRoot: root });
+  expect(result.iterationKey).toBe('v0.4.1');
+  expect(result.task).toBe('donut');
+  expect(result.heroArtifact).toBe('donut');
+
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('falls back to minor dir when patch dir is absent', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'demos-'));
+
+  mkdirSync(path.join(root, 'v0.4', 'rocket-keychain'), { recursive: true });
+  writeFileSync(
+    path.join(root, 'v0.4', 'rocket-keychain', 'meta.json'),
+    JSON.stringify({
+      heroArtifact: 'rocket-keychain',
+      overrideApprovedBy: 'pre-policy v0.4 retro',
+    }),
+  );
+  writeFileSync(path.join(root, 'v0.4', 'rocket-keychain', 'demo.mp4'), 'fake');
+
+  // No v0.4.1 dir
+  const result = selectHeroDemo({ packageVersion: '0.4.1', demosRoot: root });
+  expect(result.iterationKey).toBe('v0.4');
+  expect(result.task).toBe('rocket-keychain');
+
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('falls back to minor dir when patch dir exists but has no task subdirs', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'demos-'));
+
+  mkdirSync(path.join(root, 'v0.4.1'), { recursive: true });
+  // empty patch dir — no task subdirs
+
+  mkdirSync(path.join(root, 'v0.4', 'rocket-keychain'), { recursive: true });
+  writeFileSync(
+    path.join(root, 'v0.4', 'rocket-keychain', 'meta.json'),
+    JSON.stringify({
+      heroArtifact: 'rocket-keychain',
+      overrideApprovedBy: 'pre-policy v0.4 retro',
+    }),
+  );
+  writeFileSync(path.join(root, 'v0.4', 'rocket-keychain', 'demo.mp4'), 'fake');
+
+  const result = selectHeroDemo({ packageVersion: '0.4.1', demosRoot: root });
+  expect(result.iterationKey).toBe('v0.4');
+
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('catalog lookup uses minor key even when patch dir is selected', () => {
+  // A catalog-conformant hero can land in a patch dir; the catalog is keyed
+  // on minor, so the lookup must use minor regardless of which dir was picked.
+  const root = mkdtempSync(path.join(tmpdir(), 'demos-'));
+  const v021Slug = getCatalogForVersion('v0.21')!.candidates[0].slug;
+
+  mkdirSync(path.join(root, 'v0.21.1', 'hero-task'), { recursive: true });
+  writeFileSync(
+    path.join(root, 'v0.21.1', 'hero-task', 'meta.json'),
+    JSON.stringify({ heroArtifact: v021Slug }),
+  );
+  writeFileSync(path.join(root, 'v0.21.1', 'hero-task', 'demo.mp4'), 'fake');
+
+  const result = selectHeroDemo({ packageVersion: '0.21.1', demosRoot: root });
+  expect(result.iterationKey).toBe('v0.21.1');
+  expect(result.task).toBe('hero-task');
+  expect(result.heroArtifact).toBe(v021Slug);
+
+  rmSync(root, { recursive: true, force: true });
+});
+
 test('hero task missing demo.mp4 — throws', () => {
   const root = mkdtempSync(path.join(tmpdir(), 'demos-'));
   const slug = getCatalogForVersion('v0.21')!.candidates[0].slug;

--- a/scripts/lib/selectHeroDemo.ts
+++ b/scripts/lib/selectHeroDemo.ts
@@ -21,6 +21,14 @@ function readMeta(
   }
 }
 
+function hasTaskSubdirs(dir: string): boolean {
+  try {
+    return readdirSync(dir, { withFileTypes: true }).some((d) => d.isDirectory());
+  } catch {
+    return false;
+  }
+}
+
 export function selectHeroDemo(opts: {
   packageVersion: string;
   demosRoot: string;
@@ -30,13 +38,29 @@ export function selectHeroDemo(opts: {
   if (parts.length < 2) {
     throw new Error(`invalid package version: ${packageVersion}`);
   }
-  const [maj, min] = parts;
-  const iterationKey = `v${maj}.${min}`;
-  const iterationDir = path.join(demosRoot, iterationKey);
+  const [maj, min, patch] = parts;
+  const minorKey = `v${maj}.${min}`;
+  const patchKey = patch !== undefined ? `v${maj}.${min}.${patch}` : undefined;
 
-  if (!existsSync(iterationDir)) {
-    throw new Error(`no demo dir at ${iterationDir} for ${iterationKey}`);
+  // Patch dir takes precedence: a v0.4.1 release that ships a refreshed hero
+  // distinct from v0.4.0 lands in docs/demos/v0.4.1/ and selectHeroDemo picks
+  // it before falling back to v0.4/. If no patch dir exists, behavior is
+  // identical to before (minor-key only).
+  const candidateDirs: Array<{ key: string; dir: string }> = [];
+  if (patchKey !== undefined) {
+    const patchDir = path.join(demosRoot, patchKey);
+    if (existsSync(patchDir) && hasTaskSubdirs(patchDir)) {
+      candidateDirs.push({ key: patchKey, dir: patchDir });
+    }
   }
+  candidateDirs.push({ key: minorKey, dir: path.join(demosRoot, minorKey) });
+
+  const picked = candidateDirs.find(({ dir }) => existsSync(dir));
+  if (!picked) {
+    throw new Error(`no demo dir at ${candidateDirs.map(c => c.dir).join(' or ')} for ${minorKey}`);
+  }
+  const iterationKey = picked.key;
+  const iterationDir = picked.dir;
 
   const tasks = readdirSync(iterationDir, { withFileTypes: true })
     .filter((d) => d.isDirectory())
@@ -48,7 +72,7 @@ export function selectHeroDemo(opts: {
 
   const catalogTasks = tasks.filter((t) => {
     const meta = readMeta(path.join(iterationDir, t, 'meta.json'));
-    return !!meta?.heroArtifact && isCatalogSlug(meta.heroArtifact, iterationKey);
+    return !!meta?.heroArtifact && isCatalogSlug(meta.heroArtifact, minorKey);
   });
   const overrideTasks = tasks.filter((t) => {
     const meta = readMeta(path.join(iterationDir, t, 'meta.json'));
@@ -66,7 +90,7 @@ export function selectHeroDemo(opts: {
     throw new Error(
       `ambiguous hero: ${catalogTasks.length} tasks in ${iterationKey} have catalog-conformant heroArtifact (${catalogTasks.join(', ')})`,
     );
-  } else if (GRANDFATHERED_VERSIONS.has(iterationKey)) {
+  } else if (GRANDFATHERED_VERSIONS.has(minorKey)) {
     const primaryCandidates = tasks.filter((t) => {
       const meta = readMeta(path.join(iterationDir, t, 'meta.json'));
       return !!meta?.heroArtifact && (meta.overrideApprovedBy ?? null) === null;
@@ -81,7 +105,7 @@ export function selectHeroDemo(opts: {
         readMeta(path.join(iterationDir, task, 'meta.json'))?.heroArtifact ?? null;
     } else {
       throw new Error(
-        `grandfathered ${iterationKey} cannot auto-pick hero: ${primaryCandidates.length} primary candidates, ${tasks.length} total tasks`,
+        `grandfathered ${minorKey} cannot auto-pick hero: ${primaryCandidates.length} primary candidates, ${tasks.length} total tasks`,
       );
     }
   } else if (overrideTasks.length === 1) {


### PR DESCRIPTION
## Summary

Lets a patch release ship a refreshed hero distinct from the minor's hero. `selectHeroDemo` now checks `docs/demos/v{maj}.{min}.{patch}/` first; if absent or empty, falls back to `docs/demos/v{maj}.{min}/`.

Catalog and grandfathered-version lookups continue to use the minor key, so a catalog-conformant hero can still land in a patch dir.

Unblocks: refreshing the v0.4.1 landing-page hero with the parametric donut demo (or a future parametric robot-arm demo) without colliding with the existing v0.4 rocket-keychain hero.

## Test plan

- [x] Existing tests pass unchanged (10/10).
- [x] New: patch dir takes precedence over minor dir when both exist.
- [x] New: falls back to minor dir when patch dir is absent.
- [x] New: falls back to minor dir when patch dir exists but is empty.
- [x] New: catalog lookup uses minor key even when patch dir is selected.
- [x] tsc clean.