### PR TITLE
feat(funnel): finish Phase 2B funnel — /g, /p, /me + viewer + refine

### DIFF
--- a/src/funnel/components/CodePane.tsx
+++ b/src/funnel/components/CodePane.tsx
@@ -1,0 +1,29 @@
+import Editor from '@monaco-editor/react';
+
+export interface CodePaneProps {
+  code: string;
+  language?: string;
+}
+
+export function CodePane({ code, language = 'typescript' }: CodePaneProps) {
+  return (
+    <div className="w-full h-full border-l border-neutral-800">
+      <Editor
+        height="100%"
+        defaultLanguage={language}
+        theme="vs-dark"
+        value={code}
+        options={{
+          readOnly: true,
+          minimap: { enabled: false },
+          fontSize: 13,
+          fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
+          scrollBeyondLastLine: false,
+          automaticLayout: true,
+          padding: { top: 16 },
+          wordWrap: 'on',
+        }}
+      />
+    </div>
+  );
+}

--- a/src/funnel/components/ErrorPanel.tsx
+++ b/src/funnel/components/ErrorPanel.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+export interface ErrorPanelProps {
+  code: string;
+  message: string;
+  originalPrompt: string;
+  onRefine: (refinedPrompt: string) => void;
+  busy?: boolean;
+}
+
+export function ErrorPanel({ code, message, originalPrompt, onRefine, busy }: ErrorPanelProps) {
+  const prefill = `${originalPrompt}\n\n— previous attempt failed: ${code}: ${message}`;
+  const [value, setValue] = useState(prefill);
+
+  return (
+    <div className="rounded-xl border border-amber-700 bg-amber-950/40 p-4 text-amber-100">
+      <p className="font-medium">Generation didn't succeed: {code}</p>
+      <p className="text-sm text-amber-200/80 mt-1 break-words">{message}</p>
+      <p className="text-xs text-amber-200/60 mt-3">
+        Tweak the prompt below and try again. (Failed gens don't count against your free quota.)
+      </p>
+      <textarea
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        rows={4}
+        disabled={busy}
+        className="mt-3 w-full rounded-lg bg-neutral-900 border border-neutral-700 text-white p-3 text-sm focus:border-blue-500 focus:outline-none disabled:opacity-50"
+        onKeyDown={e => {
+          if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') onRefine(value);
+        }}
+      />
+      <div className="mt-2 flex justify-end">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => onRefine(value)}
+          className="rounded-lg bg-white text-neutral-900 px-4 py-2 text-sm font-medium disabled:opacity-50"
+        >
+          {busy ? 'Retrying…' : 'Retry'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/funnel/components/ExportButtons.tsx
+++ b/src/funnel/components/ExportButtons.tsx
@@ -1,0 +1,27 @@
+export interface ExportButtonsProps {
+  slug: string;
+  signedIn: boolean;
+}
+
+export function ExportButtons({ slug, signedIn }: ExportButtonsProps) {
+  return (
+    <div className="flex gap-2">
+      <button
+        type="button"
+        disabled
+        title={`STL export for ${slug} — server-side endpoint wiring is Phase 4`}
+        className="rounded-lg border border-neutral-700 text-neutral-300 px-3 py-1.5 text-xs hover:bg-neutral-800 disabled:opacity-50"
+      >
+        Export STL
+      </button>
+      <button
+        type="button"
+        disabled={!signedIn}
+        title={signedIn ? `STEP export for ${slug} — Phase 4` : 'Sign in to export STEP'}
+        className="rounded-lg border border-neutral-700 text-neutral-300 px-3 py-1.5 text-xs hover:bg-neutral-800 disabled:opacity-50"
+      >
+        Export STEP
+      </button>
+    </div>
+  );
+}

--- a/src/funnel/components/FunnelViewer.tsx
+++ b/src/funnel/components/FunnelViewer.tsx
@@ -1,0 +1,52 @@
+/**
+ * FunnelViewer — wraps the existing Viewer inside a self-contained provider
+ * stack so anonymous-generation pages can render 3D geometry without the
+ * full Studio shell.
+ *
+ * Integration pattern: WorkbenchProvider accepts `initialCode`; GeometryProvider
+ * auto-executes whenever `code` changes; inner component reads geometry from
+ * context and feeds Viewer with the same props Viewport.tsx uses.
+ */
+import Viewer from '../../studio/components/Viewer';
+import { WorkbenchProvider, useWorkbench } from '../../studio/context/WorkbenchContext';
+
+export interface FunnelViewerProps {
+  code: string;
+}
+
+/** Inner component — must be mounted inside WorkbenchProvider. */
+function FunnelViewerInner() {
+  const {
+    geometries,
+    previewGeometries,
+    sketchesGeometries,
+    showSketches,
+    viewMode3D,
+  } = useWorkbench();
+
+  return (
+    <div className="absolute inset-0">
+      <Viewer
+        geometries={[...geometries]}
+        previewGeometries={previewGeometries ?? []}
+        sketchesGeometries={sketchesGeometries ?? []}
+        showSketches={showSketches ?? false}
+        viewMode3D={viewMode3D}
+      />
+    </div>
+  );
+}
+
+/**
+ * Mount this component with a `code` string — it spins up the provider stack,
+ * executes the geometry, and renders the 3D canvas. No Studio chrome is pulled in.
+ */
+export function FunnelViewer({ code }: FunnelViewerProps) {
+  return (
+    <div className="relative w-full h-full bg-neutral-900">
+      <WorkbenchProvider initialCode={code}>
+        <FunnelViewerInner />
+      </WorkbenchProvider>
+    </div>
+  );
+}

--- a/src/funnel/components/SuggestionChips.tsx
+++ b/src/funnel/components/SuggestionChips.tsx
@@ -1,0 +1,24 @@
+export interface SuggestionChipsProps {
+  suggestions: string[];
+  onSelect: (suggestion: string) => void;
+  disabled?: boolean;
+}
+
+export function SuggestionChips({ suggestions, onSelect, disabled }: SuggestionChipsProps) {
+  if (suggestions.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-2">
+      {suggestions.map(s => (
+        <button
+          key={s}
+          type="button"
+          onClick={() => onSelect(s)}
+          disabled={disabled}
+          className="text-xs text-neutral-200 hover:text-white px-3 py-1.5 rounded-full border border-neutral-700 hover:border-blue-500 hover:bg-blue-950 disabled:opacity-50"
+        >
+          {s}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/funnel/lib/apiClient.ts
+++ b/src/funnel/lib/apiClient.ts
@@ -1,0 +1,91 @@
+import { getSupabase } from './supabaseClient';
+import type { Artifact } from './generateClient';
+
+export interface GenerationRow {
+  id: string;
+  status: 'running' | 'done' | 'eval_failed' | 'llm_failed' | 'timeout';
+  code: string | null;
+  prompt: string;
+  suggestions: string[];
+  diagnostics: { message?: string } | null;
+  anon_id: string | null;
+  project_id: string | null;
+  created_at: string;
+}
+
+export async function fetchGeneration(genId: string): Promise<GenerationRow | null> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('generations')
+    .select('id, status, code, prompt, suggestions, diagnostics, anon_id, project_id, created_at')
+    .eq('id', genId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return (data as GenerationRow | null) ?? null;
+}
+
+export interface SaveProjectInput {
+  generationId: string;
+  anonId?: string;
+  title: string;
+  code: string;
+  parameters: Artifact['parameters'];
+}
+
+export interface SaveProjectResult {
+  slug: string;
+  projectId: string;
+}
+
+export async function saveProject(input: SaveProjectInput): Promise<SaveProjectResult> {
+  const supabase = getSupabase();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  const base = import.meta.env.VITE_API_BASE_URL;
+  const res = await fetch(`${base}/api/v1/save`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(session ? { Authorization: `Bearer ${session.access_token}` } : {}),
+    },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    throw new Error(await res.text().catch(() => `HTTP ${res.status}`));
+  }
+  return res.json();
+}
+
+export interface ProjectRow {
+  id: string;
+  slug: string;
+  title: string;
+  privacy: 'public' | 'private';
+  current_code: string;
+  parameters: Artifact['parameters'];
+  version: number;
+  updated_at: string;
+  owner_id: string;
+}
+
+export async function fetchProjectBySlug(slug: string): Promise<ProjectRow | null> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('projects')
+    .select('id, slug, title, privacy, current_code, parameters, version, updated_at, owner_id')
+    .eq('slug', slug)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return (data as ProjectRow | null) ?? null;
+}
+
+export async function listMyProjects(): Promise<ProjectRow[]> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('projects')
+    .select('id, slug, title, privacy, current_code, parameters, version, updated_at, owner_id')
+    .order('updated_at', { ascending: false });
+  if (error) throw new Error(error.message);
+  return (data as ProjectRow[] | null) ?? [];
+}

--- a/src/studio/routes/g.$genId.tsx
+++ b/src/studio/routes/g.$genId.tsx
@@ -1,5 +1,135 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+import { FunnelViewer } from '../../funnel/components/FunnelViewer';
+import { CodePane } from '../../funnel/components/CodePane';
+import { SuggestionChips } from '../../funnel/components/SuggestionChips';
+import { ErrorPanel } from '../../funnel/components/ErrorPanel';
+import { SignInButton } from '../../funnel/components/SignInButton';
+import { useGeneration } from '../../funnel/hooks/useGeneration';
+import { useSession } from '../../funnel/hooks/useSession';
+import { fetchGeneration, saveProject, type GenerationRow } from '../../funnel/lib/apiClient';
 
 export const Route = createFileRoute('/g/$genId')({
-  component: () => <div className="p-8 text-neutral-400">Loading generation… (Task 4 fills this in)</div>,
+  component: AnonGenPage,
 });
+
+function AnonGenPage() {
+  const { genId } = Route.useParams();
+  const navigate = useNavigate();
+  const { session } = useSession();
+  const [gen, setGen] = useState<GenerationRow | null>(null);
+  const [loadErr, setLoadErr] = useState<string | null>(null);
+  const { phase, submit } = useGeneration();
+  const [savingState, setSavingState] = useState<'idle' | 'saving' | 'error'>('idle');
+
+  useEffect(() => {
+    fetchGeneration(genId).then(setGen).catch(e => setLoadErr(String(e)));
+  }, [genId]);
+
+  useEffect(() => {
+    if (phase.state === 'done') {
+      void navigate({ to: '/g/$genId', params: { genId: phase.generationId } });
+    }
+  }, [phase, navigate]);
+
+  if (loadErr) {
+    return <main className="p-8 text-red-300">Failed to load: {loadErr}</main>;
+  }
+  if (!gen) {
+    return <main className="p-8 text-neutral-400">Loading…</main>;
+  }
+
+  async function handleSave() {
+    if (!session) {
+      void navigate({ to: '/signin', search: { next: window.location.pathname } });
+      return;
+    }
+    if (!gen!.code) return;
+    setSavingState('saving');
+    try {
+      const result = await saveProject({
+        generationId: gen!.id,
+        anonId: gen!.anon_id ?? undefined,
+        title: gen!.prompt.slice(0, 60),
+        code: gen!.code,
+        parameters: [],
+      });
+      void navigate({ to: '/p/$slug', params: { slug: result.slug } });
+    } catch (err) {
+      setSavingState('error');
+      console.error('save failed', err);
+    }
+  }
+
+  const isBusy = phase.state === 'running';
+
+  return (
+    <main className="min-h-screen bg-neutral-950 text-white grid grid-rows-[auto_1fr] grid-cols-1">
+      <header className="border-b border-neutral-900 px-6 py-3 flex items-center justify-between">
+        <a href="/" className="text-lg font-bold">kernelCAD</a>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => void handleSave()}
+            disabled={isBusy || savingState === 'saving' || gen.status !== 'done' || !gen.code}
+            className="rounded-lg bg-white text-neutral-900 px-4 py-2 text-sm font-medium disabled:opacity-50"
+          >
+            {session ? (savingState === 'saving' ? 'Saving…' : 'Save this') : 'Sign in to save'}
+          </button>
+          {!session && <SignInButton redirectTo={window.location.href}>Sign in</SignInButton>}
+        </div>
+      </header>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 min-h-0">
+        <div className="bg-neutral-900 min-h-[60vh] lg:min-h-0">
+          {gen.code ? (
+            <FunnelViewer code={gen.code} />
+          ) : (
+            <div className="p-6 text-neutral-500">No geometry — generation failed.</div>
+          )}
+        </div>
+
+        <aside className="flex flex-col min-h-0 border-l border-neutral-900">
+          <div className="px-6 py-4 border-b border-neutral-900">
+            <p className="text-xs uppercase text-neutral-500 tracking-wide">Prompt</p>
+            <p className="text-sm mt-1">{gen.prompt}</p>
+          </div>
+
+          {gen.status === 'done' && gen.code && (
+            <>
+              <div className="px-6 py-4 border-b border-neutral-900">
+                <p className="text-xs uppercase text-neutral-500 tracking-wide mb-2">Refine</p>
+                <SuggestionChips
+                  suggestions={gen.suggestions}
+                  onSelect={s => void submit(`${gen.prompt}\n\nNow: ${s}`)}
+                  disabled={isBusy}
+                />
+              </div>
+              <div className="flex-1 min-h-0">
+                <CodePane code={gen.code} />
+              </div>
+            </>
+          )}
+
+          {(gen.status === 'llm_failed' ||
+            gen.status === 'eval_failed' ||
+            gen.status === 'timeout') && (
+            <div className="p-6">
+              <ErrorPanel
+                code={gen.status}
+                message={gen.diagnostics?.message ?? 'Unknown failure'}
+                originalPrompt={gen.prompt}
+                onRefine={p => void submit(p)}
+                busy={isBusy}
+              />
+            </div>
+          )}
+
+          {gen.status === 'running' && (
+            <div className="p-6 text-neutral-400 text-sm">Still running…</div>
+          )}
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/src/studio/routes/me.tsx
+++ b/src/studio/routes/me.tsx
@@ -1,0 +1,62 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+import { useSession } from '../../funnel/hooks/useSession';
+import { listMyProjects, type ProjectRow } from '../../funnel/lib/apiClient';
+
+export const Route = createFileRoute('/me')({
+  component: MePage,
+});
+
+function MePage() {
+  const { session, loading } = useSession();
+  const navigate = useNavigate();
+  const [projects, setProjects] = useState<ProjectRow[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!loading && !session) {
+      navigate({ to: '/signin', search: { next: '/me' } });
+    }
+  }, [loading, session, navigate]);
+
+  useEffect(() => {
+    if (session) {
+      listMyProjects().then(setProjects).catch(e => setErr(String(e)));
+    }
+  }, [session]);
+
+  if (loading || !session) return <main className="p-8 text-neutral-400">Loading…</main>;
+  if (err) return <main className="p-8 text-red-300">Failed to load: {err}</main>;
+
+  return (
+    <main className="min-h-screen bg-neutral-950 text-white">
+      <header className="border-b border-neutral-900 px-6 py-3 flex items-center justify-between">
+        <a href="/" className="text-lg font-bold">kernelCAD</a>
+        <span className="text-sm text-neutral-400">{session.user.email}</span>
+      </header>
+      <section className="px-6 py-8 max-w-4xl mx-auto">
+        <h1 className="text-2xl font-bold">Your projects</h1>
+        {!projects && <p className="text-neutral-400 mt-4">Loading projects…</p>}
+        {projects?.length === 0 && (
+          <p className="text-neutral-400 mt-4">
+            No projects yet. <a href="/" className="underline">Start one</a>.
+          </p>
+        )}
+        {projects && projects.length > 0 && (
+          <ul className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+            {projects.map(p => (
+              <li key={p.id} className="rounded-xl border border-neutral-800 p-4 hover:border-neutral-600">
+                <a href={`/p/${p.slug}`} className="block">
+                  <p className="font-medium">{p.title}</p>
+                  <p className="text-xs text-neutral-500 mt-1">
+                    {p.privacy} · updated {new Date(p.updated_at).toLocaleDateString()}
+                  </p>
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/studio/routes/p.$slug.tsx
+++ b/src/studio/routes/p.$slug.tsx
@@ -1,0 +1,63 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+import { FunnelViewer } from '../../funnel/components/FunnelViewer';
+import { CodePane } from '../../funnel/components/CodePane';
+import { ExportButtons } from '../../funnel/components/ExportButtons';
+import { SignInButton } from '../../funnel/components/SignInButton';
+import { useSession } from '../../funnel/hooks/useSession';
+import { fetchProjectBySlug, type ProjectRow } from '../../funnel/lib/apiClient';
+
+export const Route = createFileRoute('/p/$slug')({
+  component: ProjectPage,
+});
+
+function ProjectPage() {
+  const { slug } = Route.useParams();
+  const { session } = useSession();
+  const [project, setProject] = useState<ProjectRow | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchProjectBySlug(slug).then(setProject).catch(e => setErr(String(e)));
+  }, [slug]);
+
+  if (err) return <main className="p-8 text-red-300">Failed to load: {err}</main>;
+  if (!project) return <main className="p-8 text-neutral-400">Loading…</main>;
+
+  const isOwner = session?.user.id === project.owner_id;
+
+  return (
+    <main className="min-h-screen bg-neutral-950 text-white grid grid-rows-[auto_1fr] grid-cols-1">
+      <header className="border-b border-neutral-900 px-6 py-3 flex items-center justify-between">
+        <a href="/" className="text-lg font-bold">kernelCAD</a>
+        <div className="flex items-center gap-3">
+          <ExportButtons slug={project.slug} signedIn={!!session} />
+          {!session && <SignInButton />}
+        </div>
+      </header>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 min-h-0">
+        <div className="bg-neutral-900 min-h-[60vh] lg:min-h-0">
+          <FunnelViewer code={project.current_code} />
+        </div>
+        <aside className="flex flex-col min-h-0 border-l border-neutral-900">
+          <div className="px-6 py-4 border-b border-neutral-900 flex items-center justify-between">
+            <div>
+              <p className="text-xs uppercase text-neutral-500 tracking-wide">Project</p>
+              <h1 className="text-lg font-semibold mt-1">{project.title}</h1>
+            </div>
+            <span className="text-xs text-neutral-500">{project.privacy}</span>
+          </div>
+          <div className="flex-1 min-h-0">
+            <CodePane code={project.current_code} />
+          </div>
+          {isOwner && (
+            <div className="px-6 py-3 border-t border-neutral-900 text-xs text-neutral-500">
+              Editing via /studio for now. Refine-prompt in /p/&lt;slug&gt; arrives in slice 1.1.
+            </div>
+          )}
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/tests/e2e/funnel.spec.ts
+++ b/tests/e2e/funnel.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:5173';
+
+test('funnel: prompt -> generating UI shows', async ({ page }) => {
+  await page.goto(`${BASE}/`);
+  await expect(page.getByRole('heading', { name: /Tell AI what to build/i })).toBeVisible();
+  await page.getByRole('button', { name: /60x40x5 mm bracket/ }).click();
+  await page.getByRole('button', { name: 'Generate' }).click();
+  // Either "Working…" OR "Generation failed" appears depending on backend state.
+  await expect(
+    page.getByText(/Working…|Generation failed/i),
+  ).toBeVisible({ timeout: 60_000 });
+});
+
+test('signin route renders Google button', async ({ page }) => {
+  await page.goto(`${BASE}/signin`);
+  await expect(page.getByRole('button', { name: /Continue with Google/i })).toBeVisible();
+});
+
+test('studio route still renders existing app', async ({ page }) => {
+  await page.goto(`${BASE}/studio`);
+  // The existing Studio shell renders — relax assertion to "page didn't 404"
+  await expect(page).not.toHaveTitle(/404/);
+});

--- a/tests/funnel/SuggestionChips.test.tsx
+++ b/tests/funnel/SuggestionChips.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { SuggestionChips } from '../../src/funnel/components/SuggestionChips';
+
+afterEach(() => cleanup());
+
+describe('SuggestionChips', () => {
+  it('renders nothing when suggestions is empty', () => {
+    const { container } = render(<SuggestionChips suggestions={[]} onSelect={() => {}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders one button per suggestion', () => {
+    render(<SuggestionChips suggestions={['add fillet', 'drill hole']} onSelect={() => {}} />);
+    expect(screen.getAllByRole('button')).toHaveLength(2);
+  });
+
+  it('clicking a chip calls onSelect with that string', () => {
+    const onSelect = vi.fn();
+    render(<SuggestionChips suggestions={['add fillet']} onSelect={onSelect} />);
+    fireEvent.click(screen.getByText('add fillet'));
+    expect(onSelect).toHaveBeenCalledWith('add fillet');
+  });
+
+  it('disabled state propagates to all chips', () => {
+    render(<SuggestionChips suggestions={['add fillet']} onSelect={() => {}} disabled />);
+    const btn = screen.getByRole('button') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
Completes Phase 2B's funnel surface. Build/deploy pipeline stays in private repo (kernelCAD-server).

## What lands here
- `/g/$genId` real implementation (replaces placeholder) — viewer + code + refine chips
- `/p/$slug` saved-project view
- `/me` user's projects list
- `FunnelViewer` wrapping the existing Viewer + WorkbenchProvider chain (renders real 3D, not STL)
- `CodePane` read-only Monaco
- `SuggestionChips`, `ErrorPanel`, `ExportButtons`
- `apiClient` for Supabase queries + `POST /api/v1/save`
- 4 `SuggestionChips` tests + 3 Playwright e2e tests

## What does NOT land here (intentionally)
- CF Pages wrangler config
- GitHub Actions deploy workflow
- VITE_BASE_PATH, build commands, env var injection

Those move to `kernelCAD-server` so deploy details stay private.

## Test plan
- [x] typecheck clean
- [x] lint clean
- [x] 17 funnel tests pass (PromptBox + SignInButton + SuggestionChips + generateClient)