### PR TITLE
Funnel: email signup fallback + auth gate + UUID guard

### DIFF
--- a/src/funnel/components/EmailSignup.tsx
+++ b/src/funnel/components/EmailSignup.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+
+/**
+ * Email opt-in form for the landing page — until the prompt funnel reaches
+ * "fully working slice" status, we keep a credible "get notified" fallback.
+ *
+ * Posts to /api/subscribe (Cloudflare Pages Function backed by D1; lives in
+ * site/functions/api/subscribe.ts and is uploaded into dist/functions/ by the
+ * private deploy workflow). On success the function redirects to /thanks; on
+ * failure it redirects back to /?error=<code>#signup and the effect below
+ * surfaces the message.
+ */
+export interface EmailSignupProps {
+  /** Override the default `direct` source value (e.g. `?ref=hn`). */
+  sourceParam?: string;
+}
+
+const ERROR_MESSAGES: Record<string, string> = {
+  invalid_email: 'Please enter a valid email address.',
+  invalid_form: 'Something went wrong on our end. Try again.',
+  temporary: 'Something went wrong on our end. Try again in a moment.',
+};
+
+function readSourceFromUrl(override?: string): string {
+  if (override) return override;
+  if (typeof window === 'undefined') return 'direct';
+  const ref = new URLSearchParams(window.location.search).get('ref');
+  return ref && /^[a-zA-Z0-9_-]{1,32}$/.test(ref) ? ref : 'direct';
+}
+
+function readErrorFromUrl(): string | null {
+  if (typeof window === 'undefined') return null;
+  const err = new URLSearchParams(window.location.search).get('error');
+  if (!err) return null;
+  return ERROR_MESSAGES[err] ?? 'Could not subscribe — please try again.';
+}
+
+export function EmailSignup({ sourceParam }: EmailSignupProps) {
+  const [source] = useState(() => readSourceFromUrl(sourceParam));
+  const [error] = useState(() => readErrorFromUrl());
+
+  return (
+    <section
+      id="signup"
+      className="mx-auto mt-20 mb-16 max-w-xl rounded border border-rule bg-vellum-soft/40 px-8 py-10 text-center"
+    >
+      <h2 className="font-serif text-3xl font-medium text-ink">
+        Get notified when we ship
+      </h2>
+      <p className="mt-2 text-sm text-ink-soft">
+        ~1 email per release. No spam. Unsubscribe anytime.
+      </p>
+      <form
+        action="/api/subscribe"
+        method="POST"
+        className="mx-auto mt-6 flex max-w-md gap-2"
+      >
+        <input
+          type="email"
+          name="email"
+          placeholder="you@example.com"
+          required
+          autoComplete="email"
+          aria-label="Email address"
+          className="flex-1 rounded border border-rule bg-white px-3.5 py-2.5 text-sm text-ink placeholder:text-ink-faint focus:border-blueprint focus:outline-none font-sans"
+        />
+        <input type="hidden" name="source" value={source} />
+        <button
+          type="submit"
+          className="whitespace-nowrap rounded-lg bg-blueprint px-5 py-2.5 text-sm font-medium text-white hover:bg-blueprint-hover transition-colors font-sans"
+        >
+          Subscribe
+        </button>
+      </form>
+      <p
+        role="status"
+        aria-live="polite"
+        className={`mt-3 min-h-[1.2em] text-sm ${error ? 'text-copper' : 'text-ink-soft'}`}
+      >
+        {error}
+      </p>
+      <p className="mt-2 text-xs text-ink-faint">
+        We use Cloudflare Web Analytics for visitor counts — no cookies, no IP storage. Your email is stored in a Cloudflare D1 database; we'll only email you when a major version ships.
+      </p>
+    </section>
+  );
+}

--- a/src/funnel/hooks/useGeneration.ts
+++ b/src/funnel/hooks/useGeneration.ts
@@ -46,19 +46,31 @@ export function useGeneration() {
     for await (const e of parseSseStream(res.body)) {
       setEvents(prev => [...prev, e]);
       if (e.kind === 'generation') {
-        generationId = e.generationId;
-        anonId = e.anonId;
+        if (e.generationId) generationId = e.generationId;
+        if (e.anonId) anonId = e.anonId;
         setPhase({ state: 'running', generationId, anonId, lastEvent: e });
       } else if (e.kind === 'done') {
-        setPhase({ state: 'done', generationId: e.generationId, anonId: e.anonId, artifact: e.artifact });
+        const finalId = e.generationId || generationId;
+        const finalAnon = e.anonId || anonId;
+        if (!finalId) {
+          setPhase({ state: 'error', code: 'missing_generation_id', message: 'Generation completed but no ID was returned.' });
+          return;
+        }
+        setPhase({ state: 'done', generationId: finalId, anonId: finalAnon, artifact: e.artifact });
         return;
       } else if (e.kind === 'error') {
-        setPhase({ state: 'error', code: e.code, message: e.message, generationId: e.generationId });
+        setPhase({ state: 'error', code: e.code, message: e.message, generationId: e.generationId || generationId });
         return;
       } else {
         setPhase({ state: 'running', generationId, anonId, lastEvent: e });
       }
     }
+
+    // Stream ended without a `done` or `error` event (e.g., upstream timeout
+    // or proxy buffering). Surface this instead of silently leaving phase in
+    // `running` — otherwise a stale phase can later coerce navigation to
+    // `/g/undefined`.
+    setPhase({ state: 'error', code: 'stream_closed', message: 'Connection closed before generation finished.' });
   }, []);
 
   return { phase, events, submit };

