### PR TITLE
Require structured visual review checks

### DIFF
--- a/src/mcp/toolRegistry.ts
+++ b/src/mcp/toolRegistry.ts
@@ -564,8 +564,43 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
           goal: { type: 'string', description: 'Original user design goal. Fed into every review_cad repair prompt.' },
           attempts: {
             type: 'array',
-            description: 'Ordered design attempts. Each item is { id?, title?, file? or code? }. File attempts can be replayed by Studio build records.',
-            items: { type: 'object' },
+            description: 'Ordered design attempts. Each item is { id?, title?, file? or code?, visualReview? }. File attempts can be replayed by Studio build records.',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                title: { type: 'string' },
+                file: { type: 'string' },
+                code: { type: 'string' },
+                visualReview: {
+                  type: 'object',
+                  description: 'Evidence from the reviewing agent after rendering/opening screenshots. Accepted reviews must include screenshotPath, concrete findings, and all required checks passing.',
+                  properties: {
+                    accepted: { type: 'boolean' },
+                    screenshotPath: { type: 'string' },
+                    findings: {
+                      type: 'array',
+                      items: { type: 'string' },
+                    },
+                    checks: {
+                      type: 'array',
+                      description: 'Required checklist entries: main-object-count, proportions-match-reference, required-visible-features, no-stray-or-floating-geometry, canonical-views-physically-coherent.',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          code: { type: 'string' },
+                          passed: { type: 'boolean' },
+                          finding: { type: 'string' },
+                          screenshotPath: { type: 'string' },
+                        },
+                        required: ['code', 'passed', 'finding'],
+                      },
+                    },
+                  },
+                  required: ['accepted', 'findings'],
+                },
+              },
+            },
           },
           assembly: { type: 'string' },
           preserveInterfaces: {
@@ -583,6 +618,7 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
           },
           gripperAperture: { type: 'object', description: 'Optional gripper aperture request forwarded to review_cad.' },
           stopOnPass: { type: 'boolean', description: 'Stop after the first attempt that is functional and passes the quality gate. Default true.' },
