### PR TITLE
feat: add coupled gripper review loop

### DIFF
--- a/examples/robot-hand/two-finger-coupled-gripper.kcad.ts
+++ b/examples/robot-hand/two-finger-coupled-gripper.kcad.ts
@@ -1,0 +1,100 @@
+// Two-finger coupled gripper.
+//
+// One actuator mate (`grip`) drives two finger curl mates through
+// `arm.coupleMates(...)`. The review loop can sample the `grip` limits,
+// expand the driven poses, and report aperture between the two fingertip
+// connectors.
+
+const baseW = 36;
+const baseD = 18;
+const baseT = 4;
+const fingerLen = 36;
+const fingerW = 5;
+const fingerT = 5;
+const hingeX = 12;
+const gripMin = 0;
+const gripMax = 40;
+
+const hand = assembly('two-finger coupled gripper');
+
+const base = hand.part(
+  'palm',
+  box(baseW, baseD, baseT, true)
+    .fillet(1)
+    .translate(0, 0, baseT / 2)
+    .color('plate'),
+);
+base
+  .connector('driver', {
+    type: 'axis',
+    origin: { kind: 'vec3', value: [0, 0, baseT] },
+    axis: [0, 0, 1],
+  })
+  .connector('left-hinge', {
+    type: 'axis',
+    origin: { kind: 'vec3', value: [-hingeX, 0, baseT] },
+    axis: [0, 0, 1],
+  })
+  .connector('right-hinge', {
+    type: 'axis',
+    origin: { kind: 'vec3', value: [hingeX, 0, baseT] },
+    axis: [0, 0, 1],
+  });
+
+const driver = hand.part(
+  'grip-driver',
+  cylinder(4, 3, 24).color('gear'),
+);
+driver.connector('axis', {
+  type: 'axis',
+  origin: { kind: 'vec3', value: [0, 0, 0] },
+  axis: [0, 0, 1],
+});
+
+const left = hand.part(
+  'left-finger',
+  box(fingerLen, fingerW, fingerT, true)
+    .translate(fingerLen / 2, 0, 0)
+    .fillet(0.75)
+    .color('tool'),
+);
+left
+  .connector('hinge', {
+    type: 'axis',
+    origin: { kind: 'vec3', value: [0, 0, 0] },
+    axis: [0, 0, 1],
+  })
+  .connector('tip', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [fingerLen, 0, 0] },
+  });
+
+const right = hand.part(
+  'right-finger',
+  box(fingerLen, fingerW, fingerT, true)
+    .translate(-fingerLen / 2, 0, 0)
+    .fillet(0.75)
+    .color('tool'),
+);
+right
+  .connector('hinge', {
+    type: 'axis',
+    origin: { kind: 'vec3', value: [0, 0, 0] },
+    axis: [0, 0, 1],
+  })
+  .connector('tip', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [-fingerLen, 0, 0] },
+  });
+
+hand.mate('grip', 'palm.driver', 'grip-driver.axis', 'revolute', {
+  pose: gripMin,
+  limitsDeg: [gripMin, gripMax],
+});
+hand.mate('left-curl', 'palm.left-hinge', 'left-finger.hinge', 'revolute');
+hand.mate('right-curl', 'palm.right-hinge', 'right-finger.hinge', 'revolute');
+
+hand.coupleMates('left-curl', { source: 'grip', ratio: 1 });
+hand.coupleMates('right-curl', { source: 'grip', ratio: -1 });
+
+return hand.model();

--- a/src/capture/assembly.ts
+++ b/src/capture/assembly.ts
@@ -9,6 +9,7 @@ import {
   type ConnectorOrigin,
   type ConnectorType,
 } from '../lib/mates/connector';
