### PR TITLE
feat(examples): robot-arm fully parametric (EditableVec3 + reactive worldOrigin)

### DIFF
--- a/examples/robot-arm/desktop-3axis.kcad.ts
+++ b/examples/robot-arm/desktop-3axis.kcad.ts
@@ -1,34 +1,48 @@
 // Desktop 3-axis robot arm — worked example.
 //
-// Demonstrates how to compose a multi-part mechanical assembly out of
-// generic kernelCAD primitives + the assembly API. The kernel does NOT
-// ship a robot-arm template; this example exists to show an agent how to
-// build one (or any analogous multi-part artifact) from the lean
-// generic toolset.
+// Demonstrates how to compose a fully-parametric multi-part mechanical
+// assembly out of generic kernelCAD primitives + the assembly API. The
+// kernel does NOT ship a robot-arm template; this example exists to show an
+// agent how to build one (or any analogous multi-part artifact) from the
+// lean generic toolset.
+//
+// Every dimension is a param() call. Connector origins, joint frames, and
+// derived dimensions all participate in ParamRef arithmetic, so a single
+// setParamValue('baseX', 90) re-lowers the entire assembly: the basePlate
+// width grows, the connector frame at the plate center moves to match, and
+// the dependent revolute joint relocates with it. Worked example for the
+// agent-first parametric authoring story (kernelCAD v0.4.1+).
 
-const baseX = 70;
-const baseY = 46;
-const plateThickness = 4;
-const linkWidth = 18;
-const pivotDiameter = 5;
+const baseX = param('baseX', 70);
+const baseY = param('baseY', 46);
+const plateThickness = param('plateThickness', 4);
+const linkWidth = param('linkWidth', 18);
+const pivotDiameter = param('pivotDiameter', 5);
 
-const shoulderLength = 72;
-const elbowLength = 58;
-const wristLength = 34;
+const shoulderLength = param('shoulderLength', 72);
+const elbowLength = param('elbowLength', 58);
+const wristLength = param('wristLength', 34);
 
-const screwSpacingX = 24;
-const screwSpacingY = 12;
-const screwDiameter = 3;
+const screwSpacingX = param('screwSpacingX', 24);
+const screwSpacingY = param('screwSpacingY', 12);
+const screwDiameter = param('screwDiameter', 3);
+
+// Derived dimensions stay symbolic via ParamRef arithmetic.
+const screwHalfX = screwSpacingX.divide(2);
+const screwHalfY = screwSpacingY.divide(2);
+const wristWidth = linkWidth.multiply(0.85);
+const toolWidth = linkWidth.multiply(0.7);
+const toolLength = param('toolLength', 18);
 
 // --- parts ----------------------------------------------------------------
 
 const basePlate = box(baseX, baseY, plateThickness)
   .holes('top', {
     positions: [
-      { u: -screwSpacingX / 2, v: -screwSpacingY / 2 },
-      { u: screwSpacingX / 2, v: -screwSpacingY / 2 },
-      { u: -screwSpacingX / 2, v: screwSpacingY / 2 },
-      { u: screwSpacingX / 2, v: screwSpacingY / 2 },
+      { u: screwHalfX.negate(), v: screwHalfY.negate() },
+      { u: screwHalfX,          v: screwHalfY.negate() },
+      { u: screwHalfX.negate(), v: screwHalfY          },
+      { u: screwHalfX,          v: screwHalfY          },
     ],
     diameter: screwDiameter,
     depth: 'through',
@@ -42,12 +56,21 @@ const basePlate = box(baseX, baseY, plateThickness)
     name: 'basePivot',
   });
 
