### PR TITLE
feat: make hero gripper loop functional

### DIFF
--- a/examples/robot-arm/desktop-3axis-mates.kcad.ts
+++ b/examples/robot-arm/desktop-3axis-mates.kcad.ts
@@ -1,24 +1,21 @@
 // Parametric desktop 3-axis robot arm — v0.6 mate-graph rewrite.
 //
-// Same geometry + same body-tree topology as the v0.5
-// `desktop-3axis.kcad.ts`, but joints are declared via the v0.6 mate
-// vocabulary (`partRef.connector(...)` + `arm.mate(...)`) instead of the
-// v0.5 helpers (`arm.fixed/.revolute`). Each link is still authored in its
-// OWN LOCAL FRAME — mate-FK (`solveMates`, T16) plants the children where
-// the mates land. Visual output under default pose params matches the v0.5
-// hero pixel-for-pixel: same connector origins as the v0.5 joint origins,
-// child connectors all at [0,0,0] so the per-mate SE(3) collapses to the
-// v0.5 body-tree FK math.
+// Starts from the v0.5 `desktop-3axis.kcad.ts` body-tree hero, but joints are
+// declared via the v0.6 mate vocabulary (`partRef.connector(...)` +
+// `arm.mate(...)`) instead of the v0.5 helpers (`arm.fixed/.revolute`). Each
+// link is authored in its own local frame and mate-FK plants children where
+// their connectors land.
 //
-// 3 revolute mates (base-yaw, shoulder-pitch, elbow-pitch) expose articulation
-// DOF; the other 9 fastened mates couple decorative link-internal parts to
-// their parent link. Open tree — no closed loops — so the mate solver
-// classifies as `solved` in one pass.
+// 4 actuator mates expose articulation: base-yaw, shoulder-pitch, elbow-pitch,
+// and grip. The terminal gripper uses one visible drive mate plus two coupled
+// finger curl mates, so the review loop can sample fingertip aperture instead
+// of only tracking a rigid tool plate.
 
 // ---- pose parameters (live sliders) -------------------------------------
 const baseYawDeg       = param('baseYawDeg',       20,  { min: -180, max: 180 });
 const shoulderPitchDeg = param('shoulderPitchDeg', 35,  { min:  -45, max: 135 });
 const elbowPitchDeg    = param('elbowPitchDeg',   -55,  { min: -120, max: 120 });
+const gripDeg          = param('gripDeg',           0,  { min:    0, max:  42 });
 
 // ---- geometry parameters -------------------------------------------------
 // Footprint and base.
@@ -290,14 +287,20 @@ const forearmRootPlate = box(6, beamW.subtract(2), beamT.subtract(2), true)
 const forearmShape = forearmBeamShape.union(forearmRib).union(forearmRootPlate);
 const forearmPart = arm.part('forearm-beam', forearmShape);
 
-// 13. Gripper mounting plate at the forearm tip. The plate sits PAST the
-//     forearm beam's distal face (x = forearmLen) — was previously
-//     centered at forearmLen - 3, which slid the plate body half-inside
-//     the forearm beam and produced a large overlap. Plate now bolts onto
-//     the beam tip with a small air gap; the cylindrical neck and pin
-//     extend further out toward the gripper tool.
+// 13. Functional gripper palm at the forearm tip. The palm sits PAST the
+//     forearm beam's distal face (x = forearmLen) and carries a small
+//     visible drive disc plus two hinged fingers. The fingers are separate
+//     assembly parts so the review loop can sample the grip actuator and
+//     measure real fingertip aperture.
 const gripperPlateT = 6;
 const gripperPlateGap = 1;
+const gripperFingerLen = 34;
+const gripperFingerW = 6;
+const gripperFingerT = 6;
+const gripperHingeY = 28;
+const gripperHingeXNum = 139; // forearmLen default + gap + palm thickness + knuckle offset
+const gripDriverXNum = 132;
+const gripDriverZNum = 18;
 const gripperPlate = box(gripperPlateT, 28, 28, true)
   .fillet(2)
   .translate(forearmLen.add(gripperPlateGap).add(gripperPlateT / 2), 0, 0)
@@ -307,8 +310,31 @@ const gripperPlate = box(gripperPlateT, 28, 28, true)
   .union(
     cylinder(14, 1.5, 24).alongAxis([1, 0, 0]).translate(forearmLen.add(gripperPlateGap).add(gripperPlateT + 4), 0, 0),
   )
