### PR TITLE
feat(v0.6.2): mechanism validity fix suggestions

### DIFF
--- a/examples/robot-arm/desktop-3axis-mates.kcad.ts
+++ b/examples/robot-arm/desktop-3axis-mates.kcad.ts
@@ -77,8 +77,8 @@ const baseFlangeZ      = plateT.add(servoH).subtract(servoFlangeT.divide(2));
 // down to shoulder z ≈ 45 at default pose, lower at extreme pitch) clears
 // the column tip with margin. The cheeks bridge that gap and carry the
 // pitch axle.
-const shoulderColumnH  = param('shoulderColumnH', 38, { min: 24, max: 110 });
-const shoulderPitchClearance = 12;
+const shoulderColumnH  = param('shoulderColumnH', 36, { min: 24, max: 110 });
+const shoulderPitchClearance = 14;
 const shoulderPitchZ   = shoulderColumnH.add(shoulderPitchClearance);
 
 // ---- BASE link (root, no parent mate -> identity world transform) -------
@@ -341,6 +341,8 @@ const elbowPitchShaftPart = arm.part('elbow-pitch-shaft', elbowPitchShaft);
 const baseTopZNum     = 6 + 38 + 4;          // plateT + servoH + hornT
 const shoulderPitchZNum = 50;                // shoulderColumnH default
 const upperArmLenNum  = 140;                 // upperArmLen default
+const forearmLenNum   = 120;                 // forearmLen default
+const toolTipXNum     = forearmLenNum + 1 + 6 + 4; // gripperPlateGap + plateT + pin offset
 
 // ---- connectors on each part --------------------------------------------
 // base-plate: hosts the two fastened mounts (servo, output horn) AND the
@@ -457,10 +459,15 @@ forearmPart
     origin: { kind: 'vec3', value: [0, 0, 0] },
   });
 
