### PR TITLE
feat: add mechanical plausibility review gate

### DIFF
--- a/src/lib/mates/mechanicalPlausibility.ts
+++ b/src/lib/mates/mechanicalPlausibility.ts
@@ -1,0 +1,85 @@
+import type { Assembly } from '../../capture/assembly';
+import type { Vec3 } from '../../intent/types';
+import { parseConnectorRef } from './mate';
+
+export interface MechanicalPlausibilityDiagnostic {
+  readonly code: 'assembly.mechanical.connector-not-in-solid';
+  readonly severity: 'error';
+  readonly message: string;
+  readonly hint: string;
+  readonly mateName: string;
+  readonly partName: string;
+  readonly connectorName: string;
+  readonly connectorRef: string;
+  readonly distanceMm: number;
+  readonly bbox: { min: Vec3; max: Vec3 };
+}
+
+export interface MechanicalPlausibilityResult {
+  readonly diagnostics: readonly MechanicalPlausibilityDiagnostic[];
+  readonly checkedMateConnectorCount: number;
+}
+
+const CONNECTOR_SOLID_TOL_MM = 6;
+
+export async function reviewMechanicalPlausibility(
+  arm: Assembly,
+): Promise<MechanicalPlausibilityResult> {
+  const diagnostics: MechanicalPlausibilityDiagnostic[] = [];
+  const partsByName = new Map(arm.__parts().map((part) => [part.name, part]));
+  const boundsByPartName = new Map<string, { min: Vec3; max: Vec3 }>();
+  let checkedMateConnectorCount = 0;
+
+  for (const mate of arm.__mates()) {
+    for (const connectorRef of [mate.a, mate.b]) {
+      const parsed = parseConnectorRef(connectorRef);
+      const part = partsByName.get(parsed.partName);
+      const connector = part?.mateConnectors.find((c) => c.name === parsed.connectorName);
+      if (part === undefined || connector === undefined || connector.origin.kind !== 'vec3') continue;
+
+      checkedMateConnectorCount += 1;
+      let bbox = boundsByPartName.get(part.name);
+      if (bbox === undefined) {
+        bbox = (await part.originalShape.lower()).boundingBox();
+        boundsByPartName.set(part.name, bbox);
+      }
+
+      const distanceMm = distanceOutsideExpandedBbox(connector.origin.value, bbox, CONNECTOR_SOLID_TOL_MM);
+      if (distanceMm === 0) continue;
+
+      diagnostics.push({
+        code: 'assembly.mechanical.connector-not-in-solid',
+        severity: 'error',
+        mateName: mate.name,
+        partName: part.name,
+        connectorName: parsed.connectorName,
+        connectorRef,
+        distanceMm,
+        bbox,
+        message: `Mate '${mate.name}' connector '${connectorRef}' is ${distanceMm.toFixed(1)} mm away from modeled material on part '${part.name}'.`,
+        hint: `mechanical-plausibility.connector-not-in-solid — move '${connectorRef}' onto the part's modeled bearing/bracket/knuckle, or add support geometry around that connector so the mate has a physical load path.`,
+      });
+    }
+  }
+
+  return { diagnostics, checkedMateConnectorCount };
+}
+
+function distanceOutsideExpandedBbox(
+  point: Vec3,
+  bbox: { min: Vec3; max: Vec3 },
+  toleranceMm: number,
+): number {
+  let d2 = 0;
+  for (let axis = 0; axis < 3; axis++) {
+    const min = bbox.min[axis] - toleranceMm;
+    const max = bbox.max[axis] + toleranceMm;
+    const value = point[axis];
+    if (value < min) {
+      d2 += (min - value) ** 2;
+    } else if (value > max) {
+      d2 += (value - max) ** 2;
+    }
+  }
+  return Math.sqrt(d2);
+}

--- a/src/lib/mates/mechanismFitness.test.ts
+++ b/src/lib/mates/mechanismFitness.test.ts
@@ -6,6 +6,7 @@ import {
 } from './mechanismFitness';
 import type { PoseEnvelopeReviewResult } from './poseEnvelope';
 import type { ValidatorDiagnostic } from './validator';