+  .union(
+    box(8, 8, 8, true).fillet(0.8).translate(gripperHingeXNum - 8, gripperHingeY, 0),
+  )
+  .union(
+    box(8, 8, 8, true).fillet(0.8).translate(gripperHingeXNum - 8, -gripperHingeY, 0),
+  )
   .color('tool');
 const gripperPlatePart = arm.part('gripper-plate', gripperPlate);
+
+const gripDriver = cylinder(4, 5, 32)
+  .translate(0, 0, 0)
+  .color('gear');
+const gripDriverPart = arm.part('grip-driver', gripDriver);
+
+const leftFinger = box(gripperFingerLen, gripperFingerW, gripperFingerT, true)
+  .fillet(0.7)
+  .translate(gripperFingerLen / 2, 0, 0)
+  .color('tool');
+const leftFingerPart = arm.part('left-finger', leftFinger);
+
+const rightFinger = box(gripperFingerLen, gripperFingerW, gripperFingerT, true)
+  .fillet(0.7)
+  .translate(gripperFingerLen / 2, 0, 0)
+  .color('tool');
+const rightFingerPart = arm.part('right-finger', rightFinger);
 
 // 14. Elbow-pitch shaft (cosmetic axle stubs at the forearm root).
 //     Two short stubs protruding from each side of the forearm beam; a
@@ -341,8 +367,7 @@ const elbowPitchShaftPart = arm.part('elbow-pitch-shaft', elbowPitchShaft);
 const baseTopZNum     = 6 + 38 + 4;          // plateT + servoH + hornT
 const shoulderPitchZNum = 50;                // shoulderColumnH default
 const upperArmLenNum  = 140;                 // upperArmLen default
-const forearmLenNum   = 120;                 // forearmLen default
-const toolTipXNum     = forearmLenNum + 1 + 6 + 4; // gripperPlateGap + plateT + pin offset
+const toolTipXNum     = gripperHingeXNum + gripperFingerLen;
 
 // ---- connectors on each part --------------------------------------------
 // base-plate: hosts the two fastened mounts (servo, output horn) AND the
@@ -464,9 +489,49 @@ gripperPlatePart
     type: 'frame',
     origin: { kind: 'vec3', value: [0, 0, 0] },
   })
+  .connector('grip-axis', {
+    type: 'axis',
+    origin: { kind: 'vec3', value: [gripDriverXNum, 0, gripDriverZNum] },
+    axis: [0, 0, 1],
+  })
+  .connector('left-hinge', {
+    type: 'axis',
+    origin: { kind: 'vec3', value: [gripperHingeXNum, gripperHingeY, 0] },
+    axis: [0, 0, 1],
+  })
+  .connector('right-hinge', {
+    type: 'axis',
+    origin: { kind: 'vec3', value: [gripperHingeXNum, -gripperHingeY, 0] },
+    axis: [0, 0, 1],
+  })
   .connector('tool-tip', {
     type: 'frame',
     origin: { kind: 'vec3', value: [toolTipXNum, 0, 0] },
+  });
+gripDriverPart.connector('axis', {
+  type: 'axis',
+  origin: { kind: 'vec3', value: [0, 0, 0] },
+  axis: [0, 0, 1],
+});
+leftFingerPart
+  .connector('hinge', {
+    type: 'axis',
+    origin: { kind: 'vec3', value: [0, 0, 0] },
+    axis: [0, 0, 1],
+  })
+  .connector('tip', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [gripperFingerLen, 0, 0] },
+  });
+rightFingerPart
+  .connector('hinge', {
+    type: 'axis',
+    origin: { kind: 'vec3', value: [0, 0, 0] },
+    axis: [0, 0, 1],
+  })
+  .connector('tip', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [gripperFingerLen, 0, 0] },
   });
 elbowPitchShaftPart.connector('mount', {
   type: 'frame',
@@ -504,6 +569,14 @@ arm.mate('elbow-pitch', 'upper-arm-beam.elbow-out', 'forearm-beam.elbow-in', 're
   limitsDeg: [-55, 80],
 });
 arm.mate('gripper-plate-fix',     'forearm-beam.gripper-mount',     'gripper-plate.mount',     'fastened');
+arm.mate('grip', 'gripper-plate.grip-axis', 'grip-driver.axis', 'revolute', {
+  pose: gripDeg,
+  limitsDeg: [0, 42],
+});
+arm.mate('left-curl', 'gripper-plate.left-hinge', 'left-finger.hinge', 'revolute');
+arm.mate('right-curl', 'gripper-plate.right-hinge', 'right-finger.hinge', 'revolute');
+arm.coupleMates('left-curl', { source: 'grip', ratio: -1 });
+arm.coupleMates('right-curl', { source: 'grip', ratio: 1 });
 arm.mate('elbow-pitch-shaft-fix', 'forearm-beam.elbow-shaft-mount', 'elbow-pitch-shaft.mount', 'fastened');
 
 // ---- POSE ---------------------------------------------------------------

--- a/src/backends/occt/occtLowerer.ts
+++ b/src/backends/occt/occtLowerer.ts
@@ -11,6 +11,7 @@ import { isValidPlaneSpec } from '../../intent/types';
 import { forwardKinematics, type NumericPoses } from '../../capture/forwardKinematics';
 import type { AssemblyJointStored, AssemblyPartStored } from '../../capture/assembly';
 import { mateFk, type ResolvedMatePart } from '../../lib/mates/solver';
+import { expandCoupledPoses, type MateCouplingRecord } from '../../lib/mates/coupledPoses';
 import type { Connector } from '../../lib/mates/connector';
 import type { MateRecord } from '../../lib/mates/mate';
 import type { MateType } from '../../lib/mates/mateTypes';
@@ -1403,12 +1404,14 @@ export class OcctLowerer implements FeatureLowerer {
           jointIds?: FeatureId[];
           poses?: Record<string, EncodedPose>;
           mates?: EncodedMate[];
+          couplings?: readonly MateCouplingRecord[];
           connectorsByPartId?: Record<FeatureId, readonly Connector[]>;
         } | undefined;
         const partIds = meta?.partIds ?? [];
         const jointIds = meta?.jointIds ?? [];
         const encodedPoses = meta?.poses ?? {};
         const encodedMates: readonly EncodedMate[] = meta?.mates ?? [];
+        const mateCouplings = meta?.couplings ?? [];
         const connectorsByPartId = meta?.connectorsByPartId ?? {};
 
         const partEntries = Object.entries(inputs.byKey)
@@ -1654,7 +1657,8 @@ export class OcctLowerer implements FeatureLowerer {
             b: m.b,
             type: m.type,
           }));