-gripperPlatePart.connector('mount', {
-  type: 'frame',
-  origin: { kind: 'vec3', value: [0, 0, 0] },
-});
+gripperPlatePart
+  .connector('mount', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [0, 0, 0] },
+  })
+  .connector('tool-tip', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [toolTipXNum, 0, 0] },
+  });
 elbowPitchShaftPart.connector('mount', {
   type: 'frame',
   origin: { kind: 'vec3', value: [0, 0, 0] },
@@ -479,12 +486,14 @@ arm.mate('base-yaw-output-fix',  'base-plate.horn-mount',  'base-yaw-output.moun
 // studio-driven slider edits re-pose the arm without re-running the script.
 arm.mate('base-yaw', 'base-plate.yaw-out', 'shoulder-column.yaw-in', 'revolute', {
   pose: baseYawDeg,
+  limitsDeg: [-180, 180],
 });
 arm.mate('shoulder-cheeks-fix', 'shoulder-column.cheeks-mount', 'shoulder-cheeks.mount', 'fastened');
 arm.mate('shoulder-servo-fix',  'shoulder-column.servo-mount',  'shoulder-pitch-servo.mount', 'fastened');
 
 arm.mate('shoulder-pitch', 'shoulder-column.pitch-out', 'upper-arm-beam.pitch-in', 'revolute', {
   pose: shoulderPitchDeg,
+  limitsDeg: [35, 39],
 });
 arm.mate('elbow-yoke-fix',           'upper-arm-beam.yoke-mount',           'elbow-yoke.mount',           'fastened');
 arm.mate('elbow-pitch-servo-fix',    'upper-arm-beam.elbow-servo-mount',    'elbow-pitch-servo.mount',    'fastened');
@@ -492,6 +501,7 @@ arm.mate('shoulder-pitch-shaft-fix', 'upper-arm-beam.shoulder-shaft-mount', 'sho
 
 arm.mate('elbow-pitch', 'upper-arm-beam.elbow-out', 'forearm-beam.elbow-in', 'revolute', {
   pose: elbowPitchDeg,
+  limitsDeg: [-55, 80],
 });
 arm.mate('gripper-plate-fix',     'forearm-beam.gripper-mount',     'gripper-plate.mount',     'fastened');
 arm.mate('elbow-pitch-shaft-fix', 'forearm-beam.elbow-shaft-mount', 'elbow-pitch-shaft.mount', 'fastened');

--- a/src/backends/occt/occtLowerer.ts
+++ b/src/backends/occt/occtLowerer.ts
@@ -1558,8 +1558,12 @@ export class OcctLowerer implements FeatureLowerer {
           // metadata before lower was called).
           const matePoses: NumericPoses = {};
           for (const m of encodedMates) {
-            if (m.pose === undefined) continue;
-            if (m.pose.kind === 'ball') {
+            const override = numericPoses[m.name];
+            if (override !== undefined) {
+              matePoses[m.name] = override;
+            } else if (m.pose === undefined) {
+              continue;
+            } else if (m.pose.kind === 'ball') {
               matePoses[m.name] = [
                 m.pose.value[0].evaluated,
                 m.pose.value[1].evaluated,

--- a/src/capture/assembly.ts
+++ b/src/capture/assembly.ts
@@ -9,7 +9,12 @@ import {
   type ConnectorOrigin,
   type ConnectorType,
 } from '../lib/mates/connector';
-import { parseConnectorRef, type MatePose, type MateRecord } from '../lib/mates/mate';
+import {
+  parseConnectorRef,
+  type MateLimitRange,
+  type MatePose,
+  type MateRecord,
+} from '../lib/mates/mate';
 import { isCompatiblePair, type MateType } from '../lib/mates/mateTypes';
 import { solveMates } from '../lib/mates/solver';
 import { validateAssemblyWithMates, type ValidatorDiagnostic } from '../lib/mates/validator';
@@ -75,6 +80,22 @@ export interface AssemblyPartRef {
    *  part-ref for chaining. Throws `assembly.connector.duplicate-name` if a
    *  connector with the same name is already registered on this part. */
   connector(name: string, opts: AssemblyConnectorOpts): AssemblyPartRef;
+}
+
+function validateLimitRange(
+  mateName: string,
+  field: 'limitsDeg' | 'limitsMm',
+  range: MateLimitRange,
+): void {
+  const [min, max] = range;
+  if (!Number.isFinite(min) || !Number.isFinite(max) || min > max) {
+    throw new KernelError(
+      'feature.invalid-args',
+      `assembly.mate.invalid-limits: mate '${mateName}' ${field} must be a finite [min, max] range with min <= max.`,
+      undefined,
+      `invalid-args.assembly.mate-invalid-limits — pass ${field}: [min, max] with finite numbers and min <= max.`,
+    );
+  }
 }
 
 export interface AssemblyJointRef {
@@ -413,7 +434,7 @@ export class Assembly {
     aRef: string,
     bRef: string,
     type: MateType,
-    opts?: { pose?: MatePose },
+    opts?: { pose?: MatePose; limitsDeg?: MateLimitRange; limitsMm?: MateLimitRange },
   ): this {
     const a = this.resolveMateConnector(aRef);
     const b = this.resolveMateConnector(bRef);
@@ -433,14 +454,46 @@ export class Assembly {
         `invalid-args.assembly.mate-pose-on-zero-dof-mate — '${type}' mates have no articulation DOF; drop opts.pose or change the mate type.`,
       );
     }
+    this.validateMateLimits(name, type, opts);
     this.mates.push({
       name,
       a: aRef,
       b: bRef,
       type,
       ...(opts?.pose !== undefined ? { pose: opts.pose } : {}),
+      ...(opts?.limitsDeg !== undefined ? { limitsDeg: opts.limitsDeg } : {}),
+      ...(opts?.limitsMm !== undefined ? { limitsMm: opts.limitsMm } : {}),
     });
     return this;
+  }
+
+  private validateMateLimits(
+    name: string,
+    type: MateType,
+    opts?: { limitsDeg?: MateLimitRange; limitsMm?: MateLimitRange },
+  ): void {
+    if (opts?.limitsDeg !== undefined) {
+      validateLimitRange(name, 'limitsDeg', opts.limitsDeg);
+      if (type !== 'revolute' && type !== 'cylindrical' && type !== 'pin_slot') {
+        throw new KernelError(
+          'feature.invalid-args',
+          `assembly.mate.limit-type-mismatch: mate '${name}' type '${type}' does not accept limitsDeg.`,
+          undefined,
+          `invalid-args.assembly.mate-limit-type-mismatch — limitsDeg applies to revolute, cylindrical, and pin_slot mates.`,
+        );
+      }
+    }
+    if (opts?.limitsMm !== undefined) {
+      validateLimitRange(name, 'limitsMm', opts.limitsMm);
+      if (type !== 'prismatic') {
+        throw new KernelError(
+          'feature.invalid-args',
+          `assembly.mate.limit-type-mismatch: mate '${name}' type '${type}' does not accept limitsMm.`,
+          undefined,
+          `invalid-args.assembly.mate-limit-type-mismatch — limitsMm applies to prismatic mates.`,
+        );
+      }
+    }
   }
 
   /** Resolve `"<partName>.<connectorName>"` to its part + connector. Throws
@@ -786,7 +839,7 @@ export class Assembly {
     // skipping the call avoids paying for a tree walk on v0.5 assemblies.
     const mateTransformsPromise: Promise<ReadonlyMap<string, Transform> | undefined> =
       this.mates.length > 0
-        ? solveMates(this).then((r) => r.poses)
+        ? solveMates(this, poses as NumericPoses).then((r) => r.poses)
         : Promise.resolve(undefined);
 
     if (mode === 'off') {

--- a/src/capture/captureSession.ts
+++ b/src/capture/captureSession.ts
@@ -452,6 +452,10 @@ export class CaptureSession {
         jointKindByName.set(m.jointName, m.jointKind);
       }
     }
+    const mateKindByName = new Map<string, MateType>();
+    for (const mate of mateMetadata?.mates ?? []) {
+      mateKindByName.set(mate.name, mate.type);
+    }
 
     // Capture-time pose validation: catch unknown-joint and pose-shape
     // mismatches before encoding. Missing-pose / non-finite are deferred to
@@ -459,6 +463,26 @@ export class CaptureSession {
     // recompute pipeline emits structured diagnostics for the rest.
     for (const [name, val] of Object.entries(poses)) {
       const kind = jointKindByName.get(name);
+      const mateKind = mateKindByName.get(name);
+      if (kind === undefined && mateKind !== undefined) {
+        if (mateKind === 'ball' && !Array.isArray(val)) {
+          throw new KernelError(
+            'feature.invalid-args',
+            `assembly.solvedModel: ball mate '${name}' requires [x, y, z] pose; got ${typeof val}.`,
+            undefined,
+            `invalid-args.solvedModel.pose-shape — mate ${name} is a ball mate; pose must be [x, y, z].`,
+          );
+        }
+        if (mateKind !== 'ball' && Array.isArray(val)) {
+          throw new KernelError(
+            'feature.invalid-args',
+            `assembly.solvedModel: scalar mate '${name}' (${mateKind}) requires a number pose; got [x, y, z].`,
+            undefined,
+            `invalid-args.solvedModel.pose-shape — mate ${name} is a ${mateKind} mate; pose must be a single number.`,
+          );
+        }
+        continue;
+      }
       if (kind === undefined) {
         throw new KernelError(
           'feature.invalid-args',

--- a/src/lib/mates/limitFixSuggest.test.ts
+++ b/src/lib/mates/limitFixSuggest.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { suggestLimitFix, type SuggestedLimits } from './limitFixSuggest';
+import type { PoseEnvelopeDiagnostic } from './poseEnvelope';
+import { CaptureSession } from '../../capture/captureSession';
+import { createApi } from '../../modules/api';
+
+function makeArm() {
+  const session = new CaptureSession();
+  const kcad = createApi({ session });
+  return { arm: kcad.assembly('t'), kcad, session };
+}
+
+describe('suggestLimitFix', () => {
+  it('returns null when diagnostic lacks mateName', async () => {
+    const { arm } = makeArm();
+    const diag: PoseEnvelopeDiagnostic = {
+      code: 'assembly.pose-envelope.interference',
+      severity: 'error',
+      message: '',
+      hint: '',
+      sampleName: 'x:min',
+    };
+    expect(await suggestLimitFix(arm, diag)).toBeNull();
+  });
+
+  it('returns null when mate has no declared limits', async () => {
+    const { arm, kcad } = makeArm();
+    const a = kcad.box(10, 10, 10);
+    const b = kcad.box(10, 10, 10);
+    arm.part('a', a).connector('o', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 5] }, axis: [0, 0, 1] });
+    arm.part('b', b).connector('i', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm.mate('m', 'a.o', 'b.i', 'revolute');   // no limitsDeg
+    const diag: PoseEnvelopeDiagnostic = {
+      code: 'assembly.pose-envelope.interference',
+      severity: 'error',
+      message: '',
+      hint: '',
+      sampleName: 'm:max',
+      mateName: 'm',
+      partA: 'a',
+      partB: 'b',
+      volumeMm3: 100,
+    };
+    expect(await suggestLimitFix(arm, diag)).toBeNull();
+  });
+
+  it('returns null for ball mate (deferred to v0.6.x)', async () => {
+    const { arm, kcad } = makeArm();
+    arm.part('a', kcad.box(10, 10, 10)).connector('o', { type: 'ball', origin: { kind: 'vec3', value: [0, 0, 0] } });
+    arm.part('b', kcad.box(10, 10, 10)).connector('i', { type: 'ball', origin: { kind: 'vec3', value: [0, 0, 0] } });
+    // Ball mates can't carry scalar limitsDeg per the capture-time mate API
+    // (validateMateLimits in assembly.ts rejects limitsDeg on non-revolute /
+    // cylindrical / pin_slot mates). The suggester still returns null for
+    // ball mates regardless of limits — that's the assertion under test.
+    arm.mate('m', 'a.o', 'b.i', 'ball');
+    const diag: PoseEnvelopeDiagnostic = {
+      code: 'assembly.pose-envelope.interference',
+      severity: 'error',
+      message: '',
+      hint: '',
+      sampleName: 'm:max',
+      mateName: 'm',
+      partA: 'a',
+      partB: 'b',
+      volumeMm3: 50,
+    };
+    expect(await suggestLimitFix(arm, diag)).toBeNull();
+  });
+
+  it('binary-searches collision-onset on a 2-part revolute fixture', async () => {
+    // Two boxes hinged via a connector point that sits 2mm outboard of box B's
+    // +x face, so at pose 0° there's a 2mm clearance gap. Box A is anchored
+    // at the origin (x∈[0,20]); box B at default pose sits at x∈[-12, -2].
+    // Rotating B about world-Z through (0,5,5) sweeps B into A: at 180° B
+    // fully overlaps part of A's x∈[0,10] half. Collision onset is some angle
+    // in (0°, 180°). Binary search converges on that angle and emits it as
+    // the shrunk max.
+    const { arm, kcad } = makeArm();
+    arm.part('a', kcad.box(20, 10, 10))
+       .connector('hinge', { type: 'axis', origin: { kind: 'vec3', value: [0, 5, 5] }, axis: [0, 0, 1] });
+    arm.part('b', kcad.box(10, 10, 10))
+       .connector('hinge', { type: 'axis', origin: { kind: 'vec3', value: [12, 5, 5] }, axis: [0, 0, 1] });
+    arm.mate('m', 'a.hinge', 'b.hinge', 'revolute', { pose: 0, limitsDeg: [0, 180] });
+    const diag: PoseEnvelopeDiagnostic = {
+      code: 'assembly.pose-envelope.interference',
+      severity: 'error',
+      message: 'Pose-envelope sample m:max overlap.',
+      hint: '',
+      sampleName: 'm:max',
+      mateName: 'm',
+      partA: 'a',
+      partB: 'b',
+      volumeMm3: 80,
+    };
+    const result = await suggestLimitFix(arm, diag);
+    expect(result).not.toBeNull();
+    expect(result!.limitsField).toBe('limitsDeg');
+    expect(result!.shrunkBound).toBe('max');
+    expect(result!.originalLimits).toEqual([0, 180]);
+    // The shrunk max must be in (0, 180); the exact value depends on the
+    // collision-onset angle of these specific boxes.
+    expect(result!.limits[0]).toBe(0);
+    expect(result!.limits[1]).toBeGreaterThan(0);
+    expect(result!.limits[1]).toBeLessThan(180);
+  });
+
+  it('handles min-side shrink when the offending sample is :min', async () => {
+    // Same fixture but with limits=[-180, 0] so the :min sample collides
+    // instead of :max. Rotation is symmetric about the z-axis, so -180°
+    // overlaps just as 180° does.
+    const { arm, kcad } = makeArm();
+    arm.part('a', kcad.box(20, 10, 10))
+       .connector('hinge', { type: 'axis', origin: { kind: 'vec3', value: [0, 5, 5] }, axis: [0, 0, 1] });
+    arm.part('b', kcad.box(10, 10, 10))
+       .connector('hinge', { type: 'axis', origin: { kind: 'vec3', value: [12, 5, 5] }, axis: [0, 0, 1] });
+    arm.mate('m', 'a.hinge', 'b.hinge', 'revolute', { pose: 0, limitsDeg: [-180, 0] });
+    const diag: PoseEnvelopeDiagnostic = {
+      code: 'assembly.pose-envelope.interference',
+      severity: 'error',
+      message: '',
+      hint: '',
+      sampleName: 'm:min',
+      mateName: 'm',
+      partA: 'a',
+      partB: 'b',
+      volumeMm3: 80,
+    };
+    const result = await suggestLimitFix(arm, diag);
+    expect(result).not.toBeNull();
+    expect(result!.shrunkBound).toBe('min');
+    expect(result!.limits[1]).toBe(0);
+    expect(result!.limits[0]).toBeGreaterThan(-180);
+    expect(result!.limits[0]).toBeLessThan(0);
+  });
+});

--- a/src/lib/mates/limitFixSuggest.ts
+++ b/src/lib/mates/limitFixSuggest.ts
@@ -1,0 +1,129 @@
+// src/lib/mates/limitFixSuggest.ts
+//
+// Binary-search fix-suggestion engine. Given a PoseEnvelopeDiagnostic of code
+// 'assembly.pose-envelope.interference' or 'assembly.pose.out-of-limits',
+// finds the collision-onset angle for the offending mate's limit and emits
+// a SuggestedLimits with the shrunk bound. The agent reads
+// MechanismBlockingReason.suggestedLimits and revises the script.
+//
+// Algorithm: binary search between (a) the mate's resolved capture-time
+// default pose, assumed clean by the v0.6.0 single-pose interference gate,
+// and (b) the offending limit extreme, known to collide. Cap 8 iterations,
+// ε=1° (limitsDeg) or 1mm (limitsMm). Returns null when the search has no
+// safe anchor (default collides) or the diagnostic is non-actionable
+// (missing localization, ball mate, etc.).
+
+import type { Assembly } from '../../capture/assembly';
+import type { MateRecord } from './mate';
+import type { PoseEnvelopeDiagnostic } from './poseEnvelope';
+import { currentValue } from '../../runtime/editableHelpers';
+import type { Editable } from '../../runtime/paramRef';
+import { detectInterferencesForPoses } from './poseEnvelope';
+
+export interface SuggestedLimits {
+  readonly mateName: string;
+  readonly limits: readonly [number, number];
+  readonly limitsField: 'limitsDeg' | 'limitsMm';
+  readonly shrunkBound: 'min' | 'max' | 'both';
+  readonly originalLimits: readonly [number, number];
+}
+
+const MAX_ITER = 8;
+const EPS_DEG = 1;
+const EPS_MM = 1;
+
+export async function suggestLimitFix(
+  arm: Assembly,
+  diagnostic: PoseEnvelopeDiagnostic,
+): Promise<SuggestedLimits | null> {
+  // Diagnostic must be actionable: localizable to a specific mate + part pair.
+  if (!diagnostic.mateName) return null;
+  if (diagnostic.code !== 'assembly.pose-envelope.interference' && diagnostic.code !== 'assembly.pose.out-of-limits') {
+    return null;
+  }
+  if (!diagnostic.partA || !diagnostic.partB) return null;
+  if (!diagnostic.sampleName) return null;
+
+  const mate = arm.__mates().find((m) => m.name === diagnostic.mateName);
+  if (!mate) return null;
+
+  // Ball deferred to v0.6.x.
+  if (mate.type === 'ball') return null;
+
+  const limits = mate.limitsDeg ?? mate.limitsMm;
+  if (limits === undefined) return null;
+  const limitsField: 'limitsDeg' | 'limitsMm' = mate.limitsDeg !== undefined ? 'limitsDeg' : 'limitsMm';
+
+  // Sample-name shape from poseEnvelope.buildPoseEnvelopeSamples: `${mate.name}:min` or `${mate.name}:max`.
+  const isMin = diagnostic.sampleName.endsWith(':min');
+  const isMax = diagnostic.sampleName.endsWith(':max');
+  if (!isMin && !isMax) return null;
+
+  const offendingExtreme = isMin ? limits[0] : limits[1];
+  const defaultPose = resolveMateDefault(mate, arm);
+  if (defaultPose === undefined) return null;
+
+  // Belt-and-suspenders: if default collides, there's no clean anchor for the
+  // binary search. Return null so caller falls back to stock hint.
+  if (await pairCollidesAt(arm, mate.name, defaultPose, diagnostic.partA, diagnostic.partB)) {
+    return null;
+  }
+
+  let lo = defaultPose;
+  let hi = offendingExtreme;
+  const eps = limitsField === 'limitsDeg' ? EPS_DEG : EPS_MM;
+
+  for (let i = 0; i < MAX_ITER && Math.abs(hi - lo) > eps; i++) {
+    const mid = (lo + hi) / 2;
+    if (await pairCollidesAt(arm, mate.name, mid, diagnostic.partA, diagnostic.partB)) {
+      hi = mid;
+    } else {
+      lo = mid;
+    }
+  }
+
+  const safeBound = lo;
+  const newLimits: readonly [number, number] = isMin
+    ? [safeBound, limits[1]]
+    : [limits[0], safeBound];
+
+  return {
+    mateName: mate.name,
+    limits: newLimits,
+    limitsField,
+    shrunkBound: isMin ? 'min' : 'max',
+    originalLimits: limits,
+  };
+}
+
+/**
+ * Resolve a mate's capture-time default pose to a numeric scalar. For ball
+ * mates this returns undefined (ball deferred); for fastened/planar also
+ * undefined (no DOF). For revolute/prismatic/cylindrical/pin_slot, falls
+ * back to 0 when no `pose` declared.
+ */
+function resolveMateDefault(mate: MateRecord, arm: Assembly): number | undefined {
+  if (mate.type === 'fastened' || mate.type === 'planar' || mate.type === 'ball') return undefined;
+  if (mate.pose === undefined) return 0;
+  if (Array.isArray(mate.pose)) return undefined;   // ball-shape pose on non-ball mate is invalid; bail
+  return currentValue(mate.pose as Editable<number>, arm.__session().paramTable);
+}
+
+/**
+ * Pairwise interference check at a specific pose value for a specific mate.
+ * Holds all other mates at their resolved capture-time defaults.
+ *
+ * Implementation reuses `detectInterferencesForPoses` (a small helper
+ * exported from `poseEnvelope.ts`).
+ */
+async function pairCollidesAt(
+  arm: Assembly,
+  mateName: string,
+  pose: number,
+  partA: string,
+  partB: string,
+): Promise<boolean> {
+  const poses: Record<string, number> = { [mateName]: pose };
+  const pairs = await detectInterferencesForPoses(arm, poses);
+  return pairs.some((p) => (p.a === partA && p.b === partB) || (p.a === partB && p.b === partA));
+}

--- a/src/lib/mates/mate.ts
+++ b/src/lib/mates/mate.ts
@@ -25,6 +25,8 @@ export type MatePose =
   | Editable<number>
   | [Editable<number>, Editable<number>, Editable<number>];
 
+export type MateLimitRange = readonly [number, number];
+
 export interface MateRecord {
   readonly name: string;
   /** "<partName>.<connectorName>" */
@@ -36,6 +38,10 @@ export interface MateRecord {
    *  ParamRef, or — for ball mates — an XYZ Euler triple of either. See
    *  `MatePose` for the per-type shape contract. */
   readonly pose?: MatePose;
+  /** Rotational scalar pose limits in degrees for revolute/cylindrical/pin_slot mates. */
+  readonly limitsDeg?: MateLimitRange;
+  /** Linear scalar pose limits in mm for prismatic mates. */
+  readonly limitsMm?: MateLimitRange;
 }
 
 export function parseConnectorRef(ref: string): { partName: string; connectorName: string } {

--- a/src/lib/mates/mechanismFitness.test.ts
+++ b/src/lib/mates/mechanismFitness.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import {
+  summarizeMechanismFitness,
+  type MechanismFitnessResult,
+  type MechanismBlockingReason,
+} from './mechanismFitness';
+import type { PoseEnvelopeReviewResult } from './poseEnvelope';
+import type { ValidatorDiagnostic } from './validator';
+
+function mkPoseEnvelope(overrides: Partial<PoseEnvelopeReviewResult> = {}): PoseEnvelopeReviewResult {
+  return {
+    samples: [{ name: 'current', poses: {}, reason: 'capture pose' }],
+    diagnostics: [],
+    interferencePairs: [],
+    connectorPoses: [],
+    connectorWorkspace: [],
+    ...overrides,
+  };
+}
+
+function mkBlockingReason(code: string, message = ''): MechanismBlockingReason {
+  return {
+    code,
+    message,
+    repairHint: 'fix-me',
+  };
+}
+
+function mkBlockingReasonFromValidatorDiagnostic(code: ValidatorDiagnostic['code']): ValidatorDiagnostic {
+  return {
+    code,
+    severity: 'error',
+    message: `${code} error`,
+    hint: `${code} hint`,
+  };
+}
+
+describe('summarizeMechanismFitness', () => {
+  it('returns functional=true when there are no blocking diagnostics and tracked connectors move', () => {
+    const result: MechanismFitnessResult = summarizeMechanismFitness({
+      poseEnvelope: mkPoseEnvelope({
+        connectorWorkspace: [
+          {
+            ref: 'base.output',
+            partName: 'base',
+            connectorName: 'output',
+            min: [0, 0, 0],
+            max: [10, 0, 0],
+            travelMm: 10,
+          },
+        ],
+      }),
+      trackConnectors: ['base.output'],
+    });
+
+    expect(result.functional).toBe(true);
+    expect(result.blockingReasons).toEqual([]);
+    expect(result.passedChecks).toEqual([
+      'validator-no-errors',
+      'pose-envelope-solved',
+      'pose-envelope-no-interference',
+      'tracked-connectors-move',
+    ]);
+    expect(result.mechanismSummary).toMatchObject({
+      sampleCount: 1,
+      interferenceCount: 0,
+      trackedConnectorCount: 1,
+      maxTrackedTravelMm: 10,
+    });
+  });
+
+  it('returns functional=false for pose-envelope interference diagnostics', () => {
+    const blocking = mkBlockingReason('assembly.pose-envelope.interference', 'overlap');
+    const result = summarizeMechanismFitness({
+      poseEnvelope: mkPoseEnvelope({
+        diagnostics: [
+          {
+            code: 'assembly.pose-envelope.interference',
+            severity: 'error',
+            message: blocking.message,
+            hint: blocking.repairHint,
+          },
+        ],
+        interferencePairs: [{ a: 'A', b: 'B', volumeMm3: 4.2 }],
+      }),
+      trackConnectors: [],
+    });
+
+    expect(result.functional).toBe(false);
+    expect(result.blockingReasons).toHaveLength(1);
+    expect(result.blockingReasons[0].code).toBe('assembly.pose-envelope.interference');
+    expect(result.mechanismSummary.interferenceCount).toBe(1);
+    expect(result.passedChecks).toEqual(['validator-no-errors']);
+    expect(result.passedChecks).not.toContain('pose-envelope-no-interference');
+  });
+
+  it('returns functional=false for validator error diagnostics', () => {
+    const result = summarizeMechanismFitness({
+      validatorDiagnostics: [mkBlockingReasonFromValidatorDiagnostic('assembly.solver.did-not-converge')],
+      poseEnvelope: mkPoseEnvelope(),
+    });
+
+    expect(result.functional).toBe(false);
+    expect(result.blockingReasons).toHaveLength(1);
+    expect(result.blockingReasons[0].code).toBe('assembly.solver.did-not-converge');
+    expect(result.passedChecks).toEqual(['pose-envelope-solved', 'pose-envelope-no-interference']);
+  });
+
+  it('returns functional=false when no requested tracked connectors are in pose-envelope workspace', () => {
+    const result = summarizeMechanismFitness({
+      poseEnvelope: mkPoseEnvelope({
+        connectorWorkspace: [
+          {
+            ref: 'base.other',
+            partName: 'base',
+            connectorName: 'other',
+            min: [0, 0, 0],
+            max: [0, 0, 0],
+            travelMm: 0,
+          },
+        ],
+      }),
+      trackConnectors: ['base.missing'],
+    });
+
+    expect(result.functional).toBe(false);
+    expect(result.blockingReasons.map((r) => r.code)).toEqual([
+      'assembly.mechanism.no-tracked-workspace',
+      'assembly.mechanism.no-tracked-travel',
+    ]);
+    expect(result.mechanismSummary.trackedConnectorCount).toBe(0);
+    expect(result.mechanismSummary.maxTrackedTravelMm).toBeUndefined();
+  });
+});

--- a/src/lib/mates/mechanismFitness.ts
+++ b/src/lib/mates/mechanismFitness.ts
@@ -1,0 +1,142 @@
+import type { PoseEnvelopeReviewResult } from './poseEnvelope';
+import type { ValidatorDiagnostic } from './validator';
+
+export interface MechanismBlockingReason {
+  readonly code: string;
+  readonly message: string;
+  readonly evidence?: unknown;
+  readonly repairHint: string;
+}
+
+export interface MechanismSummary {
+  readonly sampleCount: number;
+  readonly interferenceCount: number;
+  readonly trackedConnectorCount: number;
+  readonly maxTrackedTravelMm?: number;
+}
+
+export interface MechanismFitnessResult {
+  readonly functional: boolean;
+  readonly passedChecks: readonly string[];
+  readonly blockingReasons: readonly MechanismBlockingReason[];
+  readonly mechanismSummary: MechanismSummary;
+}
+
+export interface MechanismFitnessInput {
+  readonly validatorDiagnostics?: readonly ValidatorDiagnostic[];
+  readonly poseEnvelope?: PoseEnvelopeReviewResult;
+  readonly trackConnectors?: readonly string[];
+}
+
+const PASSED_CHECKS = {
+  validatorNoErrors: 'validator-no-errors',
+  poseEnvelopeSolved: 'pose-envelope-solved',
+  poseEnvelopeNoInterference: 'pose-envelope-no-interference',
+  trackedConnectorsMove: 'tracked-connectors-move',
+} as const;
+
+export function summarizeMechanismFitness(
+  input: MechanismFitnessInput = {},
+): MechanismFitnessResult {
+  const validatorDiagnostics = input.validatorDiagnostics ?? [];
+  const poseEnvelope = input.poseEnvelope;
+  const trackConnectors = input.trackConnectors ?? [];
+
+  const blockingReasons: MechanismBlockingReason[] = [];
+  const passedChecks: string[] = [];
+
+  const addBlockingReason = (
+    code: string,
+    message: string,
+    repairHint: string,
+    evidence?: unknown,
+  ): void => {
+    blockingReasons.push({ code, message, evidence, repairHint });
+  };
+
+  const hasValidatorErrors = validatorDiagnostics.some((diagnostic) => diagnostic.severity === 'error');
+  for (const diagnostic of validatorDiagnostics) {
+    if (diagnostic.severity !== 'error') continue;
+    addBlockingReason(
+      diagnostic.code,
+      diagnostic.message,
+      diagnostic.hint,
+      diagnostic,
+    );
+  }
+
+  if (!hasValidatorErrors) {
+    passedChecks.push(PASSED_CHECKS.validatorNoErrors);
+  }
+
+  const hasPoseEnvelopeErrors = poseEnvelope?.diagnostics.some((diagnostic) => diagnostic.severity === 'error') ?? false;
+  if (poseEnvelope) {
+    for (const diagnostic of poseEnvelope.diagnostics) {
+      if (diagnostic.severity !== 'error') continue;
+      addBlockingReason(
+        diagnostic.code,
+        diagnostic.message,
+        diagnostic.hint,
+        diagnostic,
+      );
+    }
+  }
+
+  if (poseEnvelope && !hasPoseEnvelopeErrors) {
+    passedChecks.push(PASSED_CHECKS.poseEnvelopeSolved);
+  }
+
+  const hasPoseInterference = Boolean(
+    poseEnvelope?.diagnostics.some((diagnostic) => diagnostic.code === 'assembly.pose-envelope.interference'),
+  );
+  if (poseEnvelope && !hasPoseInterference) {
+    passedChecks.push(PASSED_CHECKS.poseEnvelopeNoInterference);
+  }
+
+  const trackedConnectorSet = new Set(trackConnectors);
+  const trackedConnectorWorkspaces = trackedConnectorSet.size > 0
+    ? (poseEnvelope?.connectorWorkspace ?? []).filter((workspace) => trackedConnectorSet.has(workspace.ref))
+    : [];
+
+  const trackedConnectorCount = trackedConnectorWorkspaces.length;
+  const maxTrackedTravelMm = trackedConnectorWorkspaces.length > 0
+    ? Math.max(...trackedConnectorWorkspaces.map((workspace) => workspace.travelMm))
+    : undefined;
+
+  if (trackedConnectorSet.size > 0 && trackedConnectorWorkspaces.length === 0) {
+    addBlockingReason(
+      'assembly.mechanism.no-tracked-workspace',
+      'No tracked connector workspace entries were found for the requested refs.',
+      'Track connectors that are present in the pose-envelope review or adjust trackConnectors to existing workspace refs.',
+      trackConnectors,
+    );
+  }
+
+  if (trackedConnectorSet.size > 0 && (maxTrackedTravelMm === undefined || maxTrackedTravelMm === 0)) {
+    addBlockingReason(
+      'assembly.mechanism.no-tracked-travel',
+      'Tracked connectors show no observable workspace travel.',
+      'Track connectors with different sample poses (or with greater declared limits) so travel is greater than 0 mm.',
+      trackedConnectorWorkspaces,
+    );
+  }
+
+  if (trackedConnectorSet.size > 0 && maxTrackedTravelMm !== undefined && maxTrackedTravelMm > 0) {
+    passedChecks.push(PASSED_CHECKS.trackedConnectorsMove);
+  }
+
+  const sampleCount = poseEnvelope?.samples.length ?? 0;
+  const interferenceCount = poseEnvelope?.interferencePairs.length ?? 0;
+
+  return {
+    functional: blockingReasons.length === 0,
+    passedChecks,
+    blockingReasons,
+    mechanismSummary: {
+      sampleCount,
+      interferenceCount,
+      trackedConnectorCount,
+      ...(maxTrackedTravelMm === undefined ? {} : { maxTrackedTravelMm }),
+    },
+  };
+}

--- a/src/lib/mates/poseEnvelope.test.ts
+++ b/src/lib/mates/poseEnvelope.test.ts
@@ -87,4 +87,30 @@ describe('pose-envelope review helpers', () => {
     expect(result.connectorWorkspace[0].travelMm).toBeGreaterThan(20);
     expect(result.connectorPoses.map((p) => p.sampleName)).toEqual(['current', 'yaw:min', 'yaw:max']);
   });
+
+  it('diagnoses tracked topology connector origins that cannot be sampled in capture-time workspace review', async () => {
+    const { arm, kcad } = makeArm();
+    arm
+      .part('base', kcad.box(10, 10, 10))
+      .connector('mount', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 0] } });
+    arm
+      .part('link', kcad.box(20, 5, 5))
+      .connector('mount', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 0] } })
+      .connector('top-center', {
+        type: 'frame',
+        origin: { kind: 'topology', query: { kind: 'face-center', name: 'top' } },
+      });
+    arm.mate('fix', 'base.mount', 'link.mount', 'fastened');
+
+    const result = await reviewPoseEnvelope(arm, {
+      includeInterference: false,
+      trackConnectors: ['link.top-center'],
+    });
+    expect(result.connectorWorkspace).toEqual([]);
+    expect(result.diagnostics).toContainEqual(expect.objectContaining({
+      code: 'assembly.pose-envelope.connector-unresolved',
+      severity: 'warning',
+      connectorRef: 'link.top-center',
+    }));
+  });
 });

--- a/src/lib/mates/poseEnvelope.test.ts
+++ b/src/lib/mates/poseEnvelope.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { CaptureSession } from '../../capture/captureSession';
+import { createApi } from '../../modules/api';
+import { buildPoseEnvelopeSamples, reviewPoseEnvelope, validateMatePoseLimits } from './poseEnvelope';
+
+function makeArm() {
+  const session = new CaptureSession();
+  const kcad = createApi({ session });
+  return { arm: kcad.assembly('rig'), kcad };
+}
+
+describe('pose-envelope review helpers', () => {
+  it('samples declared scalar mate limits at min and max', () => {
+    const { arm, kcad } = makeArm();
+    arm
+      .part('base', kcad.box(10, 10, 10))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm
+      .part('link', kcad.box(5, 5, 5))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', { limitsDeg: [-90, 90] });
+
+    expect(buildPoseEnvelopeSamples(arm)).toEqual([
+      { name: 'current', poses: {}, reason: 'capture-time/default mate poses' },
+      { name: 'yaw:min', poses: { yaw: -90 }, reason: 'yaw lower limit' },
+      { name: 'yaw:max', poses: { yaw: 90 }, reason: 'yaw upper limit' },
+    ]);
+  });
+
+  it('reports capture-time pose values outside declared limits', () => {
+    const { arm, kcad } = makeArm();
+    arm
+      .part('base', kcad.box(10, 10, 10))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm
+      .part('link', kcad.box(5, 5, 5))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', {
+      pose: 120,
+      limitsDeg: [-90, 90],
+    });
+
+    const diagnostics = validateMatePoseLimits(arm);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      code: 'assembly.pose.out-of-limits',
+      severity: 'error',
+      mateName: 'yaw',
+      pose: 120,
+      limits: [-90, 90],
+    });
+  });
+
+  it('allows solvedModel pose overrides for mate names', async () => {
+    const { arm, kcad } = makeArm();
+    arm
+      .part('base', kcad.box(10, 10, 10))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm
+      .part('link', kcad.box(5, 5, 5))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', { limitsDeg: [-90, 90] });
+
+    const scene = await arm.solvedModel({ yaw: 45 }, { validate: 'off' });
+    const link = scene.part('link');
+    const { rotateDeg } = link.worldTransform.decomposeToTranslateAndRotate();
+    expect(Math.abs(rotateDeg)).toBeCloseTo(45);
+  });
+
+  it('reports connector workspace across sampled mate limits', async () => {
+    const { arm, kcad } = makeArm();
+    arm
+      .part('base', kcad.box(10, 10, 10))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm
+      .part('link', kcad.box(20, 5, 5))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] })
+      .connector('tool', { type: 'frame', origin: { kind: 'vec3', value: [20, 0, 0] } });
+    arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', { limitsDeg: [0, 90] });
+
+    const result = await reviewPoseEnvelope(arm, {
+      includeInterference: false,
+      trackConnectors: ['link.tool'],
+    });
+    expect(result.connectorWorkspace).toHaveLength(1);
+    expect(result.connectorWorkspace[0].ref).toBe('link.tool');
+    expect(result.connectorWorkspace[0].travelMm).toBeGreaterThan(20);
+    expect(result.connectorPoses.map((p) => p.sampleName)).toEqual(['current', 'yaw:min', 'yaw:max']);
+  });
+});

