### PR TITLE
site: clear so100 hero override so v0.5 picker resolves desktop-3axis

### DIFF
--- a/docs/demos/v0.5/so100/meta.json
+++ b/docs/demos/v0.5/so100/meta.json
@@ -7,5 +7,5 @@
   "gitSha": "d55e4409f3c1520500d9107b3720496ca55a5f7d",
   "heroArtifact": "so100",
   "catalogSource": "memorable-builds-policy/v0.5",
-  "overrideApprovedBy": "v0.5.0 hero: SO-ARM-100 reference via lib.fromSTEP — vendor-STEP-import + locally-authored plates"
+  "overrideApprovedBy": null
 }


### PR DESCRIPTION
## Summary

`site/scripts/build-demo.ts` uses `selectHeroDemo()` which errors with `ambiguous override hero` when more than one v0.5 task has a non-null `overrideApprovedBy`. Both `robot-arm-3axis-parametric` and `so100` had one after the SO-100 pivot.

`desktop-3axis` is the actual v0.5.0 hero (geometrically correct by construction); `so100` ships as the `lib.fromSTEP` showcase example, not as the hero. Clearing its `overrideApprovedBy` makes the picker unambiguous.

Cloudflare Pages auto-deploys on push to develop; merging this lands the v0.5.0 hero on kernelcad.com.

## Test plan

- [x] Local: `npm run site:build` now succeeds (was failing on the ambiguous override)
- [x] Local preview at `http://localhost:8000/` serves `demo.json` with `version: v0.5.0`, `task: robot-arm-3axis-parametric`
- [x] Hero MP4 plays the new PBR + Z-up robot arm build (visually confirmed)