### PR TITLE
feat: pose-envelope review-loop closure (workstream 5a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,73 @@
-# kernelCAD v0.7.3
+# kernelCAD v0.7.4
+
+## v0.7.4 — 2026-05-15 — Pose-envelope review-loop closure (workstream 5a)
+
+v0.7.4 closes the pose-envelope mechanism-validity bridge from v0.6: agents declare mate travel via `limitsDeg`/`limitsMm`, request envelope-wide validation through one of three sampling strategies, gate `kernelcad evaluate` on a clean envelope, and consume a structured `RepairContext` that drives `design_loop`'s `nextActionPrompt` for autonomous fix iterations. The slice is purely additive — default behavior on every existing surface is unchanged.
+
+### Added — pose-envelope sampling
+
+- `samplesPerMate?: number` on `PoseEnvelopeSamplingOptions`. `N = N total samples per non-locked mate`. Default `1` = corners only (min + max). `N >= 3` adds `N - 2` uniformly-spaced interior points; emits names `<mate>:interior-1`, `<mate>:interior-2`, … Interior sampling catches mid-travel interferences that corner-only sampling misses.
+- `combinatorial?: boolean` on the same options. When `true`, additionally emits `2^M` samples across mates with declared limits — every combination of each mate at its `min` or `max`. Sample names: `corner:<bitmask>`. **Capped at `M <= 8`**; throws above the cap with `combinatorial sampling capped at 8 mates with declared limits; got <N>. Use samplesPerMate for higher-DOF mechanisms.` Use for worst-pose detection on low-DOF mechanisms.
+- Both options flow through `reviewPoseEnvelope`, `solvedModel`, MCP `review_cad` / `design_loop`, and the `kernelcad evaluate` CLI without re-implementation.
+
+### Added — script API
+
+- `solvedModel(poses, { validate, posesGate, samplesPerMate, combinatorial })` gains a new option `posesGate?: 'default' | 'envelope'`. Default `'default'` preserves prior behavior. `'envelope'` runs `reviewPoseEnvelope` and (when `validate === 'error'`) throws on any envelope `severity: 'error'` diagnostic. The throw message names the diagnostic codes and counts.
+- `posesGate` is **separate from** the existing severity-coded `validate` parameter so the matrix `(severity × poses-set)` is honest. The two combinations that throw are `validate: 'error'` with either `posesGate: 'default'` (today's behavior) or `posesGate: 'envelope'` (new).
+
+### Added — CLI
+
+- `kernelcad evaluate <file> [--envelope] [--samples-per-mate N] [--combinatorial]`. Exit code `0` clean, `1` script-execution failure OR sampling flags used without `--envelope`, `2` envelope-error diagnostics surfaced.
+- `--samples-per-mate` and `--combinatorial` outside the `--envelope` context exit 1 with a diagnostic so the misuse is surfaced loudly.
+
+### Added — MCP
+
+- `review_cad` and `design_loop` tool schemas in `toolRegistry.ts` advertise `samplesPerMate` (integer ≥ 1) and `combinatorial` (boolean). The handlers now plumb both fields end-to-end into `reviewPoseEnvelope` (closes the gap where the schema declared them but the handler dropped them).
+- `review_cad` now emits a structured `repairContext: RepairContext` alongside the existing freeform `suggestedRepairPrompt`. The field is present on BOTH `ok: true` and `ok: false` outputs:
+  ```typescript
+  interface RepairContext {
+    blockingReasons: readonly string[];                // 'code: message' formatted
+    topDiagnostics: ReadonlyArray<{
+      code: string;
+      sampleName?: string;
+      mateName?: string;
+      suggestedDelta?: { mate: string; widenBy?: number; narrowBy?: number };  // deg for revolute/cylindrical/pin_slot; mm for prismatic
+    }>;
+    preserveInterfaces: readonly string[];
+    designGoal: string;
+  }
+  ```
+  `topDiagnostics` is the worst 3 sorted by severity (errors first) then `volumeMm3` then code. `suggestedDelta` is computed via `suggestLimitFix` for `:min`/`:max` samples and via direct `widenBy = abs(pose - violatedBound)` for `assembly.pose.out-of-limits` at `sampleName === 'current'`.
+- `design_loop`'s per-attempt `nextActionPrompt` renders from `repairContext`: leads with `blockingReasons`, follows with up to 3 `[severity] code @ sampleName=… mate=…` lines including `→ suggested: widen by N` directives where present, closes with the restated `designGoal` and `preserveInterfaces` list. Falls back to the prior freeform path defensively when `repairContext` is unexpectedly absent.
+
+### Changed
+
+- `PoseEnvelopeDiagnostic` carries a new optional `sampleStrategy?: 'corner' | 'interior' | 'combinatorial'` context field. Classified from the originating `sampleName`. Downstream consumers (UI, agent dashboards) can group failures by strategy without re-parsing names. No code-vocabulary change — the existing 5 pose-envelope diagnostic codes are untouched.
+- `Scene.warnings` is typed `readonly SceneDiagnostic[]` where `SceneDiagnostic = ValidatorDiagnostic | PoseEnvelopeDiagnostic`. The two diagnostic shapes share `code`/`severity`/`message`/`hint`, so all existing `.map(w => w.code)` callers compile and run unchanged. The widening lets `solvedModel({ posesGate: 'envelope' })` append envelope diagnostics into the same stream without forking the warning channel.
+
+### Added — eval corpus
+
+- `eval/tasks/door-hinge-over-travel/` — agent must build a door + wall + revolute hinge with `limitsDeg: [0, 95]` such that the door clears the wall across the entire envelope. Harness gates `envelope clean` via `kernelcad evaluate --envelope --samples-per-mate 3 --json`. Expert solution + 100%-score regression test land in `eval/corpus-envelope.test.ts`.
+- `eval/tasks/gripper-aperture-sweep/` — parallel-jaw gripper with one prismatic actuator coupled 1:1 to a driven prismatic. Harness gates `aperture summary present` plus `minMm within 1mm of 0` and `maxMm within 1mm of 50` via `review_cad`'s `gripperAperture` request. Tests the `coupleMates` sample-expansion path through pose-envelope review.
+
+### Documentation
+
+- `src/skills/kernelcad-assemblies/SKILL.md` gains a full `## Pose-envelope review` section covering the `validate × posesGate` matrix, sampling-mode table with the `samplesPerMate` semantic, the `combinatorial` 2^M cap with the exact thrown message, the 5 emitted diagnostic codes with hints copied verbatim from `src/lib/mates/poseEnvelope.ts`, the CLI surface, and the workspace-bounds limitation ("sampled bound, not analytic").
+- `src/skills/kernelcad-mcp/SKILL.md` documents `samplesPerMate` / `combinatorial` on `review_cad` / `design_loop` and the `RepairContext` return shape.
+
+### Test coverage delta
+
+- `+13` new tests in `src/lib/mates/poseEnvelope.test.ts` and `src/capture/posesGate.test.ts` for sampling extensions, `sampleStrategy` classification, and the `posesGate × validate` matrix.
+- `+6` CLI tests in `tests/unit/cli/evaluateEnvelope.test.ts` for `--envelope` and misuse paths.
+- `+4` MCP tests in `tests/unit/mcp/reviewCadRepairContext.test.ts` for the structured repair context.
+- `+4` MCP tests in `tests/unit/mcp/designLoopNextActionPrompt.test.ts` for the rendered prompt.
+- `+4` MCP tests across `tests/unit/mcp/reviewCadEnvelopeOptions.test.ts` and `tests/unit/mcp/designLoopEnvelopeOptions.test.ts` for the schema-handler plumbing fix.
+- `+4` tool-registry-schema tests in `tests/unit/mcp/toolRegistrySchema.test.ts`.
+- `+2` corpus regressions in `eval/corpus-envelope.test.ts`.
+
+### Non-goals (deferred to later workstreams)
+
+This slice does NOT ship full mechanism functional validity. Mounting-hole consistency, joint-axis-to-structure binding, swept-volume self-collision beyond mate-driven motion, workspace reachability for declared end-effectors, and static-load capacity remain on the v0.7 mechanism-feasibility layer roadmap. The pose-envelope reviewer here proves envelope kinematics, not mechanism intent.
 
 ## v0.7.3 — 2026-05-15 — SDF authoring (slice 1)
 

--- a/eval/corpus-envelope.test.ts
+++ b/eval/corpus-envelope.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runTask } from './runner';
+import { MockAgentClient } from './agent';
+import { isKernelcadAvailable } from './oracle/kernelcad-client';
+
+let kernelcadAvailable = false;
+let runsDir: string;
+
+beforeAll(async () => {
+  kernelcadAvailable = await isKernelcadAvailable();
+  if (!kernelcadAvailable && process.env.CI) {
+    throw new Error(
+      'kernelcad CLI not available in CI. Set KERNELCAD_BIN=./dist/cli/index.js after `npm run build:cli`, or `npm link`.',
+    );
+  }
+});
+
+beforeEach(() => {
+  runsDir = mkdtempSync(join(tmpdir(), 'eval-corpus-envelope-'));
+});
+
+const tasks: Array<{ id: string; dir: string }> = [
+  { id: 'door-hinge-over-travel',  dir: './eval/tasks/door-hinge-over-travel' },
+  { id: 'gripper-aperture-sweep',  dir: './eval/tasks/gripper-aperture-sweep' },
+];
+
+describe('pose-envelope corpus — expert solutions score 100%', () => {
+  for (const t of tasks) {
+    it(`${t.id} — expert solution scores 100%`, async (ctx) => {
+      if (!kernelcadAvailable) return ctx.skip();
+
+      const expertScript = readFileSync(join(t.dir, 'solution-expert.kcad.ts'), 'utf8');
+      const client = new MockAgentClient([
+        {
+          text: 'Here is the part:\n```typescript\n' + expertScript + '\n```',
+          tokens_in: 4000,
+          tokens_out: 200,
+        },
+      ]);
+
+      const result = await runTask({
+        taskDir: t.dir,
+        runDir: runsDir,
+        agent: client,
+        model: 'mock-model',
+        skillMd: '',
+        startedAt: 'CORPUS-ENVELOPE',
+      });
+
+      expect(result.score).not.toBeNull();
+      expect(result.score!.gate_pass).toBe(true);
+      expect(result.score!.score).toBe(1);
+      for (const [name, passed] of Object.entries(result.score!.gates)) {
+        expect(passed, `gate '${name}' failed for ${t.id}`).toBe(true);
+      }
+    }, 60000);
+  }
+});

--- a/eval/tasks/door-hinge-over-travel/harness.ts
+++ b/eval/tasks/door-hinge-over-travel/harness.ts
@@ -1,0 +1,96 @@
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { evaluateScript } from '../../oracle/kernelcad-client';
+import type { HarnessResult } from '../../types';
+
+const LOCAL_BUILD = './dist/cli/index.js';
+
+function getBin(): { cmd: string; baseArgs: string[] } {
+  const override = process.env.KERNELCAD_BIN;
+  if (override) {
+    if (override.endsWith('.js')) return { cmd: 'node', baseArgs: [override] };
+    return { cmd: override, baseArgs: [] };
+  }
+  if (existsSync(LOCAL_BUILD)) return { cmd: 'node', baseArgs: [LOCAL_BUILD] };
+  return { cmd: 'kernelcad', baseArgs: [] };
+}
+
+interface EnvelopeDiagnostic {
+  code: string;
+  severity: string;
+  sampleName?: string;
+}
+
+interface EnvelopeResult {
+  ok: boolean;
+  envelopeDiagnostics: EnvelopeDiagnostic[];
+  envelopeSampleCount: number;
+}
+
+async function evaluateWithEnvelope(scriptPath: string): Promise<EnvelopeResult> {
+  const { cmd, baseArgs } = getBin();
+  const args = [...baseArgs, 'evaluate', '--envelope', '--samples-per-mate', '3', '--json', scriptPath];
+  return await new Promise((resolve) => {
+    const child = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => (stdout += d.toString()));
+    child.stderr.on('data', (d) => (stderr += d.toString()));
+    child.on('close', () => {
+      try {
+        const parsed = JSON.parse(stdout);
+        resolve({
+          ok: !!parsed.ok,
+          envelopeDiagnostics: Array.isArray(parsed.envelopeDiagnostics)
+            ? (parsed.envelopeDiagnostics as EnvelopeDiagnostic[])
+            : [],
+          envelopeSampleCount: typeof parsed.envelopeSampleCount === 'number' ? parsed.envelopeSampleCount : 0,
+        });
+      } catch {
+        resolve({
+          ok: false,
+          envelopeDiagnostics: [
+            {
+              code: 'cli.envelope-parse-failed',
+              severity: 'error',
+              sampleName: stderr.trim() || stdout.trim() || '(no output)',
+            },
+          ],
+          envelopeSampleCount: 0,
+        });
+      }
+    });
+  });
+}
+
+export default async function harness(scriptPath: string): Promise<HarnessResult> {
+  // Gate 1: script must evaluate cleanly (mirrors every other corpus task).
+  const ev = await evaluateScript(scriptPath);
+  if (!ev.ok) {
+    return { gates: { 'evaluates clean': false }, scored: {} };
+  }
+
+  // Gate 2: pose-envelope review at samplesPerMate=3 must report ZERO
+  // interference diagnostics across all sampled poses (min, mid, max).
+  const env = await evaluateWithEnvelope(scriptPath);
+  const interferenceCount = env.envelopeDiagnostics.filter(
+    (d) => d.code === 'assembly.pose-envelope.interference',
+  ).length;
+  const envelopeClean = env.ok && interferenceCount === 0;
+
+  // Scored signal: the script must actually declare the [0, 95] travel range.
+  // A solution that silently narrowed the limits would technically pass the
+  // envelope gate but fails the task's intent.
+  const src = readFileSync(scriptPath, 'utf8');
+  const limitsDeclared = /limitsDeg:\s*\[\s*0\s*,\s*95\s*\]/.test(src);
+
+  return {
+    gates: {
+      'evaluates clean': true,
+      'envelope clean': envelopeClean,
+    },
+    scored: {
+      'declares limitsDeg [0, 95]': limitsDeclared,
+    },
+  };
+}

--- a/eval/tasks/door-hinge-over-travel/prompt.md
+++ b/eval/tasks/door-hinge-over-travel/prompt.md
@@ -1,0 +1,33 @@
+# Task: Door Hinge Without Over-Travel Clash
+
+Model a door panel hinged to a wall via a revolute mate. The hinge must allow
+the door to swing through its full declared travel range without clashing with
+the wall at any sampled pose.
+
+Geometry:
+
+- **Wall**: 500 mm wide × 100 mm thick × 1000 mm tall. The wall stands on the
+  ground (z = 0 at the base), with its front face (the side the door swings
+  away from) defining the reference plane the door closes against.
+- **Door panel**: 300 mm wide × 40 mm thick × 800 mm tall.
+
+Mate:
+
+- Declare one `revolute` mate named `hinge` between a connector on the wall
+  and a connector on the door, with `limitsDeg: [0, 95]`.
+- Pose **0°** = door closed (panel lies along the wall's front face, in the
+  room).
+- Pose **95°** = door fully open (panel has swung outward into the room).
+
+Success criterion:
+
+- **No interference at any pose in `[0, 95]`**. The reviewer samples min, mid,
+  and max of the declared travel range; the door must clear the wall at every
+  sample. If you place the hinge connectors so that the door's body, at
+  large opening angles, sweeps back into the wall material, the review gate
+  will fail.
+
+Return `arm.solvedModel({})` (or `arm.model()`) from an `assembly(...)` so the
+review harness can read the mate graph.
+
+Z-up, millimetres, degrees.