--- a/src/funnel/lib/generateClient.ts
+++ b/src/funnel/lib/generateClient.ts
@@ -75,30 +75,34 @@ function parseEventBlock(raw: string): GenerateEvent | null {
   return mapToEvent(name, payload);
 }
 
+function asString(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
 function mapToEvent(name: string, p: Record<string, unknown>): GenerateEvent | null {
   switch (name) {
     case 'generation':
-      return { kind: 'generation', generationId: String(p.generationId), anonId: String(p.anonId) };
+      return { kind: 'generation', generationId: asString(p.generationId), anonId: asString(p.anonId) };
     case 'status':
       return { kind: 'status', phase: p.phase as 'running' | 'tool_calling' };
     case 'tool_call':
-      return { kind: 'tool_call', name: String(p.name), args: p.args };
+      return { kind: 'tool_call', name: asString(p.name), args: p.args };
     case 'tool_result':
-      return { kind: 'tool_result', name: String(p.name), ok: Boolean(p.ok) };
+      return { kind: 'tool_result', name: asString(p.name), ok: Boolean(p.ok) };
     case 'done':
       return {
         kind: 'done',
         artifact: p.artifact as Artifact,
-        generationId: String(p.generationId),
-        anonId: String(p.anonId),
+        generationId: asString(p.generationId),
+        anonId: asString(p.anonId),
         durationMs: Number(p.durationMs ?? 0),
       };
     case 'error':
       return {
         kind: 'error',
         code: p.code as 'llm_failed' | 'eval_failed' | 'timeout',
-        message: String(p.message ?? ''),
-        generationId: String(p.generationId ?? ''),
+        message: asString(p.message),
+        generationId: asString(p.generationId),
       };
     default:
       return null;

--- a/src/studio/routes/g.$genId.tsx
+++ b/src/studio/routes/g.$genId.tsx
@@ -13,16 +13,26 @@ export const Route = createFileRoute('/g/$genId')({
   component: AnonGenPage,
 });
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+function isUuid(s: string | undefined): boolean {
+  return typeof s === 'string' && UUID_RE.test(s);
+}
+
 function AnonGenPage() {
   const { genId } = Route.useParams();
   const navigate = useNavigate();
   const { session } = useSession();
   const [gen, setGen] = useState<GenerationRow | null>(null);
-  const [loadErr, setLoadErr] = useState<string | null>(null);
+  const [loadErr, setLoadErr] = useState<string | null>(() =>
+    isUuid(genId)
+      ? null
+      : 'Invalid generation link. The previous run may not have completed — try generating again from the home page.',
+  );
   const { phase, submit } = useGeneration();
   const [savingState, setSavingState] = useState<'idle' | 'saving' | 'error'>('idle');
 
   useEffect(() => {
+    if (!isUuid(genId)) return;
     fetchGeneration(genId).then(setGen).catch(e => setLoadErr(String(e)));
   }, [genId]);
 

--- a/src/studio/routes/index.tsx
+++ b/src/studio/routes/index.tsx
@@ -1,15 +1,54 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { PromptBox } from '../../funnel/components/PromptBox';
+import { EmailSignup } from '../../funnel/components/EmailSignup';
 import { useGeneration } from '../../funnel/hooks/useGeneration';
+import { useSession } from '../../funnel/hooks/useSession';
 
 export const Route = createFileRoute('/')({
   component: LandingPage,
 });
 
+// Stash the user's prompt across the Google OAuth round-trip so that after
+// sign-in we can resume generation without making them retype.
+const PENDING_PROMPT_KEY = 'kc:pendingPrompt';
+
 function LandingPage() {
   const { phase, events, submit } = useGeneration();
+  const { session, loading: sessionLoading } = useSession();
   const navigate = useNavigate();
+
+  const handleSubmit = useCallback(
+    (prompt: string) => {
+      if (!session) {
+        try {
+          window.localStorage.setItem(PENDING_PROMPT_KEY, prompt);
+        } catch {
+          // Storage unavailable (private mode) — proceed without resume.
+        }
+        void navigate({ to: '/signin', search: { next: '/' } });
+        return;
+      }
+      void submit(prompt);
+    },
+    [session, navigate, submit],
+  );
+
+  // After OAuth returns with a session, auto-resume the stashed prompt.
+  useEffect(() => {
+    if (sessionLoading || !session) return;
+    if (phase.state !== 'idle') return;
+    let pending: string | null = null;
+    try {
+      pending = window.localStorage.getItem(PENDING_PROMPT_KEY);
+    } catch {
+      return;
+    }
+    if (pending) {
+      window.localStorage.removeItem(PENDING_PROMPT_KEY);
+      void submit(pending);
+    }
+  }, [sessionLoading, session, phase.state, submit]);
 
   useEffect(() => {
     if (phase.state === 'done') {
@@ -57,7 +96,12 @@ function LandingPage() {
 
           {/* Prompt box */}
           <div className="mt-2 max-w-2xl mx-auto">
-            <PromptBox onSubmit={submit} disabled={isBusy} />
+            <PromptBox onSubmit={handleSubmit} disabled={isBusy} />
+            {!session && !sessionLoading && (
+              <p className="mt-3 text-xs text-ink-faint font-mono tracking-wide">
+                Sign in is required — Generate will prompt you to continue with Google.
+              </p>
+            )}
           </div>
 
           {/* Running status */}
@@ -81,6 +125,11 @@ function LandingPage() {
             </div>
           )}
         </header>
+
+        {/* Email opt-in — fallback signal collection until the prompt funnel
+            reaches "fully working slice" status. Remove when generation
+            success-rate + retention metrics make this redundant. */}
+        <EmailSignup />
       </div>
     </main>
   );

--- a/src/studio/routes/thanks.tsx
+++ b/src/studio/routes/thanks.tsx
@@ -1,0 +1,43 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/thanks')({
+  component: ThanksPage,
+});
+
+function ThanksPage() {
+  return (
+    <main className="min-h-screen bg-vellum text-ink font-sans">
+      <div className="max-w-[1040px] mx-auto px-10 py-7">
+        <nav className="flex justify-between items-center pb-24">
+          <a href="/" className="flex items-center gap-2.5 font-serif text-lg font-medium no-underline text-ink">
+            <svg className="w-5 h-5 text-ink" viewBox="0 0 84 84" fill="none" aria-label="kernelCAD">
+              <path d="M 14,12 L 26,12 L 26,34 Q 26,36 27.5,34.5 L 46,12 L 60,12 L 36,40 Q 35,42 36,44 L 60,72 L 46,72 L 27.5,49.5 Q 26,48 26,50 L 26,72 L 14,72 Z" fill="currentColor"/>
+            </svg>
+            <span>kernel<span className="text-blueprint">CAD</span></span>
+          </a>
+          <div className="flex gap-6 font-mono text-xs text-ink-soft tracking-wider">
+            <a href="/" className="text-ink-soft hover:text-blueprint no-underline">home</a>
+            <a href="https://github.com/w1ne/kernelCAD-web" className="text-ink-soft hover:text-blueprint no-underline">github</a>
+          </div>
+        </nav>
+
+        <header className="text-center pb-16">
+          <h1 className="font-serif text-7xl font-medium leading-[0.95] tracking-tight mb-7">
+            You're <span className="text-blueprint italic">in</span>.
+          </h1>
+          <p className="text-xl text-ink-soft max-w-xl mx-auto leading-relaxed">
+            We'll email you when the next major version ships. That's it. No drip campaigns, no spam.
+          </p>
+          <div className="mt-10">
+            <a
+              href="/"
+              className="inline-flex items-center gap-2 rounded-lg bg-blueprint px-5 py-3 text-base font-medium text-white hover:bg-blueprint-hover transition-colors font-sans"
+            >
+              Try the prompt →
+            </a>
+          </div>
+        </header>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Restore email opt-in form on the landing page (posts to /api/subscribe, redirects to a branded /thanks page on success). Keeps signal-collection alive until the prompt funnel is production-grade.
- Gate generation on auth. Pressing Generate while signed out now stashes the prompt to localStorage, redirects to /signin?next=/, and auto-resumes after Google OAuth returns. Anonymous gen → save was reordered so users always sign in *before* a model is spun up.
- Fix the "Failed to load: Error: invalid input syntax for type uuid: 'undefined'" regression. Root cause: SSE done events occasionally arrived without a generationId, which got string-coerced to the literal `"undefined"` and then routed to `/g/undefined`. Hardened in three layers — generateClient, useGeneration, and the /g/$genId route guard.

## Companion change in private deploy repo
Deploy workflow needs an extra `cp -r site/functions dist/functions` step before `pages deploy` so the /api/subscribe Pages Function ships with the SPA bundle. Committed locally in `kernelCAD-server` on `main` — **not pushed yet** since pushing the workflow triggers a deploy.

## Test plan
- [ ] `npm run dev` → landing page renders, Generate button on the prompt box redirects to /signin when signed-out
- [ ] After signing in via Google, the prompt the user typed pre-signin auto-submits on return to /
- [ ] Email opt-in form (bottom of hero) renders and submits to /api/subscribe (will 404 in local dev unless wrangler is running)
- [ ] When SSE stream closes without done/error, UI shows `stream_closed` error instead of navigating to `/g/undefined`
- [ ] Visiting `/g/undefined` directly shows the "Invalid generation link" helper text, not a Supabase UUID error
- [ ] After merge, manually trigger `Deploy kernelcad.com (Studio bundle)` workflow against `develop`