+// linkPlate factory: a parametric link with two pivot holes.
+//
+// `pad` is the inset of the pivot from each end. The original design used
+// `Math.max(width/2, pivotDiameter)` as a safety floor; under the realistic
+// param ranges we actually run (linkWidth ≥ 16, pivotDiameter ≤ 6) the
+// width-half always dominates, so we use width.divide(2) directly. If a
+// future variant needs the floor back, lift it into its own `param('pad',
+// ...)`. We skip it here to keep the example flow simple.
 function linkPlate(length, width, thickness, holeName) {
-  const pad = Math.max(width / 2, pivotDiameter);
+  const halfL = length.divide(2);
+  const pad = width.divide(2);
   return box(length, width, thickness).holes('top', {
     positions: [
-      { u: -length / 2 + pad, v: 0 },
-      { u: length / 2 - pad, v: 0 },
+      { u: halfL.subtract(pad).negate(), v: 0 },
+      { u: halfL.subtract(pad),          v: 0 },
     ],
     diameter: pivotDiameter,
     depth: 'through',
@@ -55,15 +78,13 @@ function linkPlate(length, width, thickness, holeName) {
   });
 }
 
-const shoulderLink = linkPlate(shoulderLength, linkWidth, plateThickness, 'shoulderPivots');
-const elbowLink = linkPlate(elbowLength, linkWidth, plateThickness, 'elbowPivots');
-const wristWidth = linkWidth * 0.85;
-const wristLink = linkPlate(wristLength, wristWidth, plateThickness, 'wristPivots');
+const shoulderLink = linkPlate(shoulderLength, linkWidth,  plateThickness, 'shoulderPivots');
+const elbowLink    = linkPlate(elbowLength,    linkWidth,  plateThickness, 'elbowPivots');
+const wristLink    = linkPlate(wristLength,    wristWidth, plateThickness, 'wristPivots');
 
-const toolWidth = linkWidth * 0.7;
 const toolPlaceholder = union(
-  box(Math.max(18, wristLength * 0.45), toolWidth, plateThickness),
-  cylinder(plateThickness, pivotDiameter / 2 + 1).translate(0, toolWidth / 2, 0),
+  box(toolLength, toolWidth, plateThickness),
+  cylinder(plateThickness, pivotDiameter.divide(2).add(1)).translate(0, toolWidth.divide(2), 0),
 );
 
 // --- assembly -------------------------------------------------------------
@@ -73,46 +94,50 @@ const arm = assembly('desktop 3-axis robot arm');
 const base = arm.part('base-plate', basePlate, {
   at: [0, 0, 0],
   connectors: {
-    pivot: { origin: [baseX / 2, baseY / 2, plateThickness], axis: [0, 0, 1] },
+    pivot: { origin: [baseX.divide(2), baseY.divide(2), plateThickness], axis: [0, 0, 1] },
   },
 });
 
 const shoulder = arm.part('shoulder-link', shoulderLink, {
   connectors: {
-    root: { origin: [0, linkWidth / 2, plateThickness / 2], axis: [0, 1, 0] },
-    tip: { origin: [shoulderLength, linkWidth / 2, plateThickness / 2], axis: [0, 1, 0] },
+    root: { origin: [0,              linkWidth.divide(2), plateThickness.divide(2)], axis: [0, 1, 0] },
+    tip:  { origin: [shoulderLength, linkWidth.divide(2), plateThickness.divide(2)], axis: [0, 1, 0] },
   },
   connect: { connector: 'root', to: base.connector('pivot'), name: 'base-to-shoulder' },
 });
 
 const elbow = arm.part('elbow-link', elbowLink, {
   connectors: {
-    root: { origin: [0, linkWidth / 2, plateThickness / 2], axis: [0, 1, 0] },
-    tip: { origin: [elbowLength, linkWidth / 2, plateThickness / 2], axis: [0, 1, 0] },
+    root: { origin: [0,           linkWidth.divide(2), plateThickness.divide(2)], axis: [0, 1, 0] },
+    tip:  { origin: [elbowLength, linkWidth.divide(2), plateThickness.divide(2)], axis: [0, 1, 0] },
   },
   connect: { connector: 'root', to: shoulder.connector('tip'), name: 'shoulder-to-elbow' },
 });
 
 const wrist = arm.part('wrist-link', wristLink, {
   connectors: {
-    root: { origin: [0, wristWidth / 2, plateThickness / 2], axis: [0, 1, 0] },
-    tip: { origin: [wristLength, wristWidth / 2, plateThickness / 2], axis: [0, 1, 0] },
+    root: { origin: [0,           wristWidth.divide(2), plateThickness.divide(2)], axis: [0, 1, 0] },
+    tip:  { origin: [wristLength, wristWidth.divide(2), plateThickness.divide(2)], axis: [0, 1, 0] },
   },
   connect: { connector: 'root', to: elbow.connector('tip'), name: 'elbow-to-wrist' },
 });
 
 arm.part('tool-placeholder', toolPlaceholder, {
   connectors: {
-    mount: { origin: [0, toolWidth / 2, plateThickness / 2], axis: [0, 1, 0] },
+    mount: { origin: [0, toolWidth.divide(2), plateThickness.divide(2)], axis: [0, 1, 0] },
   },
   connect: { connector: 'mount', to: wrist.connector('tip'), name: 'wrist-to-tool' },
 });
 
 // --- joints ---------------------------------------------------------------
 
+// Joint origins are the parent connector's worldOrigin — passing the
+// symbolic Vec3Param directly, so editing baseX/shoulderLength/etc.
+// reactively moves the joint frames alongside the connector frames.
+
 arm.revolute('base-yaw', base, shoulder, {
   axis: [0, 0, 1],
-  origin: [baseX / 2, baseY / 2, plateThickness],
+  origin: base.connector('pivot').worldOrigin,
   limitsDeg: [-120, 120],
 });
 


### PR DESCRIPTION
## Summary

Rewrites `examples/robot-arm/desktop-3axis.kcad.ts` from plain JS const numbers to `param()` calls with `ParamRef` arithmetic across every dimension. Restores the parametric-authoring story for the worked example — restored after PR #107 had to demote it to plain numbers because `param('x', 70) / 2` produced `NaN`.

Demonstrates the `EditableVec3 + reactive worldOrigin` shape that landed in PR #122:
- 12 `param()` declarations (baseX, baseY, plateThickness, linkWidth, pivotDiameter, shoulder/elbow/wrist lengths, screw spacing, screw diameter, toolLength).
- Connector origins use `[baseX.divide(2), baseY.divide(2), plateThickness]` etc.
- Joint origins are passed as `base.connector('pivot').worldOrigin` directly — no manual reconstruction.
- A single `setParamValue('baseX', 90)` reactively re-lowers the basePlate, the connector frame at the plate center, the connected shoulder placement, and the dependent revolute joint origin in one pass.

## Worked example, end to end

```ts
const baseX = param('baseX', 70);
const base = arm.part('base-plate', basePlate, {
  connectors: { pivot: { origin: [baseX.divide(2), baseY.divide(2), plateThickness], axis: [0, 0, 1] } },
});
arm.revolute('base-yaw', base, shoulder, {
  axis: [0, 0, 1],
  origin: base.connector('pivot').worldOrigin,
  limitsDeg: [-120, 120],
});
```

## Test plan

- [x] `tests/integration/examples/robotArmExample.test.ts` — 2/2 passing (was failing before this PR because the example couldn't lower its parametric form).
- [x] Full suite green: 1437 passing.
- [x] `npm run lint` clean.
- [x] `npm run build:cli` clean.
- [x] Smoke: `npx tsx src/cli/index.ts evaluate <parametric-arm.kcad.ts>` returns `Features: 7 / OK`.

## Notes

- Replaced `Math.max(width/2, pivotDiameter)` in `linkPlate` with `width.divide(2)`. Comparison-driven max isn't expressible on `ParamRef` (out of scope per the paramref-arithmetic-methods spec); under the realistic param ranges (linkWidth ≥ 16, pivotDiameter ≤ 6) the width-half always dominates, so the floor is yagni for this design. Documented inline.
- Added a `param('toolLength', 18)` instead of `Math.max(18, wristLength * 0.45)` so the tool placeholder length stays editable independently of the wrist link length.
- Hole positions use `screwHalfX.negate()` on the negative side instead of `-screwSpacingX/2`, since unary minus isn't an operator on `ParamRef`. `negate()` is the explicit equivalent.