--- a/eval/tasks/door-hinge-over-travel/solution-expert.kcad.ts
+++ b/eval/tasks/door-hinge-over-travel/solution-expert.kcad.ts
@@ -1,0 +1,75 @@
+// Door hinged to a wall via one revolute mate.
+//
+// The hinge must allow the door to swing through 0°-95° without the panel
+// clashing back into the wall at any sampled pose. The pose-envelope review
+// gate samples min, mid (interior), and max of the declared travel range;
+// every sample must be interference-free.
+//
+// Pedagogy:
+// - Place the door's hinge connector at ONE VERTICAL EDGE of the door, NOT
+//   at the door's centerline. A center-pivoted door would sweep half its
+//   panel back through the wall at large opening angles.
+// - Mount the wall's hinge connector a small clearance OFF the wall front
+//   face (HINGE_GAP_MM below). With a finite-thickness door pivoting at a
+//   front-face edge, the door's BACK-face hinge-side corner would otherwise
+//   graze (and at 95° punch into) the wall as the door opens.
+// - Use axis [0, 0, -1] for both connectors so that positive joint travel
+//   carries the door INTO the room (negative world-y), away from the wall.
+
+const WALL_W   = 500;   // wall width (along world x)
+const WALL_T   = 100;   // wall thickness (along world y, the depth of the wall)
+const WALL_H   = 1000;  // wall height (along world z)
+
+const DOOR_W   = 300;   // door panel width (along door-local +x at pose 0)
+const DOOR_T   =  40;   // door panel thickness (along door-local -y at pose 0)
+const DOOR_H   = 800;   // door panel height (along world z)
+
+const HINGE_X      = -200; // hinge x in world; offset from wall center so the
+                           // door does not extend past the wall's left edge
+const HINGE_Z      =  500; // hinge z (mid-height of wall and door)
+const HINGE_GAP_MM =    5; // clearance between hinge axis and wall front face;
+                           // without this gap the door's back-face hinge-side
+                           // corner intrudes into the wall at large angles.
+
+const HINGE_LIMITS_DEG: [number, number] = [0, 95];
+
+const door = assembly('door-hinge-over-travel');
+
+// Wall: centered horizontally at x=0, sitting on the ground (z=0..WALL_H),
+// front face at y=0, depth extending into +y. The "room" is the half-space y<0.
+const wallShape = box(WALL_W, WALL_T, WALL_H, true)
+  .translate(0, WALL_T / 2, WALL_H / 2)
+  .color('frame');
+const wallPart = door.part('wall', wallShape);
+
+// Door: authored in its own local frame so its hinge edge sits at local origin.
+// The body extends in +x (away from the hinge along the wall's front at pose 0)
+// and in -y (into the room) by DOOR_T thickness; centered vertically about z=0.
+const doorShape = box(DOOR_W, DOOR_T, DOOR_H, true)
+  .translate(DOOR_W / 2, -DOOR_T / 2, 0)
+  .color('plate');
+const doorPart = door.part('door', doorShape);
+
+// Wall hinge connector: HINGE_GAP_MM in front of the wall front face. Axis
+// [0,0,-1] means positive revolute pose rotates the child clockwise when
+// viewed from +z, which carries the door body into -y (into the room).
+wallPart.connector('hinge', {
+  type: 'axis',
+  origin: { kind: 'vec3', value: [HINGE_X, -HINGE_GAP_MM, HINGE_Z] },
+  axis: [0, 0, -1],
+});
+
+// Door hinge connector: at the door's hinge-edge centerline (door-local origin).
+// Axis matches the wall connector so the mate is compatible.
+doorPart.connector('hinge', {
+  type: 'axis',
+  origin: { kind: 'vec3', value: [0, 0, 0] },
+  axis: [0, 0, -1],
+});
+
+// One revolute mate: 0° = closed (door panel parallel to wall front), 95° = open.
+door.mate('hinge', 'wall.hinge', 'door.hinge', 'revolute', {
+  limitsDeg: [0, 95],
+});
+
+return door.solvedModel({});

--- a/eval/tasks/door-hinge-over-travel/solution-expert.kcad.ts
+++ b/eval/tasks/door-hinge-over-travel/solution-expert.kcad.ts
@@ -31,8 +31,6 @@ const HINGE_GAP_MM =    5; // clearance between hinge axis and wall front face;
                            // without this gap the door's back-face hinge-side
                            // corner intrudes into the wall at large angles.
 
-const HINGE_LIMITS_DEG: [number, number] = [0, 95];
-
 const door = assembly('door-hinge-over-travel');
 
 // Wall: centered horizontally at x=0, sitting on the ground (z=0..WALL_H),

--- a/eval/tasks/gripper-aperture-sweep/harness.ts
+++ b/eval/tasks/gripper-aperture-sweep/harness.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { evaluateScript } from '../../oracle/kernelcad-client';
+import type { HarnessResult } from '../../types';
+import { reviewCadTool } from '../../../src/mcp/tools/reviewCad';
+
+export default async function harness(scriptPath: string): Promise<HarnessResult> {
+  const ev = await evaluateScript(scriptPath);
+  if (!ev.ok) {
+    return { gates: { 'evaluates clean': false }, scored: {} };
+  }
+
+  const review = await reviewCadTool({
+    file: scriptPath,
+    includePoseEnvelope: true,
+    includeInterference: false,
+    gripperAperture: { left: 'left-finger.tip', right: 'right-finger.tip' },
+  });
+
+  const apertureSummary = review.gripperAperture;
+  const aperturePresent = apertureSummary !== undefined;
+
+  const minMm = apertureSummary?.minMm;
+  const maxMm = apertureSummary?.maxMm;
+  const minWithinTolerance = typeof minMm === 'number' && Math.abs(minMm - 0) <= 1;
+  const maxWithinTolerance = typeof maxMm === 'number' && Math.abs(maxMm - 50) <= 1;
+
+  const src = readFileSync(scriptPath, 'utf8');
+  // Match a prismatic-mate limits declaration. The exact bound expression may
+  // be a literal `25` or a named constant (e.g. `travelMm`); we only require
+  // that `limitsMm:` appears at least once on the script.
+  const declaresPrismaticLimits = /limitsMm\s*:\s*\[/.test(src);
+
+  return {
+    gates: {
+      'evaluates clean': true,
+      'aperture summary present': aperturePresent,
+    },
+    scored: {
+      'minMm within 1mm of 0': minWithinTolerance,
+      'maxMm within 1mm of 50': maxWithinTolerance,
+      'declares prismatic limitsMm': declaresPrismaticLimits,
+    },
+  };
+}

--- a/eval/tasks/gripper-aperture-sweep/prompt.md
+++ b/eval/tasks/gripper-aperture-sweep/prompt.md
@@ -1,0 +1,29 @@
+# Task: Parallel-Jaw Gripper Aperture Sweep
+
+Build a parallel-jaw gripper assembly whose two fingers slide apart so the
+tip-to-tip aperture sweeps from 0 mm (closed) to 50 mm (open). The review
+loop will sample the actuator mate's limits and read the aperture summary at
+both extremes.
+
+Functional requirements:
+
+- One palm (base) part. The exact base dimensions are up to you; pick
+  something obviously palm-shaped (e.g. 60 × 40 × 20 mm).
+- Two finger parts — `left-finger` and `right-finger` — each attached to the
+  palm by a **prismatic** mate that slides the finger along the X axis. The
+  fingers must move in opposite X directions so a single positive stroke
+  opens the gripper.
+- One actuator mate declares `limitsMm: [0, 25]`. A symmetric driven mate is
+  coupled to it via `arm.coupleMates(...)` so both fingers extend together
+  for a single source pose. Total tip-to-tip aperture therefore sweeps from
+  0 mm to 50 mm.
+- Each finger must carry a `frame`-type connector named `tip` placed at the
+  finger's fingertip. At source pose 0 both `tip` connectors coincide on the
+  X=0 plane; at source pose 25 the tips are 50 mm apart along X.
+- Return `arm.model()` from the script.
+
+The harness will invoke `review_cad` with
+`gripperAperture: { left: 'left-finger.tip', right: 'right-finger.tip' }` and
+check that `minMm` lands within 1 mm of 0 and `maxMm` within 1 mm of 50.
+
+Z-up, millimetres, degrees.

--- a/eval/tasks/gripper-aperture-sweep/solution-expert.kcad.ts
+++ b/eval/tasks/gripper-aperture-sweep/solution-expert.kcad.ts
@@ -1,0 +1,66 @@
+// Parallel-jaw gripper. Two prismatic fingers slide apart along ±X; the
+// `right-slide` mate is the actuator (limits 0..25 mm) and `left-slide` is
+// coupled to it 1:1 so a single source pose drives both jaws symmetrically.
+// At pose 0 both fingertips touch at the X=0 plane; at the upper limit each
+// jaw has translated 25 mm so the tips are 50 mm apart.
+//
+// Pose-envelope review samples the source mate's limits and computes
+// aperture between `left-finger.tip` and `right-finger.tip` at each sample.
+
+const baseW = 60;        // palm width  (X)
+const baseD = 40;        // palm depth  (Y)
+const baseH = 20;        // palm height (Z)
+const jawT  = 8;         // jaw thickness along travel axis (X)
+const jawD  = 30;        // jaw depth (Y)
+const jawH  = 50;        // jaw height (Z)
+const travelMm = 25;     // per-jaw stroke; total aperture = 2 * travelMm
+
+const hand = assembly('parallel-jaw gripper');
+
+const palm = hand.part('palm', box(baseW, baseD, baseH, true).color('plate'));
+palm
+  .connector('left-rail', {
+    type: 'axis',
+    origin: { kind: 'vec3', value: [0, 0, baseH / 2] },
+    axis: [-1, 0, 0],            // positive pose moves left jaw in -X
+  })
+  .connector('right-rail', {
+    type: 'axis',
+    origin: { kind: 'vec3', value: [0, 0, baseH / 2] },
+    axis: [1, 0, 0],             // positive pose moves right jaw in +X
+  });
+
+const left = hand.part('left-finger', box(jawT, jawD, jawH, true).color('tool'));
+left
+  .connector('rail', {
+    type: 'axis',
+    origin: { kind: 'vec3', value: [jawT / 2, 0, -jawH / 2] },
+    axis: [-1, 0, 0],
+  })
+  .connector('tip', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [jawT / 2, 0, jawH / 2] },
+  });
+
+const right = hand.part('right-finger', box(jawT, jawD, jawH, true).color('tool'));
+right
+  .connector('rail', {
+    type: 'axis',
+    origin: { kind: 'vec3', value: [-jawT / 2, 0, -jawH / 2] },
+    axis: [1, 0, 0],
+  })
+  .connector('tip', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [-jawT / 2, 0, jawH / 2] },
+  });
+
+// Actuator: `right-slide` carries the declared travel limits.
+hand.mate('right-slide', 'palm.right-rail', 'right-finger.rail', 'prismatic', {
+  limitsMm: [0, travelMm],
+});
+// Mirror: `left-slide` is driven 1:1 from `right-slide`. The mirrored connector
+// axis ([-1,0,0]) flips the world translation back into -X for the left jaw.
+hand.mate('left-slide', 'palm.left-rail', 'left-finger.rail', 'prismatic');
+hand.coupleMates('left-slide', { source: 'right-slide', ratio: 1 });
+
+return hand.model();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kernelcad",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kernelcad",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kernelcad",
   "private": false,
-  "version": "0.7.3",
+  "version": "0.7.4",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/src/capture/assembly.ts
+++ b/src/capture/assembly.ts
@@ -1,6 +1,6 @@
 import { lookupSourceColor } from '../backends/occt/lookupSourceColor';
 import { KernelError } from '../intent/kernelError';
-import { Scene, type ScenePart } from '../intent/scene';
+import { Scene, type SceneDiagnostic, type ScenePart } from '../intent/scene';
 import type { EditableVec3, FeatureId, Param, Unit, Vec3, Vec3Param } from '../intent/types';
 import { formatScalarForError, isValidEditableVec3, isValidVec3 } from '../intent/types';
 import {
@@ -17,8 +17,12 @@ import {
   type MateRecord,
 } from '../lib/mates/mate';
 import { isCompatiblePair, type MateType } from '../lib/mates/mateTypes';
+import {
+  reviewPoseEnvelope,
+  type PoseEnvelopeDiagnostic,
+} from '../lib/mates/poseEnvelope';
 import { solveMates } from '../lib/mates/solver';
-import { validateAssemblyWithMates, type ValidatorDiagnostic } from '../lib/mates/validator';
+import { validateAssemblyWithMates } from '../lib/mates/validator';
 import { currentValue, toParam, toVec3Param } from '../runtime/editableHelpers';
 import { isParamRef, paramExprToDebugString, type Editable, type ParamRefExpr } from '../runtime/paramRef';
 import { Transform } from '../runtime/se3';
@@ -1063,7 +1067,31 @@ export class Assembly {
    */
   solvedModel(
     poses: Poses,
-    opts?: { validate?: 'warn' | 'error' | 'off' },
+    opts?: {
+      validate?: 'warn' | 'error' | 'off';
+      /**
+       * Which poses the validation gate covers. Orthogonal to `validate`
+       * (which controls severity).
+       *
+       * - `'default'` (default) → the existing behavior: gate runs over the
+       *   default/capture-time pose only. No pose-envelope review runs.
+       * - `'envelope'` → after the existing default-pose gate, run
+       *   `reviewPoseEnvelope(this, { samplesPerMate, combinatorial,
+       *   includeInterference: true })` and fold the envelope diagnostics
+       *   into the gate. Under `validate: 'error'` any envelope-error fails
+       *   the call; under `validate: 'warn'` they surface on `scene.warnings`
+       *   without throwing.
+       *
+       * Per-mate envelope sweep is configured by `samplesPerMate` /
+       * `combinatorial` below — same semantics as `reviewPoseEnvelope`'s
+       * `PoseEnvelopeSamplingOptions`.
+       */
+      posesGate?: 'default' | 'envelope';
+      /** Forwarded to `reviewPoseEnvelope` when `posesGate === 'envelope'`. */
+      samplesPerMate?: number;
+      /** Forwarded to `reviewPoseEnvelope` when `posesGate === 'envelope'`. */
+      combinatorial?: boolean;
+    },
   ): Promise<Scene> {
     if (this.parts.length === 0) {
       throw new KernelError(
@@ -1130,14 +1158,28 @@ export class Assembly {
         ? this.computeInterferencesForGate(sceneShape)
         : Promise.resolve(undefined);
 
+    // T6: optional pose-envelope review runs AFTER the default-pose
+    // validator so its diagnostics layer on top of the existing gate.
+    // `posesGate` is orthogonal to `validate` — see the opts JSDoc above.
+    const posesGate: 'default' | 'envelope' = opts?.posesGate ?? 'default';
+    const envelopePromise: Promise<readonly PoseEnvelopeDiagnostic[]> =
+      posesGate === 'envelope'
+        ? reviewPoseEnvelope(this, {
+            ...(opts?.samplesPerMate !== undefined ? { samplesPerMate: opts.samplesPerMate } : {}),
+            ...(opts?.combinatorial !== undefined ? { combinatorial: opts.combinatorial } : {}),
+            includeInterference: true,
+          }).then((r) => r.diagnostics)
+        : Promise.resolve([] as readonly PoseEnvelopeDiagnostic[]);
+
     return Promise.all([
       interferencePromise,
       mateTransformsPromise,
     ]).then(async ([interferencePairs, mateT]) => {
       const result = await validateAssemblyWithMates(this, interferencePairs);
-      return { result, mateT };
+      const envelopeDiagnostics = await envelopePromise;
+      return { result, mateT, envelopeDiagnostics };
     }).then(
-      ({ result, mateT }) => {
+      ({ result, mateT, envelopeDiagnostics }) => {
         if (mode === 'error') {
           const errDiag = result.diagnostics.find((d) => d.severity === 'error');
           // Status-driven fallback: `over-constrained` / `did-not-converge`
@@ -1160,11 +1202,37 @@ export class Assembly {
               `invalid-args.assembly.${result.status} — inspect arm via validateAssemblyWithMates(arm) for the per-mate diagnostic chain.`,
             );
           }
+          // T6: throw if the pose-envelope review (when enabled) surfaced any
+          // error-severity diagnostic. The message lists code counts so a
+          // caller can grep for the specific failure family.
+          const envelopeErrors = envelopeDiagnostics.filter((d) => d.severity === 'error');
+          if (envelopeErrors.length > 0) {
+            const counts = new Map<string, number>();
+            for (const d of envelopeErrors) {
+              counts.set(d.code, (counts.get(d.code) ?? 0) + 1);
+            }
+            const codeSummary = Array.from(counts.entries())
+              .map(([code, count]) => `${code} (x${count})`)
+              .join(', ');
+            const sampleHint = envelopeErrors[0].hint;
+            throw new KernelError(
+              'feature.invalid-args',
+              `solvedModel: pose-envelope errors: ${codeSummary}`,
+              undefined,
+              sampleHint,
+            );
+          }
           // error mode: warnings/info silently dropped per T9 spec.
           return this.makeScene(sceneShape, [], mateT);
         }
-        // warn mode: attach all diagnostics (error/warning/info) to scene.warnings.
-        return this.makeScene(sceneShape, result.diagnostics, mateT);
+        // warn mode: attach all diagnostics (error/warning/info) to
+        // scene.warnings. When posesGate === 'envelope', the envelope review
+        // diagnostics are appended after the default-pose validator's.
+        const aggregated: readonly SceneDiagnostic[] = [
+          ...result.diagnostics,
+          ...envelopeDiagnostics,
+        ];
+        return this.makeScene(sceneShape, aggregated, mateT);
       },
     );
   }
@@ -1261,7 +1329,7 @@ export class Assembly {
    */
   private makeScene(
     sceneShape: Shape,
-    warnings: readonly ValidatorDiagnostic[] = [],
+    warnings: readonly SceneDiagnostic[] = [],
     matePartTransforms?: ReadonlyMap<string, Transform>,
   ): Scene {
     const sceneFeatureId = sceneShape.id;

--- a/src/capture/posesGate.test.ts
+++ b/src/capture/posesGate.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { CaptureSession } from './captureSession';
+import { createApi } from '../modules/api';
+
+function makeArm() {
+  const session = new CaptureSession();
+  const kcad = createApi({ session });
+  return { arm: kcad.assembly('rig'), kcad };
+}
+
+/**
+ * Task 6 — `posesGate` option on `Assembly.solvedModel`.
+ *
+ * `posesGate: 'envelope'` runs `reviewPoseEnvelope` after the existing
+ * default-pose validation and folds its diagnostics into the gate. Default
+ * remains `'default'` (today's behavior — envelope review NOT run).
+ *
+ * Failure mode chosen for tests 2/3: a revolute mate whose capture-time pose
+ * sits OUTSIDE its declared limits. `validateMatePoseLimits` (called inside
+ * `reviewPoseEnvelope`) emits `assembly.pose.out-of-limits` at severity
+ * `error` on the `current` sample. The existing default-pose validator does
+ * NOT flag this, so the diagnostic is genuinely envelope-only — which is
+ * exactly what `posesGate` is intended to gate on.
+ */
+describe('Assembly.solvedModel posesGate option', () => {
+  it('posesGate defaults to "default" and does NOT run envelope review', async () => {
+    const { arm, kcad } = makeArm();
+    arm
+      .part('base', kcad.box(10, 10, 10))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm
+      .part('link', kcad.box(5, 5, 5))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    // Pose sits OUTSIDE declared limits — would be flagged ONLY by the
+    // envelope review. Default `posesGate: 'default'` must NOT run it.
+    arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', {
+      pose: 120,
+      limitsDeg: [-90, 90],
+    });
+
+    const scene = await arm.solvedModel({});
+    // Today's warn-mode behavior preserved: pose-envelope-only diagnostic
+    // codes must NOT appear in scene.warnings when posesGate is unset.
+    const codes = scene.warnings.map((w) => w.code);
+    expect(codes).not.toContain('assembly.pose.out-of-limits');
+    expect(codes).not.toContain('assembly.pose-envelope.interference');
+    expect(codes).not.toContain('assembly.pose-envelope.solve-failed');
+    expect(codes).not.toContain('assembly.pose-envelope.connector-unresolved');
+  });
+
+  it('posesGate=envelope + validate=error throws when envelope sample has interference', async () => {
+    const { arm, kcad } = makeArm();
+    arm
+      .part('base', kcad.box(10, 10, 10))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm
+      .part('link', kcad.box(5, 5, 5))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', {
+      pose: 120,
+      limitsDeg: [-90, 90],
+    });
+
+    await expect(
+      arm.solvedModel({}, { validate: 'error', posesGate: 'envelope' }),
+    ).rejects.toThrow(/pose-envelope|out-of-limits/);
+  });
+
+  it('posesGate=envelope + validate=warn does NOT throw', async () => {
+    const { arm, kcad } = makeArm();
+    arm
+      .part('base', kcad.box(10, 10, 10))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm
+      .part('link', kcad.box(5, 5, 5))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', {
+      pose: 120,
+      limitsDeg: [-90, 90],
+    });
+
+    const scene = await arm.solvedModel({}, { validate: 'warn', posesGate: 'envelope' });
+    // Diagnostics surface on scene.warnings; the gate does not throw.
+    const codes = scene.warnings.map((w) => w.code);
+    expect(codes).toContain('assembly.pose.out-of-limits');
+  });
+
+  it('posesGate=default does NOT throw even with envelope-only errors', async () => {
+    const { arm, kcad } = makeArm();
+    arm
+      .part('base', kcad.box(10, 10, 10))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm
+      .part('link', kcad.box(5, 5, 5))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', {
+      pose: 120,
+      limitsDeg: [-90, 90],
+    });
+
+    // Default posesGate ('default') keeps today's behavior: envelope-only
+    // errors do not gate the call, even under `validate: 'error'`.
+    await expect(arm.solvedModel({}, { validate: 'error' })).resolves.toBeDefined();
+  });
+});