+import type { MechanicalPlausibilityDiagnostic } from './mechanicalPlausibility';
 
 function mkPoseEnvelope(overrides: Partial<PoseEnvelopeReviewResult> = {}): PoseEnvelopeReviewResult {
   return {
@@ -32,6 +33,21 @@ function mkBlockingReasonFromValidatorDiagnostic(code: ValidatorDiagnostic['code
     severity: 'error',
     message: `${code} error`,
     hint: `${code} hint`,
+  };
+}
+
+function mkMechanicalDiagnostic(): MechanicalPlausibilityDiagnostic {
+  return {
+    code: 'assembly.mechanical.connector-not-in-solid',
+    severity: 'error',
+    message: 'connector is away from modeled material',
+    hint: 'add support geometry',
+    mateName: 'yaw',
+    partName: 'link',
+    connectorName: 'axis',
+    connectorRef: 'link.axis',
+    distanceMm: 42,
+    bbox: { min: [50, -2, -2], max: [70, 2, 2] },
   };
 }
 
@@ -104,6 +120,18 @@ describe('summarizeMechanismFitness', () => {
     expect(result.blockingReasons).toHaveLength(1);
     expect(result.blockingReasons[0].code).toBe('assembly.solver.did-not-converge');
     expect(result.passedChecks).toEqual(['pose-envelope-solved', 'pose-envelope-no-interference']);
+  });
+
+  it('returns functional=false for mechanical plausibility diagnostics', () => {
+    const result = summarizeMechanismFitness({
+      mechanicalPlausibilityDiagnostics: [mkMechanicalDiagnostic()],
+      poseEnvelope: mkPoseEnvelope(),
+    });
+
+    expect(result.functional).toBe(false);
+    expect(result.blockingReasons).toHaveLength(1);
+    expect(result.blockingReasons[0].code).toBe('assembly.mechanical.connector-not-in-solid');
+    expect(result.mechanismSummary.mechanicalPlausibilityIssueCount).toBe(1);
   });
 
   it('returns functional=false when no requested tracked connectors are in pose-envelope workspace', () => {

--- a/src/lib/mates/mechanismFitness.ts
+++ b/src/lib/mates/mechanismFitness.ts
@@ -1,5 +1,6 @@
 import type { PoseEnvelopeReviewResult } from './poseEnvelope';
 import type { ValidatorDiagnostic } from './validator';
+import type { MechanicalPlausibilityDiagnostic } from './mechanicalPlausibility';
 
 export interface MechanismBlockingReason {
   readonly code: string;
@@ -16,6 +17,7 @@ export interface MechanismSummary {
   readonly gripperApertureMinMm?: number;
   readonly gripperApertureMaxMm?: number;
   readonly gripperApertureTravelMm?: number;
+  readonly mechanicalPlausibilityIssueCount?: number;
 }
 
 export interface MechanismFitnessResult {
@@ -27,6 +29,7 @@ export interface MechanismFitnessResult {
 
 export interface MechanismFitnessInput {
   readonly validatorDiagnostics?: readonly ValidatorDiagnostic[];
+  readonly mechanicalPlausibilityDiagnostics?: readonly MechanicalPlausibilityDiagnostic[];
   readonly poseEnvelope?: PoseEnvelopeReviewResult;
   readonly trackConnectors?: readonly string[];
 }
@@ -43,6 +46,7 @@ export function summarizeMechanismFitness(
   input: MechanismFitnessInput = {},
 ): MechanismFitnessResult {
   const validatorDiagnostics = input.validatorDiagnostics ?? [];
+  const mechanicalPlausibilityDiagnostics = input.mechanicalPlausibilityDiagnostics ?? [];
   const poseEnvelope = input.poseEnvelope;
   const trackConnectors = input.trackConnectors ?? [];
 
@@ -71,6 +75,15 @@ export function summarizeMechanismFitness(
 
   if (!hasValidatorErrors) {
     passedChecks.push(PASSED_CHECKS.validatorNoErrors);
+  }
+
+  for (const diagnostic of mechanicalPlausibilityDiagnostics) {
+    addBlockingReason(
+      diagnostic.code,
+      diagnostic.message,
+      diagnostic.hint,
+      diagnostic,
+    );
   }
 
   const hasPoseEnvelopeErrors = poseEnvelope?.diagnostics.some((diagnostic) => diagnostic.severity === 'error') ?? false;
@@ -144,6 +157,7 @@ export function summarizeMechanismFitness(
 
   const sampleCount = poseEnvelope?.samples.length ?? 0;
   const interferenceCount = poseEnvelope?.interferencePairs.length ?? 0;
+  const mechanicalPlausibilityIssueCount = mechanicalPlausibilityDiagnostics.length;
 
   return {
     functional: blockingReasons.length === 0,
@@ -159,6 +173,7 @@ export function summarizeMechanismFitness(
         gripperApertureMaxMm: poseEnvelope.gripperAperture.maxMm,
         gripperApertureTravelMm: poseEnvelope.gripperAperture.travelMm,
       }),
+      ...(mechanicalPlausibilityIssueCount === 0 ? {} : { mechanicalPlausibilityIssueCount }),
     },
   };
 }

--- a/src/mcp/toolRegistry.ts
+++ b/src/mcp/toolRegistry.ts
@@ -510,7 +510,7 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
   {
     definition: {
       name: 'review_cad',
-      description: 'Run the deterministic CAD review loop: evaluate the script, validate the assembly/mate graph, sample declared mate limits, optionally check interferences at sampled poses, report connector workspace bounds, and return a mechanism fitness verdict for agent self-review.',
+      description: 'Run the deterministic CAD review loop: evaluate the script, validate the assembly/mate graph, check mate connectors touch modeled material, sample declared mate limits, optionally check interferences at sampled poses, report connector workspace bounds, and return a mechanism fitness verdict for agent self-review.',
       inputSchema: {
         type: 'object',
         properties: {

--- a/src/mcp/tools/reviewCad.ts
+++ b/src/mcp/tools/reviewCad.ts
@@ -10,6 +10,10 @@ import {
 import type { GripperApertureRequest } from '../../lib/mates/gripperAperture';
 import type { PoseEnvelopeDiagnostic, PoseEnvelopeReviewResult } from '../../lib/mates/poseEnvelope';
 import { reviewPoseEnvelope } from '../../lib/mates/poseEnvelope';
+import {
+  reviewMechanicalPlausibility,
+  type MechanicalPlausibilityDiagnostic,
+} from '../../lib/mates/mechanicalPlausibility';
 import type { ValidatorDiagnostic, ValidatorStatus } from '../../lib/mates/validator';
 import { validateAssemblyWithMates } from '../../lib/mates/validator';
 import { clearActiveMcpSession, setActiveMcpSession } from '../activeSession';
@@ -29,7 +33,7 @@ export type ReviewCadOutput =
   | {
       ok: true;
       featureCount: number;
-      diagnostics: Array<CompilerDiagnostic | ValidatorDiagnostic | PoseEnvelopeDiagnostic>;
+      diagnostics: Array<CompilerDiagnostic | ValidatorDiagnostic | PoseEnvelopeDiagnostic | MechanicalPlausibilityDiagnostic>;
       assembly: string;
       validator: {
         status: ValidatorStatus;
@@ -45,7 +49,7 @@ export type ReviewCadOutput =
   | {
       ok: false;
       featureCount: number;
-      diagnostics: Array<CompilerDiagnostic | ValidatorDiagnostic | PoseEnvelopeDiagnostic>;
+      diagnostics: Array<CompilerDiagnostic | ValidatorDiagnostic | PoseEnvelopeDiagnostic | MechanicalPlausibilityDiagnostic>;
       assembly?: string;
       validator?: {
         status: ValidatorStatus;
@@ -92,6 +96,7 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
   }
 
   const validator = await validateAssemblyWithMates(arm);
+  const mechanicalPlausibility = await reviewMechanicalPlausibility(arm);
   const includePoseEnvelope = input.includePoseEnvelope ?? true;
   const poseEnvelope = includePoseEnvelope
     ? await reviewPoseEnvelope(arm, {
@@ -105,10 +110,12 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
   const diagnostics = [
     ...withNextActions(evaluation.diagnostics),
     ...validator.diagnostics,
+    ...mechanicalPlausibility.diagnostics,
     ...(poseEnvelope?.diagnostics ?? []),
   ];
   const fitness = summarizeMechanismFitness({
     validatorDiagnostics: validator.diagnostics,
+    mechanicalPlausibilityDiagnostics: mechanicalPlausibility.diagnostics,
     poseEnvelope,
     trackConnectors: poseEnvelope !== undefined ? input.trackConnectors : undefined,
   });
@@ -178,7 +185,7 @@ function selectAssembly(
 }
 
 function buildSuggestedRepairPrompt(
-  diagnostics: readonly (CompilerDiagnostic | ValidatorDiagnostic | PoseEnvelopeDiagnostic)[],
+  diagnostics: readonly (CompilerDiagnostic | ValidatorDiagnostic | PoseEnvelopeDiagnostic | MechanicalPlausibilityDiagnostic)[],
   blockingReasons: readonly MechanismBlockingReason[] = [],
 ): string {
   if (diagnostics.length === 0 && blockingReasons.length === 0) {

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -728,10 +728,10 @@ MCP tools mirror the `.kcad.ts` surface for runtime introspection:
   name; coupled driven mates are expanded from their source mate before solve.
 - `review_cad({ file? | code?, assembly?, includePoseEnvelope?, includeInterference?, epsilonMm3?, trackConnectors?, gripperAperture? })` —
   run the deterministic agent review loop: evaluate, validate mates, sample
-  declared pose limits, report connector workspace bounds, and return raw
-  diagnostics plus a fitness summary (`fitness.functional`,
-  `fitness.blockingReasons`, `fitness.mechanismSummary`) after an assembly is
-  selected. Pass
+  declared pose limits, check that mate connectors touch modeled material,
+  report connector workspace bounds, and return raw diagnostics plus a fitness
+  summary (`fitness.functional`, `fitness.blockingReasons`,
+  `fitness.mechanismSummary`) after an assembly is selected. Pass
   `trackConnectors: ['gripper-plate.tool-tip']` to focus workspace output on an
   end-effector; connector workspace is only computed when pose-envelope
   sampling is enabled. For grippers, pass
@@ -944,7 +944,7 @@ When you have `kernelcad mcp` available, use the MCP tools for dynamic introspec
 - `list_mates({ assembly? })` — return the declared mate records on the active assembly: `{ mates: [{ name, a, b, type, pose?, limitsDeg?, limitsMm? }, ...] }`.
 - `validate_assembly({ assembly? })` — run the mate-aware validator on the active assembly; returns `{ status, diagnostics, partCount, jointCount }` where each diagnostic carries `code` and `hint` for recovery.
 - `solve_mates({ assembly?, poses? })` — run the v0.6 mate-graph solver on the active assembly; returns `{ status, poses, iterations? }` with each pose serialized as `{ translation, rotateAxis, rotateDeg }`. The `poses` input overrides mate pose values by mate name; coupled driven mates are expanded from their source mate before solve.
-- `review_cad({ file? | code?, assembly?, includePoseEnvelope?, includeInterference?, epsilonMm3?, trackConnectors?, gripperAperture? })` — evaluate a script, validate its assembly/mate graph, sample declared mate limits, optionally run BREP interference checks at those samples, report connector workspace bounds, optionally report gripper aperture between two fingertip connector refs, and return raw diagnostics plus a fitness summary (`fitness.functional`, `fitness.blockingReasons`, `fitness.mechanismSummary`) after an assembly is selected. Connector workspace and gripper aperture are only computed when pose-envelope sampling is enabled.
+- `review_cad({ file? | code?, assembly?, includePoseEnvelope?, includeInterference?, epsilonMm3?, trackConnectors?, gripperAperture? })` — evaluate a script, validate its assembly/mate graph, check that mate connectors touch modeled material, sample declared mate limits, optionally run BREP interference checks at those samples, report connector workspace bounds, optionally report gripper aperture between two fingertip connector refs, and return raw diagnostics plus a fitness summary (`fitness.functional`, `fitness.blockingReasons`, `fitness.mechanismSummary`) after an assembly is selected. Connector workspace and gripper aperture are only computed when pose-envelope sampling is enabled.
 
 ## Out of Scope
 

--- a/tests/integration/examples/desktop3axisMates.test.ts
+++ b/tests/integration/examples/desktop3axisMates.test.ts
@@ -137,7 +137,7 @@ describe('desktop-3axis-mates hero (v0.6)', () => {
     expect(result.pairs).toEqual([]);
   }, 180_000);
 
-  it('passes the functional review loop with non-trivial tool-tip workspace', async () => {
+  it('reports mechanical plausibility blockers for unsupported connector geometry', async () => {
     const result = await reviewCadTool({
       file: EXAMPLE_PATH,
       trackConnectors: ['gripper-plate.tool-tip', 'left-finger.tip', 'right-finger.tip'],
@@ -147,8 +147,8 @@ describe('desktop-3axis-mates hero (v0.6)', () => {
       },
     });
 
-    expect(result.ok).toBe(true);
-    if (result.ok) {
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
       expect(result.poseEnvelope?.diagnostics).toEqual([]);
       expect(result.poseEnvelope?.interferencePairs).toEqual([]);
       expect(result.poseEnvelope?.samples.map((s) => s.name)).toEqual([
@@ -167,7 +167,10 @@ describe('desktop-3axis-mates hero (v0.6)', () => {
       expect(result.connectorWorkspace?.[0].travelMm).toBeGreaterThan(50);
       expect(result.gripperAperture?.maxMm).toBeGreaterThan(result.gripperAperture?.minMm ?? 0);
       expect(result.gripperAperture?.travelMm).toBeGreaterThan(15);
-      expect(result.fitness.passedChecks).toContain('gripper-aperture-moves');
+      expect(result.fitness?.passedChecks).toContain('gripper-aperture-moves');
+      expect(result.fitness?.functional).toBe(false);
+      expect(result.fitness?.blockingReasons.some((reason) => reason.code === 'assembly.mechanical.connector-not-in-solid')).toBe(true);
+      expect(result.fitness?.mechanismSummary.mechanicalPlausibilityIssueCount).toBeGreaterThan(0);
     }
   }, 240_000);
 

--- a/tests/integration/mcp/reviewCad.test.ts
+++ b/tests/integration/mcp/reviewCad.test.ts
@@ -63,6 +63,30 @@ describe('review_cad MCP tool', () => {
     }
   });
 
+  it('blocks mechanically implausible mates whose connector is not on modeled material', async () => {
+    const r = await reviewCadTool({
+      includeInterference: false,
+      code: `
+        const arm = assembly('floating-hinge');
+        arm.part('base', box(20, 20, 8, true))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('link', box(30, 4, 4, true).translate(60, 0, 0))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', {
+          limitsDeg: [0, 90],
+        });
+        return arm.model();
+      `,
+    });
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.fitness?.functional).toBe(false);
+      expect(r.fitness?.blockingReasons.some((reason) => reason.code === 'assembly.mechanical.connector-not-in-solid')).toBe(true);
+      expect(r.suggestedRepairPrompt).toMatch(/assembly\.mechanical\.connector-not-in-solid/);
+    }
+  });
+
   it('reports gripper aperture travel for coupled fingertip connectors', async () => {
     const r = await reviewCadTool({
       includeInterference: false,
@@ -70,7 +94,7 @@ describe('review_cad MCP tool', () => {
       gripperAperture: { left: 'left.tip', right: 'right.tip' },
       code: `
         const arm = assembly('hand');
-        arm.part('base', box(10, 10, 2))
+        arm.part('base', box(30, 30, 4, true))
           .connector('driver', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] })
           .connector('left', { type: 'axis', origin: { kind: 'vec3', value: [-10, 0, 0] }, axis: [0, 0, 1] })
           .connector('right', { type: 'axis', origin: { kind: 'vec3', value: [10, 0, 0] }, axis: [0, 0, 1] });


### PR DESCRIPTION
## Summary
- add a mechanical plausibility pass to review_cad that rejects mate connectors which do not touch modeled material
- route those diagnostics into fitness.blockingReasons and suggested repair prompts
- update the desktop hero review test so the loop now catches the current unsupported connector geometry instead of calling it functional

## Why
The solver could previously pass assemblies where parts were kinematically connected but visually/mechanically floating. This gives agents deterministic feedback before claiming a robot hand or gripper is buildable.

## Verification
- npm run typecheck
- npm run lint
- npm test -- --run src/lib/mates/mechanismFitness.test.ts tests/integration/mcp/reviewCad.test.ts tests/integration/examples/desktop3axisMates.test.ts
- npm test -- --run src/lib/mates
- npm run build:cli
- git diff --check