+          requireVisualReview: { type: 'boolean', description: 'Require screenshot-backed visualReview with structured checks before accepting an attempt. Default true; set false only for explicit non-visual batch checks.' },
           allowReviewWarnings: {
             type: 'array',
             items: { type: 'string' },

--- a/src/mcp/tools/designLoop.ts
+++ b/src/mcp/tools/designLoop.ts
@@ -16,6 +16,14 @@ export interface DesignLoopVisualReview {
   accepted: boolean;
   screenshotPath?: string;
   findings: string[];
+  checks?: DesignLoopVisualReviewCheck[];
+}
+
+export interface DesignLoopVisualReviewCheck {
+  code: string;
+  passed: boolean;
+  finding: string;
+  screenshotPath?: string;
 }
 
 export interface DesignLoopInput {
@@ -234,19 +242,19 @@ function visualReviewFacts(
   const missingCode = 'assembly.visual.review-required';
   const rejectedCode = 'assembly.visual.review-rejected';
   const incompleteCode = 'assembly.visual.review-incomplete';
-  if (
-    allowReviewWarnings.includes(missingCode)
-    || allowReviewWarnings.includes(rejectedCode)
-    || allowReviewWarnings.includes(incompleteCode)
-  ) return [];
+  const failedCheckCode = 'assembly.visual.review-check-failed';
+  const fact = (code: string, message: string, hint: string) =>
+    allowReviewWarnings.includes(code)
+      ? []
+      : [{ code, severity: 'warning', message, hint }];
+
   if (!requireVisualReview) return [];
   if (visualReview === undefined) {
-    return [{
-      code: missingCode,
-      severity: 'warning',
-      message: 'This design-loop run requires screenshot review, but the attempt has no visualReview result.',
-      hint: 'visual-review.required — render screenshots from Studio/demo-player, inspect whether the model visually matches the requested physical mechanism, then attach visualReview with screenshotPath, findings, and accepted.',
-    }];
+    return fact(
+      missingCode,
+      'This design-loop run requires screenshot review, but the attempt has no visualReview result.',
+      'visual-review.required — render screenshots from Studio/demo-player, inspect whether the model visually matches the requested physical mechanism, then attach visualReview with screenshotPath, findings, checks, and accepted.',
+    );
   }
   if (visualReview.accepted) {
     const missing: string[] = [];
@@ -256,20 +264,60 @@ function visualReviewFacts(
     if (visualReview.findings.length === 0 || visualReview.findings.every((finding) => finding.trim() === '')) {
       missing.push('findings');
     }
-    if (missing.length === 0) return [];
-    return [{
-      code: incompleteCode,
-      severity: 'warning',
-      message: `Accepted screenshot review is incomplete; missing ${missing.join(' and ')}.`,
-      hint: 'visual-review.incomplete — as the vision-capable agent, render or open a screenshot, inspect it for floating parts, unsupported joints, disconnected drive paths, arbitrary fragments, occluded code/model mismatch, and then record screenshotPath plus concrete findings before accepting.',
-    }];
+    if (visualReview.checks === undefined || visualReview.checks.length === 0) {
+      missing.push('visualReview.checks');
+    }
+    const checkResults = visualReview.checks ?? [];
+    const missingCheckCodes = requiredVisualReviewCheckCodes().filter((code) =>
+      !checkResults.some((check) => check.code === code),
+    );
+    if (missingCheckCodes.length > 0) {
+      missing.push(`checks for ${missingCheckCodes.join(', ')}`);
+    }
+    const checksMissingFindings = checkResults
+      .filter((check) => check.finding.trim() === '')
+      .map((check) => check.code);
+    if (checksMissingFindings.length > 0) {
+      missing.push(`check findings for ${checksMissingFindings.join(', ')}`);
+    }
+    if (missing.length === 0) {
+      const failedChecks = checkResults.filter((check) => !check.passed);
+      if (failedChecks.length === 0) return [];
+      return fact(
+        failedCheckCode,
+        `Accepted screenshot review has failed checks: ${failedChecks.map((check) => `${check.code}: ${check.finding}`).join(' ')}`,
+        'visual-review.check-failed — an accepted visual review cannot contain failed checks. Repair the specific failed visual checks, render screenshots again, and only accept when every required check passes.',
+      );
+    }
+    return fact(
+      incompleteCode,
+      `Accepted screenshot review is incomplete; missing ${missing.join(' and ')}.`,
+      'visual-review.incomplete — as the vision-capable agent, render or open screenshots, inspect them against the required visualReview.checks checklist, and record screenshotPath plus concrete findings before accepting.',
+    );
   }
-  return [{
-    code: rejectedCode,
-    severity: 'warning',
-    message: `Screenshot review rejected this attempt: ${visualReview.findings.join(' ')}`,
-    hint: 'visual-review.rejected — redesign from the prompt or a mechanism primitive, render screenshots again, and only set accepted when the model is visually/mechanically legible.',
-  }];
+  const failedChecks = (visualReview.checks ?? []).filter((check) => !check.passed);
+  if (failedChecks.length > 0) {
+    return fact(
+      failedCheckCode,
+      `Screenshot review failed required checks: ${failedChecks.map((check) => `${check.code}: ${check.finding}`).join(' ')}`,
+      'visual-review.check-failed — repair the specific failed visual checks, render screenshots again, and only accept when every required check passes.',
+    );
+  }
+  return fact(
+    rejectedCode,
+    `Screenshot review rejected this attempt: ${visualReview.findings.join(' ')}`,
+    'visual-review.rejected — redesign from the prompt or a mechanism primitive, render screenshots again, and only set accepted when the model is visually/mechanically legible.',
+  );
+}
+
+function requiredVisualReviewCheckCodes(): readonly string[] {
+  return [
+    'main-object-count',
+    'proportions-match-reference',
+    'required-visible-features',
+    'no-stray-or-floating-geometry',
+    'canonical-views-physically-coherent',
+  ];
 }
 
 function countPattern(source: string, pattern: RegExp): number {

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -749,12 +749,17 @@ for runtime introspection:
   attempts that still have unresolved warnings, return repair prompts, and
   optionally write a Studio replay record. Visual review is required by
   default: each accepted attempt must include `visualReview: { accepted,
-  screenshotPath, findings }` after the vision-capable agent renders/opens the
-  screenshot and records concrete observations. Missing `screenshotPath` or
-  empty `findings` fails with `assembly.visual.review-incomplete`. Use
-  `requireVisualReview: false` only for explicit non-visual batch checks. Only
-  use `allowReviewWarnings` when the original prompt explicitly permits that
-  warning code.
+  screenshotPath, findings, checks }` after the vision-capable agent
+  renders/opens screenshots and records concrete observations. Accepted
+  reviews must pass these checklist codes: `main-object-count`,
+  `proportions-match-reference`, `required-visible-features`,
+  `no-stray-or-floating-geometry`, and
+  `canonical-views-physically-coherent`. Missing `screenshotPath`, empty
+  `findings`, missing checklist entries, or blank check findings fails with
+  `assembly.visual.review-incomplete`; failed checks fail with
+  `assembly.visual.review-check-failed`. Use `requireVisualReview: false` only
+  for explicit non-visual batch checks. Only use `allowReviewWarnings` when the
+  original prompt explicitly permits that warning code.
 
 #### Drive transmissions
 
@@ -1030,7 +1035,7 @@ When you have `kernelcad mcp` available, use the MCP tools for dynamic introspec
 - `validate_assembly({ assembly? })` — run the mate-aware validator on the active assembly; returns `{ status, diagnostics, partCount, jointCount }` where each diagnostic carries `code` and `hint` for recovery.
 - `solve_mates({ assembly?, poses? })` — run the v0.6 mate-graph solver on the active assembly; returns `{ status, poses, iterations? }` with each pose serialized as `{ translation, rotateAxis, rotateDeg }`. The `poses` input overrides mate pose values by mate name; coupled driven mates are expanded from their source mate before solve.
 - `review_cad({ file? | code?, assembly?, includePoseEnvelope?, includeInterference?, epsilonMm3?, trackConnectors?, gripperAperture? })` — evaluate a script, validate its assembly/mate graph, check that mate connectors touch modeled material, sample declared mate limits, optionally run BREP interference checks at those samples, report connector workspace bounds, optionally report gripper aperture between two fingertip connector refs, and return raw diagnostics plus a fitness summary (`fitness.functional`, `fitness.blockingReasons`, `fitness.mechanismSummary`) after an assembly is selected. Connector workspace and gripper aperture are only computed when pose-envelope sampling is enabled.
-- `design_loop({ goal, attempts, assembly?, preserveInterfaces?, includePoseEnvelope?, includeInterference?, epsilonMm3?, trackConnectors?, gripperAperture?, stopOnPass?, allowReviewWarnings?, requireVisualReview?, outputRecordPath?, recordTitle? })` — review ordered design attempts, continue past functional attempts with unresolved warnings, require screenshot review via per-attempt `visualReview` by default, return repair prompts, and optionally write a Studio-compatible replay record. Accepted visual reviews must include `screenshotPath` and non-empty `findings`; otherwise `assembly.visual.review-incomplete` keeps the attempt from passing. Set `requireVisualReview: false` only for explicit non-visual batch checks.
+- `design_loop({ goal, attempts, assembly?, preserveInterfaces?, includePoseEnvelope?, includeInterference?, epsilonMm3?, trackConnectors?, gripperAperture?, stopOnPass?, allowReviewWarnings?, requireVisualReview?, outputRecordPath?, recordTitle? })` — review ordered design attempts, continue past functional attempts with unresolved warnings, require screenshot review via per-attempt `visualReview` by default, return repair prompts, and optionally write a Studio-compatible replay record. Accepted visual reviews must include `screenshotPath`, non-empty `findings`, and passing `checks` for `main-object-count`, `proportions-match-reference`, `required-visible-features`, `no-stray-or-floating-geometry`, and `canonical-views-physically-coherent`; otherwise `assembly.visual.review-incomplete` or `assembly.visual.review-check-failed` keeps the attempt from passing. Set `requireVisualReview: false` only for explicit non-visual batch checks.
 - `arm.transmission(name, { kind, sourceMate, drivenMates, actuator?, input?, output?, path, ratio?, notes? })` is script API, not an MCP tool. Use it when `coupleMates(...)` declares a driven mate. `review_cad` emits `assembly.transmission.missing-for-coupled-mate` if a coupled mate has no matching transmission path.
 - `review_cad` emits `assembly.transmission.path-disconnected` when consecutive
   transmission `path` parts are separated at the current pose or any sampled

--- a/tests/integration/mcp/designLoop.test.ts
+++ b/tests/integration/mcp/designLoop.test.ts
@@ -6,6 +6,13 @@ import { designLoopTool } from '../../../src/mcp/tools/designLoop';
 
 describe('design_loop MCP tool', () => {
   const tempDirs: string[] = [];
+  const passingVisualChecks = [
+    { code: 'main-object-count', passed: true, finding: 'The screenshot shows one primary object, not duplicate assemblies.' },
+    { code: 'proportions-match-reference', passed: true, finding: 'The major proportions match the requested object closely enough for this pass.' },
+    { code: 'required-visible-features', passed: true, finding: 'The required visible features are present and legible.' },
+    { code: 'no-stray-or-floating-geometry', passed: true, finding: 'No stray, floating, or unexplained extra geometry is visible.' },
+    { code: 'canonical-views-physically-coherent', passed: true, finding: 'Canonical views still read as one physically coherent object.' },
+  ];
 
   afterEach(async () => {
     await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
@@ -47,6 +54,7 @@ describe('design_loop MCP tool', () => {
             accepted: true,
             screenshotPath: '/tmp/accepted-supported-clevis-arm.png',
             findings: ['Screenshot shows a supported clevis arm with continuous links and no obvious floating blocks.'],
+            checks: passingVisualChecks,
           },
         },
       ],
@@ -125,6 +133,7 @@ describe('design_loop MCP tool', () => {
             accepted: true,
             screenshotPath: '/tmp/clean-bracket.png',
             findings: ['Screenshot shows a simple connected bracket with no unexplained floating solids.'],
+            checks: passingVisualChecks,
           },
         },
       ],
@@ -196,6 +205,7 @@ describe('design_loop MCP tool', () => {
             accepted: true,
             screenshotPath: '/tmp/clean-cylinder-arm.png',
             findings: ['Screenshot shows a compact cylindrical base and link without cuboid clutter.'],
+            checks: passingVisualChecks,
           },
         },
       ],
@@ -239,6 +249,7 @@ describe('design_loop MCP tool', () => {
             accepted: true,
             screenshotPath: '/tmp/robot-arm-reviewed.png',
             findings: ['Screenshot shows continuous base and link with no floating blocks.'],
+            checks: passingVisualChecks,
           },
         },
       ],
@@ -335,6 +346,81 @@ describe('design_loop MCP tool', () => {
       expect.objectContaining({ code: 'assembly.visual.review-incomplete' }),
     ]));
     expect(result.attempts[0].nextActionPrompt).toContain('findings');
+  });
+
+  it('rejects accepted visual reviews that do not include structured reviewer checks', async () => {
+    const result = await designLoopTool({
+      goal: 'Build a watch from a screenshot and require the agent to review it against the rendered evidence.',
+      includeInterference: false,
+      attempts: [
+        {
+          id: '01',
+          title: 'Accepted with only vague screenshot findings',
+          code: `
+            const arm = assembly('clean-bracket');
+            arm.part('base', box(30, 20, 6, true))
+              .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 3] }, axis: [0, 0, 1] });
+            arm.part('link', box(30, 8, 6, true))
+              .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+            arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', { limitsDeg: [-20, 20] });
+            return arm.model();
+          `,
+          visualReview: {
+            accepted: true,
+            screenshotPath: '/tmp/vague-review.png',
+            findings: ['Looks okay.'],
+          },
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.attempts[0]).toMatchObject({
+      functional: true,
+      qualityOk: false,
+      ok: false,
+    });
+    expect(result.attempts[0].reviewFacts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'assembly.visual.review-incomplete' }),
+    ]));
+    expect(result.attempts[0].nextActionPrompt).toContain('visualReview.checks');
+  });
+
+  it('rejects accepted visual reviews when any required reviewer check fails', async () => {
+    const result = await designLoopTool({
+      goal: 'Build a watch from a screenshot and require the agent to reject duplicate visible bodies.',
+      includeInterference: false,
+      attempts: [
+        {
+          id: '01',
+          title: 'Accepted despite duplicate object',
+          code: `
+            const arm = assembly('clean-bracket');
+            arm.part('base', box(30, 20, 6, true))
+              .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 3] }, axis: [0, 0, 1] });
+            arm.part('link', box(30, 8, 6, true))
+              .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+            arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', { limitsDeg: [-20, 20] });
+            return arm.model();
+          `,
+          visualReview: {
+            accepted: true,
+            screenshotPath: '/tmp/duplicate-watch.png',
+            findings: ['The model still appears to contain two watch bodies.'],
+            checks: [
+              ...passingVisualChecks.filter((check) => check.code !== 'main-object-count'),
+              { code: 'main-object-count', passed: false, finding: 'The screenshot appears to show two overlapping main objects.' },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.attempts[0].reviewFacts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'assembly.visual.review-check-failed' }),
+    ]));
+    expect(result.attempts[0].nextActionPrompt).toContain('main-object-count');
   });
 
   it('allows explicit opt-out for non-visual batch checks', async () => {


### PR DESCRIPTION
## Summary
- Require accepted `design_loop` visual reviews to include structured reviewer checks, not just a screenshot path and vague findings.
- Reject accepted attempts when required visual checks are missing or any check fails.
- Document the model-agnostic reviewer contract in the MCP schema and kernelCAD skill docs.

## Test Plan
- npm test -- tests/integration/mcp/designLoop.test.ts
- npm test -- tests/integration/mcp/serverToolDispatch.test.ts tests/unit/skill/skillMechanismLoopDocs.test.ts
- npx tsc --noEmit -p tsconfig.app.json
- npm run lint