--- a/src/cli/commands/evaluate.ts
+++ b/src/cli/commands/evaluate.ts
@@ -5,6 +5,11 @@ import type { CompilerDiagnostic } from '../../diagnostics/diagnostic';
 import { withNextActions } from '../../diagnostics/diagnostic';
 import { kernelErrorToDiagnostic } from '../../script-runtime/kernelErrorToDiagnostic';
 import { buildModel, buildModelFromFile, type BuiltModel } from '../../kernel/buildModel';
+import type { Assembly } from '../../capture/assembly';
+import {
+  reviewPoseEnvelope,
+  type PoseEnvelopeDiagnostic,
+} from '../../lib/mates/poseEnvelope';
 
 export interface EvaluateInput {
   file?: string;
@@ -99,6 +104,156 @@ export async function evaluateScript(input: EvaluateInput): Promise<EvaluateResu
   return (await evaluateAndBuildScript(input)).evaluation;
 }
 
+export interface EvaluateWithEnvelopeInput extends EvaluateInput {
+  /** When true, run `reviewPoseEnvelope` on every captured assembly after
+   *  the script settles. Any envelope `severity: 'error'` diagnostic causes
+   *  exit code 2. When false (the default), behavior matches plain
+   *  `evaluateScript` — capture-time validity gate only. */
+  envelope?: boolean;
+  /** Forwarded to `reviewPoseEnvelope` when `envelope` is true. Integer ≥ 1.
+   *  Specifying without `envelope: true` is a misuse — sets `exitCode: 1`
+   *  and populates `misuseMessage`. */
+  samplesPerMate?: number;
+  /** Forwarded to `reviewPoseEnvelope` when `envelope` is true. Specifying
+   *  without `envelope: true` is a misuse — sets `exitCode: 1` and
+   *  populates `misuseMessage`. */
+  combinatorial?: boolean;
+}
+
+export interface EvaluateWithEnvelopeResult {
+  /** 0: clean evaluation (script ran AND envelope clean if --envelope set)
+   *  1: script-execution failure OR misuse of flags
+   *  2: envelope-error diagnostics surfaced (only possible when --envelope) */
+  exitCode: number;
+  featureCount: number;
+  diagnostics: CompilerDiagnostic[];
+  /** All envelope diagnostics (across every captured assembly) when
+   *  `envelope: true`. Undefined when envelope review didn't run. */
+  envelopeDiagnostics?: PoseEnvelopeDiagnostic[];
+  /** Total pose-envelope sample count across every captured assembly.
+   *  Undefined when envelope review didn't run. */
+  envelopeSampleCount?: number;
+  /** Set when the caller passed an envelope sampling flag without
+   *  `envelope: true`. Triggers `exitCode: 1`. */
+  misuseMessage?: string;
+}
+
+/**
+ * Implements `kernelcad evaluate --envelope [--samples-per-mate N]
+ * [--combinatorial]`. After the script runs, captured assemblies are pulled
+ * off the session and `reviewPoseEnvelope` runs on each. Any envelope
+ * `severity: 'error'` diagnostic produces exit code 2.
+ *
+ * If sampling flags are supplied without `--envelope`, the call is rejected
+ * with `exitCode: 1` and a `misuseMessage` — sampling has no effect without
+ * the gate.
+ *
+ * Per Task 7 of the pose-envelope review-loop closure plan.
+ */
+export async function evaluateWithEnvelope(
+  input: EvaluateWithEnvelopeInput,
+): Promise<EvaluateWithEnvelopeResult> {
+  // Misuse check first — agent supplies sampling flags without enabling the
+  // gate. Fail fast and tell the user how to enable it. No script run.
+  if (!input.envelope) {
+    if (input.samplesPerMate !== undefined) {
+      return {
+        exitCode: 1,
+        featureCount: 0,
+        diagnostics: [],
+        misuseMessage:
+          '--samples-per-mate has no effect without --envelope. Pass --envelope to run the pose-envelope gate.',
+      };
+    }
+    if (input.combinatorial) {
+      return {
+        exitCode: 1,
+        featureCount: 0,
+        diagnostics: [],
+        misuseMessage:
+          '--combinatorial has no effect without --envelope. Pass --envelope to run the pose-envelope gate.',
+      };
+    }
+  }
+
+  if (input.samplesPerMate !== undefined && (!Number.isInteger(input.samplesPerMate) || input.samplesPerMate < 1)) {
+    return {
+      exitCode: 1,
+      featureCount: 0,
+      diagnostics: [],
+      misuseMessage:
+        `--samples-per-mate must be an integer ≥ 1; got ${input.samplesPerMate}.`,
+    };
+  }
+
+  const built = await evaluateAndBuildScript({ file: input.file, code: input.code });
+  const { evaluation, model } = built;
+
+  if (!input.envelope) {
+    return {
+      exitCode: evaluation.exitCode,
+      featureCount: evaluation.featureCount,
+      diagnostics: evaluation.diagnostics,
+    };
+  }
+
+  if (evaluation.exitCode !== 0) {
+    // Don't run envelope on a broken script — surface the underlying failure.
+    return {
+      exitCode: evaluation.exitCode,
+      featureCount: evaluation.featureCount,
+      diagnostics: evaluation.diagnostics,
+      envelopeDiagnostics: [],
+      envelopeSampleCount: 0,
+    };
+  }
+
+  if (!model) {
+    // Shouldn't happen for exitCode 0, but be defensive.
+    return {
+      exitCode: evaluation.exitCode,
+      featureCount: evaluation.featureCount,
+      diagnostics: evaluation.diagnostics,
+      envelopeDiagnostics: [],
+      envelopeSampleCount: 0,
+    };
+  }
+
+  const assemblies = Array.from(model.session.assemblies.values()) as Assembly[];
+  if (assemblies.length === 0) {
+    return {
+      exitCode: 0,
+      featureCount: evaluation.featureCount,
+      diagnostics: evaluation.diagnostics,
+      envelopeDiagnostics: [],
+      envelopeSampleCount: 0,
+    };
+  }
+
+  const reviewOpts: { samplesPerMate?: number; combinatorial?: boolean; includeInterference: true } = {
+    includeInterference: true,
+  };
+  if (input.samplesPerMate !== undefined) reviewOpts.samplesPerMate = input.samplesPerMate;
+  if (input.combinatorial) reviewOpts.combinatorial = true;
+
+  const envelopeDiagnostics: PoseEnvelopeDiagnostic[] = [];
+  let envelopeSampleCount = 0;
+  for (const arm of assemblies) {
+    const review = await reviewPoseEnvelope(arm, reviewOpts);
+    envelopeDiagnostics.push(...review.diagnostics);
+    envelopeSampleCount += review.samples.length;
+  }
+
+  const hasError = envelopeDiagnostics.some((d) => d.severity === 'error');
+  return {
+    exitCode: hasError ? 2 : 0,
+    featureCount: evaluation.featureCount,
+    diagnostics: evaluation.diagnostics,
+    envelopeDiagnostics,
+    envelopeSampleCount,
+  };
+}
+
 function isFileReadError(e: unknown): boolean {
   return (
     typeof e === 'object' &&
@@ -114,22 +269,55 @@ export function evaluateCommand(): Command {
     .description('Run a .kcad.ts script and report diagnostics')
     .argument('<file>', 'path to a .kcad.ts script')
     .option('--json', 'emit diagnostics as JSON')
-    .action(async (file: string, opts: { json?: boolean }) => {
-      const r = await evaluateScript({ file });
+    .option('--envelope', 'after the script runs, run reviewPoseEnvelope on every captured assembly; non-zero exit on envelope-error')
+    .option('--samples-per-mate <n>', 'interior samples per mate for the envelope sweep (integer ≥ 1)', (v) => parseInt(v, 10))
+    .option('--combinatorial', 'enumerate corner combinations across all limited mates (cap: 8 mates)')
+    .action(async (file: string, opts: { json?: boolean; envelope?: boolean; samplesPerMate?: number; combinatorial?: boolean }) => {
+      const r = await evaluateWithEnvelope({
+        file,
+        ...(opts.envelope ? { envelope: true } : {}),
+        ...(opts.samplesPerMate !== undefined ? { samplesPerMate: opts.samplesPerMate } : {}),
+        ...(opts.combinatorial ? { combinatorial: true } : {}),
+      });
+
+      if (r.misuseMessage) {
+        console.error(r.misuseMessage);
+        process.exitCode = r.exitCode;
+        return;
+      }
+
+      const envelopeErrors = (r.envelopeDiagnostics ?? []).filter((d) => d.severity === 'error');
+
       if (opts.json) {
         console.log(JSON.stringify({
           ok: r.exitCode === 0,
           featureCount: r.featureCount,
           diagnostics: r.diagnostics,
+          ...(r.envelopeDiagnostics !== undefined ? {
+            envelopeDiagnostics: r.envelopeDiagnostics,
+            envelopeSampleCount: r.envelopeSampleCount,
+          } : {}),
         }, null, 2));
       } else {
         console.log(`Features: ${r.featureCount}`);
         if (r.diagnostics.length > 0) {
           console.log(formatHuman(r.diagnostics));
         }
+        if (envelopeErrors.length > 0) {
+          console.error(formatEnvelopeDiagnostics(envelopeErrors));
+        } else if (r.envelopeDiagnostics !== undefined) {
+          console.log(`Pose-envelope: ${r.envelopeSampleCount} sample${r.envelopeSampleCount === 1 ? '' : 's'} clean.`);
+        }
         if (r.exitCode === 0) console.log('OK');
       }
       process.exitCode = r.exitCode;
     });
   return cmd;
+}
+
+function formatEnvelopeDiagnostics(diags: readonly PoseEnvelopeDiagnostic[]): string {
+  return diags.map((d) => {
+    const where = d.sampleName ? `sample '${d.sampleName}'` : '<envelope>';
+    return `${d.severity.toUpperCase()} [${d.code}] ${where}: ${d.message}\n  Hint: ${d.hint}`;
+  }).join('\n');
 }

--- a/src/intent/scene.ts
+++ b/src/intent/scene.ts
@@ -13,10 +13,22 @@
 import type { Shape } from '../capture/proxy';
 import type { Connector } from '../lib/mates/connector';
 import type { MateRecord } from '../lib/mates/mate';
+import type { PoseEnvelopeDiagnostic } from '../lib/mates/poseEnvelope';
 import type { ValidatorDiagnostic } from '../lib/mates/validator';
 import type { Transform } from '../runtime/se3';
 import type { Vec3 } from './types';
 import { KernelError } from './kernelError';
+
+/** Aggregated diagnostic surfaced on `Scene.warnings`. Carries either a
+ *  default-pose validator diagnostic (`ValidatorDiagnostic`, attached by the
+ *  baseline `Assembly.solvedModel({validate: 'warn'})` flow) or a
+ *  pose-envelope review diagnostic (`PoseEnvelopeDiagnostic`, attached when
+ *  `solvedModel(poses, { posesGate: 'envelope' })` is requested in T6).
+ *
+ *  Both shapes share `code` (string), `severity`, `message`, and `hint`, so
+ *  the common-path `.map(w => w.code)` / `.filter(w => w.severity === ...)`
+ *  consumer patterns work without narrowing. */
+export type SceneDiagnostic = ValidatorDiagnostic | PoseEnvelopeDiagnostic;
 
 /** A single placed part in a Scene. The `shape` is authored in its own
  *  local frame; the `worldTransform` carries the post-FK placement. */
@@ -71,7 +83,7 @@ export class Scene implements Iterable<ScenePart> {
    *  throw, and the surviving warnings/info are silently dropped). Always
    *  present (possibly empty); never undefined, so consumers don't need a
    *  presence check. */
-  readonly warnings: readonly ValidatorDiagnostic[];
+  readonly warnings: readonly SceneDiagnostic[];
   private _bbox: SceneBbox | null = null;
   private readonly bboxFn: () => SceneBbox;
   private readonly exportFn?: SceneExportFn;
@@ -91,7 +103,7 @@ export class Scene implements Iterable<ScenePart> {
     exportFn?: SceneExportFn,
     sourceFeatureId?: string,
     mates?: readonly MateRecord[],
-    warnings?: readonly ValidatorDiagnostic[],
+    warnings?: readonly SceneDiagnostic[],
   ) {
     this.assemblyName = assemblyName;
     this.parts = Object.freeze([...parts]);

--- a/src/lib/mates/poseEnvelope.test.ts
+++ b/src/lib/mates/poseEnvelope.test.ts
@@ -139,6 +139,30 @@ describe('pose-envelope review helpers', () => {
     expect(result.connectorPoses.map((p) => p.sampleName)).toEqual(['current', 'yaw:min', 'yaw:max']);
   });
 
+  it('reviewPoseEnvelope honors samplesPerMate and produces interior pose samples', async () => {
+    const { arm, kcad } = makeArm();
+    arm
+      .part('base', kcad.box(10, 10, 10))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm
+      .part('link', kcad.box(5, 5, 5))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', { limitsDeg: [-90, 90] });
+
+    const defaultResult = await reviewPoseEnvelope(arm, { includeInterference: false });
+    expect(defaultResult.samples.map((s) => s.name)).toEqual(['current', 'yaw:min', 'yaw:max']);
+
+    const result = await reviewPoseEnvelope(arm, {
+      includeInterference: false,
+      samplesPerMate: 4,
+    });
+    const names = result.samples.map((s) => s.name);
+    expect(names).toHaveLength(5);
+    expect(names).toContain('yaw:interior-1');
+    expect(names).toContain('yaw:interior-2');
+    expect(names).toEqual(['current', 'yaw:min', 'yaw:interior-1', 'yaw:interior-2', 'yaw:max']);
+  });
+
   it('diagnoses tracked topology connector origins that cannot be sampled in capture-time workspace review', async () => {
     const { arm, kcad } = makeArm();
     arm

--- a/src/lib/mates/poseEnvelope.test.ts
+++ b/src/lib/mates/poseEnvelope.test.ts
@@ -27,6 +27,57 @@ describe('pose-envelope review helpers', () => {
     ]);
   });
 
+  it('samples interior points within mate limits when samplesPerMate > 1', () => {
+    const { arm, kcad } = makeArm();
+    arm
+      .part('base', kcad.box(10, 10, 10))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm
+      .part('link', kcad.box(5, 5, 5))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm.mate('hinge', 'base.axis', 'link.axis', 'revolute', { limitsDeg: [-90, 90] });
+
+    const samples = buildPoseEnvelopeSamples(arm, { samplesPerMate: 4 });
+    const hingeSamples = samples.filter((s) => s.name !== 'current');
+    const hingeValues = hingeSamples.map((s) => s.poses.hinge as number).sort((a, b) => a - b);
+
+    expect(hingeValues).toHaveLength(4);
+    expect(hingeValues[0]).toBe(-90);
+    expect(hingeValues[1]).toBeCloseTo(-30, 0);
+    expect(hingeValues[2]).toBeCloseTo(30, 0);
+    expect(hingeValues[3]).toBe(90);
+  });
+
+  it('preserves corner-only sampling when samplesPerMate is 1 or unset', () => {
+    const { arm, kcad } = makeArm();
+    arm
+      .part('base', kcad.box(10, 10, 10))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm
+      .part('link', kcad.box(5, 5, 5))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm.mate('hinge', 'base.axis', 'link.axis', 'revolute', { limitsDeg: [-90, 90] });
+
+    const defaultNames = buildPoseEnvelopeSamples(arm).map((s) => s.name);
+    const oneNames = buildPoseEnvelopeSamples(arm, { samplesPerMate: 1 }).map((s) => s.name);
+    expect(defaultNames).toEqual(['current', 'hinge:min', 'hinge:max']);
+    expect(oneNames).toEqual(['current', 'hinge:min', 'hinge:max']);
+  });
+
+  it('emits only min and max when samplesPerMate is 2 (no interior points)', () => {
+    const { arm, kcad } = makeArm();
+    arm
+      .part('base', kcad.box(10, 10, 10))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm
+      .part('link', kcad.box(5, 5, 5))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm.mate('hinge', 'base.axis', 'link.axis', 'revolute', { limitsDeg: [-90, 90] });
+
+    const names = buildPoseEnvelopeSamples(arm, { samplesPerMate: 2 }).map((s) => s.name);
+    expect(names).toEqual(['current', 'hinge:min', 'hinge:max']);
+  });
+
   it('reports capture-time pose values outside declared limits', () => {
     const { arm, kcad } = makeArm();
     arm

--- a/src/lib/mates/poseEnvelope.test.ts
+++ b/src/lib/mates/poseEnvelope.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { CaptureSession } from '../../capture/captureSession';
 import { createApi } from '../../modules/api';
-import { buildPoseEnvelopeSamples, reviewPoseEnvelope, validateMatePoseLimits } from './poseEnvelope';
+import {
+  buildPoseEnvelopeSamples,
+  classifySampleStrategy,
+  reviewPoseEnvelope,
+  validateMatePoseLimits,
+} from './poseEnvelope';
 
 function makeArm() {
   const session = new CaptureSession();
@@ -250,5 +255,45 @@ describe('pose-envelope review helpers', () => {
       severity: 'warning',
       connectorRef: 'link.top-center',
     }));
+  });
+
+  it('classifySampleStrategy returns correct strategy for each sample name pattern', () => {
+    expect(classifySampleStrategy('current')).toBe('corner');
+    expect(classifySampleStrategy('hinge:min')).toBe('corner');
+    expect(classifySampleStrategy('hinge:max')).toBe('corner');
+    expect(classifySampleStrategy('yaw:interior-1')).toBe('interior');
+    expect(classifySampleStrategy('yaw:interior-42')).toBe('interior');
+    expect(classifySampleStrategy('corner:00')).toBe('combinatorial');
+    expect(classifySampleStrategy('corner:1101')).toBe('combinatorial');
+    expect(classifySampleStrategy(undefined)).toBeUndefined();
+    expect(classifySampleStrategy('something-weird')).toBeUndefined();
+  });
+
+  it('tags pose-envelope diagnostics with sampleStrategy based on sample name', async () => {
+    const { arm, kcad } = makeArm();
+    arm
+      .part('base', kcad.box(10, 10, 10))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm
+      .part('link', kcad.box(5, 5, 5))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', {
+      pose: 120,
+      limitsDeg: [-90, 90],
+    });
+
+    const result = await reviewPoseEnvelope(arm, { includeInterference: false });
+    const outOfLimits = result.diagnostics.filter(
+      (d) => d.code === 'assembly.pose.out-of-limits',
+    );
+    expect(outOfLimits.length).toBeGreaterThan(0);
+    for (const diag of outOfLimits) {
+      expect(diag.sampleStrategy).toBe('corner');
+    }
+
+    // validateMatePoseLimits standalone path also carries sampleStrategy.
+    const standalone = validateMatePoseLimits(arm);
+    expect(standalone).toHaveLength(1);
+    expect(standalone[0].sampleStrategy).toBe('corner');
   });
 });

--- a/src/lib/mates/poseEnvelope.test.ts
+++ b/src/lib/mates/poseEnvelope.test.ts
@@ -163,6 +163,69 @@ describe('pose-envelope review helpers', () => {
     expect(names).toEqual(['current', 'yaw:min', 'yaw:interior-1', 'yaw:interior-2', 'yaw:max']);
   });
 
+  it('produces 2^N combinatorial corner samples when combinatorial=true', () => {
+    const { arm, kcad } = makeArm();
+    arm
+      .part('base', kcad.box(10, 10, 10))
+      .connector('yaw', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] })
+      .connector('pitch', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [1, 0, 0] });
+    arm
+      .part('link1', kcad.box(5, 5, 5))
+      .connector('yaw', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm
+      .part('link2', kcad.box(5, 5, 5))
+      .connector('pitch', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [1, 0, 0] });
+    arm.mate('yaw', 'base.yaw', 'link1.yaw', 'revolute', { limitsDeg: [-90, 90] });
+    arm.mate('pitch', 'base.pitch', 'link2.pitch', 'revolute', { limitsDeg: [-45, 45] });
+
+    const samples = buildPoseEnvelopeSamples(arm, { combinatorial: true });
+    const cornerSamples = samples.filter((s) => s.name.startsWith('corner:'));
+    expect(cornerSamples).toHaveLength(4);
+    const cornerNames = cornerSamples.map((s) => s.name).sort();
+    expect(cornerNames).toEqual(['corner:00', 'corner:01', 'corner:10', 'corner:11']);
+    const yawValues = new Set(cornerSamples.map((s) => s.poses.yaw as number));
+    const pitchValues = new Set(cornerSamples.map((s) => s.poses.pitch as number));
+    expect(yawValues).toEqual(new Set([-90, 90]));
+    expect(pitchValues).toEqual(new Set([-45, 45]));
+  });
+
+  it('refuses combinatorial sampling above 8 mates with declared limits', () => {
+    const { arm, kcad } = makeArm();
+    arm
+      .part('seg0', kcad.box(5, 5, 5))
+      .connector('out', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    for (let i = 1; i <= 9; i++) {
+      arm
+        .part(`seg${i}`, kcad.box(5, 5, 5))
+        .connector('in', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] })
+        .connector('out', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+      arm.mate(`j${i}`, `seg${i - 1}.out`, `seg${i}.in`, 'revolute', { limitsDeg: [-30, 30] });
+    }
+
+    expect(() => buildPoseEnvelopeSamples(arm, { combinatorial: true })).toThrowError(
+      /combinatorial sampling capped at 8/,
+    );
+  });
+
+  it('combinatorial sampling coexists with samplesPerMate interior points', () => {
+    const { arm, kcad } = makeArm();
+    arm
+      .part('base', kcad.box(10, 10, 10))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm
+      .part('link', kcad.box(5, 5, 5))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm.mate('hinge', 'base.axis', 'link.axis', 'revolute', { limitsDeg: [-90, 90] });
+
+    const samples = buildPoseEnvelopeSamples(arm, { samplesPerMate: 4, combinatorial: true });
+    const names = samples.map((s) => s.name);
+    expect(names).toContain('hinge:interior-1');
+    expect(names).toContain('hinge:interior-2');
+    expect(names).toContain('corner:0');
+    expect(names).toContain('corner:1');
+    expect(samples).toHaveLength(7);
+  });
+
   it('diagnoses tracked topology connector origins that cannot be sampled in capture-time workspace review', async () => {
     const { arm, kcad } = makeArm();
     arm

--- a/src/lib/mates/poseEnvelope.ts
+++ b/src/lib/mates/poseEnvelope.ts
@@ -51,7 +51,7 @@ export interface PoseEnvelopeSamplingOptions {
   combinatorial?: boolean;
 }
 
-export interface PoseEnvelopeReviewOptions {
+export interface PoseEnvelopeReviewOptions extends PoseEnvelopeSamplingOptions {
   readonly includeInterference?: boolean;
   readonly epsilonMm3?: number;
   readonly trackConnectors?: readonly string[];
@@ -163,7 +163,10 @@ export async function reviewPoseEnvelope(
 ): Promise<PoseEnvelopeReviewResult> {
   const includeInterference = opts.includeInterference ?? true;
   const epsilon = opts.epsilonMm3 ?? DEFAULT_EPSILON_MM3;
-  const samples = buildPoseEnvelopeSamples(arm);
+  const samples = buildPoseEnvelopeSamples(arm, {
+    samplesPerMate: opts.samplesPerMate,
+    combinatorial: opts.combinatorial,
+  });
   const diagnostics: PoseEnvelopeDiagnostic[] = [];
   const interferencePairs: Array<InterferencePair & { sampleName: string }> = [];
   const connectorPoses: TrackedConnectorPose[] = [];

--- a/src/lib/mates/poseEnvelope.ts
+++ b/src/lib/mates/poseEnvelope.ts
@@ -46,6 +46,11 @@ export interface PoseEnvelopeSample {
   readonly reason: string;
 }
 
+export interface PoseEnvelopeSamplingOptions {
+  samplesPerMate?: number;
+  combinatorial?: boolean;
+}
+
 export interface PoseEnvelopeReviewOptions {
   readonly includeInterference?: boolean;
   readonly epsilonMm3?: number;
@@ -82,7 +87,11 @@ export interface ConnectorWorkspace {
 
 const DEFAULT_EPSILON_MM3 = 0.01;
 
-export function buildPoseEnvelopeSamples(arm: Assembly): PoseEnvelopeSample[] {
+export function buildPoseEnvelopeSamples(
+  arm: Assembly,
+  options: PoseEnvelopeSamplingOptions = {},
+): PoseEnvelopeSample[] {
+  const samplesPerMate = options.samplesPerMate ?? 1;
   const samples: PoseEnvelopeSample[] = [
     { name: 'current', poses: {}, reason: 'capture-time/default mate poses' },
   ];
@@ -97,6 +106,18 @@ export function buildPoseEnvelopeSamples(arm: Assembly): PoseEnvelopeSample[] {
       reason: `${mate.name} lower limit`,
     });
     if (max !== min) {
+      if (samplesPerMate >= 3) {
+        const interiorCount = samplesPerMate - 2;
+        for (let i = 1; i <= interiorCount; i++) {
+          const t = i / (interiorCount + 1);
+          const value = min + (max - min) * t;
+          samples.push({
+            name: `${mate.name}:interior-${i}`,
+            poses: expandCoupledPoses(arm.__mates(), arm.__mateCouplings(), { [mate.name]: value }),
+            reason: `${mate.name} interior sample ${i}/${interiorCount}`,
+          });
+        }
+      }
       samples.push({
         name: `${mate.name}:max`,
         poses: expandCoupledPoses(arm.__mates(), arm.__mateCouplings(), { [mate.name]: max }),

--- a/src/lib/mates/poseEnvelope.ts
+++ b/src/lib/mates/poseEnvelope.ts
@@ -126,6 +126,38 @@ export function buildPoseEnvelopeSamples(
     }
   }
 
+  if (options.combinatorial) {
+    const limited = arm.__mates().filter((m) => (m.limitsDeg ?? m.limitsMm) !== undefined);
+    if (limited.length > 8) {
+      throw new Error(
+        `combinatorial sampling capped at 8 mates with declared limits; got ${limited.length}. Use samplesPerMate for higher-DOF mechanisms.`,
+      );
+    }
+    // With 0 limited mates the only "corner" is the empty pose, which duplicates
+    // the `current` sample emitted above — skip enumeration entirely to keep the
+    // output deduped.
+    if (limited.length >= 1) {
+      const width = limited.length;
+      const total = 1 << width;
+      for (let mask = 0; mask < total; mask++) {
+        const overrides: NumericPoses = {};
+        for (let i = 0; i < width; i++) {
+          const mate = limited[i];
+          const limits = (mate.limitsDeg ?? mate.limitsMm) as readonly [number, number];
+          // Bit i (LSB = mate 0) — set bit -> max, unset -> min.
+          const useMax = ((mask >> i) & 1) === 1;
+          overrides[mate.name] = useMax ? limits[1] : limits[0];
+        }
+        const maskBits = mask.toString(2).padStart(width, '0');
+        samples.push({
+          name: `corner:${maskBits}`,
+          poses: expandCoupledPoses(arm.__mates(), arm.__mateCouplings(), overrides),
+          reason: `combinatorial corner ${mask + 1}/${total}`,
+        });
+      }
+    }
+  }
+
   return samples;
 }
 

--- a/src/lib/mates/poseEnvelope.ts
+++ b/src/lib/mates/poseEnvelope.ts
@@ -31,6 +31,7 @@ export interface PoseEnvelopeDiagnostic {
   readonly message: string;
   readonly hint: string;
   readonly sampleName?: string;
+  readonly sampleStrategy?: 'corner' | 'interior' | 'combinatorial';
   readonly mateName?: string;
   readonly pose?: number | [number, number, number];
   readonly limits?: readonly [number, number];
@@ -38,6 +39,24 @@ export interface PoseEnvelopeDiagnostic {
   readonly partB?: string;
   readonly volumeMm3?: number;
   readonly connectorRef?: string;
+}
+
+/**
+ * Classifies a pose-envelope sample name into the sampling strategy that
+ * produced it. Names follow the patterns emitted by `buildPoseEnvelopeSamples`:
+ *   - `current`, `<mate>:min`, `<mate>:max` → `'corner'`
+ *   - `<mate>:interior-<i>` → `'interior'`
+ *   - `corner:<bitmask>` → `'combinatorial'`
+ *   - `undefined` or any unrecognized pattern → `undefined`
+ */
+export function classifySampleStrategy(
+  sampleName: string | undefined,
+): 'corner' | 'interior' | 'combinatorial' | undefined {
+  if (sampleName === undefined) return undefined;
+  if (sampleName.startsWith('corner:')) return 'combinatorial';
+  if (/:interior-\d+$/.test(sampleName)) return 'interior';
+  if (sampleName === 'current' || /:(min|max)$/.test(sampleName)) return 'corner';
+  return undefined;
 }
 
 export interface PoseEnvelopeSample {
@@ -178,6 +197,7 @@ export function validateMatePoseLimits(
         code: 'assembly.pose.out-of-limits',
         severity: 'error',
         sampleName,
+        sampleStrategy: classifySampleStrategy(sampleName),
         mateName: mate.name,
         pose,
         limits,
@@ -230,6 +250,7 @@ export async function reviewPoseEnvelope(
           code: 'assembly.pose-envelope.solve-failed',
           severity: 'error',
           sampleName: sample.name,
+          sampleStrategy: classifySampleStrategy(sample.name),
           message: `Pose-envelope sample '${sample.name}' produced solver status '${solved.status}'.`,
           hint: `invalid-args.assembly.pose-envelope-solve-failed — repair the mate graph or reduce declared travel before trusting this mechanism range.`,
         });
@@ -239,6 +260,7 @@ export async function reviewPoseEnvelope(
         code: 'assembly.pose-envelope.solve-failed',
         severity: 'error',
         sampleName: sample.name,
+        sampleStrategy: classifySampleStrategy(sample.name),
         message: `Pose-envelope sample '${sample.name}' could not be solved: ${e instanceof Error ? e.message : String(e)}`,
         hint: `invalid-args.assembly.pose-envelope-solve-failed — inspect the mate refs, connector origins, and pose shapes for this sample.`,
       });
@@ -252,6 +274,7 @@ export async function reviewPoseEnvelope(
         code: 'assembly.pose-envelope.interference',
         severity: 'error',
         sampleName: sample.name,
+        sampleStrategy: classifySampleStrategy(sample.name),
         partA: pair.a,
         partB: pair.b,
         volumeMm3: pair.volumeMm3,

--- a/src/mcp/toolRegistry.ts
+++ b/src/mcp/toolRegistry.ts
@@ -681,6 +681,15 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
           },
           includePoseEnvelope: { type: 'boolean', description: 'Whether to sample declared mate limits. Default true.' },
           includeInterference: { type: 'boolean', description: 'Whether sampled poses run BREP interference checks. Default true.' },
+          samplesPerMate: {
+            type: 'integer',
+            minimum: 1,
+            description: 'Pose-envelope samples per declared-limit mate. 1 (default) = corners only; >=3 adds uniform interior points between min and max. Total samples per non-locked mate = samplesPerMate.',
+          },
+          combinatorial: {
+            type: 'boolean',
+            description: 'Sample all 2^N limit-corner combinations across mates with declared limits. Capped at 8 mates with limits; combine with samplesPerMate for both interior coverage and worst-pose detection. Default false.',
+          },
           epsilonMm3: { type: 'number', description: 'Interference volume threshold in mm^3. Default 0.01.' },
           trackConnectors: {
             type: 'array',
@@ -748,6 +757,15 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
           },
           includePoseEnvelope: { type: 'boolean', description: 'Forwarded to review_cad. Default true.' },
           includeInterference: { type: 'boolean', description: 'Forwarded to review_cad. Default true.' },
+          samplesPerMate: {
+            type: 'integer',
+            minimum: 1,
+            description: 'Pose-envelope samples per declared-limit mate. 1 (default) = corners only; >=3 adds uniform interior points between min and max. Total samples per non-locked mate = samplesPerMate.',
+          },
+          combinatorial: {
+            type: 'boolean',
+            description: 'Sample all 2^N limit-corner combinations across mates with declared limits. Capped at 8 mates with limits; combine with samplesPerMate for both interior coverage and worst-pose detection. Default false.',
+          },
           epsilonMm3: { type: 'number', description: 'Forwarded to review_cad.' },
           trackConnectors: {
             type: 'array',

--- a/src/mcp/tools/designLoop.ts
+++ b/src/mcp/tools/designLoop.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, relative, resolve } from 'node:path';
 import type { GripperApertureRequest } from '../../lib/mates/gripperAperture';
 import type { MechanismFitnessResult } from '../../lib/mates/mechanismFitness';
-import { reviewCadTool, type ReviewCadInput, type ReviewCadOutput } from './reviewCad';
+import { reviewCadTool, type RepairContext, type ReviewCadInput, type ReviewCadOutput } from './reviewCad';
 
 export interface DesignLoopAttemptInput {
   id?: string;
@@ -209,8 +209,105 @@ function toAttemptResult(input: {
       ? buildQualityRepairPrompt(reviewFacts)
       : input.review.ok
       ? fitness?.repairDirective ?? 'No repair needed. Preserve the current design and rerun review_cad after changes.'
-      : input.review.suggestedRepairPrompt,
+      : buildFailureRepairPrompt(input.review),
   };
+}
+
+function buildFailureRepairPrompt(review: Extract<ReviewCadOutput, { ok: false }>): string {
+  const context = review.repairContext;
+  if (context === undefined) {
+    // Defensive fallback: predecessor commits guarantee repairContext on every
+    // review output, but keep the prior string for callers that injected an
+    // older ReviewCadOutput shape (unit tests, fixtures).
+    return review.suggestedRepairPrompt;
+  }
+  const severityByKey = indexDiagnosticSeverity(review.diagnostics);
+  const blockingLines = context.blockingReasons.map((reason) => `- ${reason}`);
+  const topLines = context.topDiagnostics
+    .slice(0, 3)
+    .map((entry) => renderTopDiagnostic(entry, severityByKey));
+  const repairDirectiveBlock = review.fitness !== undefined
+    ? `Repair mode: ${review.fitness.repairMode}\nDirective: ${review.fitness.repairDirective}`
+    : undefined;
+  const designLines: string[] = [];
+  if (context.designGoal.trim() !== '') {
+    designLines.push(`Design goal: ${context.designGoal}`);
+  }
+  if (context.preserveInterfaces.length > 0) {
+    designLines.push(`Preserve interfaces: ${context.preserveInterfaces.join(', ')}`);
+  }
+  const sections: string[] = [];
+  if (blockingLines.length > 0) {
+    sections.push(`Blocking reasons:\n${blockingLines.join('\n')}`);
+  }
+  if (topLines.length > 0) {
+    sections.push(`Top diagnostics:\n${topLines.join('\n')}`);
+  }
+  if (repairDirectiveBlock !== undefined) {
+    sections.push(repairDirectiveBlock);
+  }
+  if (designLines.length > 0) {
+    sections.push(designLines.join('\n'));
+  }
+  if (sections.length === 0) {
+    return review.suggestedRepairPrompt;
+  }
+  return sections.join('\n\n');
+}
+
+function renderTopDiagnostic(
+  entry: RepairContext['topDiagnostics'][number],
+  severityByKey: ReadonlyMap<string, string>,
+): string {
+  const severity = severityByKey.get(diagnosticKey(entry.code, entry.sampleName)) ?? 'error';
+  const parts: string[] = [`[${severity}] ${entry.code}`];
+  const scope: string[] = [];
+  if (entry.sampleName !== undefined) scope.push(`sampleName=${entry.sampleName}`);
+  if (entry.mateName !== undefined) scope.push(`mate=${entry.mateName}`);
+  if (scope.length > 0) parts.push(`@ ${scope.join(' ')}`);
+  if (entry.suggestedDelta !== undefined) {
+    parts.push(`-> suggested: ${formatSuggestedDelta(entry.suggestedDelta)}`);
+  }
+  return `- ${parts.join(' ')}`;
+}
+
+function formatSuggestedDelta(
+  delta: NonNullable<RepairContext['topDiagnostics'][number]['suggestedDelta']>,
+): string {
+  if (typeof delta.widenBy === 'number') {
+    return `widen by ${formatDeltaValue(delta.widenBy)}`;
+  }
+  if (typeof delta.narrowBy === 'number') {
+    return `narrow by ${formatDeltaValue(delta.narrowBy)}`;
+  }
+  return `adjust ${delta.mate}`;
+}
+
+function formatDeltaValue(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(2);
+}
+
+function indexDiagnosticSeverity(
+  diagnostics: readonly { code: string; severity: string; sampleName?: string }[],
+): ReadonlyMap<string, string> {
+  const map = new Map<string, string>();
+  for (const diagnostic of diagnostics) {
+    const sampleName = 'sampleName' in diagnostic && typeof diagnostic.sampleName === 'string'
+      ? diagnostic.sampleName
+      : undefined;
+    const key = diagnosticKey(diagnostic.code, sampleName);
+    if (!map.has(key)) map.set(key, normalizeSeverity(diagnostic.severity));
+  }
+  return map;
+}
+
+function diagnosticKey(code: string, sampleName: string | undefined): string {
+  return `${code}::${sampleName ?? ''}`;
+}
+
+function normalizeSeverity(severity: string): string {
+  if (severity === 'warn') return 'warning';
+  return severity;
 }
 
 function scriptQualityFacts(

--- a/src/mcp/tools/designLoop.ts
+++ b/src/mcp/tools/designLoop.ts
@@ -36,6 +36,8 @@ export interface DesignLoopInput {
   epsilonMm3?: number;
   trackConnectors?: string[];
   gripperAperture?: GripperApertureRequest;
+  samplesPerMate?: number;
+  combinatorial?: boolean;
   stopOnPass?: boolean;
   allowReviewWarnings?: string[];
   requireVisualReview?: boolean;
@@ -122,6 +124,8 @@ export async function designLoopTool(input: DesignLoopInput): Promise<DesignLoop
       epsilonMm3: input.epsilonMm3,
       trackConnectors: input.trackConnectors,
       gripperAperture: input.gripperAperture,
+      samplesPerMate: input.samplesPerMate,
+      combinatorial: input.combinatorial,
     };
     const review = await reviewCadTool(reviewInput);
     const source = attempt.code ?? (attempt.file !== undefined ? await readFile(attempt.file, 'utf-8') : '');

--- a/src/mcp/tools/reviewCad.ts
+++ b/src/mcp/tools/reviewCad.ts
@@ -37,6 +37,8 @@ export interface ReviewCadInput {
   epsilonMm3?: number;
   trackConnectors?: string[];
   gripperAperture?: GripperApertureRequest;
+  samplesPerMate?: number;
+  combinatorial?: boolean;
 }
 
 export interface RepairContext {
@@ -141,6 +143,8 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
         epsilonMm3: input.epsilonMm3,
         trackConnectors: input.trackConnectors,
         gripperAperture: input.gripperAperture,
+        samplesPerMate: input.samplesPerMate,
+        combinatorial: input.combinatorial,
       })
     : undefined;
 

--- a/src/mcp/tools/reviewCad.ts
+++ b/src/mcp/tools/reviewCad.ts
@@ -9,6 +9,7 @@ import {
 import type { GripperApertureRequest } from '../../lib/mates/gripperAperture';
 import type { PoseEnvelopeDiagnostic, PoseEnvelopeReviewResult } from '../../lib/mates/poseEnvelope';
 import { reviewPoseEnvelope } from '../../lib/mates/poseEnvelope';
+import { suggestLimitFix } from '../../lib/mates/limitFixSuggest';
 import {
   reviewMechanicalPlausibility,
   type MechanicalPlausibilityDiagnostic,
@@ -38,6 +39,18 @@ export interface ReviewCadInput {
   gripperAperture?: GripperApertureRequest;
 }
 
+export interface RepairContext {
+  readonly blockingReasons: readonly string[];
+  readonly topDiagnostics: ReadonlyArray<{
+    readonly code: string;
+    readonly sampleName?: string;
+    readonly mateName?: string;
+    readonly suggestedDelta?: { mate: string; widenBy?: number; narrowBy?: number };
+  }>;
+  readonly preserveInterfaces: readonly string[];
+  readonly designGoal: string;
+}
+
 export type ReviewCadOutput =
   | {
       ok: true;
@@ -54,6 +67,7 @@ export type ReviewCadOutput =
       connectorWorkspace?: PoseEnvelopeReviewResult['connectorWorkspace'];
       gripperAperture?: PoseEnvelopeReviewResult['gripperAperture'];
       fitness: MechanismFitnessResult;
+      repairContext: RepairContext;
     }
   | {
       ok: false;
@@ -70,18 +84,29 @@ export type ReviewCadOutput =
       connectorWorkspace?: PoseEnvelopeReviewResult['connectorWorkspace'];
       gripperAperture?: PoseEnvelopeReviewResult['gripperAperture'];
       fitness?: MechanismFitnessResult;
+      repairContext: RepairContext;
       suggestedRepairPrompt: string;
     };
+
+type ReviewDiagnostic =
+  | CompilerDiagnostic
+  | ValidatorDiagnostic
+  | PoseEnvelopeDiagnostic
+  | MechanicalPlausibilityDiagnostic
+  | MechanicalIntentDiagnostic
+  | MechanicalTransmissionDiagnostic;
 
 export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOutput> {
   const { evaluation, model } = await evaluateForReview(input as EvaluateInput);
   if (evaluation.exitCode !== 0 || !model) {
     clearActiveMcpSession();
+    const diagnostics = withNextActions(evaluation.diagnostics);
     return {
       ok: false,
       featureCount: evaluation.featureCount,
-      diagnostics: withNextActions(evaluation.diagnostics),
-      suggestedRepairPrompt: buildSuggestedRepairPrompt(withNextActions(evaluation.diagnostics), undefined, input),
+      diagnostics,
+      repairContext: await buildRepairContext(undefined, diagnostics, undefined, input),
+      suggestedRepairPrompt: buildSuggestedRepairPrompt(diagnostics, undefined, input),
     };
   }
 
@@ -100,6 +125,7 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
       ok: false,
       featureCount: evaluation.featureCount,
       diagnostics: [],
+      repairContext: await buildRepairContext(undefined, [], undefined, input),
       suggestedRepairPrompt: `${message} Return arm.model() or arm.solvedModel(...) from a script that calls assembly(...).`,
     };
   }
@@ -136,6 +162,8 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
   });
   const ok = fitness.functional;
 
+  const repairContext = await buildRepairContext(arm, diagnostics, fitness, input);
+
   if (ok) {
     return {
       ok: true,
@@ -152,6 +180,7 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
       ...(poseEnvelope !== undefined ? { connectorWorkspace: poseEnvelope.connectorWorkspace } : {}),
       ...(poseEnvelope?.gripperAperture !== undefined ? { gripperAperture: poseEnvelope.gripperAperture } : {}),
       fitness,
+      repairContext,
     };
   }
 
@@ -170,6 +199,7 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
     ...(poseEnvelope !== undefined ? { connectorWorkspace: poseEnvelope.connectorWorkspace } : {}),
     ...(poseEnvelope?.gripperAperture !== undefined ? { gripperAperture: poseEnvelope.gripperAperture } : {}),
     fitness,
+    repairContext,
     suggestedRepairPrompt: buildSuggestedRepairPrompt(diagnostics, fitness, input),
   };
 }
@@ -197,6 +227,126 @@ function selectAssembly(
   return name !== undefined
     ? assemblies.get(name)
     : assemblies.values().next().value;
+}
+
+function severityRank(diag: ReviewDiagnostic): number {
+  // CompilerDiagnostic uses 'warn'; structured diagnostics use 'warning'. Both
+  // are warning-tier and sort below 'error'. 'info' (validator-only) sorts last.
+  switch (diag.severity) {
+    case 'error':
+      return 0;
+    case 'warning':
+    case 'warn':
+      return 1;
+    default:
+      return 2;
+  }
+}
+
+function diagnosticMateName(diag: ReviewDiagnostic): string | undefined {
+  return 'mateName' in diag && typeof diag.mateName === 'string' ? diag.mateName : undefined;
+}
+
+function diagnosticSampleName(diag: ReviewDiagnostic): string | undefined {
+  return 'sampleName' in diag && typeof diag.sampleName === 'string' ? diag.sampleName : undefined;
+}
+
+function diagnosticVolume(diag: ReviewDiagnostic): number | undefined {
+  return 'volumeMm3' in diag && typeof diag.volumeMm3 === 'number' ? diag.volumeMm3 : undefined;
+}
+
+function compareDiagnostics(a: ReviewDiagnostic, b: ReviewDiagnostic): number {
+  // Severity DESC (error first), then volumeMm3 DESC (where present),
+  // then stable lex order on code, then on sampleName.
+  const sevDelta = severityRank(a) - severityRank(b);
+  if (sevDelta !== 0) return sevDelta;
+  const va = diagnosticVolume(a);
+  const vb = diagnosticVolume(b);
+  if (va !== undefined || vb !== undefined) {
+    if (va === undefined) return 1;   // entries with volume sort first
+    if (vb === undefined) return -1;
+    if (vb !== va) return vb - va;
+  }
+  if (a.code !== b.code) return a.code < b.code ? -1 : 1;
+  const sa = diagnosticSampleName(a) ?? '';
+  const sb = diagnosticSampleName(b) ?? '';
+  if (sa !== sb) return sa < sb ? -1 : 1;
+  return 0;
+}
+
+async function computeSuggestedDelta(
+  arm: Assembly | undefined,
+  diag: ReviewDiagnostic,
+): Promise<{ mate: string; widenBy?: number; narrowBy?: number } | undefined> {
+  if (diag.code !== 'assembly.pose.out-of-limits') return undefined;
+  const mateName = diagnosticMateName(diag);
+  if (mateName === undefined) return undefined;
+
+  // For out-of-limits the diagnostic carries the static pose and declared
+  // limits; the repair is to widen the bound the pose crossed. Direct
+  // computation here keeps semantics correct (suggestLimitFix only narrows,
+  // and bails on sampleName='current' which is what out-of-limits emits).
+  const pose = 'pose' in diag ? diag.pose : undefined;
+  const limits = 'limits' in diag ? diag.limits : undefined;
+  if (typeof pose === 'number' && Array.isArray(limits) && limits.length === 2) {
+    const [min, max] = limits as readonly [number, number];
+    if (pose > max) return { mate: mateName, widenBy: pose - max };
+    if (pose < min) return { mate: mateName, widenBy: min - pose };
+  }
+
+  // Fall back to suggestLimitFix for diagnostics that name a :min/:max sample
+  // (won't fire for the current out-of-limits path but kept for completeness
+  // should the diagnostic shape change).
+  if (arm !== undefined) {
+    const fix = await suggestLimitFix(arm, diag as PoseEnvelopeDiagnostic);
+    if (fix !== null) {
+      const [oMin, oMax] = fix.originalLimits;
+      const [nMin, nMax] = fix.limits;
+      if (fix.shrunkBound === 'max') {
+        return { mate: fix.mateName, narrowBy: oMax - nMax };
+      }
+      if (fix.shrunkBound === 'min') {
+        return { mate: fix.mateName, narrowBy: nMin - oMin };
+      }
+    }
+  }
+
+  return undefined;
+}
+
+async function buildRepairContext(
+  arm: Assembly | undefined,
+  diagnostics: readonly ReviewDiagnostic[],
+  fitness: MechanismFitnessResult | undefined,
+  input: Pick<ReviewCadInput, 'designGoal' | 'preserveInterfaces'>,
+): Promise<RepairContext> {
+  const blockingReasons = (fitness?.blockingReasons ?? []).map(
+    (reason) => `${reason.code}: ${reason.message}`,
+  );
+  const sorted = [...diagnostics].sort(compareDiagnostics).slice(0, 3);
+  const topDiagnostics = await Promise.all(
+    sorted.map(async (diag) => {
+      const entry: {
+        code: string;
+        sampleName?: string;
+        mateName?: string;
+        suggestedDelta?: { mate: string; widenBy?: number; narrowBy?: number };
+      } = { code: diag.code };
+      const sample = diagnosticSampleName(diag);
+      if (sample !== undefined) entry.sampleName = sample;
+      const mate = diagnosticMateName(diag);
+      if (mate !== undefined) entry.mateName = mate;
+      const delta = await computeSuggestedDelta(arm, diag);
+      if (delta !== undefined) entry.suggestedDelta = delta;
+      return entry;
+    }),
+  );
+  return {
+    blockingReasons,
+    topDiagnostics,
+    preserveInterfaces: input.preserveInterfaces ?? [],
+    designGoal: input.designGoal ?? '',
+  };
 }
 
 function buildSuggestedRepairPrompt(

--- a/src/skills/kernelcad-assemblies/SKILL.md
+++ b/src/skills/kernelcad-assemblies/SKILL.md
@@ -185,7 +185,7 @@ const snapScene = solved.toScene();               // snapshot Scene; call .toUni
 - **Numeric joint origins.** Joint origins are plain `Vec3`, not `EditableVec3`. Editing geometry params (e.g. `baseX`) reshapes parts but not joint frames; future slice will lift joint origins to `EditableVec3` once `setParamValue` reactivity is wired through.
 - **One frame per part.** Joint origins are `Vec3` numeric, can't bind to faces/edges/vertices yet.
 - **Body-tree only.** Each part has at most one parent joint; no closed-chain (4-bar linkage) kinematics.
-- **Motion-limit review is validator/tooling-level.** `limitsDeg`/`limitsMm` are checked by pose-envelope review (`review_cad` / `validateMatePoseLimits`); raw `solve()` still computes the requested pose.
+- **Motion-limit review is validator/tooling-level.** `limitsDeg`/`limitsMm` are checked by pose-envelope review (`review_cad`, `validateMatePoseLimits`, or `solvedModel(poses, { posesGate: 'envelope' })`); raw `solve()` still computes the requested pose.
 - Calling `solve()` twice on the same Assembly compounds transforms; build a fresh `assembly()` per pose query.
 
 ## Connectors and mates
@@ -323,6 +323,139 @@ The MCP server exposes assembly-specific tools for runtime introspection:
 - `review_cad({ file? | code?, assembly?, includePoseEnvelope?, includeInterference?, epsilonMm3?, trackConnectors?, gripperAperture? })` — run the deterministic agent review loop: evaluate, validate mates, sample declared pose limits, check that mate connectors touch modeled material, report connector workspace bounds, and return raw diagnostics plus a fitness summary (`fitness.functional`, `fitness.blockingReasons`, `fitness.mechanismSummary`) after an assembly is selected. Pass `trackConnectors: ['gripper-plate.tool-tip']` to focus workspace output on an end-effector; connector workspace is only computed when pose-envelope sampling is enabled. For grippers, pass `gripperAperture: { left: 'left-finger.tip', right: 'right-finger.tip' }` to get `minMm`, `maxMm`, `travelMm`, and per-sample fingertip distances.
 - `design_loop({ goal, attempts, assembly?, preserveInterfaces?, includePoseEnvelope?, includeInterference?, epsilonMm3?, trackConnectors?, gripperAperture?, stopOnPass?, allowReviewWarnings?, requireVisualReview?, outputRecordPath?, recordTitle? })` — run ordered design attempts through `review_cad`, continue past functional attempts that still have unresolved warnings, return repair prompts, and optionally write a Studio replay record. Visual review is required by default: each accepted attempt must include `visualReview: { accepted, screenshotPath, findings, checks }` after the vision-capable agent renders/opens screenshots and records concrete observations. Accepted reviews must pass these checklist codes: `main-object-count`, `proportions-match-reference`, `required-visible-features`, `no-stray-or-floating-geometry`, and `canonical-views-physically-coherent`. Missing `screenshotPath`, empty `findings`, missing checklist entries, or blank check findings fails with `assembly.visual.review-incomplete`; failed checks fail with `assembly.visual.review-check-failed`. Use `requireVisualReview: false` only for explicit non-visual batch checks. Only use `allowReviewWarnings` when the original prompt explicitly permits that warning code.
 
+## Pose-envelope review
+
+The default `solvedModel(poses, { validate })` gate only checks the single pose you passed in. Mechanisms fail in the wild because they clash, leave their connector untouched, or break the solver at the *extremes* of declared mate travel — poses that the default gate never visits. The pose-envelope review samples every mate with declared `limitsDeg` / `limitsMm` and runs the same validator + interference + connector-contact checks at each sample.
+
+### `solvedModel(poses, opts)` parameters
+
+```typescript
+arm.solvedModel(poses, {
+  validate?: 'warn' | 'error' | 'off',     // existing — controls severity
+  posesGate?: 'default' | 'envelope',      // which poses the gate covers
+  samplesPerMate?: number,                  // forwarded to the envelope sweep
+  combinatorial?: boolean,                  // forwarded to the envelope sweep
+});
+```
+
+`validate` and `posesGate` are orthogonal:
+
+| `validate` | `posesGate` | Behavior |
+|---|---|---|
+| `'off'`   | (any)        | No validation. `scene.warnings` is the empty array. |
+| `'warn'`  | `'default'`  | (default) Default-pose validator only. Diagnostics attach to `scene.warnings`. |
+| `'warn'`  | `'envelope'` | Default-pose validator runs, then `reviewPoseEnvelope` runs over sampled poses. All diagnostics — including envelope errors — attach to `scene.warnings`. Never throws. |
+| `'error'` | `'default'`  | Default-pose validator throws on the first error-severity diagnostic. |
+| `'error'` | `'envelope'` | Default-pose validator runs first; if clean, the envelope review runs and any envelope-error diagnostic throws `KernelError('feature.invalid-args')` with a message listing the failing code counts (e.g. `pose-envelope errors: assembly.pose-envelope.interference (x3)`) and the first offender's hint. |
+
+`scene.warnings` is typed `SceneDiagnostic[]` — the union `ValidatorDiagnostic | PoseEnvelopeDiagnostic` — so an envelope-mode warn-run lets you iterate every sample's findings without losing the validator entries.
+
+### `samplesPerMate` — interior coverage
+
+`samplesPerMate` is the **total** sample count per non-locked mate. The endpoint pair is always emitted; interior points are added only at `N >= 3`.
+
+| `samplesPerMate` | Samples per mate with declared limits |
+|---|---|
+| `1` (default) | `{min, max}` — corners only |
+| `2`           | `{min, max}` — identical to `1` (no room for interior) |
+| `3`           | `{min, midpoint, max}` |
+| `N >= 3`      | `{min, plus N-2 uniform interior points, max}` |
+
+A revolute with `limitsDeg: [-90, 90]` and `samplesPerMate: 4` produces poses at `-90, -30, 30, 90`. Use this when the worst pose isn't at a corner — long links sweeping through air gaps, or interference that only shows up mid-stroke.
+
+### `combinatorial` — corner-tuple sweep
+
+`combinatorial: true` enumerates all `2^M` min/max combinations across mates with declared limits, where `M` is the count of limited mates. This catches diagonal interference: two joints that are each clean at their own corners but collide when both go to their extremes simultaneously.
+
+Footgun: solve cost scales as `2^M`. `M=8` is 256 solves; `M=9` throws synchronously from `buildPoseEnvelopeSamples` with `combinatorial sampling capped at 8 mates with declared limits; got <N>. Use samplesPerMate for higher-DOF mechanisms.` Reach for `combinatorial` only when you've already minimized declared-limit mates, or for a small sub-assembly under design review.
+
+`samplesPerMate` and `combinatorial` compose: enable both for interior coverage plus worst-pose diagonal detection.
+
+### Diagnostic shape and `sampleStrategy`
+
+Envelope diagnostics carry a `sampleStrategy` field so downstream tools (Studio review panes, repair-loop summarizers) can tell which sweep family caught the failure:
+
+```typescript
+interface PoseEnvelopeDiagnostic {
+  readonly code: PoseEnvelopeDiagnosticCode;
+  readonly severity: 'warning' | 'error';
+  readonly message: string;
+  readonly hint: string;
+  readonly sampleName?: string;
+  readonly sampleStrategy?: 'corner' | 'interior' | 'combinatorial';
+  readonly mateName?: string;
+  readonly pose?: number | [number, number, number];
+  readonly limits?: readonly [number, number];
+  readonly partA?: string;
+  readonly partB?: string;
+  readonly volumeMm3?: number;
+  readonly connectorRef?: string;
+}
+```
+
+`sampleStrategy` classification: `<mate>:min` / `<mate>:max` / `current` → `'corner'`; `<mate>:interior-<i>` → `'interior'`; `corner:<bitmask>` → `'combinatorial'`. Five emitting codes:
+
+- `assembly.pose.out-of-limits` — a sample pose fell outside the mate's declared `limitsDeg`/`limitsMm`. Hint: `invalid-args.assembly.pose-out-of-limits — clamp '<mate>' to [<min>, <max>] or widen the mate limits if the mechanism is intended to travel that far.`
+- `assembly.pose-envelope.solve-failed` — solver reported `over-constrained` / `did-not-converge` at this sample. Hint: `invalid-args.assembly.pose-envelope-solve-failed — repair the mate graph or reduce declared travel before trusting this mechanism range.`
+- `assembly.pose-envelope.interference` — sampled pose makes two parts overlap by more than `epsilonMm3`. Hint: `invalid-args.assembly.pose-envelope-interference — add clearance, reduce mate travel, or move the connector/mount geometry so the swept pose stays collision-free.`
+- `assembly.pose-envelope.connector-unresolved` — a tracked connector has a topology-based origin and was skipped from workspace bounds. Hint: `invalid-args.assembly.pose-envelope-connector-unresolved — use a numeric vec3 connector origin for workspace review, or run a lowerer-backed topology resolver before requesting this connector.`
+- `assembly.gripper-aperture.connector-missing` — one or both fingertip connector refs weren't observed. Hint: `invalid-args.assembly.gripper-aperture-connector-missing — pass gripperAperture refs that exist as numeric frame connectors and are included in pose-envelope samples.`
+
+### Worked example
+
+A single-link hinge that clashes only at the upper limit:
+
+```typescript
+const base  = arm.part('base',  box(60, 60, 8));
+const link  = arm.part('link',  box(80, 12, 8).translate(40, 0, 8));
+base.connector('hinge-base', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 8] }, axis: [0, 0, 1] });
+link.connector('hinge-end',  { type: 'axis', origin: { kind: 'vec3', value: [-40, 0, 0] }, axis: [0, 0, 1] });
+arm.mate('hinge', 'base.hinge-base', 'link.hinge-end', 'revolute', {
+  limitsDeg: [-30, 175],   // 175 sweeps the link into the base
+});
+
+const scene = await arm.solvedModel({}, {
+  posesGate: 'envelope',
+  samplesPerMate: 4,
+  validate: 'error',
+});
+// Throws KernelError('feature.invalid-args'):
+//   "solvedModel: pose-envelope errors: assembly.pose-envelope.interference (x1)"
+//   hint: invalid-args.assembly.pose-envelope-interference — add clearance, …
+```
+
+Switching to `validate: 'warn'` returns a Scene whose `warnings` array contains the same diagnostic with `sampleStrategy: 'corner'`, `sampleName: 'hinge:max'`, `partA: 'base'`, `partB: 'link'`, and the overlap volume. Repair: tighten `limitsDeg` to e.g. `[-30, 90]`, or move the link's origin.
+
+### CLI surface
+
+`kernelcad evaluate <file> [--envelope] [--samples-per-mate N] [--combinatorial]` runs the envelope review across every captured assembly. Exit 0 (clean) / 1 (script error, or sampling flags used without `--envelope`) / 2 (envelope-error diagnostics surfaced). Passing `--samples-per-mate` or `--combinatorial` without `--envelope` is rejected to prevent silent no-ops.
+
+### MCP surface
+
+`review_cad` and `design_loop` accept `samplesPerMate` (integer ≥ 1) and `combinatorial` (boolean) with the same semantics as the script API. `review_cad` also returns `repairContext` on both `ok: true` and `ok: false` branches:
+
+```typescript
+interface RepairContext {
+  readonly blockingReasons: readonly string[];    // formatted "code: message"
+  readonly topDiagnostics: ReadonlyArray<{
+    readonly code: string;
+    readonly sampleName?: string;
+    readonly mateName?: string;
+    readonly suggestedDelta?: { mate: string; widenBy?: number; narrowBy?: number };
+  }>;
+  readonly preserveInterfaces: readonly string[];
+  readonly designGoal: string;
+}
+```
+
+`suggestedDelta.widenBy` / `narrowBy` are in **degrees for revolute / cylindrical / pin_slot mates, mm for prismatic mates** — the same unit as the diagnostic's `limits` field. `design_loop` renders its `nextActionPrompt` directly from this context: blocking reasons first, then the top three diagnostics with explicit `widen by N` / `narrow by N` directives when a suggested delta is present.
+
+### Known limitations
+
+- **Sampled bounds, not analytic.** `connectorWorkspace.min` / `.max` are AABB extremes computed from the sampled poses. Sparse sampling (`samplesPerMate: 1`) understates the true reachable region because the worst pose isn't always at a corner. For workspace-critical claims, use `samplesPerMate >= 4` and/or `combinatorial: true` on the limited DOF subset.
+- **Numeric vec3 connectors only for workspace.** Topology-bound connector origins surface `assembly.pose-envelope.connector-unresolved` (warning) and are skipped from `connectorWorkspace`. Switch the tracked connector to `{ kind: 'vec3', value: [...] }` for inclusion.
+- **`limitsDeg`/`limitsMm` required.** Mates without declared limits are not sampled — they contribute only the `current` pose. The pose-envelope review is silent on infinite-travel mates by design.
+
 ## Drive transmissions
 
 Mate coupling is not physical transmission. If you use `arm.coupleMates(driven, { source, ratio })`, also declare how motion gets from the actuator/input mate to the driven output:
@@ -372,6 +505,11 @@ For robot arms specifically, preserve at least these interfaces between repair a
 | `assembly.connector.topology-not-resolvable` | connector declaration — unresolvable topology query |
 | `assembly.transmission.missing-for-coupled-mate` | review_cad — coupled mate without transmission |
 | `assembly.transmission.path-disconnected` | review_cad — transmission path has air gap |
+| `assembly.pose.out-of-limits` | pose-envelope — sample fell outside declared mate limits |
+| `assembly.pose-envelope.solve-failed` | pose-envelope — solver hit over-constrained / did-not-converge at sample |
+| `assembly.pose-envelope.interference` | pose-envelope — sampled pose overlaps two parts |
+| `assembly.pose-envelope.connector-unresolved` | pose-envelope — tracked connector has topology-based origin |
+| `assembly.gripper-aperture.connector-missing` | pose-envelope — fingertip connector ref not observed |
 | `assembly.visual.review-incomplete` | design_loop — missing screenshot/findings/checklist |
 | `assembly.visual.review-check-failed` | design_loop — a visual checklist check failed |
 

--- a/src/skills/kernelcad-mcp/SKILL.md
+++ b/src/skills/kernelcad-mcp/SKILL.md
@@ -62,8 +62,26 @@ All edit tools return the modified source plus diagnostics. Re-run `kernelcad ev
 - `list_mates({ assembly? })` — return the declared mate records on the active assembly: `{ mates: [{ name, a, b, type, pose?, limitsDeg?, limitsMm? }, ...] }`.
 - `validate_assembly({ assembly? })` — run the mate-aware validator on the active assembly; returns `{ status, diagnostics, partCount, jointCount }` where each diagnostic carries `code` and `hint` for recovery.
 - `solve_mates({ assembly?, poses? })` — run the mate-graph solver on the active assembly; returns `{ status, poses, iterations? }` with each pose serialized as `{ translation, rotateAxis, rotateDeg }`. The `poses` input overrides mate pose values by mate name; coupled driven mates are expanded from their source mate before solve.
-- `review_cad({ file? | code?, assembly?, includePoseEnvelope?, includeInterference?, epsilonMm3?, trackConnectors?, gripperAperture? })` — evaluate a script, validate its assembly/mate graph, check that mate connectors touch modeled material, sample declared mate limits, optionally run BREP interference checks at those samples, report connector workspace bounds, optionally report gripper aperture between two fingertip connector refs, and return raw diagnostics plus a fitness summary (`fitness.functional`, `fitness.blockingReasons`, `fitness.mechanismSummary`) after an assembly is selected.
-- `design_loop({ goal, attempts, assembly?, preserveInterfaces?, includePoseEnvelope?, includeInterference?, epsilonMm3?, trackConnectors?, gripperAperture?, stopOnPass?, allowReviewWarnings?, requireVisualReview?, outputRecordPath?, recordTitle? })` — review ordered design attempts, return repair prompts, and optionally write a Studio-compatible replay record. Accepted visual reviews must include `screenshotPath`, non-empty `findings`, and passing checks; otherwise `assembly.visual.review-incomplete`, `assembly.visual.review-evidence-weak`, or `assembly.visual.review-check-failed` keeps the attempt from passing. Set `requireVisualReview: false` only for explicit non-visual batch checks.
+- `review_cad({ file? | code?, assembly?, includePoseEnvelope?, includeInterference?, samplesPerMate?, combinatorial?, epsilonMm3?, trackConnectors?, gripperAperture? })` — evaluate a script, validate its assembly/mate graph, check that mate connectors touch modeled material, sample declared mate limits, optionally run BREP interference checks at those samples, report connector workspace bounds, optionally report gripper aperture between two fingertip connector refs, and return raw diagnostics plus a fitness summary (`fitness.functional`, `fitness.blockingReasons`, `fitness.mechanismSummary`) after an assembly is selected. `samplesPerMate` (integer ≥ 1, default 1) is the **total** sample count per declared-limit mate — `1`/`2` = corners only, `>=3` adds `samplesPerMate - 2` uniform interior points. `combinatorial` (default false) emits all `2^M` min/max corner-tuples across mates with declared limits and is capped at `M <= 8` (`M=9` throws with `combinatorial sampling capped at 8 mates with declared limits`). `review_cad` always returns `repairContext: RepairContext` (see below).
+- `design_loop({ goal, attempts, assembly?, preserveInterfaces?, includePoseEnvelope?, includeInterference?, samplesPerMate?, combinatorial?, epsilonMm3?, trackConnectors?, gripperAperture?, stopOnPass?, allowReviewWarnings?, requireVisualReview?, outputRecordPath?, recordTitle? })` — review ordered design attempts, return repair prompts, and optionally write a Studio-compatible replay record. `samplesPerMate` / `combinatorial` are forwarded to `review_cad` with the same semantics (corners-only at `1`, interior coverage at `>=3`, full-corner sweep at `combinatorial: true`, cap of 8 limited mates). `nextActionPrompt` is rendered from each attempt's `repairContext` — blocking reasons first, then the top three diagnostics with explicit `widen by N` / `narrow by N` directives when a `suggestedDelta` is present. Accepted visual reviews must include `screenshotPath`, non-empty `findings`, and passing checks; otherwise `assembly.visual.review-incomplete`, `assembly.visual.review-evidence-weak`, or `assembly.visual.review-check-failed` keeps the attempt from passing. Set `requireVisualReview: false` only for explicit non-visual batch checks.
+
+`review_cad` returns this `repairContext` on both the `ok: true` and `ok: false` branches so a calling agent always has a structured handle on what to fix and what to preserve:
+
+```typescript
+interface RepairContext {
+  readonly blockingReasons: readonly string[];    // formatted "code: message" from fitness.blockingReasons
+  readonly topDiagnostics: ReadonlyArray<{
+    readonly code: string;
+    readonly sampleName?: string;
+    readonly mateName?: string;
+    readonly suggestedDelta?: { mate: string; widenBy?: number; narrowBy?: number };
+  }>;
+  readonly preserveInterfaces: readonly string[];
+  readonly designGoal: string;
+}
+```
+
+`suggestedDelta.widenBy` / `narrowBy` are in **degrees** for revolute / cylindrical / pin_slot mates and **mm** for prismatic mates — the same unit as the diagnostic's `limits` field. `topDiagnostics` is capped at three entries, ordered by severity. `preserveInterfaces` and `designGoal` echo the inputs so the repair agent doesn't drop them between attempts.
 
 ### Export
 

--- a/tests/unit/cli/evaluateEnvelope.test.ts
+++ b/tests/unit/cli/evaluateEnvelope.test.ts
@@ -1,0 +1,123 @@
+// tests/unit/cli/evaluateEnvelope.test.ts
+//
+// Task 7 of pose-envelope review-loop closure: `kernelcad evaluate`
+// `--envelope` / `--samples-per-mate <n>` / `--combinatorial` flags.
+//
+// Predecessor (Task 6): `Assembly.solvedModel(poses, {posesGate:'envelope'})`
+// already runs `reviewPoseEnvelope` and throws under `validate:'error'`. This
+// task wires CLI flags so the harness gate fires on the script's captured
+// assemblies even when the script never calls `solvedModel(...)` (e.g.
+// returns `arm.model()`).
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { evaluateWithEnvelope } from '../../../src/cli/commands/evaluate';
+import { initOcct } from '../../../src/backends/occt/occtBackend';
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('kernelcad evaluate --envelope', () => {
+  beforeAll(async () => { await initOcct(); }, 60000);
+
+  it('kernelcad evaluate --envelope exits 2 when pose-envelope has an error diagnostic', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'kcad-test-'));
+    const file = join(tmp, 'out-of-limits.kcad.ts');
+    writeFileSync(file, `
+      const arm = assembly('rig');
+      arm.part('base', box(10, 10, 10))
+        .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+      arm.part('link', box(5, 5, 5))
+        .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+      arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', {
+        pose: 120,
+        limitsDeg: [-90, 90],
+      });
+      return arm.model();
+    `);
+
+    const result = await evaluateWithEnvelope({ file, envelope: true });
+    expect(result.exitCode).toBe(2);
+    const errCodes = result.envelopeDiagnostics?.filter((d) => d.severity === 'error').map((d) => d.code) ?? [];
+    expect(errCodes).toContain('assembly.pose.out-of-limits');
+  }, 60000);
+
+  it('kernelcad evaluate (no flag) exits 0 on the same script', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'kcad-test-'));
+    const file = join(tmp, 'out-of-limits.kcad.ts');
+    writeFileSync(file, `
+      const arm = assembly('rig');
+      arm.part('base', box(10, 10, 10))
+        .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+      arm.part('link', box(5, 5, 5))
+        .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+      arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', {
+        pose: 120,
+        limitsDeg: [-90, 90],
+      });
+      return arm.model();
+    `);
+
+    const result = await evaluateWithEnvelope({ file, envelope: false });
+    expect(result.exitCode).toBe(0);
+  }, 60000);
+
+  it('kernelcad evaluate --samples-per-mate 4 without --envelope exits 1 with diagnostic', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'kcad-test-'));
+    const file = join(tmp, 'demo.kcad.ts');
+    writeFileSync(file, `
+      const b = box(10, 10, 10);
+      return b;
+    `);
+
+    const result = await evaluateWithEnvelope({ file, envelope: false, samplesPerMate: 4 });
+    expect(result.exitCode).toBe(1);
+    expect(result.misuseMessage).toMatch(/--samples-per-mate has no effect without --envelope/);
+  }, 60000);
+
+  it('kernelcad evaluate --envelope --samples-per-mate 4 propagates sampling to the gate', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'kcad-test-'));
+    const file = join(tmp, 'single-part.kcad.ts');
+    // Per task: "if too brittle [to construct a clean multi-part envelope
+    // under includeInterference: true], just verify that the CLI accepts the
+    // flag and exits 0 on a clean script — coverage is in the unit tests,
+    // integration just confirms wiring." Single-part assembly: no mates, so
+    // no per-mate samples are added; only the 'current' sample runs. No
+    // pairwise interference is possible with one part. exit 0 confirms the
+    // CLI parses --samples-per-mate without crashing.
+    writeFileSync(file, `
+      const arm = assembly('rig');
+      arm.part('base', box(10, 10, 10));
+      return arm.model();
+    `);
+
+    const result = await evaluateWithEnvelope({ file, envelope: true, samplesPerMate: 4 });
+    expect(result.exitCode).toBe(0);
+    expect(result.envelopeSampleCount).toBe(1);
+  }, 60000);
+
+  it('returns exitCode 0 with no envelope output when --envelope set but script has no assemblies', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'kcad-test-'));
+    const file = join(tmp, 'noasm.kcad.ts');
+    writeFileSync(file, `
+      const b = box(10, 10, 10);
+      return b;
+    `);
+
+    const result = await evaluateWithEnvelope({ file, envelope: true });
+    expect(result.exitCode).toBe(0);
+    expect(result.envelopeDiagnostics ?? []).toEqual([]);
+  }, 60000);
+
+  it('kernelcad evaluate --combinatorial without --envelope exits 1 with diagnostic', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'kcad-test-'));
+    const file = join(tmp, 'demo.kcad.ts');
+    writeFileSync(file, `
+      const b = box(10, 10, 10);
+      return b;
+    `);
+
+    const result = await evaluateWithEnvelope({ file, envelope: false, combinatorial: true });
+    expect(result.exitCode).toBe(1);
+    expect(result.misuseMessage).toMatch(/--combinatorial has no effect without --envelope/);
+  }, 60000);
+});

--- a/tests/unit/mcp/designLoopEnvelopeOptions.test.ts
+++ b/tests/unit/mcp/designLoopEnvelopeOptions.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { MechanismFitnessResult } from '../../../src/lib/mates/mechanismFitness';
+import type { ReviewCadInput, ReviewCadOutput } from '../../../src/mcp/tools/reviewCad';
+
+const mockReviewCadTool = vi.fn<(input: ReviewCadInput) => Promise<ReviewCadOutput>>();
+
+vi.mock('../../../src/mcp/tools/reviewCad', () => ({
+  reviewCadTool: (input: ReviewCadInput) => mockReviewCadTool(input),
+}));
+
+// Imported after the mock so designLoopTool's reviewCadTool reference is the mock.
+import { designLoopTool } from '../../../src/mcp/tools/designLoop';
+
+function cleanFitness(): MechanismFitnessResult {
+  return {
+    functional: true,
+    repairMode: 'none',
+    repairDirective: 'No repair needed. Preserve the current design and rerun review_cad after changes.',
+    passedChecks: ['validator-no-errors'],
+    blockingReasons: [],
+    mechanismSummary: {
+      sampleCount: 0,
+      interferenceCount: 0,
+      trackedConnectorCount: 0,
+    },
+  };
+}
+
+function cleanReviewOutput(): ReviewCadOutput {
+  return {
+    ok: true,
+    featureCount: 1,
+    diagnostics: [],
+    assembly: 'clean',
+    validator: { status: 'ok', diagnostics: [], partCount: 1, jointCount: 0 },
+    fitness: cleanFitness(),
+    repairContext: {
+      blockingReasons: [],
+      topDiagnostics: [],
+      preserveInterfaces: [],
+      designGoal: '',
+    },
+  };
+}
+
+describe('design_loop envelope-option pass-through', () => {
+  it('designLoopTool forwards samplesPerMate per attempt', async () => {
+    mockReviewCadTool.mockReset();
+    mockReviewCadTool.mockResolvedValue(cleanReviewOutput());
+
+    await designLoopTool({
+      goal: 'Test samplesPerMate plumbing.',
+      requireVisualReview: false,
+      samplesPerMate: 5,
+      attempts: [{ id: '01', title: 'attempt-1', code: 'return undefined;' }],
+    });
+
+    expect(mockReviewCadTool).toHaveBeenCalledTimes(1);
+    const reviewInput = mockReviewCadTool.mock.calls[0]?.[0];
+    expect(reviewInput?.samplesPerMate).toBe(5);
+  });
+
+  it('designLoopTool forwards combinatorial per attempt', async () => {
+    mockReviewCadTool.mockReset();
+    mockReviewCadTool.mockResolvedValue(cleanReviewOutput());
+
+    await designLoopTool({
+      goal: 'Test combinatorial plumbing.',
+      requireVisualReview: false,
+      combinatorial: true,
+      attempts: [{ id: '01', title: 'attempt-1', code: 'return undefined;' }],
+    });
+
+    expect(mockReviewCadTool).toHaveBeenCalledTimes(1);
+    const reviewInput = mockReviewCadTool.mock.calls[0]?.[0];
+    expect(reviewInput?.combinatorial).toBe(true);
+  });
+});

--- a/tests/unit/mcp/designLoopNextActionPrompt.test.ts
+++ b/tests/unit/mcp/designLoopNextActionPrompt.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { MechanismFitnessResult } from '../../../src/lib/mates/mechanismFitness';
+import type { ReviewCadInput, ReviewCadOutput } from '../../../src/mcp/tools/reviewCad';
+
+const mockReviewCadTool = vi.fn<(input: ReviewCadInput) => Promise<ReviewCadOutput>>();
+
+vi.mock('../../../src/mcp/tools/reviewCad', () => ({
+  reviewCadTool: (input: ReviewCadInput) => mockReviewCadTool(input),
+}));
+
+// Imported after the mock so designLoopTool's reviewCadTool reference is the mock.
+import { designLoopTool } from '../../../src/mcp/tools/designLoop';
+
+function failingFitness(): MechanismFitnessResult {
+  return {
+    functional: false,
+    repairMode: 'parameter-tune',
+    repairDirective: 'Widen the hinge mate limits to cover the requested pose.',
+    passedChecks: [],
+    blockingReasons: [
+      {
+        code: 'assembly.pose.out-of-limits',
+        message: "mate 'hinge' pose 120° exceeds limits [-90, 90].",
+        repairHint: 'Widen the limits of the hinge mate to cover pose 120.',
+      },
+    ],
+    mechanismSummary: {
+      sampleCount: 0,
+      interferenceCount: 0,
+      trackedConnectorCount: 0,
+    },
+  };
+}
+
+function failingReviewOutput(): ReviewCadOutput {
+  return {
+    ok: false,
+    featureCount: 1,
+    diagnostics: [
+      {
+        code: 'assembly.pose.out-of-limits',
+        severity: 'error',
+        message: "mate 'hinge' pose 120° exceeds limits [-90, 90].",
+        hint: 'Widen the limits of the hinge mate to cover pose 120.',
+        mateName: 'hinge',
+        pose: 120,
+        limits: [-90, 90],
+        sampleName: 'current',
+        // PoseEnvelopeDiagnostic shape; cast loosened for the unit test.
+      } as unknown as ReviewCadOutput['diagnostics'][number],
+    ],
+    assembly: 'rig',
+    validator: {
+      status: 'ok',
+      diagnostics: [],
+      partCount: 2,
+      jointCount: 1,
+    },
+    fitness: failingFitness(),
+    repairContext: {
+      blockingReasons: [
+        "assembly.pose.out-of-limits: mate 'hinge' pose 120° exceeds limits [-90, 90].",
+      ],
+      topDiagnostics: [
+        {
+          code: 'assembly.pose.out-of-limits',
+          sampleName: 'current',
+          mateName: 'hinge',
+          suggestedDelta: { mate: 'hinge', widenBy: 30 },
+        },
+      ],
+      preserveInterfaces: ['base-yaw mate'],
+      designGoal: 'Test hinge widening repair flow.',
+    },
+    suggestedRepairPrompt: 'Repair the kernelCAD script using these deterministic review facts:\nRepair mode: parameter-tune\nDirective: Widen the hinge mate limits to cover the requested pose.\n\n- assembly.pose.out-of-limits [current]: mate exceeds limits. Hint: Widen the limits.',
+  };
+}
+
+function cleanReviewOutput(): ReviewCadOutput {
+  return {
+    ok: true,
+    featureCount: 1,
+    diagnostics: [],
+    assembly: 'clean',
+    validator: { status: 'ok', diagnostics: [], partCount: 1, jointCount: 0 },
+    fitness: {
+      functional: true,
+      repairMode: 'none',
+      repairDirective: 'No repair needed. Preserve the current design and rerun review_cad after changes.',
+      passedChecks: ['validator-no-errors'],
+      blockingReasons: [],
+      mechanismSummary: {
+        sampleCount: 0,
+        interferenceCount: 0,
+        trackedConnectorCount: 0,
+      },
+    },
+    repairContext: {
+      blockingReasons: [],
+      topDiagnostics: [],
+      preserveInterfaces: [],
+      designGoal: 'Test clean pass.',
+    },
+  };
+}
+
+describe('design_loop nextActionPrompt rendering from RepairContext', () => {
+  it('nextActionPrompt cites blockingReasons from RepairContext on failure', async () => {
+    mockReviewCadTool.mockReset();
+    mockReviewCadTool.mockResolvedValue(failingReviewOutput());
+
+    const result = await designLoopTool({
+      goal: 'Test hinge widening repair flow.',
+      preserveInterfaces: ['base-yaw mate'],
+      requireVisualReview: false,
+      attempts: [{ id: '01', title: 'Out-of-limits', code: 'return undefined;' }],
+    });
+
+    expect(result.ok).toBe(false);
+    const prompt = result.attempts[0].nextActionPrompt;
+    expect(prompt).toContain("mate 'hinge' pose 120° exceeds limits [-90, 90].");
+  });
+
+  it('nextActionPrompt cites top diagnostics with suggestedDelta when present', async () => {
+    mockReviewCadTool.mockReset();
+    mockReviewCadTool.mockResolvedValue(failingReviewOutput());
+
+    const result = await designLoopTool({
+      goal: 'Test hinge widening repair flow.',
+      requireVisualReview: false,
+      attempts: [{ id: '01', title: 'Out-of-limits', code: 'return undefined;' }],
+    });
+
+    const prompt = result.attempts[0].nextActionPrompt;
+    expect(prompt).toMatch(/widen by 30/i);
+    expect(prompt).toContain('hinge');
+  });
+
+  it('nextActionPrompt does not duplicate suggestedRepairPrompt verbatim', async () => {
+    mockReviewCadTool.mockReset();
+    const review = failingReviewOutput();
+    mockReviewCadTool.mockResolvedValue(review);
+
+    const result = await designLoopTool({
+      goal: 'Test hinge widening repair flow.',
+      requireVisualReview: false,
+      attempts: [{ id: '01', title: 'Out-of-limits', code: 'return undefined;' }],
+    });
+
+    const prompt = result.attempts[0].nextActionPrompt;
+    // Verifies the prompt was BUILT from the structured context (has structured-bullet shape),
+    // not just copy-pasted from result.suggestedRepairPrompt.
+    expect(prompt).toMatch(/\[error\]|Top diagnostics:/i);
+    // And the prompt should not be byte-equal to the raw suggestedRepairPrompt.
+    expect(prompt).not.toBe((review as { suggestedRepairPrompt: string }).suggestedRepairPrompt);
+  });
+
+  it('nextActionPrompt happy path still says "no interferences" on ok:true', async () => {
+    mockReviewCadTool.mockReset();
+    mockReviewCadTool.mockResolvedValue(cleanReviewOutput());
+
+    const result = await designLoopTool({
+      goal: 'Test clean pass.',
+      requireVisualReview: false,
+      attempts: [{ id: '01', title: 'Clean', code: 'return undefined;' }],
+    });
+
+    expect(result.ok).toBe(true);
+    const prompt = result.attempts[0].nextActionPrompt;
+    // ok:true uses fitness.repairDirective. No [error] lines.
+    expect(prompt).not.toMatch(/\[error\]/);
+    expect(prompt).toMatch(/no repair needed|preserve the current design/i);
+  });
+});

--- a/tests/unit/mcp/reviewCadEnvelopeOptions.test.ts
+++ b/tests/unit/mcp/reviewCadEnvelopeOptions.test.ts
@@ -1,0 +1,78 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PoseEnvelopeReviewOptions, PoseEnvelopeReviewResult } from '../../../src/lib/mates/poseEnvelope';
+import { initOcct } from '../../../src/backends/occt/occtBackend';
+import { clearActiveMcpSession } from '../../../src/mcp/activeSession';
+
+const reviewPoseEnvelopeSpy = vi.fn<
+  (arm: unknown, opts?: PoseEnvelopeReviewOptions) => Promise<PoseEnvelopeReviewResult>
+>();
+
+vi.mock('../../../src/lib/mates/poseEnvelope', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/lib/mates/poseEnvelope')>(
+    '../../../src/lib/mates/poseEnvelope',
+  );
+  return {
+    ...actual,
+    reviewPoseEnvelope: (arm: unknown, opts?: PoseEnvelopeReviewOptions) =>
+      reviewPoseEnvelopeSpy(arm, opts),
+  };
+});
+
+// Imported AFTER the mock so reviewCadTool's reviewPoseEnvelope reference is the spy.
+import { reviewCadTool } from '../../../src/mcp/tools/reviewCad';
+
+function emptyEnvelopeResult(): PoseEnvelopeReviewResult {
+  return {
+    samples: [],
+    diagnostics: [],
+    interferencePairs: [],
+    connectorPoses: [],
+    connectorWorkspace: [],
+  };
+}
+
+const SIMPLE_ARM_CODE = `
+  const arm = assembly('rig');
+  arm.part('base', box(10, 10, 10))
+    .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+  arm.part('link', box(5, 5, 5))
+    .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+  arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', {
+    pose: 0,
+    limitsDeg: [-90, 90],
+  });
+  return arm.model();
+`;
+
+describe('review_cad envelope-option pass-through', () => {
+  beforeAll(async () => { await initOcct(); }, 60000);
+  beforeEach(() => {
+    clearActiveMcpSession();
+    reviewPoseEnvelopeSpy.mockReset();
+    reviewPoseEnvelopeSpy.mockResolvedValue(emptyEnvelopeResult());
+  });
+
+  it('reviewCadTool forwards samplesPerMate to reviewPoseEnvelope', async () => {
+    await reviewCadTool({
+      code: SIMPLE_ARM_CODE,
+      includeInterference: false,
+      samplesPerMate: 4,
+    });
+
+    expect(reviewPoseEnvelopeSpy).toHaveBeenCalledTimes(1);
+    const opts = reviewPoseEnvelopeSpy.mock.calls[0]?.[1];
+    expect(opts?.samplesPerMate).toBe(4);
+  });
+
+  it('reviewCadTool forwards combinatorial to reviewPoseEnvelope', async () => {
+    await reviewCadTool({
+      code: SIMPLE_ARM_CODE,
+      includeInterference: false,
+      combinatorial: true,
+    });
+
+    expect(reviewPoseEnvelopeSpy).toHaveBeenCalledTimes(1);
+    const opts = reviewPoseEnvelopeSpy.mock.calls[0]?.[1];
+    expect(opts?.combinatorial).toBe(true);
+  });
+});

--- a/tests/unit/mcp/reviewCadRepairContext.test.ts
+++ b/tests/unit/mcp/reviewCadRepairContext.test.ts
@@ -1,0 +1,119 @@
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { initOcct } from '../../../src/backends/occt/occtBackend';
+import { clearActiveMcpSession } from '../../../src/mcp/activeSession';
+import { reviewCadTool } from '../../../src/mcp/tools/reviewCad';
+
+describe('review_cad repairContext', () => {
+  beforeAll(async () => { await initOcct(); }, 60000);
+  beforeEach(() => { clearActiveMcpSession(); });
+
+  it('emits repairContext on ok:true output', async () => {
+    const r = await reviewCadTool({
+      includeInterference: false,
+      code: `
+        const arm = assembly('clean');
+        arm.part('base', box(10, 10, 10));
+        return arm.model();
+      `,
+    });
+
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.repairContext).toBeDefined();
+      expect(r.repairContext.blockingReasons.length).toBe(0);
+      expect(r.repairContext.preserveInterfaces).toEqual([]);
+      expect(r.repairContext.designGoal).toBe('');
+    }
+  });
+
+  it('emits repairContext with top 3 diagnostics on ok:false output', async () => {
+    const r = await reviewCadTool({
+      includeInterference: false,
+      code: `
+        const arm = assembly('rig');
+        arm.part('base', box(10, 10, 10))
+          .connector('axisA', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] })
+          .connector('axisB', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('linkA', box(5, 5, 5))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('linkB', box(5, 5, 5))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.mate('yaw', 'base.axisA', 'linkA.axis', 'revolute', {
+          pose: 120,
+          limitsDeg: [-90, 90],
+        });
+        arm.mate('pitch', 'base.axisB', 'linkB.axis', 'revolute', {
+          pose: 200,
+          limitsDeg: [-45, 45],
+        });
+        return arm.model();
+      `,
+    });
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.repairContext).toBeDefined();
+      expect(r.repairContext.topDiagnostics.length).toBeGreaterThanOrEqual(1);
+      expect(r.repairContext.topDiagnostics.length).toBeLessThanOrEqual(3);
+      // Errors sort before warnings: every adjacent pair must be in order.
+      // Since we only inspect codes/severity is encoded in the original
+      // diagnostics list, we re-derive severity by matching back.
+      const codes = r.repairContext.topDiagnostics.map((d) => d.code);
+      // At least one entry should be the out-of-limits error.
+      expect(codes).toContain('assembly.pose.out-of-limits');
+      expect(typeof r.suggestedRepairPrompt).toBe('string');
+      expect(r.suggestedRepairPrompt.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('populates suggestedDelta for assembly.pose.out-of-limits diagnostics', async () => {
+    const r = await reviewCadTool({
+      includeInterference: false,
+      code: `
+        const arm = assembly('rig');
+        arm.part('base', box(10, 10, 10))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('link', box(5, 5, 5))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', {
+          pose: 120,
+          limitsDeg: [-90, 90],
+        });
+        return arm.model();
+      `,
+    });
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      const oob = r.repairContext.topDiagnostics.find(
+        (d) => d.code === 'assembly.pose.out-of-limits',
+      );
+      expect(oob).toBeDefined();
+      expect(oob?.mateName).toBe('yaw');
+      expect(oob?.suggestedDelta).toBeDefined();
+      expect(oob?.suggestedDelta?.mate).toBe('yaw');
+      // pose=120, limits=[-90, 90] → widen the max bound by 30.
+      const delta = oob!.suggestedDelta!;
+      const widen = typeof delta.widenBy === 'number';
+      const narrow = typeof delta.narrowBy === 'number';
+      expect(widen || narrow).toBe(true);
+    }
+  });
+
+  it('passes through preserveInterfaces and designGoal from input', async () => {
+    const r = await reviewCadTool({
+      includeInterference: false,
+      designGoal: 'test goal',
+      preserveInterfaces: ['foo'],
+      code: `
+        const arm = assembly('rig');
+        arm.part('base', box(10, 10, 10));
+        return arm.model();
+      `,
+    });
+
+    expect(r.repairContext).toBeDefined();
+    expect(r.repairContext.designGoal).toBe('test goal');
+    expect(r.repairContext.preserveInterfaces).toEqual(['foo']);
+  });
+});

--- a/tests/unit/mcp/toolRegistrySchema.test.ts
+++ b/tests/unit/mcp/toolRegistrySchema.test.ts
@@ -1,0 +1,47 @@
+// tests/unit/mcp/toolRegistrySchema.test.ts
+import { describe, it, expect } from 'vitest';
+import { TOOL_REGISTRY } from '../../../src/mcp/toolRegistry';
+
+function findTool(name: string) {
+  const entry = TOOL_REGISTRY.find(e => e.definition.name === name);
+  if (!entry) throw new Error(`tool not found: ${name}`);
+  return entry.definition;
+}
+
+describe('toolRegistry pose-envelope schema options', () => {
+  it('review_cad schema declares samplesPerMate as integer with minimum 1', () => {
+    const def = findTool('review_cad');
+    const prop = def.inputSchema.properties.samplesPerMate as {
+      type: string;
+      minimum: number;
+    };
+    expect(prop).toBeDefined();
+    expect(prop.type).toBe('integer');
+    expect(prop.minimum).toBe(1);
+  });
+
+  it('review_cad schema declares combinatorial as boolean', () => {
+    const def = findTool('review_cad');
+    const prop = def.inputSchema.properties.combinatorial as { type: string };
+    expect(prop).toBeDefined();
+    expect(prop.type).toBe('boolean');
+  });
+
+  it('design_loop schema declares samplesPerMate as integer with minimum 1', () => {
+    const def = findTool('design_loop');
+    const prop = def.inputSchema.properties.samplesPerMate as {
+      type: string;
+      minimum: number;
+    };
+    expect(prop).toBeDefined();
+    expect(prop.type).toBe('integer');
+    expect(prop.minimum).toBe(1);
+  });
+
+  it('design_loop schema declares combinatorial as boolean', () => {
+    const def = findTool('design_loop');
+    const prop = def.inputSchema.properties.combinatorial as { type: string };
+    expect(prop).toBeDefined();
+    expect(prop.type).toBe('boolean');
+  });
+});


### PR DESCRIPTION
## Summary

Closes workstream 5a from the v0.2→v1.0 gap-closure roadmap: the pose-envelope mechanism-validity bridge between v0.6 default-pose validity and the full v0.7 mechanism-feasibility layer. The slice is **purely additive** — every default on every existing surface is unchanged.

- **Sampling extensions** (`src/lib/mates/poseEnvelope.ts`): `samplesPerMate` (N total samples per non-locked mate; N>=3 adds N-2 uniform interior points) + `combinatorial` (2^M corner-tuple sweep, capped at M<=8).
- **`posesGate` option on `solvedModel`** — orthogonal to the existing severity-coded `validate` so the `(severity × poses-set)` matrix is honest.
- **`kernelcad evaluate --envelope`** — exit 0 / 1 / 2 contract; `--samples-per-mate` / `--combinatorial` without `--envelope` exits 1 with diagnostic.
- **Structured `RepairContext`** on `review_cad` alongside the existing freeform `suggestedRepairPrompt`. `design_loop` renders `nextActionPrompt` from it (lead with `blockingReasons`, top-3 diagnostics with `widen by N` / `narrow by N` directives).
- **`sampleStrategy?: 'corner' | 'interior' | 'combinatorial'`** context field on `PoseEnvelopeDiagnostic` — no new diagnostic codes (A4 anchor preserved).
- **MCP plumbing fix**: tool-registry schema had advertised `samplesPerMate`/`combinatorial` but the `review_cad` and `design_loop` handlers were silently dropping them — now end-to-end through `ReviewCadInput` and `DesignLoopInput`.
- **2 eval corpus tasks**: `door-hinge-over-travel` (envelope-clean across full revolute travel) and `gripper-aperture-sweep` (`gripperAperture` summary across prismatic coupling). Registered in `eval/corpus-envelope.test.ts` via the existing `runTask` runner — eval Δ is the customer-gated-pivot ship signal.

Spec: `kernelCAD-private/docs/specs/2026-05-15-pose-envelope-review-loop-closure-design.md`
Plan: `kernelCAD-private/docs/plans/2026-05-15-pose-envelope-review-loop-closure.md`
Lineage: `kernelCAD-private/docs/lineage/2026-05-15-pose-envelope-closure.md`

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build:cli` — bundle rebuilds with skill tree
- [x] Full vitest suite: 2089 passed / 25 skipped / 1 flake (`tests/integration/mcp/designLoop.test.ts` — known full-suite contention, 12/12 in isolation; documented in session notes)
- [x] New tests added: +35 across sampling, gate, CLI, MCP plumbing, RepairContext, design_loop prompt, schema, and corpus regressions
- [x] `npx vitest run eval/corpus-envelope.test.ts` — both new corpus tasks score 100% on expert solutions
- [x] No competitor refs in repo files (grep clean)
- [x] No new diagnostic codes — A4 sentinel coverage unchanged
- [x] Two-stage final review APPROVE (no blocking findings; 4 follow-up items captured for next slice)

## Anchor properties

- **A1 Open** — no license/dep changes.
- **A2 MCP-native** — every new option reachable through MCP; schema-handler parity now defended by 8 dedicated tests.
- **A3 AST-edit-primacy** — pose-envelope review is a pure read; no shadow IR; fix loop is caller-driven (no LLM coupling in the kernel).
- **A4 Diagnostic-rigorous** — no new codes; existing 5 are catalogued + hint-covered; sentinel tests stay green.

## Version

`0.7.3` → **`0.7.4`** (patch; closure work on the v0.7 line, not a new module gate — `v0.X.0` demo-discipline rule does not bind).