+import type { MateCouplingRecord } from '../lib/mates/coupledPoses';
 import {
   parseConnectorRef,
   type MateLimitRange,
@@ -205,6 +206,7 @@ export class Assembly {
   /** v0.6 Task 5: mate records declared via `arm.mate(name, aRef, bRef, type)`.
    *  Surfaced on `Scene.mates` returned by `model()` / `solvedModel()`. */
   private readonly mates: MateRecord[] = [];
+  private readonly mateCouplings: MateCouplingRecord[] = [];
 
   constructor(name: string, session: CaptureSession) {
     this.name = name;
@@ -467,6 +469,46 @@ export class Assembly {
     return this;
   }
 
+  coupleMates(
+    driven: string,
+    opts: { source: string; ratio: number; offset?: number },
+  ): this {
+    const source = this.mates.find((mate) => mate.name === opts.source);
+    const drivenMate = this.mates.find((mate) => mate.name === driven);
+    if (!source || !drivenMate) {
+      const known = this.mates.map((mate) => mate.name).join(', ') || '(none)';
+      throw new KernelError(
+        'feature.invalid-args',
+        `assembly.coupleMates: source '${opts.source}' or driven mate '${driven}' is not declared. Defined mates: ${known}.`,
+        undefined,
+        `invalid-args.assembly.coupled-mate-not-found — call arm.mate(...) for both source and driven mates before arm.coupleMates(...).`,
+      );
+    }
+    if (!isScalarCouplingMate(source.type) || !isScalarCouplingMate(drivenMate.type)) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `assembly.coupleMates: source '${source.name}' (${source.type}) and driven '${drivenMate.name}' (${drivenMate.type}) must both be scalar articulated mates.`,
+        undefined,
+        `invalid-args.assembly.coupled-mate-type — couple only revolute, prismatic, cylindrical, or pin_slot mates.`,
+      );
+    }
+    if (!Number.isFinite(opts.ratio) || (opts.offset !== undefined && !Number.isFinite(opts.offset))) {
+      throw new KernelError(
+        'feature.invalid-args',
+        'assembly.coupleMates: ratio and offset must be finite numbers.',
+        undefined,
+        `invalid-args.assembly.coupled-mate-invalid-scale — pass finite numeric ratio and offset values.`,
+      );
+    }
+    this.mateCouplings.push({
+      driven,
+      source: opts.source,
+      ratio: opts.ratio,
+      ...(opts.offset !== undefined ? { offset: opts.offset } : {}),
+    });
+    return this;
+  }
+
   private validateMateLimits(
     name: string,
     type: MateType,
@@ -550,6 +592,10 @@ export class Assembly {
    */
   __mates(): readonly MateRecord[] {
     return this.mates;
+  }
+
+  __mateCouplings(): readonly MateCouplingRecord[] {
+    return this.mateCouplings;
   }
 
   /**
@@ -1265,6 +1311,13 @@ function isValidJointLimits(value: [number, number]): boolean {
     value.every((n) => typeof n === 'number' && Number.isFinite(n)) &&
     value[0] < value[1]
   );
+}
+
+function isScalarCouplingMate(type: MateType): boolean {
+  return type === 'revolute'
+    || type === 'prismatic'
+    || type === 'cylindrical'
+    || type === 'pin_slot';
 }
 
 function normalizeConnectors(

--- a/src/lib/mates/coupledPoses.test.ts
+++ b/src/lib/mates/coupledPoses.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { expandCoupledPoses, type MateCouplingRecord } from './coupledPoses';
+import type { MateRecord } from './mate';
+
+const mates: MateRecord[] = [
+  { name: 'grip', a: 'base.axis', b: 'driver.axis', type: 'revolute', pose: 10, limitsDeg: [0, 40] },
+  { name: 'left-curl', a: 'base.axis', b: 'left.axis', type: 'revolute' },
+  { name: 'right-curl', a: 'base.axis', b: 'right.axis', type: 'revolute' },
+];
+
+const couplings: MateCouplingRecord[] = [
+  { driven: 'left-curl', source: 'grip', ratio: 1, offset: 0 },
+  { driven: 'right-curl', source: 'grip', ratio: -1, offset: 0 },
+];
+
+describe('expandCoupledPoses', () => {
+  it('derives driven scalar poses from source pose', () => {
+    expect(expandCoupledPoses(mates, couplings, { grip: 20 })).toEqual({
+      grip: 20,
+      'left-curl': 20,
+      'right-curl': -20,
+    });
+  });
+
+  it('keeps explicit driven override for debugging', () => {
+    expect(expandCoupledPoses(mates, couplings, { grip: 20, 'right-curl': -5 })).toEqual({
+      grip: 20,
+      'left-curl': 20,
+      'right-curl': -5,
+    });
+  });
+
+  it('uses capture-time source pose when no override is provided', () => {
+    expect(expandCoupledPoses(mates, couplings, {})).toEqual({
+      'left-curl': 10,
+      'right-curl': -10,
+    });
+  });
+
+  it('applies offsets after ratios', () => {
+    expect(expandCoupledPoses(mates, [
+      { driven: 'left-curl', source: 'grip', ratio: 0.5, offset: 3 },
+    ], { grip: 20 })).toEqual({
+      grip: 20,
+      'left-curl': 13,
+    });
+  });
+});

--- a/src/lib/mates/coupledPoses.ts
+++ b/src/lib/mates/coupledPoses.ts
@@ -1,0 +1,62 @@
+import type { NumericPoses } from '../../capture/forwardKinematics';
+import type { MateRecord } from './mate';
+
+export interface MateCouplingRecord {
+  readonly driven: string;
+  readonly source: string;
+  readonly ratio: number;
+  readonly offset?: number;
+}
+
+export interface ExpandCoupledPosesOptions {
+  readonly resolveSourcePose?: (
+    source: MateRecord,
+    poses: NumericPoses,
+  ) => number | [number, number, number] | undefined;
+}
+
+export function expandCoupledPoses(
+  mates: readonly MateRecord[],
+  couplings: readonly MateCouplingRecord[],
+  poses: NumericPoses = {},
+  options: ExpandCoupledPosesOptions = {},
+): NumericPoses {
+  if (couplings.length === 0) return { ...poses };
+
+  const mateByName = new Map(mates.map((mate) => [mate.name, mate]));
+  const expanded: NumericPoses = { ...poses };
+
+  for (const coupling of couplings) {
+    if (expanded[coupling.driven] !== undefined) continue;
+
+    const sourcePose = resolveSourcePose(
+      mateByName.get(coupling.source),
+      expanded,
+      options.resolveSourcePose,
+    );
+    if (sourcePose === undefined || Array.isArray(sourcePose)) continue;
+
+    expanded[coupling.driven] = sourcePose * coupling.ratio + (coupling.offset ?? 0);
+  }
+
+  return expanded;
+}
+
+function resolveSourcePose(
+  source: MateRecord | undefined,
+  poses: NumericPoses,
+  resolver: ExpandCoupledPosesOptions['resolveSourcePose'],
+): number | [number, number, number] | undefined {
+  if (!source) return undefined;
+
+  const override = poses[source.name];
+  if (override !== undefined) return override;
+
+  const resolved = resolver?.(source, poses);
+  if (resolved !== undefined) return resolved;
+
+  const pose = source.pose;
+  if (typeof pose === 'number') return pose;
+
+  return undefined;
+}

--- a/src/lib/mates/gripperAperture.test.ts
+++ b/src/lib/mates/gripperAperture.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { computeGripperAperture } from './gripperAperture';
+import type { TrackedConnectorPose } from './poseEnvelope';
+
+const poses: TrackedConnectorPose[] = [
+  {
+    sampleName: 'open',
+    ref: 'left.tip',
+    partName: 'left',
+    connectorName: 'tip',
+    world: [-10, 0, 0],
+  },
+  {
+    sampleName: 'open',
+    ref: 'right.tip',
+    partName: 'right',
+    connectorName: 'tip',
+    world: [10, 0, 0],
+  },
+  {
+    sampleName: 'closed',
+    ref: 'left.tip',
+    partName: 'left',
+    connectorName: 'tip',
+    world: [-3, 0, 0],
+  },
+  {
+    sampleName: 'closed',
+    ref: 'right.tip',
+    partName: 'right',
+    connectorName: 'tip',
+    world: [3, 0, 0],
+  },
+];
+
+describe('computeGripperAperture', () => {
+  it('computes min, max, and travel from paired fingertip samples', () => {
+    expect(computeGripperAperture(poses, { left: 'left.tip', right: 'right.tip' })).toEqual({
+      summary: {
+        left: 'left.tip',
+        right: 'right.tip',
+        minMm: 6,
+        maxMm: 20,
+        travelMm: 14,
+        samples: [
+          { sampleName: 'closed', distanceMm: 6 },
+          { sampleName: 'open', distanceMm: 20 },
+        ],
+      },
+      missingRefs: [],
+    });
+  });
+
+  it('reports missing refs when one fingertip connector has no poses', () => {
+    expect(computeGripperAperture(poses, { left: 'left.tip', right: 'missing.tip' })).toEqual({
+      missingRefs: ['missing.tip'],
+    });
+  });
+});

--- a/src/lib/mates/gripperAperture.ts
+++ b/src/lib/mates/gripperAperture.ts
@@ -1,0 +1,71 @@
+import type { TrackedConnectorPose } from './poseEnvelope';
+
+export interface GripperApertureRequest {
+  readonly left: string;
+  readonly right: string;
+}
+
+export interface GripperApertureSample {
+  readonly sampleName: string;
+  readonly distanceMm: number;
+}
+
+export interface GripperApertureSummary {
+  readonly left: string;
+  readonly right: string;
+  readonly minMm: number;
+  readonly maxMm: number;
+  readonly travelMm: number;
+  readonly samples: readonly GripperApertureSample[];
+}
+
+export type GripperApertureResult =
+  | { readonly summary: GripperApertureSummary; readonly missingRefs: readonly string[] }
+  | { readonly summary?: undefined; readonly missingRefs: readonly string[] };
+
+export function computeGripperAperture(
+  poses: readonly TrackedConnectorPose[],
+  request: GripperApertureRequest,
+): GripperApertureResult {
+  const left = poses.filter((pose) => pose.ref === request.left);
+  const right = poses.filter((pose) => pose.ref === request.right);
+  const missingRefs = [
+    ...(left.length === 0 ? [request.left] : []),
+    ...(right.length === 0 ? [request.right] : []),
+  ];
+  if (missingRefs.length > 0) return { missingRefs };
+
+  const rightBySample = new Map(right.map((pose) => [pose.sampleName, pose]));
+  const samples: GripperApertureSample[] = [];
+  for (const leftPose of left) {
+    const rightPose = rightBySample.get(leftPose.sampleName);
+    if (!rightPose) continue;
+    samples.push({
+      sampleName: leftPose.sampleName,
+      distanceMm: distance(leftPose.world, rightPose.world),
+    });
+  }
+
+  if (samples.length === 0) return { missingRefs: [request.left, request.right] };
+
+  samples.sort((a, b) => a.sampleName.localeCompare(b.sampleName));
+  const distances = samples.map((sample) => sample.distanceMm);
+  const minMm = Math.min(...distances);
+  const maxMm = Math.max(...distances);
+
+  return {
+    summary: {
+      left: request.left,
+      right: request.right,
+      minMm,
+      maxMm,
+      travelMm: maxMm - minMm,
+      samples,
+    },
+    missingRefs: [],
+  };
+}
+
+function distance(a: readonly [number, number, number], b: readonly [number, number, number]): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}

--- a/src/lib/mates/mechanismFitness.ts
+++ b/src/lib/mates/mechanismFitness.ts
@@ -13,6 +13,9 @@ export interface MechanismSummary {
   readonly interferenceCount: number;
   readonly trackedConnectorCount: number;
   readonly maxTrackedTravelMm?: number;
+  readonly gripperApertureMinMm?: number;
+  readonly gripperApertureMaxMm?: number;
+  readonly gripperApertureTravelMm?: number;
 }
 
 export interface MechanismFitnessResult {
@@ -33,6 +36,7 @@ const PASSED_CHECKS = {
   poseEnvelopeSolved: 'pose-envelope-solved',
   poseEnvelopeNoInterference: 'pose-envelope-no-interference',
   trackedConnectorsMove: 'tracked-connectors-move',
+  gripperApertureMoves: 'gripper-aperture-moves',
 } as const;
 
 export function summarizeMechanismFitness(
@@ -125,6 +129,19 @@ export function summarizeMechanismFitness(
     passedChecks.push(PASSED_CHECKS.trackedConnectorsMove);
   }
 
+  if (poseEnvelope?.gripperApertureRequest !== undefined && poseEnvelope.gripperAperture === undefined) {
+    addBlockingReason(
+      'assembly.mechanism.gripper-aperture-missing',
+      'Requested gripper aperture could not be computed.',
+      'Pass two numeric frame connector refs that are present across pose-envelope samples.',
+      poseEnvelope.gripperApertureRequest,
+    );
+  }
+
+  if (poseEnvelope?.gripperAperture !== undefined && poseEnvelope.gripperAperture.travelMm > 0) {
+    passedChecks.push(PASSED_CHECKS.gripperApertureMoves);
+  }
+
   const sampleCount = poseEnvelope?.samples.length ?? 0;
   const interferenceCount = poseEnvelope?.interferencePairs.length ?? 0;
 
@@ -137,6 +154,11 @@ export function summarizeMechanismFitness(
       interferenceCount,
       trackedConnectorCount,
       ...(maxTrackedTravelMm === undefined ? {} : { maxTrackedTravelMm }),
+      ...(poseEnvelope?.gripperAperture === undefined ? {} : {
+        gripperApertureMinMm: poseEnvelope.gripperAperture.minMm,
+        gripperApertureMaxMm: poseEnvelope.gripperAperture.maxMm,
+        gripperApertureTravelMm: poseEnvelope.gripperAperture.travelMm,
+      }),
     },
   };
 }

--- a/src/lib/mates/poseEnvelope.ts
+++ b/src/lib/mates/poseEnvelope.ts
@@ -9,6 +9,12 @@ import { currentValue } from '../../runtime/editableHelpers';
 import type { Editable } from '../../runtime/paramRef';
 import { detectInterferences } from '../../script-runtime/checkInterference';
 import type { InterferencePair } from '../../script-runtime/checkInterference';
+import { expandCoupledPoses } from './coupledPoses';
+import {
+  computeGripperAperture,
+  type GripperApertureRequest,
+  type GripperApertureSummary,
+} from './gripperAperture';
 import type { MatePose, MateRecord } from './mate';
 import { solveMates } from './solver';
 
@@ -16,7 +22,8 @@ export type PoseEnvelopeDiagnosticCode =
   | 'assembly.pose.out-of-limits'
   | 'assembly.pose-envelope.solve-failed'
   | 'assembly.pose-envelope.interference'
-  | 'assembly.pose-envelope.connector-unresolved';
+  | 'assembly.pose-envelope.connector-unresolved'
+  | 'assembly.gripper-aperture.connector-missing';
 
 export interface PoseEnvelopeDiagnostic {
   readonly code: PoseEnvelopeDiagnosticCode;
@@ -43,6 +50,7 @@ export interface PoseEnvelopeReviewOptions {
   readonly includeInterference?: boolean;
   readonly epsilonMm3?: number;
   readonly trackConnectors?: readonly string[];
+  readonly gripperAperture?: GripperApertureRequest;
 }
 
 export interface PoseEnvelopeReviewResult {
@@ -51,6 +59,8 @@ export interface PoseEnvelopeReviewResult {
   readonly interferencePairs: Array<InterferencePair & { sampleName: string }>;
   readonly connectorPoses: TrackedConnectorPose[];
   readonly connectorWorkspace: ConnectorWorkspace[];
+  readonly gripperApertureRequest?: GripperApertureRequest;
+  readonly gripperAperture?: GripperApertureSummary;
 }
 
 export interface TrackedConnectorPose {
@@ -83,13 +93,13 @@ export function buildPoseEnvelopeSamples(arm: Assembly): PoseEnvelopeSample[] {
     const [min, max] = limits;
     samples.push({
       name: `${mate.name}:min`,
-      poses: { [mate.name]: min },
+      poses: expandCoupledPoses(arm.__mates(), arm.__mateCouplings(), { [mate.name]: min }),
       reason: `${mate.name} lower limit`,
     });
     if (max !== min) {
       samples.push({
         name: `${mate.name}:max`,
-        poses: { [mate.name]: max },
+        poses: expandCoupledPoses(arm.__mates(), arm.__mateCouplings(), { [mate.name]: max }),
         reason: `${mate.name} upper limit`,
       });
     }
@@ -136,7 +146,12 @@ export async function reviewPoseEnvelope(
   const diagnostics: PoseEnvelopeDiagnostic[] = [];
   const interferencePairs: Array<InterferencePair & { sampleName: string }> = [];
   const connectorPoses: TrackedConnectorPose[] = [];
-  const trackConnectors = opts.trackConnectors !== undefined ? new Set(opts.trackConnectors) : undefined;
+  const trackConnectors = opts.trackConnectors !== undefined || opts.gripperAperture !== undefined
+    ? new Set([
+        ...(opts.trackConnectors ?? []),
+        ...(opts.gripperAperture !== undefined ? [opts.gripperAperture.left, opts.gripperAperture.right] : []),
+      ])
+    : undefined;
   const unresolvedConnectorRefs = new Set<string>();
 
   for (const sample of samples) {
@@ -200,12 +215,27 @@ export async function reviewPoseEnvelope(
     });
   }
 
+  const aperture = opts.gripperAperture !== undefined
+    ? computeGripperAperture(connectorPoses, opts.gripperAperture)
+    : undefined;
+  if (opts.gripperAperture !== undefined && aperture?.summary === undefined) {
+    diagnostics.push({
+      code: 'assembly.gripper-aperture.connector-missing',
+      severity: 'warning',
+      connectorRef: aperture?.missingRefs.join(', ') ?? `${opts.gripperAperture.left}, ${opts.gripperAperture.right}`,
+      message: `Gripper aperture could not be computed because one or both fingertip connector refs were not observed.`,
+      hint: `invalid-args.assembly.gripper-aperture-connector-missing — pass gripperAperture refs that exist as numeric frame connectors and are included in pose-envelope samples.`,
+    });
+  }
+
   return {
     samples,
     diagnostics,
     interferencePairs,
     connectorPoses,
     connectorWorkspace: buildConnectorWorkspace(connectorPoses),
+    ...(opts.gripperAperture !== undefined ? { gripperApertureRequest: opts.gripperAperture } : {}),
+    ...(aperture?.summary !== undefined ? { gripperAperture: aperture.summary } : {}),
   };
 }
 

--- a/src/lib/mates/solver.ts
+++ b/src/lib/mates/solver.ts
@@ -51,6 +51,7 @@ import {
   type Connector,
   type ConnectorOrigin,
 } from './connector';
+import { expandCoupledPoses } from './coupledPoses';
 import type { MatePose, MateRecord } from './mate';
 import { parseConnectorRef } from './mate';
 import type { MateType } from './mateTypes';
@@ -172,6 +173,9 @@ export async function solveMates(
 ): Promise<SolveResult> {
   const parts = arm.__parts();
   const mates = arm.__mates();
+  const expandedPoses = expandCoupledPoses(mates, arm.__mateCouplings(), poses ?? {}, {
+    resolveSourcePose: (mate, currentPoses) => resolveMatePose(mate, arm, currentPoses),
+  });
 
   if (parts.length === 0) {
     return { status: 'solved', poses: new Map() };
@@ -190,7 +194,7 @@ export async function solveMates(
   // 2. Build a spanning tree via BFS from the first declared part. Mates not
   //    in the tree become loop-closure constraints — passed to `loopSolve`.
   const partByName = new Map(parts.map((p) => [p.name, p]));
-  const { worldT, loopMates } = await walkSpanningTree(parts, adjacency, partByName, arm, poses);
+  const { worldT, loopMates } = await walkSpanningTree(parts, adjacency, partByName, arm, expandedPoses);
 
   if (loopMates.length === 0) {
     return { status: 'solved', poses: worldT };

--- a/src/mcp/tools/reviewCad.ts
+++ b/src/mcp/tools/reviewCad.ts
@@ -7,6 +7,7 @@ import {
   type MechanismBlockingReason,
   type MechanismFitnessResult,
 } from '../../lib/mates/mechanismFitness';
+import type { GripperApertureRequest } from '../../lib/mates/gripperAperture';
 import type { PoseEnvelopeDiagnostic, PoseEnvelopeReviewResult } from '../../lib/mates/poseEnvelope';
 import { reviewPoseEnvelope } from '../../lib/mates/poseEnvelope';
 import type { ValidatorDiagnostic, ValidatorStatus } from '../../lib/mates/validator';
@@ -21,6 +22,7 @@ export interface ReviewCadInput {
   includeInterference?: boolean;
   epsilonMm3?: number;
   trackConnectors?: string[];
+  gripperAperture?: GripperApertureRequest;
 }
 
 export type ReviewCadOutput =
@@ -37,6 +39,7 @@ export type ReviewCadOutput =
       };
       poseEnvelope?: PoseEnvelopeReviewResult;
       connectorWorkspace?: PoseEnvelopeReviewResult['connectorWorkspace'];
+      gripperAperture?: PoseEnvelopeReviewResult['gripperAperture'];
       fitness: MechanismFitnessResult;
     }
   | {
@@ -52,6 +55,7 @@ export type ReviewCadOutput =
       };
       poseEnvelope?: PoseEnvelopeReviewResult;
       connectorWorkspace?: PoseEnvelopeReviewResult['connectorWorkspace'];
+      gripperAperture?: PoseEnvelopeReviewResult['gripperAperture'];
       fitness?: MechanismFitnessResult;
       suggestedRepairPrompt: string;
     };
@@ -94,6 +98,7 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
         includeInterference: input.includeInterference ?? true,
         epsilonMm3: input.epsilonMm3,
         trackConnectors: input.trackConnectors,
+        gripperAperture: input.gripperAperture,
       })
     : undefined;
 
@@ -123,6 +128,7 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
       },
       ...(poseEnvelope !== undefined ? { poseEnvelope } : {}),
       ...(poseEnvelope !== undefined ? { connectorWorkspace: poseEnvelope.connectorWorkspace } : {}),
+      ...(poseEnvelope?.gripperAperture !== undefined ? { gripperAperture: poseEnvelope.gripperAperture } : {}),
       fitness,
     };
   }
@@ -140,6 +146,7 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
     },
     ...(poseEnvelope !== undefined ? { poseEnvelope } : {}),
     ...(poseEnvelope !== undefined ? { connectorWorkspace: poseEnvelope.connectorWorkspace } : {}),
+    ...(poseEnvelope?.gripperAperture !== undefined ? { gripperAperture: poseEnvelope.gripperAperture } : {}),
     fitness,
     suggestedRepairPrompt: buildSuggestedRepairPrompt(diagnostics, fitness.blockingReasons),
   };

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -629,6 +629,25 @@ arm.mate('shoulder-bolts',  'shoulder-servo.base-mount',  'base.shoulder-mount',
 arm.mate('shoulder-rotate', 'shoulder-servo.output-shaft', 'horn.shaft-hub',     'revolute');
 ```
 
+Couple scalar articulated mates when one actuator should drive multiple
+finger/jaw joints. The driven pose is `sourcePose * ratio + offset`; explicit
+numeric `solve_mates({ poses })` overrides for a driven mate still win for
+debugging.
+
+```typescript
+arm.mate('grip', 'palm.driver', 'grip-driver.axis', 'revolute', {
+  limitsDeg: [0, 40],
+});
+arm.mate('left-curl', 'palm.left-hinge', 'left-finger.hinge', 'revolute');
+arm.mate('right-curl', 'palm.right-hinge', 'right-finger.hinge', 'revolute');
+arm.coupleMates('left-curl', { source: 'grip', ratio: 1 });
+arm.coupleMates('right-curl', { source: 'grip', ratio: -1 });
+```
+
+Use this for two-finger grippers and simple underactuated fingers before
+hand-authoring duplicated pose params. Coupling supports scalar mates:
+`revolute`, `prismatic`, `cylindrical`, and `pin_slot`.
+
 Capture-time errors throw `KernelError('feature.invalid-args')` with
 structured hints:
 
@@ -706,8 +725,8 @@ MCP tools mirror the `.kcad.ts` surface for runtime introspection:
   diagnostic carries `code` and `hint` for recovery.
 - `solve_mates({ assembly?, poses? })` — run the mate-graph solver and return
   `{ status, poses, iterations? }`. `poses` overrides mate pose values by mate
-  name.
-- `review_cad({ file? | code?, assembly?, includePoseEnvelope?, includeInterference?, epsilonMm3?, trackConnectors? })` —
+  name; coupled driven mates are expanded from their source mate before solve.
+- `review_cad({ file? | code?, assembly?, includePoseEnvelope?, includeInterference?, epsilonMm3?, trackConnectors?, gripperAperture? })` —
   run the deterministic agent review loop: evaluate, validate mates, sample
   declared pose limits, report connector workspace bounds, and return raw
   diagnostics plus a fitness summary (`fitness.functional`,
@@ -715,7 +734,9 @@ MCP tools mirror the `.kcad.ts` surface for runtime introspection:
   selected. Pass
   `trackConnectors: ['gripper-plate.tool-tip']` to focus workspace output on an
   end-effector; connector workspace is only computed when pose-envelope
-  sampling is enabled.
+  sampling is enabled. For grippers, pass
+  `gripperAperture: { left: 'left-finger.tip', right: 'right-finger.tip' }`
+  to get `minMm`, `maxMm`, `travelMm`, and per-sample fingertip distances.
 
 ### Naming features (slice 2)
 
@@ -922,8 +943,8 @@ When you have `kernelcad mcp` available, use the MCP tools for dynamic introspec
 - `add_mate({ name, a, b, type, pose?, limitsDeg?, limitsMm?, assembly? })` — declare a typed mate between two `"<partName>.<connectorName>"` refs on the active assembly. `type` is one of `fastened`/`revolute`/`prismatic`/`cylindrical`/`planar`/`ball`/`pin_slot`; capture-time validation surfaces type-mismatch / connector-not-found errors.
 - `list_mates({ assembly? })` — return the declared mate records on the active assembly: `{ mates: [{ name, a, b, type, pose?, limitsDeg?, limitsMm? }, ...] }`.
 - `validate_assembly({ assembly? })` — run the mate-aware validator on the active assembly; returns `{ status, diagnostics, partCount, jointCount }` where each diagnostic carries `code` and `hint` for recovery.
-- `solve_mates({ assembly?, poses? })` — run the v0.6 mate-graph solver on the active assembly; returns `{ status, poses, iterations? }` with each pose serialized as `{ translation, rotateAxis, rotateDeg }`. The `poses` input overrides mate pose values by mate name.
-- `review_cad({ file? | code?, assembly?, includePoseEnvelope?, includeInterference?, epsilonMm3?, trackConnectors? })` — evaluate a script, validate its assembly/mate graph, sample declared mate limits, optionally run BREP interference checks at those samples, report connector workspace bounds, and return raw diagnostics plus a fitness summary (`fitness.functional`, `fitness.blockingReasons`, `fitness.mechanismSummary`) after an assembly is selected. Connector workspace is only computed when pose-envelope sampling is enabled.
+- `solve_mates({ assembly?, poses? })` — run the v0.6 mate-graph solver on the active assembly; returns `{ status, poses, iterations? }` with each pose serialized as `{ translation, rotateAxis, rotateDeg }`. The `poses` input overrides mate pose values by mate name; coupled driven mates are expanded from their source mate before solve.
+- `review_cad({ file? | code?, assembly?, includePoseEnvelope?, includeInterference?, epsilonMm3?, trackConnectors?, gripperAperture? })` — evaluate a script, validate its assembly/mate graph, sample declared mate limits, optionally run BREP interference checks at those samples, report connector workspace bounds, optionally report gripper aperture between two fingertip connector refs, and return raw diagnostics plus a fitness summary (`fitness.functional`, `fitness.blockingReasons`, `fitness.mechanismSummary`) after an assembly is selected. Connector workspace and gripper aperture are only computed when pose-envelope sampling is enabled.
 
 ## Out of Scope
 

--- a/tests/integration/examples/twoFingerCoupledGripper.test.ts
+++ b/tests/integration/examples/twoFingerCoupledGripper.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve as resolvePath } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { evaluateAndBuildScript } from '../../../src/cli/commands/evaluate';
+import { reviewCadTool } from '../../../src/mcp/tools/reviewCad';
+import { runScript } from '../../../src/script-runtime/runScript';
+import { Scene } from '../../../src/intent/scene';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const EXAMPLE_PATH = 'examples/robot-hand/two-finger-coupled-gripper.kcad.ts';
+const EXAMPLE_ABSOLUTE = resolvePath(__dirname, '../../..', EXAMPLE_PATH);
+
+describe('two-finger coupled gripper example', () => {
+  it('evaluates and declares coupled fingertip intent', async () => {
+    const result = await evaluateAndBuildScript({ file: EXAMPLE_PATH });
+
+    expect(result.evaluation.exitCode).toBe(0);
+    const errors = result.evaluation.diagnostics.filter((diagnostic) => diagnostic.severity === 'error');
+    expect(errors).toEqual([]);
+
+    const code = await readFile(EXAMPLE_ABSOLUTE, 'utf8');
+    const { returnValue } = await runScript({
+      code,
+      fileName: EXAMPLE_ABSOLUTE,
+      scriptDir: dirname(EXAMPLE_ABSOLUTE),
+    });
+    expect(returnValue).toBeInstanceOf(Scene);
+    const scene = returnValue as Scene;
+    expect(scene.mates?.map((mate) => mate.name)).toEqual(['grip', 'left-curl', 'right-curl']);
+    expect(scene.part('left-finger').connectors?.some((connector) => connector.name === 'tip')).toBe(true);
+    expect(scene.part('right-finger').connectors?.some((connector) => connector.name === 'tip')).toBe(true);
+  }, 120_000);
+
+  it('passes review_cad with gripper aperture travel', async () => {
+    const result = await reviewCadTool({
+      file: EXAMPLE_PATH,
+      includeInterference: false,
+      trackConnectors: ['left-finger.tip', 'right-finger.tip'],
+      gripperAperture: { left: 'left-finger.tip', right: 'right-finger.tip' },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.gripperAperture?.travelMm).toBeGreaterThan(10);
+      expect(result.fitness.passedChecks).toContain('gripper-aperture-moves');
+      expect(result.fitness.mechanismSummary.gripperApertureTravelMm).toBeGreaterThan(10);
+    }
+  }, 180_000);
+});

--- a/tests/integration/mcp/reviewCad.test.ts
+++ b/tests/integration/mcp/reviewCad.test.ts
@@ -63,6 +63,43 @@ describe('review_cad MCP tool', () => {
     }
   });
 
+  it('reports gripper aperture travel for coupled fingertip connectors', async () => {
+    const r = await reviewCadTool({
+      includeInterference: false,
+      trackConnectors: ['left.tip', 'right.tip'],
+      gripperAperture: { left: 'left.tip', right: 'right.tip' },
+      code: `
+        const arm = assembly('hand');
+        arm.part('base', box(10, 10, 2))
+          .connector('driver', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] })
+          .connector('left', { type: 'axis', origin: { kind: 'vec3', value: [-10, 0, 0] }, axis: [0, 0, 1] })
+          .connector('right', { type: 'axis', origin: { kind: 'vec3', value: [10, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('driver', box(2, 2, 2))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('left', box(30, 3, 3))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] })
+          .connector('tip', { type: 'frame', origin: { kind: 'vec3', value: [40, 0, 0] } });
+        arm.part('right', box(30, 3, 3))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] })
+          .connector('tip', { type: 'frame', origin: { kind: 'vec3', value: [-40, 0, 0] } });
+        arm.mate('grip', 'base.driver', 'driver.axis', 'revolute', { pose: 0, limitsDeg: [0, 40] });
+        arm.mate('left-curl', 'base.left', 'left.axis', 'revolute');
+        arm.mate('right-curl', 'base.right', 'right.axis', 'revolute');
+        arm.coupleMates('left-curl', { source: 'grip', ratio: 1 });
+        arm.coupleMates('right-curl', { source: 'grip', ratio: -1 });
+        return arm.model();
+      `,
+    });
+
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.gripperAperture?.left).toBe('left.tip');
+      expect(r.gripperAperture?.right).toBe('right.tip');
+      expect(r.gripperAperture?.travelMm).toBeGreaterThan(10);
+      expect(r.fitness.mechanismSummary.gripperApertureTravelMm).toBeGreaterThan(10);
+    }
+  });
+
   it('returns actionable fitness repair facts when tracked connector workspace is missing', async () => {
     const r = await reviewCadTool({
       includeInterference: false,
@@ -89,6 +126,32 @@ describe('review_cad MCP tool', () => {
         'assembly.mechanism.no-tracked-travel',
       ]);
       expect(r.suggestedRepairPrompt).toMatch(/assembly\.mechanism\.no-tracked-workspace/);
+    }
+  });
+
+  it('returns structured repair facts when requested gripper aperture refs are missing', async () => {
+    const r = await reviewCadTool({
+      includeInterference: false,
+      gripperAperture: { left: 'left.tip', right: 'right.missing' },
+      code: `
+        const arm = assembly('rig');
+        arm.part('base', box(10, 10, 10))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('left', box(20, 5, 5))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] })
+          .connector('tip', { type: 'frame', origin: { kind: 'vec3', value: [20, 0, 0] } });
+        arm.mate('yaw', 'base.axis', 'left.axis', 'revolute', {
+          limitsDeg: [0, 90],
+        });
+        return arm.model();
+      `,
+    });
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.diagnostics.some((d) => d.code === 'assembly.gripper-aperture.connector-missing')).toBe(true);
+      expect(r.fitness?.blockingReasons.some((reason) => reason.code === 'assembly.mechanism.gripper-aperture-missing')).toBe(true);
+      expect(r.suggestedRepairPrompt).toMatch(/assembly\.mechanism\.gripper-aperture-missing/);
     }
   });
 

--- a/tests/integration/mcp/solveMates.test.ts
+++ b/tests/integration/mcp/solveMates.test.ts
@@ -62,6 +62,75 @@ describe('solve_mates MCP tool', () => {
     }
   });
 
+  it('expands coupled mate poses from one grip actuator', async () => {
+    const ev = await evaluateScriptTool({
+      code: `
+        const arm = assembly('hand');
+        arm.part('base', box(10, 10, 2))
+          .connector('left', { type: 'axis', origin: { kind: 'vec3', value: [-10, 0, 0] }, axis: [0, 0, 1] })
+          .connector('right', { type: 'axis', origin: { kind: 'vec3', value: [10, 0, 0] }, axis: [0, 0, 1] })
+          .connector('driver', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('driver', box(2, 2, 2))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('left', box(20, 3, 3))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('right', box(20, 3, 3))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.mate('grip', 'base.driver', 'driver.axis', 'revolute', { limitsDeg: [0, 40] });
+        arm.mate('left-curl', 'base.left', 'left.axis', 'revolute');
+        arm.mate('right-curl', 'base.right', 'right.axis', 'revolute');
+        arm.coupleMates('left-curl', { source: 'grip', ratio: 1 });
+        arm.coupleMates('right-curl', { source: 'grip', ratio: -1 });
+        return arm.model();
+      `,
+    });
+    expect(ev.ok).toBe(true);
+
+    const r = await solveMatesTool({ poses: { grip: 30 } });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.poses.left.rotateDeg).toBeCloseTo(30);
+      expect(r.poses.right.rotateDeg).toBeCloseTo(30);
+      expect(r.poses.left.rotateAxis[2]).toBeGreaterThan(0);
+      expect(r.poses.right.rotateAxis[2]).toBeLessThan(0);
+    }
+  });
+
+  it('expands coupled mate poses from a source ParamRef pose', async () => {
+    const ev = await evaluateScriptTool({
+      code: `
+        const gripDeg = param('gripDeg', 25, { min: 0, max: 40 });
+        const arm = assembly('hand');
+        arm.part('base', box(10, 10, 2))
+          .connector('left', { type: 'axis', origin: { kind: 'vec3', value: [-10, 0, 0] }, axis: [0, 0, 1] })
+          .connector('right', { type: 'axis', origin: { kind: 'vec3', value: [10, 0, 0] }, axis: [0, 0, 1] })
+          .connector('driver', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('driver', box(2, 2, 2))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('left', box(20, 3, 3))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('right', box(20, 3, 3))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.mate('grip', 'base.driver', 'driver.axis', 'revolute', { pose: gripDeg, limitsDeg: [0, 40] });
+        arm.mate('left-curl', 'base.left', 'left.axis', 'revolute');
+        arm.mate('right-curl', 'base.right', 'right.axis', 'revolute');
+        arm.coupleMates('left-curl', { source: 'grip', ratio: 1 });
+        arm.coupleMates('right-curl', { source: 'grip', ratio: -1 });
+        return arm.model();
+      `,
+    });
+    expect(ev.ok).toBe(true);
+
+    const r = await solveMatesTool({});
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.poses.left.rotateDeg).toBeCloseTo(25);
+      expect(r.poses.right.rotateDeg).toBeCloseTo(25);
+      expect(r.poses.left.rotateAxis[2]).toBeGreaterThan(0);
+      expect(r.poses.right.rotateAxis[2]).toBeLessThan(0);
+    }
+  });
+
   it('returns ok:false when a scalar mate receives a triple pose override', async () => {
     const ev = await evaluateScriptTool({
       code: `


### PR DESCRIPTION
## Summary
- add assembly-level mate coupling so one actuator can drive mirrored finger joints
- expand coupled poses in solve_mates and pose-envelope sampling, including ParamRef source poses
- add gripper aperture review output and mechanism-fitness checks for fingertip travel
- add a two-finger coupled gripper example and skill docs

## Verification
- npm run typecheck
- npm run lint
- npm test -- --run src/lib/mates/ tests/integration/mcp/reviewCad.test.ts tests/integration/mcp/solveMates.test.ts tests/integration/examples/twoFingerCoupledGripper.test.ts tests/unit/skill/skillToolCountDrift.test.ts
- npm run build:cli