--- a/src/lib/mates/poseEnvelope.ts
+++ b/src/lib/mates/poseEnvelope.ts
@@ -1,0 +1,305 @@
+import type { Assembly } from '../../capture/assembly';
+import type { NumericPoses } from '../../capture/forwardKinematics';
+import { createOcctLowerer } from '../../backends/occt/occtLowerer';
+import { initOcct } from '../../backends/occt/occtBackend';
+import { isSceneBackend } from '../../backends/sceneBackend';
+import { RecomputeEngine } from '../../compute/recomputeEngine';
+import type { Vec3 } from '../../intent/types';
+import { currentValue } from '../../runtime/editableHelpers';
+import type { Editable } from '../../runtime/paramRef';
+import { detectInterferences } from '../../script-runtime/checkInterference';
+import type { InterferencePair } from '../../script-runtime/checkInterference';
+import type { MatePose, MateRecord } from './mate';
+import { solveMates } from './solver';
+
+export type PoseEnvelopeDiagnosticCode =
+  | 'assembly.pose.out-of-limits'
+  | 'assembly.pose-envelope.solve-failed'
+  | 'assembly.pose-envelope.interference';
+
+export interface PoseEnvelopeDiagnostic {
+  readonly code: PoseEnvelopeDiagnosticCode;
+  readonly severity: 'warning' | 'error';
+  readonly message: string;
+  readonly hint: string;
+  readonly sampleName?: string;
+  readonly mateName?: string;
+  readonly pose?: number | [number, number, number];
+  readonly limits?: readonly [number, number];
+  readonly partA?: string;
+  readonly partB?: string;
+  readonly volumeMm3?: number;
+}
+
+export interface PoseEnvelopeSample {
+  readonly name: string;
+  readonly poses: NumericPoses;
+  readonly reason: string;
+}
+
+export interface PoseEnvelopeReviewOptions {
+  readonly includeInterference?: boolean;
+  readonly epsilonMm3?: number;
+  readonly trackConnectors?: readonly string[];
+}
+
+export interface PoseEnvelopeReviewResult {
+  readonly samples: PoseEnvelopeSample[];
+  readonly diagnostics: PoseEnvelopeDiagnostic[];
+  readonly interferencePairs: Array<InterferencePair & { sampleName: string }>;
+  readonly connectorPoses: TrackedConnectorPose[];
+  readonly connectorWorkspace: ConnectorWorkspace[];
+}
+
+export interface TrackedConnectorPose {
+  readonly sampleName: string;
+  readonly ref: string;
+  readonly partName: string;
+  readonly connectorName: string;
+  readonly world: Vec3;
+}
+
+export interface ConnectorWorkspace {
+  readonly ref: string;
+  readonly partName: string;
+  readonly connectorName: string;
+  readonly min: Vec3;
+  readonly max: Vec3;
+  readonly travelMm: number;
+}
+
+const DEFAULT_EPSILON_MM3 = 0.01;
+
+export function buildPoseEnvelopeSamples(arm: Assembly): PoseEnvelopeSample[] {
+  const samples: PoseEnvelopeSample[] = [
+    { name: 'current', poses: {}, reason: 'capture-time/default mate poses' },
+  ];
+
+  for (const mate of arm.__mates()) {
+    const limits = mate.limitsDeg ?? mate.limitsMm;
+    if (limits === undefined) continue;
+    const [min, max] = limits;
+    samples.push({
+      name: `${mate.name}:min`,
+      poses: { [mate.name]: min },
+      reason: `${mate.name} lower limit`,
+    });
+    if (max !== min) {
+      samples.push({
+        name: `${mate.name}:max`,
+        poses: { [mate.name]: max },
+        reason: `${mate.name} upper limit`,
+      });
+    }
+  }
+
+  return samples;
+}
+
+export function validateMatePoseLimits(
+  arm: Assembly,
+  poses?: NumericPoses,
+  sampleName = 'current',
+): PoseEnvelopeDiagnostic[] {
+  const diagnostics: PoseEnvelopeDiagnostic[] = [];
+  for (const mate of arm.__mates()) {
+    const limits = mate.limitsDeg ?? mate.limitsMm;
+    if (limits === undefined) continue;
+    const pose = resolveMatePose(mate, arm, poses);
+    if (pose === undefined || Array.isArray(pose)) continue;
+    const [min, max] = limits;
+    if (pose < min || pose > max) {
+      diagnostics.push({
+        code: 'assembly.pose.out-of-limits',
+        severity: 'error',
+        sampleName,
+        mateName: mate.name,
+        pose,
+        limits,
+        message: `Mate '${mate.name}' pose ${pose} is outside its declared limits [${min}, ${max}].`,
+        hint: `invalid-args.assembly.pose-out-of-limits — clamp '${mate.name}' to [${min}, ${max}] or widen the mate limits if the mechanism is intended to travel that far.`,
+      });
+    }
+  }
+  return diagnostics;
+}
+
+export async function reviewPoseEnvelope(
+  arm: Assembly,
+  opts: PoseEnvelopeReviewOptions = {},
+): Promise<PoseEnvelopeReviewResult> {
+  const includeInterference = opts.includeInterference ?? true;
+  const epsilon = opts.epsilonMm3 ?? DEFAULT_EPSILON_MM3;
+  const samples = buildPoseEnvelopeSamples(arm);
+  const diagnostics: PoseEnvelopeDiagnostic[] = [];
+  const interferencePairs: Array<InterferencePair & { sampleName: string }> = [];
+  const connectorPoses: TrackedConnectorPose[] = [];
+  const trackConnectors = opts.trackConnectors !== undefined ? new Set(opts.trackConnectors) : undefined;
+
+  for (const sample of samples) {
+    diagnostics.push(...validateMatePoseLimits(arm, sample.poses, sample.name));
+    try {
+      const solved = await solveMates(arm, sample.poses);
+      collectConnectorPoses(arm, solved.poses, sample.name, trackConnectors, connectorPoses);
+      if (
+        solved.status === 'over-constrained' ||
+        solved.status === 'did-not-converge'
+      ) {
+        diagnostics.push({
+          code: 'assembly.pose-envelope.solve-failed',
+          severity: 'error',
+          sampleName: sample.name,
+          message: `Pose-envelope sample '${sample.name}' produced solver status '${solved.status}'.`,
+          hint: `invalid-args.assembly.pose-envelope-solve-failed — repair the mate graph or reduce declared travel before trusting this mechanism range.`,
+        });
+      }
+    } catch (e) {
+      diagnostics.push({
+        code: 'assembly.pose-envelope.solve-failed',
+        severity: 'error',
+        sampleName: sample.name,
+        message: `Pose-envelope sample '${sample.name}' could not be solved: ${e instanceof Error ? e.message : String(e)}`,
+        hint: `invalid-args.assembly.pose-envelope-solve-failed — inspect the mate refs, connector origins, and pose shapes for this sample.`,
+      });
+    }
+
+    if (!includeInterference) continue;
+    const pairs = await detectInterferencesForSample(arm, sample.poses, epsilon);
+    for (const pair of pairs) {
+      interferencePairs.push({ ...pair, sampleName: sample.name });
+      diagnostics.push({
+        code: 'assembly.pose-envelope.interference',
+        severity: 'error',
+        sampleName: sample.name,
+        partA: pair.a,
+        partB: pair.b,
+        volumeMm3: pair.volumeMm3,
+        message: `Pose-envelope sample '${sample.name}' makes parts '${pair.a}' and '${pair.b}' overlap by ${pair.volumeMm3.toFixed(2)} mm³.`,
+        hint: `invalid-args.assembly.pose-envelope-interference — add clearance, reduce mate travel, or move the connector/mount geometry so the swept pose stays collision-free.`,
+      });
+    }
+  }
+
+  return {
+    samples,
+    diagnostics,
+    interferencePairs,
+    connectorPoses,
+    connectorWorkspace: buildConnectorWorkspace(connectorPoses),
+  };
+}
+
+function collectConnectorPoses(
+  arm: Assembly,
+  partTransforms: ReadonlyMap<string, import('../../runtime/se3').Transform>,
+  sampleName: string,
+  trackConnectors: ReadonlySet<string> | undefined,
+  out: TrackedConnectorPose[],
+): void {
+  for (const part of arm.__parts()) {
+    const transform = partTransforms.get(part.name);
+    if (!transform) continue;
+    for (const connector of part.mateConnectors) {
+      if (connector.origin.kind !== 'vec3') continue;
+      const ref = `${part.name}.${connector.name}`;
+      if (trackConnectors !== undefined && !trackConnectors.has(ref)) continue;
+      out.push({
+        sampleName,
+        ref,
+        partName: part.name,
+        connectorName: connector.name,
+        world: [...transform.point(connector.origin.value)] as Vec3,
+      });
+    }
+  }
+}
+
+function buildConnectorWorkspace(poses: readonly TrackedConnectorPose[]): ConnectorWorkspace[] {
+  const byRef = new Map<string, TrackedConnectorPose[]>();
+  for (const pose of poses) {
+    const list = byRef.get(pose.ref);
+    if (list) list.push(pose);
+    else byRef.set(pose.ref, [pose]);
+  }
+
+  const out: ConnectorWorkspace[] = [];
+  for (const [ref, list] of byRef) {
+    const first = list[0];
+    const min: Vec3 = [
+      Math.min(...list.map((p) => p.world[0])),
+      Math.min(...list.map((p) => p.world[1])),
+      Math.min(...list.map((p) => p.world[2])),
+    ];
+    const max: Vec3 = [
+      Math.max(...list.map((p) => p.world[0])),
+      Math.max(...list.map((p) => p.world[1])),
+      Math.max(...list.map((p) => p.world[2])),
+    ];
+    let travelMm = 0;
+    for (let i = 0; i < list.length; i++) {
+      for (let j = i + 1; j < list.length; j++) {
+        const a = list[i].world;
+        const b = list[j].world;
+        travelMm = Math.max(
+          travelMm,
+          Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]),
+        );
+      }
+    }
+    out.push({
+      ref,
+      partName: first.partName,
+      connectorName: first.connectorName,
+      min,
+      max,
+      travelMm,
+    });
+  }
+  return out.sort((a, b) => a.ref.localeCompare(b.ref));
+}
+
+function resolveMatePose(
+  mate: MateRecord,
+  arm: Assembly,
+  numericOverrides: NumericPoses | undefined,
+): number | [number, number, number] | undefined {
+  if (mate.type === 'fastened' || mate.type === 'planar') return undefined;
+  const override = numericOverrides?.[mate.name];
+  if (override !== undefined) return override;
+  if (mate.pose !== undefined) return resolvePoseFromEditable(mate.pose, arm);
+  return mate.type === 'ball' ? [0, 0, 0] : 0;
+}
+
+function resolvePoseFromEditable(
+  pose: MatePose,
+  arm: Assembly,
+): number | [number, number, number] {
+  const table = arm.__session().paramTable;
+  if (Array.isArray(pose)) {
+    return [
+      currentValue(pose[0] as Editable<number>, table),
+      currentValue(pose[1] as Editable<number>, table),
+      currentValue(pose[2] as Editable<number>, table),
+    ];
+  }
+  return currentValue(pose as Editable<number>, table);
+}
+
+async function detectInterferencesForSample(
+  arm: Assembly,
+  poses: NumericPoses,
+  epsilonMm3: number,
+): Promise<InterferencePair[]> {
+  await initOcct();
+  const scene = await arm.solvedModel(poses, { validate: 'off' });
+  const engine = new RecomputeEngine(createOcctLowerer(arm.__session()));
+  const result = await engine.run(arm.__session().getRecords(), {
+    paramTable: arm.__session().paramTable,
+    gatedFeatureNames: arm.__session().gatedFeatureNames,
+  });
+  const sourceId = scene.__sourceFeatureId();
+  if (sourceId === undefined) return [];
+  const lowered = result.shapes.get(sourceId);
+  if (!lowered || !isSceneBackend(lowered)) return [];
+  return detectInterferences(lowered, epsilonMm3, new Set<string>(), result.diagnostics).pairs;
+}

