### PR TITLE
perf(geometry-engine): self-prewarm worker + eager engine init

### DIFF
--- a/src/backends/occt/worker.ts
+++ b/src/backends/occt/worker.ts
@@ -25,39 +25,56 @@ function getString(obj: unknown, key: string): string | null {
 }
 
 let isInitialized = false;
+// Concurrent callers to init() share a single in-flight promise so the
+// self-prewarm at module load and the host's INIT message coalesce into
+// one WASM compile + OCCT bootstrap. Cleared on failure to permit retry.
+let initPromise: Promise<void> | null = null;
 let executionLock = Promise.resolve();
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let OC: any = null;
 
 async function init() {
   if (isInitialized) return;
+  if (initPromise) return initPromise;
 
-  try {
-    const mod = (await import('replicad-opencascadejs')) as unknown as {
-      default: (opts?: unknown) => Promise<unknown>;
-    };
-    const opencascade = mod.default;
+  initPromise = (async () => {
+    try {
+      const mod = (await import('replicad-opencascadejs')) as unknown as {
+        default: (opts?: unknown) => Promise<unknown>;
+      };
+      const opencascade = mod.default;
 
-    if (DEBUG) console.log('Worker: Initializing OpenCascade...');
+      if (DEBUG) console.log('Worker: Initializing OpenCascade...');
 
-    OC = await opencascade({
-      locateFile: (file: string) => {
-        if (file.endsWith('.wasm')) {
-          if (DEBUG) console.log(`Worker: Locating ${file} -> ${wasmUrl}`);
-          return wasmUrl;
-        }
-        return file;
-      },
-    });
+      OC = await opencascade({
+        locateFile: (file: string) => {
+          if (file.endsWith('.wasm')) {
+            if (DEBUG) console.log(`Worker: Locating ${file} -> ${wasmUrl}`);
+            return wasmUrl;
+          }
+          return file;
+        },
+      });
 
-    setOC(OC);
-    isInitialized = true;
-    if (DEBUG) console.log('Worker: OpenCascade initialized successfully');
-  } catch (err) {
-    console.error('Worker: Failed to initialize OpenCascade:', err);
-    throw err;
-  }
+      setOC(OC);
+      isInitialized = true;
+      if (DEBUG) console.log('Worker: OpenCascade initialized successfully');
+    } catch (err) {
+      initPromise = null;
+      console.error('Worker: Failed to initialize OpenCascade:', err);
+      throw err;
+    }
+  })();
+
+  return initPromise;
 }
+
+// Self-prewarm: begin the WASM compile + OCCT bootstrap the moment this
+// worker module loads, overlapping with the host's React render. By the
+// time the host postMessages 'INIT', init() returns the in-flight promise
+// rather than restarting the work. Errors surface via the INIT/EXECUTE
+// handlers' re-await of init().
+init().catch(() => { /* surfaced to host via re-await; swallow here */ });
 
 function postResponse(response: WorkerResponse, transfer?: Transferable[]) {
   if (transfer) self.postMessage(response, { transfer } as unknown as { transfer: Transferable[] });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,8 +3,16 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { initFeatures } from './features/init'
+import { GeometryEngine } from './lib/geometryEngine'
 
 initFeatures();
+
+// Eagerly spawn the OCCT worker so its 11 MB WASM fetch + compile and the
+// OpenCascade bootstrap overlap with React's first render. GeometryProvider
+// will call initialize() again on mount; the singleton's `isInitialized`
+// flag dedupes, so the second call is a no-op. Failures surface through
+// GeometryProvider's existing retry path.
+GeometryEngine.getInstance().initialize().catch(() => { /* see provider */ });
 
 // /demo-player skips StrictMode: it owns a singleton WebGL renderer/canvas whose
 // lifecycle doesn't tolerate the double-mount StrictMode triggers in dev.


### PR DESCRIPTION
## Why

You called out: *"why does the geometric kernel take so long to warm up, and it seems it is always warming up"*. The dominant cost on every cold path is the 11 MB \`replicad_single.wasm\` compile plus OpenCascade's internal init (~3 s on a typical laptop). Two things made it worse than necessary in Studio:

1. The worker only began \`init()\` *after* receiving the host's \`INIT\` postMessage — wasting the time between worker spawn and the message arriving.
2. \`GeometryProvider.useEffect\` is where the \`new Worker(...)\` happens, so worker spawn waited for React to render down past the WorkbenchContext.

## What changed (two small edits)

**\`src/backends/occt/worker.ts\`** — the worker self-prewarms at module load:
- New \`initPromise\` so the self-prewarm and the host's \`INIT\` coalesce into one WASM compile + OCCT bootstrap (no double init).
- Cleared on failure so retry works.
- Module-level \`init().catch()\` fires the moment the worker script loads.

**\`src/main.tsx\`** — Studio kicks off \`engine.initialize()\` right after \`initFeatures()\`:
- Worker spawn happens at app-bundle load time, not deep in the React tree.
- \`GeometryProvider\` still calls \`initialize()\` on mount; the singleton's \`isInitialized\` flag dedupes; provider's error/retry path is untouched.

## Expected impact

Cold page load: worker spawn + WASM compile + OCCT init now overlaps with React's initial render. The 3 s warmup is still there on first load, but it's hidden behind work the browser would otherwise wait on. Wall-clock perceived improvement depends on how heavy React's first render is — typically 200-800 ms hidden, sometimes more.

This does **not** address:
- CLI cold starts (every \`kernelcad render foo\` is a fresh Node process — needs daemon mode, separate PR)
- Subsequent page reloads (browser HTTP-cache helps, but WASM compile still runs — would need IndexedDB \`WebAssembly.Module\` cache)

## Test plan

- [x] Typecheck clean
- [x] \`src/lib/geometryEngine.test.ts\` (11 tests) green
- [x] \`src/context/GeometryContext.test.tsx\` (3 tests) green
- [ ] CI green
- [ ] Manual smoke: load Studio cold (DevTools → Disable cache → reload), confirm worker is spawned during initial render rather than after, and that "geometry ready" arrives sooner