### PR TITLE
fix(funnel): eagerly init Supabase in root route (OAuth session persistence)

### DIFF
--- a/src/studio/routes/__root.tsx
+++ b/src/studio/routes/__root.tsx
@@ -1,5 +1,15 @@
 import { createRootRoute, Outlet } from '@tanstack/react-router';
 import { Suspense, lazy } from 'react';
+import { getSupabase } from '../../funnel/lib/supabaseClient';
+
+// Eagerly instantiate the Supabase client at app boot so its
+// `detectSessionInUrl: true` runs on EVERY page load — not just on pages that
+// import useSession. Without this, the OAuth redirect lands at `/` with the
+// access_token in the URL hash but the hash is never consumed because the
+// landing route doesn't import the auth hook. This call is safe (singleton).
+if (typeof window !== 'undefined') {
+  getSupabase();
+}
 
 const TanStackRouterDevtools = import.meta.env.DEV
   ? lazy(() =>


### PR DESCRIPTION
OAuth callback lands at `/` with `#access_token=...` but the landing route doesn't initialize Supabase, so the hash is never consumed. Init eagerly from `__root.tsx`.

## Test plan
- [x] typecheck clean
- [ ] After deploy: sign in via Google → session persists across navigations