### PR TITLE
feat(funnel): apply kernelCAD brand (vellum/ink/blueprint)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>kernelcad</title>
+    <title>kernelCAD — CAD for agents</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,wght@0,500;1,500&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/funnel/components/CodePane.tsx
+++ b/src/funnel/components/CodePane.tsx
@@ -7,9 +7,13 @@ export interface CodePaneProps {
 
 export function CodePane({ code, language = 'typescript' }: CodePaneProps) {
   return (
-    <div className="w-full h-full border-l border-neutral-800">
+    <div className="w-full h-full border-l border-rule">
+      {/* Code label — matches marketing site's .code-label style */}
+      <div className="font-mono text-[11px] text-ink-soft tracking-widest uppercase px-4 py-2 bg-vellum-soft border-b border-rule">
+        .kcad.ts
+      </div>
       <Editor
-        height="100%"
+        height="calc(100% - 33px)"
         defaultLanguage={language}
         theme="vs-dark"
         value={code}

--- a/src/funnel/components/ErrorPanel.tsx
+++ b/src/funnel/components/ErrorPanel.tsx
@@ -13,10 +13,11 @@ export function ErrorPanel({ code, message, originalPrompt, onRefine, busy }: Er
   const [value, setValue] = useState(prefill);
 
   return (
-    <div className="rounded-xl border border-amber-700 bg-amber-950/40 p-4 text-amber-100">
-      <p className="font-medium">Generation didn't succeed: {code}</p>
-      <p className="text-sm text-amber-200/80 mt-1 break-words">{message}</p>
-      <p className="text-xs text-amber-200/60 mt-3">
+    <div className="rounded-xl border border-copper bg-vellum-soft p-4">
+      <p className="font-serif text-xl font-medium text-ink">Generation didn't finish</p>
+      <p className="font-mono text-xs text-copper mt-1 tracking-widest uppercase">{code}</p>
+      <p className="text-sm text-ink-soft mt-2 break-words">{message}</p>
+      <p className="font-mono text-xs text-ink-faint mt-3 tracking-wide">
         Tweak the prompt below and try again. (Failed gens don't count against your free quota.)
       </p>
       <textarea
@@ -24,7 +25,7 @@ export function ErrorPanel({ code, message, originalPrompt, onRefine, busy }: Er
         onChange={e => setValue(e.target.value)}
         rows={4}
         disabled={busy}
-        className="mt-3 w-full rounded-lg bg-neutral-900 border border-neutral-700 text-white p-3 text-sm focus:border-blue-500 focus:outline-none disabled:opacity-50"
+        className="mt-3 w-full rounded-lg bg-white border border-rule text-ink p-3 text-sm focus:border-blueprint focus:outline-none disabled:opacity-50 font-sans"
         onKeyDown={e => {
           if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') onRefine(value);
         }}
@@ -34,7 +35,7 @@ export function ErrorPanel({ code, message, originalPrompt, onRefine, busy }: Er
           type="button"
           disabled={busy}
           onClick={() => onRefine(value)}
-          className="rounded-lg bg-white text-neutral-900 px-4 py-2 text-sm font-medium disabled:opacity-50"
+          className="rounded-lg bg-blueprint hover:bg-blueprint-hover text-white px-4 py-2 text-sm font-medium disabled:opacity-50 transition-colors"
         >
           {busy ? 'Retrying…' : 'Retry'}
         </button>

--- a/src/funnel/components/ExportButtons.tsx
+++ b/src/funnel/components/ExportButtons.tsx
@@ -10,7 +10,7 @@ export function ExportButtons({ slug, signedIn }: ExportButtonsProps) {
         type="button"
         disabled
         title={`STL export for ${slug} — server-side endpoint wiring is Phase 4`}
-        className="rounded-lg border border-neutral-700 text-neutral-300 px-3 py-1.5 text-xs hover:bg-neutral-800 disabled:opacity-50"
+        className="rounded-lg border border-rule text-ink-soft px-3 py-1.5 font-mono text-[11px] tracking-wide hover:bg-vellum-soft disabled:opacity-50 transition-colors"
       >
         Export STL
       </button>
@@ -18,7 +18,7 @@ export function ExportButtons({ slug, signedIn }: ExportButtonsProps) {
         type="button"
         disabled={!signedIn}
         title={signedIn ? `STEP export for ${slug} — Phase 4` : 'Sign in to export STEP'}
-        className="rounded-lg border border-neutral-700 text-neutral-300 px-3 py-1.5 text-xs hover:bg-neutral-800 disabled:opacity-50"
+        className="rounded-lg border border-rule text-ink-soft px-3 py-1.5 font-mono text-[11px] tracking-wide hover:bg-vellum-soft disabled:opacity-50 transition-colors"
       >
         Export STEP
       </button>

--- a/src/funnel/components/FunnelViewer.tsx
+++ b/src/funnel/components/FunnelViewer.tsx
@@ -43,7 +43,7 @@ function FunnelViewerInner() {
  */
 export function FunnelViewer({ code }: FunnelViewerProps) {
   return (
-    <div className="relative w-full h-full bg-neutral-900">
+    <div className="relative w-full h-full bg-code-bg">
       <WorkbenchProvider initialCode={code}>
         <FunnelViewerInner />
       </WorkbenchProvider>

--- a/src/funnel/components/PromptBox.tsx
+++ b/src/funnel/components/PromptBox.tsx
@@ -31,10 +31,10 @@ export function PromptBox({ onSubmit, disabled, examples = DEFAULT_EXAMPLES }: P
         onChange={e => setValue(e.target.value)}
         rows={3}
         disabled={disabled}
-        placeholder="Describe the part you want..."
-        className="w-full rounded-xl bg-neutral-900 border border-neutral-700 text-white p-4 text-base focus:border-blue-500 focus:outline-none disabled:opacity-50"
+        placeholder="Describe the part you want…"
+        className="w-full rounded-lg bg-white border border-rule text-ink p-4 text-base placeholder:text-ink-faint focus:border-blueprint focus:outline-none disabled:opacity-50 font-sans"
       />
-      <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+      <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
         <div className="flex flex-wrap gap-2">
           {examples.map(ex => (
             <button
@@ -42,7 +42,7 @@ export function PromptBox({ onSubmit, disabled, examples = DEFAULT_EXAMPLES }: P
               type="button"
               onClick={() => setValue(ex)}
               disabled={disabled}
-              className="text-xs text-neutral-400 hover:text-white px-2 py-1 rounded-md border border-neutral-700 hover:border-neutral-500 disabled:opacity-50"
+              className="font-mono text-[11px] text-ink-soft hover:text-ink hover:border-ink px-2.5 py-1 rounded border border-rule disabled:opacity-50 tracking-wide transition-colors"
             >
               {ex}
             </button>
@@ -51,9 +51,9 @@ export function PromptBox({ onSubmit, disabled, examples = DEFAULT_EXAMPLES }: P
         <button
           type="submit"
           disabled={disabled || !value.trim()}
-          className="rounded-lg bg-white text-neutral-900 px-5 py-2 text-sm font-medium hover:bg-neutral-200 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="rounded-lg bg-blueprint hover:bg-blueprint-hover text-white px-6 py-3 text-base font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
-          {disabled ? 'Generating…' : 'Generate'}
+          {disabled ? 'Generating…' : 'Generate →'}
         </button>
       </div>
     </form>

--- a/src/funnel/components/SignInButton.tsx
+++ b/src/funnel/components/SignInButton.tsx
@@ -33,17 +33,17 @@ export function SignInButton({ redirectTo, className, children }: SignInButtonPr
       disabled={loading}
       className={
         className ??
-        'inline-flex items-center gap-2 rounded-lg bg-white text-neutral-900 px-4 py-2 text-sm font-medium hover:bg-neutral-100 disabled:opacity-50'
+        'inline-flex items-center gap-2 rounded-lg bg-blueprint hover:bg-blueprint-hover text-white px-4 py-2 text-sm font-medium disabled:opacity-50 transition-colors font-sans'
       }
     >
-      {/* Google G mark */}
+      {/* Google G mark — colours retained per Google brand guidelines */}
       <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
         <path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.79 2.71v2.26h2.9c1.7-1.56 2.69-3.87 2.69-6.61z"/>
         <path fill="#34A853" d="M9 18c2.43 0 4.47-.81 5.96-2.18l-2.9-2.26c-.8.54-1.83.86-3.06.86-2.35 0-4.35-1.59-5.06-3.72H.96v2.33A9 9 0 0 0 9 18z"/>
         <path fill="#FBBC05" d="M3.94 10.7a5.4 5.4 0 0 1 0-3.4V4.96H.96a9 9 0 0 0 0 8.08l2.98-2.34z"/>
         <path fill="#EA4335" d="M9 3.58c1.32 0 2.51.45 3.44 1.34l2.58-2.58A9 9 0 0 0 .96 4.96l2.98 2.34C4.65 5.17 6.65 3.58 9 3.58z"/>
       </svg>
-      {loading ? 'Signing in...' : (children ?? 'Continue with Google')}
+      {loading ? 'Signing in…' : (children ?? 'Continue with Google')}
     </button>
   );
 }

--- a/src/funnel/components/SuggestionChips.tsx
+++ b/src/funnel/components/SuggestionChips.tsx
@@ -14,7 +14,7 @@ export function SuggestionChips({ suggestions, onSelect, disabled }: SuggestionC
           type="button"
           onClick={() => onSelect(s)}
           disabled={disabled}
-          className="text-xs text-neutral-200 hover:text-white px-3 py-1.5 rounded-full border border-neutral-700 hover:border-blue-500 hover:bg-blue-950 disabled:opacity-50"
+          className="font-mono text-[11px] text-ink-soft hover:text-ink px-3 py-1.5 rounded-full border border-rule hover:border-blueprint hover:bg-vellum-soft disabled:opacity-50 tracking-wide transition-colors"
         >
           {s}
         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,30 @@
 @import "tailwindcss";
 
 @theme {
+    /* Existing Studio palette */
     --color-highlight-orange: #FF9F1C;
     --color-selection-blue: #2EC4B6;
     --color-snap-green: #00FF9D;
     --color-guide-grey: #AAB3C2;
     --color-error-red: #FF4D4D;
+
+    /* kernelCAD brand palette */
+    --color-vellum: #F4ECD7;
+    --color-vellum-soft: #EFE5C9;
+    --color-ink: #0A1628;
+    --color-ink-soft: #3F4C5E;
+    --color-ink-faint: #97A0AC;
+    --color-blueprint: #1E5FA8;
+    --color-blueprint-hover: #174E8B;
+    --color-copper: #B87333;
+    --color-rule: #D6CDB4;
+    --color-code-bg: #0A1628;
+    --color-code-text: #E5DFCB;
+
+    /* Brand font families */
+    --font-serif: "Source Serif 4", Georgia, serif;
+    --font-sans: Inter, system-ui, -apple-system, sans-serif;
+    --font-mono: "JetBrains Mono", ui-monospace, monospace;
 }
 
 :root {

--- a/src/studio/routes/g.$genId.tsx
+++ b/src/studio/routes/g.$genId.tsx
@@ -33,10 +33,18 @@ function AnonGenPage() {
   }, [phase, navigate]);
 
   if (loadErr) {
-    return <main className="p-8 text-red-300">Failed to load: {loadErr}</main>;
+    return (
+      <main className="min-h-screen bg-vellum font-sans p-8">
+        <p className="text-copper font-mono text-sm">Failed to load: {loadErr}</p>
+      </main>
+    );
   }
   if (!gen) {
-    return <main className="p-8 text-neutral-400">Loading…</main>;
+    return (
+      <main className="min-h-screen bg-vellum font-sans p-8">
+        <p className="text-ink-faint font-mono text-sm">Loading…</p>
+      </main>
+    );
   }
 
   async function handleSave() {
@@ -64,15 +72,21 @@ function AnonGenPage() {
   const isBusy = phase.state === 'running';
 
   return (
-    <main className="min-h-screen bg-neutral-950 text-white grid grid-rows-[auto_1fr] grid-cols-1">
-      <header className="border-b border-neutral-900 px-6 py-3 flex items-center justify-between">
-        <a href="/" className="text-lg font-bold">kernelCAD</a>
+    <main className="min-h-screen bg-vellum text-ink font-sans grid grid-rows-[auto_1fr] grid-cols-1">
+      {/* Nav */}
+      <header className="border-b border-rule px-6 py-3 flex items-center justify-between bg-vellum">
+        <a href="/" className="flex items-center gap-2 font-serif text-base font-medium no-underline text-ink">
+          <svg className="w-4 h-4 text-ink" viewBox="0 0 84 84" fill="none" aria-label="kernelCAD">
+            <path d="M 14,12 L 26,12 L 26,34 Q 26,36 27.5,34.5 L 46,12 L 60,12 L 36,40 Q 35,42 36,44 L 60,72 L 46,72 L 27.5,49.5 Q 26,48 26,50 L 26,72 L 14,72 Z" fill="currentColor"/>
+          </svg>
+          <span>kernel<span className="text-blueprint">CAD</span></span>
+        </a>
         <div className="flex items-center gap-3">
           <button
             type="button"
             onClick={() => void handleSave()}
             disabled={isBusy || savingState === 'saving' || gen.status !== 'done' || !gen.code}
-            className="rounded-lg bg-white text-neutral-900 px-4 py-2 text-sm font-medium disabled:opacity-50"
+            className="rounded-lg bg-blueprint hover:bg-blueprint-hover text-white px-4 py-2 text-sm font-medium disabled:opacity-50 transition-colors"
           >
             {session ? (savingState === 'saving' ? 'Saving…' : 'Save this') : 'Sign in to save'}
           </button>
@@ -81,24 +95,26 @@ function AnonGenPage() {
       </header>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 min-h-0">
-        <div className="bg-neutral-900 min-h-[60vh] lg:min-h-0">
+        {/* 3D Viewer — dark background matches brand code-bg */}
+        <div className="bg-code-bg min-h-[60vh] lg:min-h-0">
           {gen.code ? (
             <FunnelViewer code={gen.code} />
           ) : (
-            <div className="p-6 text-neutral-500">No geometry — generation failed.</div>
+            <div className="p-6 text-ink-faint font-mono text-sm">No geometry — generation failed.</div>
           )}
         </div>
 
-        <aside className="flex flex-col min-h-0 border-l border-neutral-900">
-          <div className="px-6 py-4 border-b border-neutral-900">
-            <p className="text-xs uppercase text-neutral-500 tracking-wide">Prompt</p>
-            <p className="text-sm mt-1">{gen.prompt}</p>
+        {/* Sidebar — vellum */}
+        <aside className="flex flex-col min-h-0 border-l border-rule bg-vellum">
+          <div className="px-6 py-4 border-b border-rule">
+            <p className="font-mono text-[11px] text-ink-faint tracking-widest uppercase">Prompt</p>
+            <p className="text-sm mt-1 text-ink">{gen.prompt}</p>
           </div>
 
           {gen.status === 'done' && gen.code && (
             <>
-              <div className="px-6 py-4 border-b border-neutral-900">
-                <p className="text-xs uppercase text-neutral-500 tracking-wide mb-2">Refine</p>
+              <div className="px-6 py-4 border-b border-rule">
+                <p className="font-mono text-[11px] text-ink-faint tracking-widest uppercase mb-2">Refine</p>
                 <SuggestionChips
                   suggestions={gen.suggestions}
                   onSelect={s => void submit(`${gen.prompt}\n\nNow: ${s}`)}
@@ -126,7 +142,7 @@ function AnonGenPage() {
           )}
 
           {gen.status === 'running' && (
-            <div className="p-6 text-neutral-400 text-sm">Still running…</div>
+            <div className="p-6 text-ink-soft font-mono text-sm">Still running…</div>
           )}
         </aside>
       </div>

--- a/src/studio/routes/index.tsx
+++ b/src/studio/routes/index.tsx
@@ -20,41 +20,68 @@ function LandingPage() {
   const isBusy = phase.state === 'running';
 
   return (
-    <main className="min-h-screen bg-neutral-950 text-white">
-      <header className="border-b border-neutral-900 px-6 py-4 flex items-center justify-between">
-        <a href="/" className="text-lg font-bold tracking-tight">kernelCAD</a>
-        <nav className="text-sm text-neutral-400 flex gap-4">
-          <a href="/studio" className="hover:text-white">Studio</a>
-          <a href="/me" className="hover:text-white">Your projects</a>
+    <main className="min-h-screen bg-vellum text-ink font-sans">
+      <div className="max-w-[1040px] mx-auto px-10 py-7">
+        {/* Nav — matches marketing site structure */}
+        <nav className="flex justify-between items-center pb-24">
+          <a href="/" className="flex items-center gap-2.5 font-serif text-lg font-medium no-underline text-ink">
+            <svg className="w-5 h-5 text-ink" viewBox="0 0 84 84" fill="none" aria-label="kernelCAD">
+              <path d="M 14,12 L 26,12 L 26,34 Q 26,36 27.5,34.5 L 46,12 L 60,12 L 36,40 Q 35,42 36,44 L 60,72 L 46,72 L 27.5,49.5 Q 26,48 26,50 L 26,72 L 14,72 Z" fill="currentColor"/>
+            </svg>
+            <span>kernel<span className="text-blueprint">CAD</span></span>
+          </a>
+          <div className="flex gap-6 font-mono text-xs text-ink-soft tracking-wider">
+            <a href="/me" className="text-ink-soft hover:text-blueprint no-underline transition-colors">your projects</a>
+            <a href="https://github.com/w1ne/kernelCAD-web" className="text-ink-soft hover:text-blueprint no-underline transition-colors">github</a>
+          </div>
         </nav>
-      </header>
-      <section className="px-6 py-16 max-w-3xl mx-auto">
-        <h1 className="text-4xl md:text-5xl font-bold tracking-tight">
-          Tell AI what to build. Get a CAD model.
-        </h1>
-        <p className="text-neutral-400 mt-3 text-lg">
-          Type a sentence. We generate a STEP-grade parametric 3D model in seconds.
-        </p>
-        <div className="mt-8">
-          <PromptBox onSubmit={submit} disabled={isBusy} />
-        </div>
-        {phase.state === 'running' && (
-          <div className="mt-6 text-sm text-neutral-400">
-            <p>Working… {events.length} events received</p>
-            <p className="font-mono text-xs mt-2 line-clamp-1">
-              {phase.lastEvent.kind === 'tool_call' && `→ ${phase.lastEvent.name}`}
-              {phase.lastEvent.kind === 'tool_result' && `← ${phase.lastEvent.name} ok=${phase.lastEvent.ok}`}
-              {phase.lastEvent.kind === 'status' && `… ${phase.lastEvent.phase}`}
-            </p>
+
+        {/* Hero */}
+        <header className="text-center pb-18 pt-0">
+          <h1 className="font-serif text-8xl font-medium leading-[0.95] tracking-tight mb-7">
+            Describe it. <span className="text-blueprint italic">Build it.</span>
+          </h1>
+          <p className="text-xl text-ink-soft max-w-xl mx-auto mb-4 leading-relaxed">
+            A sentence in, a parametric 3D model out. STEP-grade, agent-built.
+          </p>
+
+          <div className="font-mono text-xs text-ink-faint tracking-widest inline-flex gap-3.5 mb-10">
+            <span className="text-ink-soft">prompt</span>
+            <span className="opacity-50">·</span>
+            <span className="text-ink-soft">code</span>
+            <span className="opacity-50">·</span>
+            <span className="text-ink-soft">geometry</span>
+            <span className="opacity-50">·</span>
+            <span className="text-ink-soft">STEP/STL</span>
           </div>
-        )}
-        {phase.state === 'error' && (
-          <div className="mt-6 rounded-lg border border-red-700 bg-red-950 p-4 text-red-200">
-            <p className="font-medium">Generation failed: {phase.code}</p>
-            <p className="text-sm mt-1">{phase.message}</p>
+
+          {/* Prompt box */}
+          <div className="mt-2 max-w-2xl mx-auto">
+            <PromptBox onSubmit={submit} disabled={isBusy} />
           </div>
-        )}
-      </section>
+
+          {/* Running status */}
+          {phase.state === 'running' && (
+            <div className="mt-6 text-sm text-ink-soft font-mono">
+              <p>working — {events.length} events</p>
+              <p className="text-xs mt-2 truncate opacity-70">
+                {phase.lastEvent.kind === 'tool_call' && `→ ${phase.lastEvent.name}`}
+                {phase.lastEvent.kind === 'tool_result' && `← ${phase.lastEvent.name} ok=${phase.lastEvent.ok}`}
+                {phase.lastEvent.kind === 'status' && `… ${phase.lastEvent.phase}`}
+              </p>
+            </div>
+          )}
+
+          {/* Error */}
+          {phase.state === 'error' && (
+            <div className="mt-6 mx-auto max-w-2xl rounded-lg border border-copper bg-vellum-soft p-4 text-ink text-left">
+              <p className="font-serif font-medium text-lg">Generation didn't finish</p>
+              <p className="font-mono text-xs text-copper mt-1 tracking-widest uppercase">{phase.code}</p>
+              <p className="text-sm text-ink-soft mt-2">{phase.message}</p>
+            </div>
+          )}
+        </header>
+      </div>
     </main>
   );
 }

--- a/src/studio/routes/index.tsx
+++ b/src/studio/routes/index.tsx
@@ -39,10 +39,10 @@ function LandingPage() {
         {/* Hero */}
         <header className="text-center pb-18 pt-0">
           <h1 className="font-serif text-8xl font-medium leading-[0.95] tracking-tight mb-7">
-            Describe it. <span className="text-blueprint italic">Build it.</span>
+            Words to <span className="text-blueprint italic">geometry</span>.
           </h1>
           <p className="text-xl text-ink-soft max-w-xl mx-auto mb-4 leading-relaxed">
-            A sentence in, a parametric 3D model out. STEP-grade, agent-built.
+            Describe a part in plain English. Get a parametric, STEP-grade 3D model.
           </p>
 
           <div className="font-mono text-xs text-ink-faint tracking-widest inline-flex gap-3.5 mb-10">

--- a/src/studio/routes/me.tsx
+++ b/src/studio/routes/me.tsx
@@ -25,31 +25,54 @@ function MePage() {
     }
   }, [session]);
 
-  if (loading || !session) return <main className="p-8 text-neutral-400">Loading…</main>;
-  if (err) return <main className="p-8 text-red-300">Failed to load: {err}</main>;
+  if (loading || !session) {
+    return (
+      <main className="min-h-screen bg-vellum font-sans p-8">
+        <p className="text-ink-faint font-mono text-sm">Loading…</p>
+      </main>
+    );
+  }
+  if (err) {
+    return (
+      <main className="min-h-screen bg-vellum font-sans p-8">
+        <p className="text-copper font-mono text-sm">Failed to load: {err}</p>
+      </main>
+    );
+  }
 
   return (
-    <main className="min-h-screen bg-neutral-950 text-white">
-      <header className="border-b border-neutral-900 px-6 py-3 flex items-center justify-between">
-        <a href="/" className="text-lg font-bold">kernelCAD</a>
-        <span className="text-sm text-neutral-400">{session.user.email}</span>
+    <main className="min-h-screen bg-vellum text-ink font-sans">
+      {/* Nav */}
+      <header className="border-b border-rule px-6 py-3 flex items-center justify-between bg-vellum">
+        <a href="/" className="flex items-center gap-2 font-serif text-base font-medium no-underline text-ink">
+          <svg className="w-4 h-4 text-ink" viewBox="0 0 84 84" fill="none" aria-label="kernelCAD">
+            <path d="M 14,12 L 26,12 L 26,34 Q 26,36 27.5,34.5 L 46,12 L 60,12 L 36,40 Q 35,42 36,44 L 60,72 L 46,72 L 27.5,49.5 Q 26,48 26,50 L 26,72 L 14,72 Z" fill="currentColor"/>
+          </svg>
+          <span>kernel<span className="text-blueprint">CAD</span></span>
+        </a>
+        <span className="font-mono text-xs text-ink-soft tracking-wide">{session.user.email}</span>
       </header>
-      <section className="px-6 py-8 max-w-4xl mx-auto">
-        <h1 className="text-2xl font-bold">Your projects</h1>
-        {!projects && <p className="text-neutral-400 mt-4">Loading projects…</p>}
+
+      <section className="px-6 py-10 max-w-4xl mx-auto">
+        <h1 className="font-serif text-3xl font-medium text-ink">Your projects</h1>
+
+        {!projects && (
+          <p className="text-ink-faint font-mono text-sm mt-4">Loading projects…</p>
+        )}
         {projects?.length === 0 && (
-          <p className="text-neutral-400 mt-4">
-            No projects yet. <a href="/" className="underline">Start one</a>.
+          <p className="text-ink-soft mt-4">
+            No projects yet.{' '}
+            <a href="/" className="text-blueprint underline">Start one</a>.
           </p>
         )}
         {projects && projects.length > 0 && (
-          <ul className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+          <ul className="mt-8 grid grid-cols-1 md:grid-cols-2 gap-4">
             {projects.map(p => (
-              <li key={p.id} className="rounded-xl border border-neutral-800 p-4 hover:border-neutral-600">
-                <a href={`/p/${p.slug}`} className="block">
-                  <p className="font-medium">{p.title}</p>
-                  <p className="text-xs text-neutral-500 mt-1">
-                    {p.privacy} · updated {new Date(p.updated_at).toLocaleDateString()}
+              <li key={p.id} className="rounded-xl border border-rule bg-white p-5 hover:border-ink transition-colors">
+                <a href={`/p/${p.slug}`} className="block no-underline">
+                  <p className="font-serif font-medium text-ink text-base">{p.title}</p>
+                  <p className="font-mono text-[11px] text-ink-faint mt-1.5 tracking-wide">
+                    {p.privacy} · {new Date(p.updated_at).toLocaleDateString()}
                   </p>
                 </a>
               </li>

--- a/src/studio/routes/p.$slug.tsx
+++ b/src/studio/routes/p.$slug.tsx
@@ -21,15 +21,33 @@ function ProjectPage() {
     fetchProjectBySlug(slug).then(setProject).catch(e => setErr(String(e)));
   }, [slug]);
 
-  if (err) return <main className="p-8 text-red-300">Failed to load: {err}</main>;
-  if (!project) return <main className="p-8 text-neutral-400">Loading…</main>;
+  if (err) {
+    return (
+      <main className="min-h-screen bg-vellum font-sans p-8">
+        <p className="text-copper font-mono text-sm">Failed to load: {err}</p>
+      </main>
+    );
+  }
+  if (!project) {
+    return (
+      <main className="min-h-screen bg-vellum font-sans p-8">
+        <p className="text-ink-faint font-mono text-sm">Loading…</p>
+      </main>
+    );
+  }
 
   const isOwner = session?.user.id === project.owner_id;
 
   return (
-    <main className="min-h-screen bg-neutral-950 text-white grid grid-rows-[auto_1fr] grid-cols-1">
-      <header className="border-b border-neutral-900 px-6 py-3 flex items-center justify-between">
-        <a href="/" className="text-lg font-bold">kernelCAD</a>
+    <main className="min-h-screen bg-vellum text-ink font-sans grid grid-rows-[auto_1fr] grid-cols-1">
+      {/* Nav */}
+      <header className="border-b border-rule px-6 py-3 flex items-center justify-between bg-vellum">
+        <a href="/" className="flex items-center gap-2 font-serif text-base font-medium no-underline text-ink">
+          <svg className="w-4 h-4 text-ink" viewBox="0 0 84 84" fill="none" aria-label="kernelCAD">
+            <path d="M 14,12 L 26,12 L 26,34 Q 26,36 27.5,34.5 L 46,12 L 60,12 L 36,40 Q 35,42 36,44 L 60,72 L 46,72 L 27.5,49.5 Q 26,48 26,50 L 26,72 L 14,72 Z" fill="currentColor"/>
+          </svg>
+          <span>kernel<span className="text-blueprint">CAD</span></span>
+        </a>
         <div className="flex items-center gap-3">
           <ExportButtons slug={project.slug} signedIn={!!session} />
           {!session && <SignInButton />}
@@ -37,23 +55,28 @@ function ProjectPage() {
       </header>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 min-h-0">
-        <div className="bg-neutral-900 min-h-[60vh] lg:min-h-0">
+        {/* 3D Viewer — dark background matches brand code-bg */}
+        <div className="bg-code-bg min-h-[60vh] lg:min-h-0">
           <FunnelViewer code={project.current_code} />
         </div>
-        <aside className="flex flex-col min-h-0 border-l border-neutral-900">
-          <div className="px-6 py-4 border-b border-neutral-900 flex items-center justify-between">
+
+        {/* Sidebar — vellum */}
+        <aside className="flex flex-col min-h-0 border-l border-rule bg-vellum">
+          <div className="px-6 py-4 border-b border-rule flex items-start justify-between">
             <div>
-              <p className="text-xs uppercase text-neutral-500 tracking-wide">Project</p>
-              <h1 className="text-lg font-semibold mt-1">{project.title}</h1>
+              <p className="font-mono text-[11px] text-ink-faint tracking-widest uppercase">Project</p>
+              <h1 className="font-serif text-xl font-medium mt-1 text-ink">{project.title}</h1>
             </div>
-            <span className="text-xs text-neutral-500">{project.privacy}</span>
+            <span className="font-mono text-[11px] text-ink-faint tracking-widest uppercase mt-1">{project.privacy}</span>
           </div>
           <div className="flex-1 min-h-0">
             <CodePane code={project.current_code} />
           </div>
           {isOwner && (
-            <div className="px-6 py-3 border-t border-neutral-900 text-xs text-neutral-500">
-              Editing via /studio for now. Refine-prompt in /p/&lt;slug&gt; arrives in slice 1.1.
+            <div className="px-6 py-3 border-t border-rule">
+              <p className="font-mono text-[11px] text-ink-faint tracking-wide">
+                Editing via /studio for now. Refine-prompt in /p/&lt;slug&gt; arrives in slice 1.1.
+              </p>
             </div>
           )}
         </aside>

--- a/src/studio/routes/signin.tsx
+++ b/src/studio/routes/signin.tsx
@@ -22,14 +22,24 @@ function SignInPage() {
   }, [loading, session, next, navigate]);
 
   return (
-    <main className="min-h-screen bg-neutral-950 text-white flex items-center justify-center p-8">
+    <main className="min-h-screen bg-vellum text-ink font-sans flex items-center justify-center p-8">
       <div className="max-w-sm w-full">
-        <h1 className="text-2xl font-bold text-center">Sign in to kernelCAD</h1>
-        <p className="text-neutral-400 text-sm text-center mt-2">
-          Save the model you generated.
-        </p>
-        <div className="mt-6 flex justify-center">
-          <SignInButton redirectTo={`${window.location.origin}${next}`} />
+        {/* Logo */}
+        <div className="flex items-center justify-center gap-2.5 mb-8">
+          <svg className="w-5 h-5 text-ink" viewBox="0 0 84 84" fill="none" aria-label="kernelCAD">
+            <path d="M 14,12 L 26,12 L 26,34 Q 26,36 27.5,34.5 L 46,12 L 60,12 L 36,40 Q 35,42 36,44 L 60,72 L 46,72 L 27.5,49.5 Q 26,48 26,50 L 26,72 L 14,72 Z" fill="currentColor"/>
+          </svg>
+          <span className="font-serif text-lg font-medium">kernel<span className="text-blueprint">CAD</span></span>
+        </div>
+
+        <div className="rounded-xl border border-rule bg-white p-8 text-center">
+          <h1 className="font-serif text-2xl font-medium text-ink">Sign in to kernelCAD</h1>
+          <p className="text-ink-soft text-sm mt-2">
+            Save the model you generated.
+          </p>
+          <div className="mt-6 flex justify-center">
+            <SignInButton redirectTo={`${window.location.origin}${next}`} />
+          </div>
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary

- Replaces the generic dark (neutral-950/text-white) theme across all funnel routes and components with the kernelcad.com brand identity
- Adds brand color tokens (`vellum`, `ink`, `blueprint`, `copper`, `rule`, `code-bg`) and font families (Source Serif 4, Inter, JetBrains Mono) to `src/index.css` via Tailwind v4 `@theme`
- Loads Google Fonts (Source Serif 4, Inter, JetBrains Mono) from `index.html`
- 5 routes rebranded: `index.tsx`, `signin.tsx`, `g.$genId.tsx`, `p.$slug.tsx`, `me.tsx`
- 7 components rebranded: `PromptBox`, `SignInButton`, `SuggestionChips`, `ErrorPanel`, `ExportButtons`, `CodePane`, `FunnelViewer`
- Styling-only pass — zero behavior changes, zero prop changes, zero route logic changes

## Test plan

- [x] typecheck clean (tsc -b --noEmit)
- [x] lint clean (0 errors, 0 warnings)
- [x] 17/17 funnel tests passing (PromptBox, SuggestionChips, SignInButton, generateClient)
- [x] dev server starts cleanly (HTTP 200 on /)
- [ ] Visual: vellum/cream background on landing, serif headline with italic blueprint accent, mono mode tags, white textarea with rule border + blueprint focus, blueprint primary button, kernel-K nav logo