### PR TITLE
feat(funnel): /p/<slug> + /me routes

### DIFF
--- a/src/funnel/components/ExportButtons.tsx
+++ b/src/funnel/components/ExportButtons.tsx
@@ -1,0 +1,27 @@
+export interface ExportButtonsProps {
+  slug: string;
+  signedIn: boolean;
+}
+
+export function ExportButtons({ slug, signedIn }: ExportButtonsProps) {
+  return (
+    <div className="flex gap-2">
+      <button
+        type="button"
+        disabled
+        title={`STL export for ${slug} — server-side endpoint wiring is Phase 4`}
+        className="rounded-lg border border-neutral-700 text-neutral-300 px-3 py-1.5 text-xs hover:bg-neutral-800 disabled:opacity-50"
+      >
+        Export STL
+      </button>
+      <button
+        type="button"
+        disabled={!signedIn}
+        title={signedIn ? `STEP export for ${slug} — Phase 4` : 'Sign in to export STEP'}
+        className="rounded-lg border border-neutral-700 text-neutral-300 px-3 py-1.5 text-xs hover:bg-neutral-800 disabled:opacity-50"
+      >
+        Export STEP
+      </button>
+    </div>
+  );
+}

--- a/src/routes/me.tsx
+++ b/src/routes/me.tsx
@@ -1,0 +1,62 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+import { useSession } from '../funnel/hooks/useSession';
+import { listMyProjects, type ProjectRow } from '../funnel/lib/apiClient';
+
+export const Route = createFileRoute('/me')({
+  component: MePage,
+});
+
+function MePage() {
+  const { session, loading } = useSession();
+  const navigate = useNavigate();
+  const [projects, setProjects] = useState<ProjectRow[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!loading && !session) {
+      navigate({ to: '/signin', search: { next: '/me' } });
+    }
+  }, [loading, session, navigate]);
+
+  useEffect(() => {
+    if (session) {
+      listMyProjects().then(setProjects).catch(e => setErr(String(e)));
+    }
+  }, [session]);
+
+  if (loading || !session) return <main className="p-8 text-neutral-400">Loading…</main>;
+  if (err) return <main className="p-8 text-red-300">Failed to load: {err}</main>;
+
+  return (
+    <main className="min-h-screen bg-neutral-950 text-white">
+      <header className="border-b border-neutral-900 px-6 py-3 flex items-center justify-between">
+        <a href="/" className="text-lg font-bold">kernelCAD</a>
+        <span className="text-sm text-neutral-400">{session.user.email}</span>
+      </header>
+      <section className="px-6 py-8 max-w-4xl mx-auto">
+        <h1 className="text-2xl font-bold">Your projects</h1>
+        {!projects && <p className="text-neutral-400 mt-4">Loading projects…</p>}
+        {projects?.length === 0 && (
+          <p className="text-neutral-400 mt-4">
+            No projects yet. <a href="/" className="underline">Start one</a>.
+          </p>
+        )}
+        {projects && projects.length > 0 && (
+          <ul className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+            {projects.map(p => (
+              <li key={p.id} className="rounded-xl border border-neutral-800 p-4 hover:border-neutral-600">
+                <a href={`/p/${p.slug}`} className="block">
+                  <p className="font-medium">{p.title}</p>
+                  <p className="text-xs text-neutral-500 mt-1">
+                    {p.privacy} · updated {new Date(p.updated_at).toLocaleDateString()}
+                  </p>
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/routes/p.$slug.tsx
+++ b/src/routes/p.$slug.tsx
@@ -1,7 +1,63 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+import { FunnelViewer } from '../funnel/components/FunnelViewer';
+import { CodePane } from '../funnel/components/CodePane';
+import { ExportButtons } from '../funnel/components/ExportButtons';
+import { SignInButton } from '../funnel/components/SignInButton';
+import { useSession } from '../funnel/hooks/useSession';
+import { fetchProjectBySlug, type ProjectRow } from '../funnel/lib/apiClient';
 
 export const Route = createFileRoute('/p/$slug')({
-  component: () => (
-    <div className="p-8 text-neutral-400">Loading project… (Task 5 fills this in)</div>
-  ),
+  component: ProjectPage,
 });
+
+function ProjectPage() {
+  const { slug } = Route.useParams();
+  const { session } = useSession();
+  const [project, setProject] = useState<ProjectRow | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchProjectBySlug(slug).then(setProject).catch(e => setErr(String(e)));
+  }, [slug]);
+
+  if (err) return <main className="p-8 text-red-300">Failed to load: {err}</main>;
+  if (!project) return <main className="p-8 text-neutral-400">Loading…</main>;
+
+  const isOwner = session?.user.id === project.owner_id;
+
+  return (
+    <main className="min-h-screen bg-neutral-950 text-white grid grid-rows-[auto_1fr] grid-cols-1">
+      <header className="border-b border-neutral-900 px-6 py-3 flex items-center justify-between">
+        <a href="/" className="text-lg font-bold">kernelCAD</a>
+        <div className="flex items-center gap-3">
+          <ExportButtons slug={project.slug} signedIn={!!session} />
+          {!session && <SignInButton />}
+        </div>
+      </header>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 min-h-0">
+        <div className="bg-neutral-900 min-h-[60vh] lg:min-h-0">
+          <FunnelViewer code={project.current_code} />
+        </div>
+        <aside className="flex flex-col min-h-0 border-l border-neutral-900">
+          <div className="px-6 py-4 border-b border-neutral-900 flex items-center justify-between">
+            <div>
+              <p className="text-xs uppercase text-neutral-500 tracking-wide">Project</p>
+              <h1 className="text-lg font-semibold mt-1">{project.title}</h1>
+            </div>
+            <span className="text-xs text-neutral-500">{project.privacy}</span>
+          </div>
+          <div className="flex-1 min-h-0">
+            <CodePane code={project.current_code} />
+          </div>
+          {isOwner && (
+            <div className="px-6 py-3 border-t border-neutral-900 text-xs text-neutral-500">
+              Editing via /studio for now. Refine-prompt in /p/&lt;slug&gt; arrives in slice 1.1.
+            </div>
+          )}
+        </aside>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
Phase 2B Task 5 — kernelCAD-web side.

- /p/<slug>: renders saved project via FunnelViewer + CodePane (read-only); shows ExportButtons + sign-in CTA in header
- /me: lists user's projects via Supabase RLS (own rows only); redirects unauthenticated users to /signin
- ExportButtons: STL/STEP placeholders (server-side endpoints land in Phase 4)

Server-side counterpart shipped separately: kernelCAD-server commit on main with POST /api/v1/save.

## Test plan
- [x] typecheck and lint pass clean
- [x] build succeeds (no compile errors)
- [x] Full test suite unchanged from base branch (pre-existing 1 failure unrelated to this task)
- [ ] End-to-end save flow tested manually after Task 6 merges