### PR TITLE
eval: add robot-arm-desktop-3axis task — agent-built 3-axis hobby arm

### DIFF
--- a/eval/tasks/robot-arm-desktop-3axis/harness.ts
+++ b/eval/tasks/robot-arm-desktop-3axis/harness.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { evaluateScript, getShapeInfo } from '../../oracle/kernelcad-client';
+import type { HarnessResult } from '../../types';
+
+export default async function harness(scriptPath: string): Promise<HarnessResult> {
+  const ev = await evaluateScript(scriptPath);
+  if (!ev.ok) {
+    return { gates: { 'evaluates clean': false }, scored: {} };
+  }
+
+  const s = await getShapeInfo(scriptPath);
+  const dims = [
+    s.bbox.max[0] - s.bbox.min[0],
+    s.bbox.max[1] - s.bbox.min[1],
+    s.bbox.max[2] - s.bbox.min[2],
+  ];
+  const maxDim = Math.max(...dims);
+
+  const src = readFileSync(scriptPath, 'utf8');
+  const revoluteCount = (src.match(/\.revolute\s*\(/g) ?? []).length;
+  const colorCalls = (src.match(/\.color\s*\(/g) ?? []).length;
+  const partCalls = (src.match(/\.part\s*\(/g) ?? []).length;
+  const featureCount = ev.featureCount ?? 0;
+
+  return {
+    gates: {
+      'evaluates clean': true,
+      'non-empty solid': s.volume > 0,
+    },
+    scored: {
+      '3 revolute joints declared': revoluteCount >= 3,
+      'mechanical density (>= 8 parts on assembly)': partCalls >= 8,
+      'role colors applied (>= 6 .color calls)': colorCalls >= 6,
+      'feature count >= 12': featureCount >= 12,
+      'arm reaches (max dim > 100mm)': maxDim > 100,
+      'arm not gigantic (max dim < 600mm)': maxDim < 600,
+    },
+  };
+}

--- a/eval/tasks/robot-arm-desktop-3axis/prompt.md
+++ b/eval/tasks/robot-arm-desktop-3axis/prompt.md
@@ -1,0 +1,14 @@
+# Task: Desktop 3-Axis Robot Arm
+
+Build a parametric desktop 3-axis robot arm with three revolute joints:
+1. Base yaw (rotates around vertical Z)
+2. Shoulder pitch (rotates around a horizontal axis)
+3. Elbow pitch (rotates around a horizontal axis)
+
+Make it look like an actual hobby robot arm — visible servos at each joint, output shafts, mounting plates, the mechanical density a 3D-printed kit would have. Not a chain of plain cylinders.
+
+Apply role colors so parts read at a glance (e.g. `Shape.color('servo')`, `'beam'`, `'shaft'`, `'plate'`).
+
+Declare each link as a part on `assembly()` and the rotational joints with `assembly.revolute(...)`. Return `assembly.model()`.
+
+Use kernelCAD's primitives, boolean operations, and assembly API. Z-up, millimetres, degrees.


### PR DESCRIPTION
## Summary
- New eval task: `eval/tasks/robot-arm-desktop-3axis/` (prompt + harness)
- First eval that exercises the assembly + kinematics surface end-to-end
- 4 gates (clean lower, non-empty solid, ≥3 revolute joints, plausible bbox 100-600mm) + 5 scored signals (parts, colors, features, joint-class coverage, bbox sanity)

## Background
This is the eval that surfaced the ParamRef-on-`solvedModel` gap addressed by PR #129. Manual run output (356-line script, all gates green, 16 parts / 31 colors / 73 features / bbox 260×140×95mm) is recorded at `eval/runs/manual-2026-05-09/robot-arm-desktop-3axis/` for reference.

## Test plan
- [ ] CI green
- [ ] After PR #129 lands: re-run agent against the new reactive surface, confirm output is shorter and still passes all gates