### PR TITLE
feat(mcp): pin public toolRegistry contract + add getToolDefinition

### DIFF
--- a/src/agent/mcp/toolRegistry.publicContract.test.ts
+++ b/src/agent/mcp/toolRegistry.publicContract.test.ts
@@ -8,6 +8,8 @@ import {
 } from './toolRegistry';
 
 describe('toolRegistry public contract', () => {
+  // 'list_api' is a stable, always-registered tool used as a contract anchor below.
+  // If you rename or remove it, update the references in this file.
   it('exports TOOL_REGISTRY as a non-empty array of entries with definition+handler', () => {
     expect(Array.isArray(TOOL_REGISTRY)).toBe(true);
     expect(TOOL_REGISTRY.length).toBeGreaterThan(0);
@@ -42,12 +44,9 @@ describe('toolRegistry public contract', () => {
     expect(getToolDefinition('nonexistent_tool_xyz')).toBeUndefined();
   });
 
-  it('type McpToolDefinition is exported', () => {
-    const _typeCheck: McpToolDefinition = {
-      name: 'x',
-      description: 'y',
-      inputSchema: { type: 'object', properties: {} },
-    };
-    expect(_typeCheck.name).toBe('x');
+  it('type McpToolDefinition is exported and compatible with getToolDefinition return', () => {
+    // Assignment compiles only if McpToolDefinition matches the returned shape.
+    const def: McpToolDefinition | undefined = getToolDefinition('list_api');
+    expect(def).toBeDefined();
   });
 });

--- a/src/agent/mcp/toolRegistry.publicContract.test.ts
+++ b/src/agent/mcp/toolRegistry.publicContract.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TOOL_REGISTRY,
+  TOOLS,
+  callMcpTool,
+  getToolDefinition,
+  type McpToolDefinition,
+} from './toolRegistry';
+
+describe('toolRegistry public contract', () => {
+  it('exports TOOL_REGISTRY as a non-empty array of entries with definition+handler', () => {
+    expect(Array.isArray(TOOL_REGISTRY)).toBe(true);
+    expect(TOOL_REGISTRY.length).toBeGreaterThan(0);
+    for (const entry of TOOL_REGISTRY) {
+      expect(typeof entry.definition.name).toBe('string');
+      expect(typeof entry.definition.description).toBe('string');
+      expect(entry.definition.inputSchema.type).toBe('object');
+      expect(typeof entry.handler).toBe('function');
+    }
+  });
+
+  it('exports TOOLS as a flat definitions array matching TOOL_REGISTRY length', () => {
+    expect(TOOLS.length).toBe(TOOL_REGISTRY.length);
+    for (let i = 0; i < TOOLS.length; i++) {
+      expect(TOOLS[i].name).toBe(TOOL_REGISTRY[i].definition.name);
+    }
+  });
+
+  it('exports callMcpTool that dispatches by name and returns a result', async () => {
+    const result = await callMcpTool('list_api', {});
+    expect(result).toBeDefined();
+  });
+
+  it('exports callMcpTool that throws on unknown tool name', async () => {
+    await expect(callMcpTool('nonexistent_tool_xyz', {})).rejects.toThrow();
+  });
+
+  it('exports getToolDefinition(name) returning the definition or undefined', () => {
+    const def = getToolDefinition('list_api');
+    expect(def).toBeDefined();
+    expect(def?.name).toBe('list_api');
+    expect(getToolDefinition('nonexistent_tool_xyz')).toBeUndefined();
+  });
+
+  it('type McpToolDefinition is exported', () => {
+    const _typeCheck: McpToolDefinition = {
+      name: 'x',
+      description: 'y',
+      inputSchema: { type: 'object', properties: {} },
+    };
+    expect(_typeCheck.name).toBe('x');
+  });
+});

--- a/src/agent/mcp/toolRegistry.ts
+++ b/src/agent/mcp/toolRegistry.ts
@@ -855,10 +855,41 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
 
 const toolHandlers = new Map(TOOL_REGISTRY.map(entry => [entry.definition.name, entry.handler]));
 
+/**
+ * Flat array of all tool definitions, in registry order.
+ *
+ * Public contract — depended on by kernelCAD-server.
+ */
 export const TOOLS = TOOL_REGISTRY.map(entry => entry.definition);
 
+/**
+ * Dispatch an MCP tool call by name. Transport-agnostic: used by stdio MCP server,
+ * remote MCP gateway (kernelCAD-server), and the server-side agent orchestrator.
+ *
+ * Public contract — depended on by kernelCAD-server. Do NOT remove or change the
+ * signature without bumping the consumer SHA explicitly.
+ *
+ * @param name - The MCP tool name
+ * @param input - The tool's input arguments (validated against inputSchema by the handler)
+ * @returns The tool's result (shape varies per tool — see individual tool files)
+ * @throws Error if `name` does not match any registered tool
+ */
 export async function callMcpTool(name: string, input: Record<string, unknown>): Promise<unknown> {
   const handler = toolHandlers.get(name);
   if (!handler) throw new Error(`Unknown tool: ${name}`);
   return handler(input);
+}
+
+/**
+ * Look up a tool's MCP definition by name.
+ *
+ * Public contract — depended on by kernelCAD-server (vendor/kernelcad/ submodule).
+ * Do NOT remove or change the signature without bumping the consumer SHA explicitly.
+ *
+ * @param name - The MCP tool name (e.g. 'evaluate_script')
+ * @returns The McpToolDefinition, or undefined if no tool by that name exists
+ */
+export function getToolDefinition(name: string): McpToolDefinition | undefined {
+  const entry = TOOL_REGISTRY.find(e => e.definition.name === name);
+  return entry?.definition;
 }

--- a/src/agent/mcp/toolRegistry.ts
+++ b/src/agent/mcp/toolRegistry.ts
@@ -51,6 +51,14 @@ interface ToolRegistryEntry {
   handler: ToolHandler;
 }
 
+/**
+ * Registry of every MCP tool — pairs each definition with its handler.
+ *
+ * Public contract — depended on by kernelCAD-server (vendor/kernelcad/ submodule).
+ * The shape of `ToolRegistryEntry` (`{ definition: McpToolDefinition, handler: ToolHandler }`)
+ * is the source of truth; `TOOLS` and the in-process Map indexes are derived from it.
+ * Do NOT change the entry shape or remove entries without bumping the consumer SHA explicitly.
+ */
 export const TOOL_REGISTRY: ToolRegistryEntry[] = [
   {
     definition: {
@@ -854,6 +862,7 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
 ];
 
 const toolHandlers = new Map(TOOL_REGISTRY.map(entry => [entry.definition.name, entry.handler]));
+const toolDefinitions = new Map(TOOL_REGISTRY.map(entry => [entry.definition.name, entry.definition]));
 
 /**
  * Flat array of all tool definitions, in registry order.
@@ -890,6 +899,5 @@ export async function callMcpTool(name: string, input: Record<string, unknown>):
  * @returns The McpToolDefinition, or undefined if no tool by that name exists
  */
 export function getToolDefinition(name: string): McpToolDefinition | undefined {
-  const entry = TOOL_REGISTRY.find(e => e.definition.name === name);
-  return entry?.definition;
+  return toolDefinitions.get(name);
 }


### PR DESCRIPTION
## Summary
- Adds `getToolDefinition(name)` helper to look up a tool definition by name
- Adds JSDoc to the public exports of `src/mcp/toolRegistry.ts` documenting that they are the contract consumed by the upcoming `kernelCAD-server` private repo
- Adds a contract test pinning all five public exports

This is Phase 1 Task 1 of the kernelcad.com first-customer hosted-product slice. The new `kernelCAD-server` private repo will vendor kernelCAD-web at a pinned submodule SHA and consume these exports in-process.

## Test plan
- [x] `npm test -- src/mcp/toolRegistry.publicContract.test.ts` — all 6 tests pass
- [x] `npm run typecheck` — clean