-          const mateWorldT = mateFk(resolvedParts, mates, matePoses);
+          const expandedMatePoses = expandCoupledPoses(mates, mateCouplings, matePoses);
+          const mateWorldT = mateFk(resolvedParts, mates, expandedMatePoses);
           // Merge: mate-derived transforms WIN over joint-derived transforms.
           // Disconnected-from-mates parts retain their joint-FK transform (or
           // identity if no joint either). This is the explicit precedence

--- a/src/capture/assembly.ts
+++ b/src/capture/assembly.ts
@@ -805,7 +805,11 @@ export class Assembly {
         pose: { kind: 'scalar', value: toParam(m.pose, 'deg') },
       };
     });
-    return { connectorsByPartId, mates: encodedMates };
+    return {
+      connectorsByPartId,
+      mates: encodedMates,
+      couplings: [...this.mateCouplings],
+    };
   }
 
   /**

--- a/src/capture/captureSession.ts
+++ b/src/capture/captureSession.ts
@@ -18,6 +18,7 @@ import type { Editable } from '../runtime/paramRef';
 import type { ShapeBackend } from '../backends/backend';
 import { KernelError } from '../intent/kernelError';
 import type { Connector } from '../lib/mates/connector';
+import type { MateCouplingRecord } from '../lib/mates/coupledPoses';
 import type { MateType } from '../lib/mates/mateTypes';
 
 /**
@@ -37,6 +38,7 @@ import type { MateType } from '../lib/mates/mateTypes';
 export interface SolvedAssemblyMateMetadata {
   readonly connectorsByPartId: Record<FeatureId, readonly Connector[]>;
   readonly mates: readonly EncodedMateRecord[];
+  readonly couplings?: readonly MateCouplingRecord[];
 }
 
 /** Mate record with `pose` encoded for the recompute pipeline. Mirrors
@@ -549,6 +551,7 @@ export class CaptureSession {
         ...(mateMetadata !== undefined && mateMetadata.mates.length > 0
           ? {
               mates: mateMetadata.mates,
+              couplings: mateMetadata.couplings ?? [],
               connectorsByPartId: mateMetadata.connectorsByPartId,
             }
           : {}),

--- a/tests/integration/examples/desktop3axisMates.test.ts
+++ b/tests/integration/examples/desktop3axisMates.test.ts
@@ -3,14 +3,14 @@
 //
 // The hero is a mate-driven rewrite of the v0.5 `desktop-3axis.kcad.ts`:
 // parts authored in their own local frames, mate-FK (`solveMates`) plants
-// them. Same body-tree topology, same geometry parameters, swap
-// `arm.fixed/.revolute` → `arm.mate(...)`.
+// them. It now keeps the existing arm hero and adds a functional terminal
+// gripper driven by one grip mate plus two coupled finger curls.
 //
 // Three checks:
 //   1. Evaluate end-to-end via `evaluateAndBuildScript` — the harness flips
 //      the validate-gate default to `'error'`, so any error-severity
 //      diagnostic surfaces as a non-zero exitCode.
-//   2. Inventory the FeatureRecords: 12 parts (one per `arm.part(...)`),
+//   2. Inventory the FeatureRecords: 16 parts (one per `arm.part(...)`),
 //      no `assemblyJoint` records (the v0.6 vocabulary doesn't emit them),
 //      trailing `solvedAssembly`.
 //   3. Run via `runScript` and assert per-part `worldTransform`s reflect
@@ -46,13 +46,14 @@ describe('desktop-3axis-mates hero (v0.6)', () => {
     const parts = records.filter((r) => r.kind === 'assemblyPart');
     const joints = records.filter((r) => r.kind === 'assemblyJoint');
 
-    // 12 parts: base-plate, base-yaw-servo, base-yaw-output, shoulder-column,
+    // 16 parts: base-plate, base-yaw-servo, base-yaw-output, shoulder-column,
     // shoulder-cheeks, shoulder-pitch-servo, upper-arm-beam, elbow-yoke,
     // elbow-pitch-servo, shoulder-pitch-shaft, forearm-beam, gripper-plate,
-    // elbow-pitch-shaft. (Twelve revolute + fastened mates, but mates don't
+    // grip-driver, left-finger, right-finger, elbow-pitch-shaft.
+    // (Fifteen revolute + fastened mates, but mates don't
     // emit `assemblyJoint` records — they ride on the assembly's mate list
     // and surface on `Scene.mates`.)
-    expect(parts.length).toBe(13);
+    expect(parts.length).toBe(16);
     expect(joints.length).toBe(0);
 
     // The trailing capture-time record is the solvedAssembly, which the
@@ -71,9 +72,10 @@ describe('desktop-3axis-mates hero (v0.6)', () => {
     expect(returnValue).toBeInstanceOf(Scene);
     const scene = returnValue as Scene;
 
-    // Hero declares 13 parts and 12 mates (3 revolute, 9 fastened).
-    expect(scene.parts.length).toBe(13);
-    expect(scene.mates?.length).toBe(12);
+    // Hero declares 16 parts and 15 mates (6 revolute, 9 fastened). The
+    // terminal gripper has one actuator mate that drives two finger curls.
+    expect(scene.parts.length).toBe(16);
+    expect(scene.mates?.length).toBe(15);
     expect(scene.mates?.filter((m) => m.type === 'revolute').map((m) => ({
       name: m.name,
       limitsDeg: m.limitsDeg,
@@ -81,8 +83,13 @@ describe('desktop-3axis-mates hero (v0.6)', () => {
       { name: 'base-yaw', limitsDeg: [-180, 180] },
       { name: 'shoulder-pitch', limitsDeg: [35, 39] },
       { name: 'elbow-pitch', limitsDeg: [-55, 80] },
+      { name: 'grip', limitsDeg: [0, 42] },
+      { name: 'left-curl', limitsDeg: undefined },
+      { name: 'right-curl', limitsDeg: undefined },
     ]);
     expect(scene.part('gripper-plate').connectors?.some((c) => c.name === 'tool-tip')).toBe(true);
+    expect(scene.part('left-finger').connectors?.some((c) => c.name === 'tip')).toBe(true);
+    expect(scene.part('right-finger').connectors?.some((c) => c.name === 'tip')).toBe(true);
 
     // Base-plate is the root — its worldTransform should be identity
     // (origin at world origin).
@@ -114,7 +121,7 @@ describe('desktop-3axis-mates hero (v0.6)', () => {
 
   it('reports zero interferences at default poses', async () => {
     // Industry-standard clash detection (BREP common-volume) over the
-    // 13-part mate-driven assembly. The v0.6 hero ships with all parts
+    // 16-part mate-driven assembly. The v0.6 hero ships with all parts
     // verified non-interfering at the default articulation
     // (baseYawDeg=20°, shoulderPitchDeg=35°, elbowPitchDeg=-55°).
     const code = await readFile(EXAMPLE_ABSOLUTE, 'utf8');
@@ -126,14 +133,18 @@ describe('desktop-3axis-mates hero (v0.6)', () => {
       ignorePairs: new Set<string>(),
     });
 
-    expect(result.partCount).toBe(13);
+    expect(result.partCount).toBe(16);
     expect(result.pairs).toEqual([]);
   }, 180_000);
 
   it('passes the functional review loop with non-trivial tool-tip workspace', async () => {
     const result = await reviewCadTool({
       file: EXAMPLE_PATH,
-      trackConnectors: ['gripper-plate.tool-tip'],
+      trackConnectors: ['gripper-plate.tool-tip', 'left-finger.tip', 'right-finger.tip'],
+      gripperAperture: {
+        left: 'left-finger.tip',
+        right: 'right-finger.tip',
+      },
     });
 
     expect(result.ok).toBe(true);
@@ -148,10 +159,15 @@ describe('desktop-3axis-mates hero (v0.6)', () => {
         'shoulder-pitch:max',
         'elbow-pitch:min',
         'elbow-pitch:max',
+        'grip:min',
+        'grip:max',
       ]);
-      expect(result.connectorWorkspace).toHaveLength(1);
+      expect(result.connectorWorkspace).toHaveLength(3);
       expect(result.connectorWorkspace?.[0].ref).toBe('gripper-plate.tool-tip');
       expect(result.connectorWorkspace?.[0].travelMm).toBeGreaterThan(50);
+      expect(result.gripperAperture?.maxMm).toBeGreaterThan(result.gripperAperture?.minMm ?? 0);
+      expect(result.gripperAperture?.travelMm).toBeGreaterThan(15);
+      expect(result.fitness.passedChecks).toContain('gripper-aperture-moves');
     }
   }, 240_000);
 

--- a/tests/integration/lowering/solvedAssemblyMateFk.test.ts
+++ b/tests/integration/lowering/solvedAssemblyMateFk.test.ts
@@ -115,4 +115,28 @@ describe('solvedAssembly lowerer — mate-FK integration (v0.6 T17)', () => {
     // X bbox is now dominated by parent (10x10), not child.
     expect(bb90.max[0]).toBeLessThan(11);
   });
+
+  it('expands coupled mate poses before rendering solvedAssembly', async () => {
+    const { shape, diagnostics } = await lowerScript(`
+      const arm = assembly('coupled-render');
+      const parent = arm.part('parent', box(4, 4, 4, true));
+      parent
+        .connector('driver', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] })
+        .connector('hinge', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+      const driver = arm.part('driver', cylinder(2, 2));
+      driver.connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+      const finger = arm.part('finger', box(20, 4, 4, false));
+      finger.connector('hinge', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+      arm.mate('grip', 'parent.driver', 'driver.axis', 'revolute', { pose: 90 });
+      arm.mate('curl', 'parent.hinge', 'finger.hinge', 'revolute');
+      arm.coupleMates('curl', { source: 'grip', ratio: 1 });
+      return (await arm.solvedModel({}, { validate: 'off' })).toCompound();
+    `);
+
+    expect(diagnostics.filter(d => d.severity === 'error')).toEqual([]);
+    expect(shape).toBeDefined();
+    const bb = shape!.boundingBox();
+    expect(bb.max[1]).toBeGreaterThan(15);
+    expect(bb.max[0]).toBeLessThan(6);
+  });
 });


### PR DESCRIPTION
## Summary
- upgrade the existing desktop 3-axis hero with a real grip actuator and coupled left/right finger curls
- carry mate coupling metadata into solvedAssembly so rendered output follows the same loop state as solve/review tools
- extend hero review coverage with fingertip tracking and aperture movement checks

## Loop Evidence
- review loop reports zero blocking reasons and zero interference pairs
- gripper aperture moves from ~56.0 mm open to ~10.5 mm closed, ~45.5 mm travel
- exposed and fixed the render gap where solvedModel ignored coupled mate poses

## Verification
- npm run typecheck
- npm run lint
- npm test -- --run tests/integration/lowering/solvedAssemblyMateFk.test.ts tests/integration/examples/desktop3axisMates.test.ts src/lib/mates/coupledPoses.test.ts src/lib/mates/gripperAperture.test.ts tests/integration/mcp/reviewCad.test.ts tests/integration/mcp/solveMates.test.ts
- npm run build:cli
- git diff --check