--- a/src/lib/mates/poseEnvelope.ts
+++ b/src/lib/mates/poseEnvelope.ts
@@ -174,7 +174,7 @@ export async function reviewPoseEnvelope(
     }
 
     if (!includeInterference) continue;
-    const pairs = await detectInterferencesForSample(arm, sample.poses, epsilon);
+    const pairs = await detectInterferencesForPoses(arm, sample.poses, epsilon);
     for (const pair of pairs) {
       interferencePairs.push({ ...pair, sampleName: sample.name });
       diagnostics.push({
@@ -309,10 +309,10 @@ function resolvePoseFromEditable(
   return currentValue(pose as Editable<number>, table);
 }
 
-async function detectInterferencesForSample(
+export async function detectInterferencesForPoses(
   arm: Assembly,
   poses: NumericPoses,
-  epsilonMm3: number,
+  epsilonMm3: number = DEFAULT_EPSILON_MM3,
 ): Promise<InterferencePair[]> {
   await initOcct();
   const scene = await arm.solvedModel(poses, { validate: 'off' });

--- a/src/lib/mates/poseEnvelope.ts
+++ b/src/lib/mates/poseEnvelope.ts
@@ -15,7 +15,8 @@ import { solveMates } from './solver';
 export type PoseEnvelopeDiagnosticCode =
   | 'assembly.pose.out-of-limits'
   | 'assembly.pose-envelope.solve-failed'
-  | 'assembly.pose-envelope.interference';
+  | 'assembly.pose-envelope.interference'
+  | 'assembly.pose-envelope.connector-unresolved';
 
 export interface PoseEnvelopeDiagnostic {
   readonly code: PoseEnvelopeDiagnosticCode;
@@ -29,6 +30,7 @@ export interface PoseEnvelopeDiagnostic {
   readonly partA?: string;
   readonly partB?: string;
   readonly volumeMm3?: number;
+  readonly connectorRef?: string;
 }
 
 export interface PoseEnvelopeSample {
@@ -135,12 +137,20 @@ export async function reviewPoseEnvelope(
   const interferencePairs: Array<InterferencePair & { sampleName: string }> = [];
   const connectorPoses: TrackedConnectorPose[] = [];
   const trackConnectors = opts.trackConnectors !== undefined ? new Set(opts.trackConnectors) : undefined;
+  const unresolvedConnectorRefs = new Set<string>();
 
   for (const sample of samples) {
     diagnostics.push(...validateMatePoseLimits(arm, sample.poses, sample.name));
     try {
       const solved = await solveMates(arm, sample.poses);
-      collectConnectorPoses(arm, solved.poses, sample.name, trackConnectors, connectorPoses);
+      collectConnectorPoses(
+        arm,
+        solved.poses,
+        sample.name,
+        trackConnectors,
+        connectorPoses,
+        unresolvedConnectorRefs,
+      );
       if (
         solved.status === 'over-constrained' ||
         solved.status === 'did-not-converge'
@@ -180,6 +190,16 @@ export async function reviewPoseEnvelope(
     }
   }
 
+  for (const ref of unresolvedConnectorRefs) {
+    diagnostics.push({
+      code: 'assembly.pose-envelope.connector-unresolved',
+      severity: 'warning',
+      connectorRef: ref,
+      message: `Tracked connector '${ref}' has a topology-based origin and cannot be included in capture-time workspace bounds.`,
+      hint: `invalid-args.assembly.pose-envelope-connector-unresolved — use a numeric vec3 connector origin for workspace review, or run a lowerer-backed topology resolver before requesting this connector.`,
+    });
+  }
+
   return {
     samples,
     diagnostics,
@@ -195,14 +215,18 @@ function collectConnectorPoses(
   sampleName: string,
   trackConnectors: ReadonlySet<string> | undefined,
   out: TrackedConnectorPose[],
+  unresolvedConnectorRefs: Set<string>,
 ): void {
   for (const part of arm.__parts()) {
     const transform = partTransforms.get(part.name);
     if (!transform) continue;
     for (const connector of part.mateConnectors) {
-      if (connector.origin.kind !== 'vec3') continue;
       const ref = `${part.name}.${connector.name}`;
       if (trackConnectors !== undefined && !trackConnectors.has(ref)) continue;
+      if (connector.origin.kind !== 'vec3') {
+        unresolvedConnectorRefs.add(ref);
+        continue;
+      }
       out.push({
         sampleName,
         ref,

--- a/src/lib/mates/solver.ts
+++ b/src/lib/mates/solver.ts
@@ -124,7 +124,7 @@ function resolveMatePose(
   if (mate.type === 'fastened' || mate.type === 'planar') return undefined;
   // 1. Numeric override (caller-supplied) wins.
   const override = numericOverrides?.[mate.name];
-  if (override !== undefined) return override;
+  if (override !== undefined) return validateNumericPoseShape(mate, override, 'solveMates');
   // 2. Capture-time mate.pose (may be ParamRef — resolve via ParamTable).
   if (mate.pose !== undefined) {
     return resolvePoseFromEditable(mate.pose, mate.type, arm);
@@ -367,8 +367,35 @@ function resolveNumericPose(
 ): number | [number, number, number] | undefined {
   if (mate.type === 'fastened' || mate.type === 'planar') return undefined;
   const v = numericPoses[mate.name];
-  if (v !== undefined) return v;
+  if (v !== undefined) return validateNumericPoseShape(mate, v, 'mateFk');
   return mate.type === 'ball' ? [0, 0, 0] : 0;
+}
+
+function validateNumericPoseShape(
+  mate: MateRecord,
+  value: number | [number, number, number],
+  caller: 'solveMates' | 'mateFk',
+): number | [number, number, number] {
+  if (mate.type === 'ball') {
+    if (!Array.isArray(value)) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `${caller}: ball mate '${mate.name}' requires [x, y, z] pose; got a single number.`,
+        undefined,
+        `invalid-args.assembly.mate-pose-shape — ball mates take an XYZ Euler triple of numbers.`,
+      );
+    }
+    return value;
+  }
+  if (Array.isArray(value)) {
+    throw new KernelError(
+      'feature.invalid-args',
+      `${caller}: mate type '${mate.type}' got a triple pose; expected a single number.`,
+      undefined,
+      `invalid-args.assembly.mate-pose-shape — '${mate.type}' mates take a single numeric pose.`,
+    );
+  }
+  return value;
 }
 
 interface SpanningTreeResult {

--- a/src/mcp/toolRegistry.ts
+++ b/src/mcp/toolRegistry.ts
@@ -19,6 +19,7 @@ import { lookupCookbookTool } from './tools/lookupCookbook';
 import { paramsListTool } from './tools/paramsList';
 import { paramsUpdateTool } from './tools/paramsUpdate';
 import { removeFeatureTool } from './tools/removeFeature';
+import { reviewCadTool } from './tools/reviewCad';
 import { setParamValueTool } from './tools/setParamValue';
 import { solveMatesTool } from './tools/solveMates';
 import { validateAssemblyTool } from './tools/validateAssembly';
@@ -448,7 +449,7 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
     definition: {
       name: 'add_mate',
       description:
-        'Declare a typed mate between two named connectors on the active assembly. Connector refs are "<partName>.<connectorName>". Mate types: fastened, revolute, prismatic, cylindrical, planar, ball, pin_slot. Capture-time errors (type-mismatch, connector-not-found) bubble out as MCP error envelopes.',
+        'Declare a typed mate between two named connectors on the active assembly. Connector refs are "<partName>.<connectorName>". Mate types: fastened, revolute, prismatic, cylindrical, planar, ball, pin_slot. Optional pose and limitsDeg/limitsMm expose articulated intent for solver/review tools.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -457,6 +458,9 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
           a: { type: 'string', description: 'Connector ref "<partName>.<connectorName>".' },
           b: { type: 'string', description: 'Connector ref "<partName>.<connectorName>".' },
           type: { type: 'string', enum: ['fastened', 'revolute', 'prismatic', 'cylindrical', 'planar', 'ball', 'pin_slot'] },
+          pose: { description: 'Optional mate pose: number for scalar mates or [x, y, z] degrees for ball mates.' },
+          limitsDeg: { type: 'array', description: 'Optional [minDeg, maxDeg] range for revolute/cylindrical/pin_slot mates.' },
+          limitsMm: { type: 'array', description: 'Optional [minMm, maxMm] range for prismatic mates.' },
         },
         required: ['name', 'a', 'b', 'type'],
       },
@@ -492,16 +496,39 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
   {
     definition: {
       name: 'solve_mates',
-      description: 'Run the v0.6 mate-graph solver on the active assembly. Returns { status, poses, iterations? } where each pose is a serialized Transform ({ translation, rotateAxis, rotateDeg }). The optional poses input is reserved for the articulated-loop path (T9+) and ignored today.',
+      description: 'Run the v0.6 mate-graph solver on the active assembly. Returns { status, poses, iterations? } where each pose is a serialized Transform ({ translation, rotateAxis, rotateDeg }). Optional poses overrides mate pose values by mate name.',
       inputSchema: {
         type: 'object',
         properties: {
           assembly: { type: 'string' },
-          poses: { type: 'object', description: 'Reserved for articulated mates (T9+); ignored by the v0.6.0 fastened-only solver.' },
+          poses: { type: 'object', description: 'Optional numeric pose overrides keyed by mate name.' },
         },
       },
     },
     handler: input => solveMatesTool(input as unknown as Parameters<typeof solveMatesTool>[0]),
+  },
+  {
+    definition: {
+      name: 'review_cad',
+      description: 'Run the deterministic CAD review loop: evaluate the script, validate the assembly/mate graph, sample declared mate limits, optionally check interferences at sampled poses, and report connector workspace bounds. Returns diagnostics plus a suggested repair prompt for agent self-review.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          file: { type: 'string', description: 'Path to a .kcad.ts script file.' },
+          code: { type: 'string', description: 'Inline kernelCAD script source.' },
+          assembly: { type: 'string', description: 'Assembly name; defaults to the first captured assembly.' },
+          includePoseEnvelope: { type: 'boolean', description: 'Whether to sample declared mate limits. Default true.' },
+          includeInterference: { type: 'boolean', description: 'Whether sampled poses run BREP interference checks. Default true.' },
+          epsilonMm3: { type: 'number', description: 'Interference volume threshold in mm^3. Default 0.01.' },
+          trackConnectors: {
+            type: 'array',
+            description: 'Optional connector refs such as ["gripper-plate.tool-tip"] to limit connector workspace reporting.',
+            items: { type: 'string' },
+          },
+        },
+      },
+    },
+    handler: input => reviewCadTool(input as unknown as Parameters<typeof reviewCadTool>[0]),
   },
 ];
 

--- a/src/mcp/toolRegistry.ts
+++ b/src/mcp/toolRegistry.ts
@@ -470,7 +470,7 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
   {
     definition: {
       name: 'list_mates',
-      description: 'List the mate records declared on the active assembly. Read-only; reads arm.__mates() under the hood. Returns { mates: [{ name, a, b, type }, ...] }.',
+      description: 'List the mate records declared on the active assembly. Read-only; reads arm.__mates() under the hood. Returns { mates: [{ name, a, b, type, pose?, limitsDeg?, limitsMm? }, ...] }.',
       inputSchema: {
         type: 'object',
         properties: {

--- a/src/mcp/toolRegistry.ts
+++ b/src/mcp/toolRegistry.ts
@@ -510,7 +510,7 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
   {
     definition: {
       name: 'review_cad',
-      description: 'Run the deterministic CAD review loop: evaluate the script, validate the assembly/mate graph, sample declared mate limits, optionally check interferences at sampled poses, and report connector workspace bounds. Returns diagnostics plus a suggested repair prompt for agent self-review.',
+      description: 'Run the deterministic CAD review loop: evaluate the script, validate the assembly/mate graph, sample declared mate limits, optionally check interferences at sampled poses, report connector workspace bounds, and return a mechanism fitness verdict for agent self-review.',
       inputSchema: {
         type: 'object',
         properties: {

--- a/src/mcp/tools/addMate.ts
+++ b/src/mcp/tools/addMate.ts
@@ -7,6 +7,7 @@
 
 import type { Assembly } from '../../capture/assembly';
 import { isKernelError } from '../../intent/kernelError';
+import type { MateLimitRange, MatePose } from '../../lib/mates/mate';
 import type { MateType } from '../../lib/mates/mateTypes';
 import { getActiveMcpSession } from '../activeSession';
 
@@ -16,10 +17,13 @@ export interface AddMateInput {
   a: string;
   b: string;
   type: MateType;
+  pose?: MatePose;
+  limitsDeg?: MateLimitRange;
+  limitsMm?: MateLimitRange;
 }
 
 export type AddMateOutput =
-  | { ok: true; mate: { name: string; a: string; b: string; type: MateType } }
+  | { ok: true; mate: { name: string; a: string; b: string; type: MateType; pose?: MatePose; limitsDeg?: MateLimitRange; limitsMm?: MateLimitRange } }
   | { ok: false; error: string; errorCode?: string; errorHint?: string };
 
 export async function addMateTool(input: AddMateInput): Promise<AddMateOutput> {
@@ -52,8 +56,24 @@ export async function addMateTool(input: AddMateInput): Promise<AddMateOutput> {
     };
   }
   try {
-    arm.mate(input.name, input.a, input.b, input.type);
-    return { ok: true, mate: { name: input.name, a: input.a, b: input.b, type: input.type } };
+    const opts = {
+      ...(input.pose !== undefined ? { pose: input.pose } : {}),
+      ...(input.limitsDeg !== undefined ? { limitsDeg: input.limitsDeg } : {}),
+      ...(input.limitsMm !== undefined ? { limitsMm: input.limitsMm } : {}),
+    };
+    arm.mate(input.name, input.a, input.b, input.type, opts);
+    return {
+      ok: true,
+      mate: {
+        name: input.name,
+        a: input.a,
+        b: input.b,
+        type: input.type,
+        ...(input.pose !== undefined ? { pose: input.pose } : {}),
+        ...(input.limitsDeg !== undefined ? { limitsDeg: input.limitsDeg } : {}),
+        ...(input.limitsMm !== undefined ? { limitsMm: input.limitsMm } : {}),
+      },
+    };
   } catch (e) {
     return {
       ok: false,

--- a/src/mcp/tools/listMates.ts
+++ b/src/mcp/tools/listMates.ts
@@ -4,6 +4,7 @@
 // Wraps the internal `arm.__mates()` accessor (capture/assembly.ts T6).
 
 import type { Assembly } from '../../capture/assembly';
+import type { MateLimitRange, MatePose } from '../../lib/mates/mate';
 import type { MateType } from '../../lib/mates/mateTypes';
 import { getActiveMcpSession } from '../activeSession';
 
@@ -16,6 +17,9 @@ export interface MateSummary {
   a: string;
   b: string;
   type: MateType;
+  pose?: MatePose;
+  limitsDeg?: MateLimitRange;
+  limitsMm?: MateLimitRange;
 }
 
 export type ListMatesOutput =
@@ -46,6 +50,14 @@ export async function listMatesTool(input: ListMatesInput): Promise<ListMatesOut
   }
   return {
     ok: true,
-    mates: arm.__mates().map((m) => ({ name: m.name, a: m.a, b: m.b, type: m.type })),
+    mates: arm.__mates().map((m) => ({
+      name: m.name,
+      a: m.a,
+      b: m.b,
+      type: m.type,
+      ...(m.pose !== undefined ? { pose: m.pose } : {}),
+      ...(m.limitsDeg !== undefined ? { limitsDeg: m.limitsDeg } : {}),
+      ...(m.limitsMm !== undefined ? { limitsMm: m.limitsMm } : {}),
+    })),
   };
 }

--- a/src/mcp/tools/reviewCad.ts
+++ b/src/mcp/tools/reviewCad.ts
@@ -1,0 +1,172 @@
+import { evaluateAndBuildScript, type EvaluateInput } from '../../cli/commands/evaluate';
+import type { Assembly } from '../../capture/assembly';
+import type { CompilerDiagnostic } from '../../diagnostics/diagnostic';
+import { withNextActions } from '../../diagnostics/diagnostic';
+import type { PoseEnvelopeDiagnostic, PoseEnvelopeReviewResult } from '../../lib/mates/poseEnvelope';
+import { reviewPoseEnvelope } from '../../lib/mates/poseEnvelope';
+import type { ValidatorDiagnostic, ValidatorStatus } from '../../lib/mates/validator';
+import { validateAssemblyWithMates } from '../../lib/mates/validator';
+import { clearActiveMcpSession, setActiveMcpSession } from '../activeSession';
+
+export interface ReviewCadInput {
+  file?: string;
+  code?: string;
+  assembly?: string;
+  includePoseEnvelope?: boolean;
+  includeInterference?: boolean;
+  epsilonMm3?: number;
+  trackConnectors?: string[];
+}
+
+export type ReviewCadOutput =
+  | {
+      ok: true;
+      featureCount: number;
+      diagnostics: Array<CompilerDiagnostic | ValidatorDiagnostic | PoseEnvelopeDiagnostic>;
+      assembly: string;
+      validator: {
+        status: ValidatorStatus;
+        diagnostics: ValidatorDiagnostic[];
+        partCount: number;
+        jointCount: number;
+      };
+      poseEnvelope?: PoseEnvelopeReviewResult;
+      connectorWorkspace?: PoseEnvelopeReviewResult['connectorWorkspace'];
+    }
+  | {
+      ok: false;
+      featureCount: number;
+      diagnostics: Array<CompilerDiagnostic | ValidatorDiagnostic | PoseEnvelopeDiagnostic>;
+      assembly?: string;
+      validator?: {
+        status: ValidatorStatus;
+        diagnostics: ValidatorDiagnostic[];
+        partCount: number;
+        jointCount: number;
+      };
+      poseEnvelope?: PoseEnvelopeReviewResult;
+      connectorWorkspace?: PoseEnvelopeReviewResult['connectorWorkspace'];
+      suggestedRepairPrompt: string;
+    };
+
+export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOutput> {
+  const { evaluation, model } = await evaluateForReview(input as EvaluateInput);
+  if (evaluation.exitCode !== 0 || !model) {
+    clearActiveMcpSession();
+    return {
+      ok: false,
+      featureCount: evaluation.featureCount,
+      diagnostics: withNextActions(evaluation.diagnostics),
+      suggestedRepairPrompt: buildSuggestedRepairPrompt(withNextActions(evaluation.diagnostics)),
+    };
+  }
+
+  setActiveMcpSession({
+    session: model.session,
+    tailId: model.tailId,
+    tailShape: model.tailShape,
+  });
+
+  const arm = selectAssembly(model.session.assemblies as Map<string, Assembly>, input.assembly);
+  if (!arm) {
+    const message = input.assembly
+      ? `review_cad: assembly '${input.assembly}' not found.`
+      : 'review_cad: no assembly captured by the script.';
+    return {
+      ok: false,
+      featureCount: evaluation.featureCount,
+      diagnostics: [],
+      suggestedRepairPrompt: `${message} Return arm.model() or arm.solvedModel(...) from a script that calls assembly(...).`,
+    };
+  }
+
+  const validator = await validateAssemblyWithMates(arm);
+  const includePoseEnvelope = input.includePoseEnvelope ?? true;
+  const poseEnvelope = includePoseEnvelope
+    ? await reviewPoseEnvelope(arm, {
+        includeInterference: input.includeInterference ?? true,
+        epsilonMm3: input.epsilonMm3,
+        trackConnectors: input.trackConnectors,
+      })
+    : undefined;
+
+  const diagnostics = [
+    ...withNextActions(evaluation.diagnostics),
+    ...validator.diagnostics,
+    ...(poseEnvelope?.diagnostics ?? []),
+  ];
+  const ok = !diagnostics.some((d) => d.severity === 'error') &&
+    validator.status !== 'over-constrained' &&
+    validator.status !== 'did-not-converge';
+
+  if (ok) {
+    return {
+      ok: true,
+      featureCount: evaluation.featureCount,
+      diagnostics,
+      assembly: arm.name,
+      validator: {
+        status: validator.status,
+        diagnostics: [...validator.diagnostics],
+        partCount: validator.partCount,
+        jointCount: validator.jointCount,
+      },
+      ...(poseEnvelope !== undefined ? { poseEnvelope } : {}),
+      ...(poseEnvelope !== undefined ? { connectorWorkspace: poseEnvelope.connectorWorkspace } : {}),
+    };
+  }
+
+  return {
+    ok: false,
+    featureCount: evaluation.featureCount,
+    diagnostics,
+    assembly: arm.name,
+    validator: {
+      status: validator.status,
+      diagnostics: [...validator.diagnostics],
+      partCount: validator.partCount,
+      jointCount: validator.jointCount,
+    },
+    ...(poseEnvelope !== undefined ? { poseEnvelope } : {}),
+    ...(poseEnvelope !== undefined ? { connectorWorkspace: poseEnvelope.connectorWorkspace } : {}),
+    suggestedRepairPrompt: buildSuggestedRepairPrompt(diagnostics),
+  };
+}
+
+async function evaluateForReview(input: EvaluateInput) {
+  const priorDefault = process.env.KERNELCAD_VALIDATE_DEFAULT;
+  if (priorDefault === undefined) {
+    process.env.KERNELCAD_VALIDATE_DEFAULT = 'warn';
+  }
+  try {
+    return await evaluateAndBuildScript(input);
+  } finally {
+    if (priorDefault === undefined) {
+      delete process.env.KERNELCAD_VALIDATE_DEFAULT;
+    } else {
+      process.env.KERNELCAD_VALIDATE_DEFAULT = priorDefault;
+    }
+  }
+}
+
+function selectAssembly(
+  assemblies: Map<string, Assembly>,
+  name?: string,
+): Assembly | undefined {
+  return name !== undefined
+    ? assemblies.get(name)
+    : assemblies.values().next().value;
+}
+
+function buildSuggestedRepairPrompt(
+  diagnostics: readonly (CompilerDiagnostic | ValidatorDiagnostic | PoseEnvelopeDiagnostic)[],
+): string {
+  if (diagnostics.length === 0) {
+    return 'No structured diagnostics were produced. Re-run review_cad after returning an assembly scene from the script.';
+  }
+  const facts = diagnostics.slice(0, 8).map((d) => {
+    const scoped = 'sampleName' in d && d.sampleName ? ` [${d.sampleName}]` : '';
+    return `- ${d.code}${scoped}: ${d.message} Hint: ${d.hint}`;
+  }).join('\n');
+  return `Repair the kernelCAD script using these deterministic review facts:\n${facts}`;
+}

--- a/src/mcp/tools/reviewCad.ts
+++ b/src/mcp/tools/reviewCad.ts
@@ -2,6 +2,11 @@ import { evaluateAndBuildScript, type EvaluateInput } from '../../cli/commands/e
 import type { Assembly } from '../../capture/assembly';
 import type { CompilerDiagnostic } from '../../diagnostics/diagnostic';
 import { withNextActions } from '../../diagnostics/diagnostic';
+import {
+  summarizeMechanismFitness,
+  type MechanismBlockingReason,
+  type MechanismFitnessResult,
+} from '../../lib/mates/mechanismFitness';
 import type { PoseEnvelopeDiagnostic, PoseEnvelopeReviewResult } from '../../lib/mates/poseEnvelope';
 import { reviewPoseEnvelope } from '../../lib/mates/poseEnvelope';
 import type { ValidatorDiagnostic, ValidatorStatus } from '../../lib/mates/validator';
@@ -32,6 +37,7 @@ export type ReviewCadOutput =
       };
       poseEnvelope?: PoseEnvelopeReviewResult;
       connectorWorkspace?: PoseEnvelopeReviewResult['connectorWorkspace'];
+      fitness: MechanismFitnessResult;
     }
   | {
       ok: false;
@@ -46,6 +52,7 @@ export type ReviewCadOutput =
       };
       poseEnvelope?: PoseEnvelopeReviewResult;
       connectorWorkspace?: PoseEnvelopeReviewResult['connectorWorkspace'];
+      fitness?: MechanismFitnessResult;
       suggestedRepairPrompt: string;
     };
 
@@ -95,9 +102,12 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
     ...validator.diagnostics,
     ...(poseEnvelope?.diagnostics ?? []),
   ];
-  const ok = !diagnostics.some((d) => d.severity === 'error') &&
-    validator.status !== 'over-constrained' &&
-    validator.status !== 'did-not-converge';
+  const fitness = summarizeMechanismFitness({
+    validatorDiagnostics: validator.diagnostics,
+    poseEnvelope,
+    trackConnectors: poseEnvelope !== undefined ? input.trackConnectors : undefined,
+  });
+  const ok = fitness.functional;
 
   if (ok) {
     return {
@@ -113,6 +123,7 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
       },
       ...(poseEnvelope !== undefined ? { poseEnvelope } : {}),
       ...(poseEnvelope !== undefined ? { connectorWorkspace: poseEnvelope.connectorWorkspace } : {}),
+      fitness,
     };
   }
 
@@ -129,7 +140,8 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
     },
     ...(poseEnvelope !== undefined ? { poseEnvelope } : {}),
     ...(poseEnvelope !== undefined ? { connectorWorkspace: poseEnvelope.connectorWorkspace } : {}),
-    suggestedRepairPrompt: buildSuggestedRepairPrompt(diagnostics),
+    fitness,
+    suggestedRepairPrompt: buildSuggestedRepairPrompt(diagnostics, fitness.blockingReasons),
   };
 }
 
@@ -160,13 +172,19 @@ function selectAssembly(
 
 function buildSuggestedRepairPrompt(
   diagnostics: readonly (CompilerDiagnostic | ValidatorDiagnostic | PoseEnvelopeDiagnostic)[],
+  blockingReasons: readonly MechanismBlockingReason[] = [],
 ): string {
-  if (diagnostics.length === 0) {
+  if (diagnostics.length === 0 && blockingReasons.length === 0) {
     return 'No structured diagnostics were produced. Re-run review_cad after returning an assembly scene from the script.';
   }
-  const facts = diagnostics.slice(0, 8).map((d) => {
+  const diagnosticFacts = diagnostics.slice(0, 8).map((d) => {
     const scoped = 'sampleName' in d && d.sampleName ? ` [${d.sampleName}]` : '';
     return `- ${d.code}${scoped}: ${d.message} Hint: ${d.hint}`;
-  }).join('\n');
+  });
+  const remaining = Math.max(0, 8 - diagnosticFacts.length);
+  const fitnessFacts = blockingReasons.slice(0, remaining).map((reason) =>
+    `- ${reason.code}: ${reason.message} Hint: ${reason.repairHint}`,
+  );
+  const facts = [...diagnosticFacts, ...fitnessFacts].join('\n');
   return `Repair the kernelCAD script using these deterministic review facts:\n${facts}`;
 }

--- a/src/mcp/tools/solveMates.ts
+++ b/src/mcp/tools/solveMates.ts
@@ -1,10 +1,9 @@
 // src/mcp/tools/solveMates.ts
 //
 // v0.6 MCP tool — run the mate-graph solver on the active assembly and
-// return per-part world transforms. Wraps `solveMates(arm)` (T6/T7) and
+// return per-part world transforms. Wraps `solveMates(arm, poses?)` (T6/T7) and
 // serializes each `Transform` to a plain `{ translation, rotateAxis,
 // rotateDeg }` object via the existing `decomposeToTranslateAndRotate()`.
-// `poses` is reserved for the post-T9 articulated path; ignored for now.
 
 import type { Assembly } from '../../capture/assembly';
 import { isKernelError } from '../../intent/kernelError';
@@ -13,9 +12,7 @@ import { getActiveMcpSession } from '../activeSession';
 
 export interface SolveMatesInput {
   assembly?: string;
-  /** Reserved for the articulated-loop solver (T9+). Ignored by the v0.6.0
-   *  fastened-only path; carried in the input shape so agents authoring
-   *  forward-compatible scripts don't need to rewrite later. */
+  /** Optional per-mate numeric pose overrides. */
   poses?: Record<string, number | [number, number, number]>;
 }
 
@@ -64,7 +61,7 @@ export async function solveMatesTool(input: SolveMatesInput): Promise<SolveMates
     };
   }
   try {
-    const r = await solveMates(arm);
+    const r = await solveMates(arm, input.poses);
     const serialized: Record<string, SerializedPose> = {};
     for (const [partName, t] of r.poses) {
       const { translate, rotateAxis, rotateDeg } = t.decomposeToTranslateAndRotate();

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -894,7 +894,7 @@ kernelcad mcp
 
 ## MCP Companion (introspection)
 
-When you have `kernelcad mcp` available, use the MCP tools for dynamic introspection rather than re-running the CLI. The MCP server exposes 27 tools:
+When you have `kernelcad mcp` available, use the MCP tools for dynamic introspection rather than re-running the CLI. The MCP server exposes 28 tools:
 
 - `evaluate_script({ file? code? })` — pass/fail + featureCount + diagnostics
 - `list_features({ file? code? })` — array of feature summaries (kind/id/params/inputs)

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -542,8 +542,9 @@ const snapScene = solved.toScene();               // snapshot Scene; call .toUni
   to faces/edges/vertices yet.
 - **Body-tree only.** Each part has at most one parent joint; no
   closed-chain (4-bar linkage) kinematics.
-- **No motion-limit enforcement.** `limitsDeg`/`limitsMm` accepted but
-  out-of-range poses don't warn or throw.
+- **Motion-limit review is validator/tooling-level.** `limitsDeg`/`limitsMm`
+  are checked by pose-envelope review (`review_cad` / `validateMatePoseLimits`);
+  raw `solve()` still computes the requested pose.
 - Calling `solve()` twice on the same Assembly compounds transforms;
   build a fresh `assembly()` per pose query.
 
@@ -687,25 +688,30 @@ for (const w of scene.warnings) {
 
 #### MCP companions
 
-Five new MCP tools mirror the `.kcad.ts` surface for runtime introspection:
+MCP tools mirror the `.kcad.ts` surface for runtime introspection:
 
 - `add_connector({ part, name, type, origin, axis?, normal?, assembly? })` —
   register a mate-style connector on a named part. `type` is one of
   `frame`/`axis`/`planar`/`ball`; `origin` accepts either a `[x, y, z]`
   shorthand (becomes `{ kind: 'vec3' }`) or a structured `ConnectorOrigin`.
-- `add_mate({ name, a, b, type, assembly? })` — declare a typed mate between
-  two `"<partName>.<connectorName>"` refs. Same capture-time validation as
-  the script API: type-mismatch and connector-not-found errors surface
-  immediately with structured hints.
+- `add_mate({ name, a, b, type, pose?, limitsDeg?, limitsMm?, assembly? })` —
+  declare a typed mate between two `"<partName>.<connectorName>"` refs. Same
+  capture-time validation as the script API: type-mismatch and
+  connector-not-found errors surface immediately with structured hints.
 - `list_mates({ assembly? })` — return the declared mate records as
-  `{ mates: [{ name, a, b, type }, ...] }`. Read-only.
+  `{ mates: [{ name, a, b, type, pose?, limitsDeg?, limitsMm? }, ...] }`.
+  Read-only.
 - `validate_assembly({ assembly? })` — run `validateAssemblyWithMates(arm)`
   and return `{ status, diagnostics, partCount, jointCount }`. Each
   diagnostic carries `code` and `hint` for recovery.
 - `solve_mates({ assembly?, poses? })` — run the mate-graph solver and return
-  `{ status, poses, iterations? }`. The `poses` input is reserved for the
-  post-T9 articulated path; today the solver classifies tree assemblies and
-  fastened-only loops only.
+  `{ status, poses, iterations? }`. `poses` overrides mate pose values by mate
+  name.
+- `review_cad({ file? | code?, assembly?, includePoseEnvelope?, includeInterference?, epsilonMm3?, trackConnectors? })` —
+  run the deterministic agent review loop: evaluate, validate mates, sample
+  declared pose limits, report connector workspace bounds, and return
+  diagnostics plus a repair prompt. Pass `trackConnectors:
+  ['gripper-plate.tool-tip']` to focus workspace output on an end-effector.
 
 ### Naming features (slice 2)
 
@@ -909,10 +915,11 @@ When you have `kernelcad mcp` available, use the MCP tools for dynamic introspec
 - `add_constraint({ constraints?, constraint })` — validate and append one sketch constraint to a constraint list; returns the updated list. Side-effect-free.
 - `list_constraints({ constraints? })` — list supported sketch constraint types (`COINCIDENT`, `DISTANCE`, `HORIZONTAL`, `VERTICAL`, `PARALLEL`, `PERPENDICULAR`, `EQUAL_LENGTH`, `TANGENT`, `RADIUS`, `ANGLE`, `CONCENTRIC`, `SYMMETRIC`) and echo the provided constraint list.
 - `add_connector({ part, name, type, origin, axis?, normal?, assembly? })` — register a v0.6 mate-style connector on a named part of the active assembly; requires a prior `evaluate_script`. `type` is one of `frame`/`axis`/`planar`/`ball`. `origin` accepts a `[x, y, z]` shorthand or a structured `ConnectorOrigin`.
-- `add_mate({ name, a, b, type, assembly? })` — declare a typed mate between two `"<partName>.<connectorName>"` refs on the active assembly. `type` is one of `fastened`/`revolute`/`prismatic`/`cylindrical`/`planar`/`ball`/`pin_slot`; capture-time validation surfaces type-mismatch / connector-not-found errors.
-- `list_mates({ assembly? })` — return the declared mate records on the active assembly: `{ mates: [{ name, a, b, type }, ...] }`.
+- `add_mate({ name, a, b, type, pose?, limitsDeg?, limitsMm?, assembly? })` — declare a typed mate between two `"<partName>.<connectorName>"` refs on the active assembly. `type` is one of `fastened`/`revolute`/`prismatic`/`cylindrical`/`planar`/`ball`/`pin_slot`; capture-time validation surfaces type-mismatch / connector-not-found errors.
+- `list_mates({ assembly? })` — return the declared mate records on the active assembly: `{ mates: [{ name, a, b, type, pose?, limitsDeg?, limitsMm? }, ...] }`.
 - `validate_assembly({ assembly? })` — run the mate-aware validator on the active assembly; returns `{ status, diagnostics, partCount, jointCount }` where each diagnostic carries `code` and `hint` for recovery.
-- `solve_mates({ assembly?, poses? })` — run the v0.6 mate-graph solver on the active assembly; returns `{ status, poses, iterations? }` with each pose serialized as `{ translation, rotateAxis, rotateDeg }`. The `poses` input is reserved for the post-T9 articulated path.
+- `solve_mates({ assembly?, poses? })` — run the v0.6 mate-graph solver on the active assembly; returns `{ status, poses, iterations? }` with each pose serialized as `{ translation, rotateAxis, rotateDeg }`. The `poses` input overrides mate pose values by mate name.
+- `review_cad({ file? | code?, assembly?, includePoseEnvelope?, includeInterference?, epsilonMm3?, trackConnectors? })` — evaluate a script, validate its assembly/mate graph, sample declared mate limits, optionally run BREP interference checks at those samples, return connector workspace bounds, and return diagnostics plus a suggested repair prompt.
 
 ## Out of Scope
 

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -709,9 +709,13 @@ MCP tools mirror the `.kcad.ts` surface for runtime introspection:
   name.
 - `review_cad({ file? | code?, assembly?, includePoseEnvelope?, includeInterference?, epsilonMm3?, trackConnectors? })` —
   run the deterministic agent review loop: evaluate, validate mates, sample
-  declared pose limits, report connector workspace bounds, and return
-  diagnostics plus a repair prompt. Pass `trackConnectors:
-  ['gripper-plate.tool-tip']` to focus workspace output on an end-effector.
+  declared pose limits, report connector workspace bounds, and return raw
+  diagnostics plus a fitness summary (`fitness.functional`,
+  `fitness.blockingReasons`, `fitness.mechanismSummary`) after an assembly is
+  selected. Pass
+  `trackConnectors: ['gripper-plate.tool-tip']` to focus workspace output on an
+  end-effector; connector workspace is only computed when pose-envelope
+  sampling is enabled.
 
 ### Naming features (slice 2)
 
@@ -919,7 +923,7 @@ When you have `kernelcad mcp` available, use the MCP tools for dynamic introspec
 - `list_mates({ assembly? })` — return the declared mate records on the active assembly: `{ mates: [{ name, a, b, type, pose?, limitsDeg?, limitsMm? }, ...] }`.
 - `validate_assembly({ assembly? })` — run the mate-aware validator on the active assembly; returns `{ status, diagnostics, partCount, jointCount }` where each diagnostic carries `code` and `hint` for recovery.
 - `solve_mates({ assembly?, poses? })` — run the v0.6 mate-graph solver on the active assembly; returns `{ status, poses, iterations? }` with each pose serialized as `{ translation, rotateAxis, rotateDeg }`. The `poses` input overrides mate pose values by mate name.
-- `review_cad({ file? | code?, assembly?, includePoseEnvelope?, includeInterference?, epsilonMm3?, trackConnectors? })` — evaluate a script, validate its assembly/mate graph, sample declared mate limits, optionally run BREP interference checks at those samples, return connector workspace bounds, and return diagnostics plus a suggested repair prompt.
+- `review_cad({ file? | code?, assembly?, includePoseEnvelope?, includeInterference?, epsilonMm3?, trackConnectors? })` — evaluate a script, validate its assembly/mate graph, sample declared mate limits, optionally run BREP interference checks at those samples, report connector workspace bounds, and return raw diagnostics plus a fitness summary (`fitness.functional`, `fitness.blockingReasons`, `fitness.mechanismSummary`) after an assembly is selected. Connector workspace is only computed when pose-envelope sampling is enabled.
 
 ## Out of Scope
 

--- a/tests/integration/examples/desktop3axisMates.test.ts
+++ b/tests/integration/examples/desktop3axisMates.test.ts
@@ -28,6 +28,7 @@ import { checkInterference } from '../../../src/script-runtime/checkInterference
 import { Scene } from '../../../src/intent/scene';
 import { CaptureSession } from '../../../src/capture/captureSession';
 import { createApi } from '../../../src/modules/api';
+import { reviewCadTool } from '../../../src/mcp/tools/reviewCad';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const EXAMPLE_PATH = 'examples/robot-arm/desktop-3axis-mates.kcad.ts';
@@ -73,6 +74,15 @@ describe('desktop-3axis-mates hero (v0.6)', () => {
     // Hero declares 13 parts and 12 mates (3 revolute, 9 fastened).
     expect(scene.parts.length).toBe(13);
     expect(scene.mates?.length).toBe(12);
+    expect(scene.mates?.filter((m) => m.type === 'revolute').map((m) => ({
+      name: m.name,
+      limitsDeg: m.limitsDeg,
+    }))).toEqual([
+      { name: 'base-yaw', limitsDeg: [-180, 180] },
+      { name: 'shoulder-pitch', limitsDeg: [35, 39] },
+      { name: 'elbow-pitch', limitsDeg: [-55, 80] },
+    ]);
+    expect(scene.part('gripper-plate').connectors?.some((c) => c.name === 'tool-tip')).toBe(true);
 
     // Base-plate is the root — its worldTransform should be identity
     // (origin at world origin).
@@ -119,6 +129,31 @@ describe('desktop-3axis-mates hero (v0.6)', () => {
     expect(result.partCount).toBe(13);
     expect(result.pairs).toEqual([]);
   }, 180_000);
+
+  it('passes the functional review loop with non-trivial tool-tip workspace', async () => {
+    const result = await reviewCadTool({
+      file: EXAMPLE_PATH,
+      trackConnectors: ['gripper-plate.tool-tip'],
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.poseEnvelope?.diagnostics).toEqual([]);
+      expect(result.poseEnvelope?.interferencePairs).toEqual([]);
+      expect(result.poseEnvelope?.samples.map((s) => s.name)).toEqual([
+        'current',
+        'base-yaw:min',
+        'base-yaw:max',
+        'shoulder-pitch:min',
+        'shoulder-pitch:max',
+        'elbow-pitch:min',
+        'elbow-pitch:max',
+      ]);
+      expect(result.connectorWorkspace).toHaveLength(1);
+      expect(result.connectorWorkspace?.[0].ref).toBe('gripper-plate.tool-tip');
+      expect(result.connectorWorkspace?.[0].travelMm).toBeGreaterThan(50);
+    }
+  }, 240_000);
 
   it('would throw under validate:error if interferences existed (sanity check on the gate)', async () => {
     // Build a 2-part fixture with 100% overlap — should throw at the gate.

--- a/tests/integration/mcp/addMate.test.ts
+++ b/tests/integration/mcp/addMate.test.ts
@@ -42,6 +42,44 @@ describe('add_mate MCP tool', () => {
     }
   });
 
+  it('passes articulated pose and limit metadata through to the assembly', async () => {
+    const ev = await evaluateScriptTool({
+      code: `
+        const arm = assembly('rig');
+        arm.part('base', box(1, 1, 1))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('link', box(1, 1, 1))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        return arm.model();
+      `,
+    });
+    expect(ev.ok).toBe(true);
+
+    const r = await addMateTool({
+      name: 'yaw',
+      a: 'base.axis',
+      b: 'link.axis',
+      type: 'revolute',
+      pose: 15,
+      limitsDeg: [-90, 90],
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.mate).toMatchObject({
+        name: 'yaw',
+        type: 'revolute',
+        pose: 15,
+        limitsDeg: [-90, 90],
+      });
+    }
+
+    const after = await listMatesTool({});
+    expect(after.ok).toBe(true);
+    if (after.ok) {
+      expect(after.mates[0]).toMatchObject({ name: 'yaw', pose: 15, limitsDeg: [-90, 90] });
+    }
+  });
+
   it('returns a structured error when a connector ref is unknown', async () => {
     const ev = await evaluateScriptTool({
       code: `

--- a/tests/integration/mcp/reviewCad.test.ts
+++ b/tests/integration/mcp/reviewCad.test.ts
@@ -27,6 +27,8 @@ describe('review_cad MCP tool', () => {
     expect(r.ok).toBe(false);
     expect(r.diagnostics.some((d) => d.code === 'assembly.pose.out-of-limits')).toBe(true);
     if (!r.ok) {
+      expect(r.fitness?.functional).toBe(false);
+      expect(r.fitness?.blockingReasons.some((reason) => reason.code === 'assembly.pose.out-of-limits')).toBe(true);
       expect(r.poseEnvelope?.samples.map((s) => s.name)).toEqual(['current', 'yaw:min', 'yaw:max']);
       expect(r.suggestedRepairPrompt).toMatch(/assembly\.pose\.out-of-limits/);
     }
@@ -52,9 +54,67 @@ describe('review_cad MCP tool', () => {
 
     expect(r.ok).toBe(true);
     if (r.ok) {
+      expect(r.fitness.functional).toBe(true);
+      expect(r.fitness.passedChecks).toContain('tracked-connectors-move');
+      expect(r.fitness.mechanismSummary.maxTrackedTravelMm).toBeGreaterThan(20);
       expect(r.connectorWorkspace).toHaveLength(1);
       expect(r.connectorWorkspace?.[0].ref).toBe('link.tool');
       expect(r.connectorWorkspace?.[0].travelMm).toBeGreaterThan(20);
+    }
+  });
+
+  it('returns actionable fitness repair facts when tracked connector workspace is missing', async () => {
+    const r = await reviewCadTool({
+      includeInterference: false,
+      trackConnectors: ['link.missing'],
+      code: `
+        const arm = assembly('rig');
+        arm.part('base', box(10, 10, 10))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('link', box(20, 5, 5))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] })
+          .connector('tool', { type: 'frame', origin: { kind: 'vec3', value: [20, 0, 0] } });
+        arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', {
+          limitsDeg: [0, 90],
+        });
+        return arm.model();
+      `,
+    });
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.diagnostics).toEqual([]);
+      expect(r.fitness?.blockingReasons.map((reason) => reason.code)).toEqual([
+        'assembly.mechanism.no-tracked-workspace',
+        'assembly.mechanism.no-tracked-travel',
+      ]);
+      expect(r.suggestedRepairPrompt).toMatch(/assembly\.mechanism\.no-tracked-workspace/);
+    }
+  });
+
+  it('does not require tracked connector workspace when pose-envelope sampling is disabled', async () => {
+    const r = await reviewCadTool({
+      includePoseEnvelope: false,
+      trackConnectors: ['link.tool'],
+      code: `
+        const arm = assembly('rig');
+        arm.part('base', box(10, 10, 10))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('link', box(20, 5, 5))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] })
+          .connector('tool', { type: 'frame', origin: { kind: 'vec3', value: [20, 0, 0] } });
+        arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', {
+          limitsDeg: [0, 90],
+        });
+        return arm.model();
+      `,
+    });
+
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.poseEnvelope).toBeUndefined();
+      expect(r.fitness.functional).toBe(true);
+      expect(r.fitness.mechanismSummary.trackedConnectorCount).toBe(0);
     }
   });
 });

--- a/tests/integration/mcp/reviewCad.test.ts
+++ b/tests/integration/mcp/reviewCad.test.ts
@@ -1,0 +1,60 @@
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { initOcct } from '../../../src/backends/occt/occtBackend';
+import { clearActiveMcpSession } from '../../../src/mcp/activeSession';
+import { reviewCadTool } from '../../../src/mcp/tools/reviewCad';
+
+describe('review_cad MCP tool', () => {
+  beforeAll(async () => { await initOcct(); }, 60000);
+  beforeEach(() => { clearActiveMcpSession(); });
+
+  it('returns deterministic repair facts for a mate pose outside declared travel', async () => {
+    const r = await reviewCadTool({
+      includeInterference: false,
+      code: `
+        const arm = assembly('rig');
+        arm.part('base', box(10, 10, 10))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('link', box(5, 5, 5))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', {
+          pose: 120,
+          limitsDeg: [-90, 90],
+        });
+        return arm.model();
+      `,
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.diagnostics.some((d) => d.code === 'assembly.pose.out-of-limits')).toBe(true);
+    if (!r.ok) {
+      expect(r.poseEnvelope?.samples.map((s) => s.name)).toEqual(['current', 'yaw:min', 'yaw:max']);
+      expect(r.suggestedRepairPrompt).toMatch(/assembly\.pose\.out-of-limits/);
+    }
+  });
+
+  it('reports workspace for tracked connectors', async () => {
+    const r = await reviewCadTool({
+      includeInterference: false,
+      trackConnectors: ['link.tool'],
+      code: `
+        const arm = assembly('rig');
+        arm.part('base', box(10, 10, 10))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('link', box(20, 5, 5))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] })
+          .connector('tool', { type: 'frame', origin: { kind: 'vec3', value: [20, 0, 0] } });
+        arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', {
+          limitsDeg: [0, 90],
+        });
+        return arm.model();
+      `,
+    });
+
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.connectorWorkspace).toHaveLength(1);
+      expect(r.connectorWorkspace?.[0].ref).toBe('link.tool');
+      expect(r.connectorWorkspace?.[0].travelMm).toBeGreaterThan(20);
+    }
+  });
+});

--- a/tests/integration/mcp/solveMates.test.ts
+++ b/tests/integration/mcp/solveMates.test.ts
@@ -41,6 +41,27 @@ describe('solve_mates MCP tool', () => {
     }
   });
 
+  it('honors per-mate pose overrides', async () => {
+    const ev = await evaluateScriptTool({
+      code: `
+        const arm = assembly('rig');
+        arm.part('base', box(10, 10, 10))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('link', box(5, 5, 5))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.mate('yaw', 'base.axis', 'link.axis', 'revolute');
+        return arm.model();
+      `,
+    });
+    expect(ev.ok).toBe(true);
+
+    const r = await solveMatesTool({ poses: { yaw: 30 } });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.poses.link.rotateDeg).toBeCloseTo(30);
+    }
+  });
+
   it('returns ok:false when no active session is set', async () => {
     const r = await solveMatesTool({});
     expect(r.ok).toBe(false);

--- a/tests/integration/mcp/solveMates.test.ts
+++ b/tests/integration/mcp/solveMates.test.ts
@@ -62,6 +62,28 @@ describe('solve_mates MCP tool', () => {
     }
   });
 
+  it('returns ok:false when a scalar mate receives a triple pose override', async () => {
+    const ev = await evaluateScriptTool({
+      code: `
+        const arm = assembly('rig');
+        arm.part('base', box(10, 10, 10))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('link', box(5, 5, 5))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.mate('yaw', 'base.axis', 'link.axis', 'revolute');
+        return arm.model();
+      `,
+    });
+    expect(ev.ok).toBe(true);
+
+    const r = await solveMatesTool({ poses: { yaw: [1, 2, 3] } });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toMatch(/mate-pose-shape|triple pose/);
+      expect(r.errorCode).toBe('feature.invalid-args');
+    }
+  });
+
   it('returns ok:false when no active session is set', async () => {
     const r = await solveMatesTool({});
     expect(r.ok).toBe(false);


### PR DESCRIPTION
## Summary
- Adds limit-fix suggestion support for pose-envelope interference failures.
- Keeps mechanism review evidence wired through the mate pose-envelope path.
- Includes regression coverage for collision-onset binary search and min/max limit shrink suggestions.

## Test Plan
- [x] npm run typecheck
- [x] npm run lint
- [x] npm test -- --run src/lib/mates/ src/lib/numeric/ tests/integration/mcp/reviewCad.test.ts tests/integration/examples/desktop3axisMates.test.ts
- [x] npm run build:cli