### PR TITLE
Funnel: open generated + saved artifacts in the full Studio shell

### DIFF
--- a/src/studio/App.tsx
+++ b/src/studio/App.tsx
@@ -115,13 +115,21 @@ function isDemoPlayerRoute(): boolean {
   return window.location.pathname === '/demo-player';
 }
 
-export default function App() {
+interface AppProps {
+  /** Seed the workbench with this code on first mount. Used by the funnel
+   * routes (/g/$genId, /p/$slug) to open generated/saved artifacts inside
+   * the full Studio shell rather than a stripped viewer. */
+  initialCode?: string;
+}
+
+export default function App({ initialCode: initialCodeProp }: AppProps = {}) {
   if (isDemoPlayerRoute()) {
     return <DemoPlayerPage />;
   }
 
   const isDevLab = typeof window !== 'undefined' && window.location.pathname.startsWith('/dev-lab');
-  const initialCode = isDevLab ? (devLabScenarios[0]?.code ?? undefined) : undefined;
+  const initialCode =
+    initialCodeProp ?? (isDevLab ? (devLabScenarios[0]?.code ?? undefined) : undefined);
 
   return (
     <WorkbenchProvider initialCode={initialCode}>

--- a/src/studio/routes/g.$genId.tsx
+++ b/src/studio/routes/g.$genId.tsx
@@ -1,11 +1,7 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
-import { FunnelViewer } from '../../funnel/components/FunnelViewer';
-import { CodePane } from '../../funnel/components/CodePane';
-import { SuggestionChips } from '../../funnel/components/SuggestionChips';
-import { ErrorPanel } from '../../funnel/components/ErrorPanel';
+import App from '../App';
 import { SignInButton } from '../../funnel/components/SignInButton';
-import { useGeneration } from '../../funnel/hooks/useGeneration';
 import { useSession } from '../../funnel/hooks/useSession';
 import { fetchGeneration, saveProject, type GenerationRow } from '../../funnel/lib/apiClient';
 
@@ -28,19 +24,12 @@ function AnonGenPage() {
       ? null
       : 'Invalid generation link. The previous run may not have completed — try generating again from the home page.',
   );
-  const { phase, submit } = useGeneration();
   const [savingState, setSavingState] = useState<'idle' | 'saving' | 'error'>('idle');
 
   useEffect(() => {
     if (!isUuid(genId)) return;
     fetchGeneration(genId).then(setGen).catch(e => setLoadErr(String(e)));
   }, [genId]);
-
-  useEffect(() => {
-    if (phase.state === 'done') {
-      void navigate({ to: '/g/$genId', params: { genId: phase.generationId } });
-    }
-  }, [phase, navigate]);
 
   if (loadErr) {
     return (
@@ -79,83 +68,48 @@ function AnonGenPage() {
     }
   }
 
-  const isBusy = phase.state === 'running';
+  if (gen.status !== 'done' || !gen.code) {
+    return (
+      <main className="min-h-screen bg-vellum font-sans p-8">
+        <p className="text-ink font-mono text-sm">
+          {gen.status === 'running' && 'Generation still running — refresh in a few seconds.'}
+          {gen.status !== 'running' && `Generation failed (${gen.status}). Try a new prompt.`}
+        </p>
+      </main>
+    );
+  }
 
+  // Full Studio shell with the generated code preloaded. Floating overlay
+  // gives one-click save + prompt context without taking real estate from
+  // the workbench. The shell's own Header handles export / view modes /
+  // local project management.
   return (
-    <main className="min-h-screen bg-vellum text-ink font-sans grid grid-rows-[auto_1fr] grid-cols-1">
-      {/* Nav */}
-      <header className="border-b border-rule px-6 py-3 flex items-center justify-between bg-vellum">
-        <a href="/" className="flex items-center gap-2 font-serif text-base font-medium no-underline text-ink">
-          <svg className="w-4 h-4 text-ink" viewBox="0 0 84 84" fill="none" aria-label="kernelCAD">
-            <path d="M 14,12 L 26,12 L 26,34 Q 26,36 27.5,34.5 L 46,12 L 60,12 L 36,40 Q 35,42 36,44 L 60,72 L 46,72 L 27.5,49.5 Q 26,48 26,50 L 26,72 L 14,72 Z" fill="currentColor"/>
-          </svg>
-          <span>kernel<span className="text-blueprint">CAD</span></span>
-        </a>
-        <div className="flex items-center gap-3">
+    <div className="relative w-screen h-screen overflow-hidden">
+      <App initialCode={gen.code} />
+
+      <div className="pointer-events-none absolute top-3 right-3 z-50 flex items-start gap-3">
+        <div className="pointer-events-auto rounded-lg border border-rule bg-vellum/95 backdrop-blur px-3 py-2 shadow-sm max-w-md">
+          <p className="font-mono text-[10px] text-ink-faint tracking-widest uppercase">Prompt</p>
+          <p className="text-xs text-ink mt-0.5 line-clamp-2">{gen.prompt}</p>
+        </div>
+        <div className="pointer-events-auto flex items-center gap-2">
           <button
             type="button"
             onClick={() => void handleSave()}
-            disabled={isBusy || savingState === 'saving' || gen.status !== 'done' || !gen.code}
-            className="rounded-lg bg-blueprint hover:bg-blueprint-hover text-white px-4 py-2 text-sm font-medium disabled:opacity-50 transition-colors"
+            disabled={savingState === 'saving'}
+            className="rounded-lg bg-blueprint hover:bg-blueprint-hover text-white px-4 py-2 text-sm font-medium disabled:opacity-50 transition-colors font-sans shadow-sm"
           >
-            {session ? (savingState === 'saving' ? 'Saving…' : 'Save this') : 'Sign in to save'}
+            {session
+              ? savingState === 'saving'
+                ? 'Saving…'
+                : savingState === 'error'
+                  ? 'Retry save'
+                  : 'Save this'
+              : 'Sign in to save'}
           </button>
           {!session && <SignInButton redirectTo={window.location.href}>Sign in</SignInButton>}
         </div>
-      </header>
-
-      <div className="grid grid-cols-1 lg:grid-cols-2 min-h-0">
-        {/* 3D Viewer — dark background matches brand code-bg */}
-        <div className="bg-code-bg min-h-[60vh] lg:min-h-0">
-          {gen.code ? (
-            <FunnelViewer code={gen.code} />
-          ) : (
-            <div className="p-6 text-ink-faint font-mono text-sm">No geometry — generation failed.</div>
-          )}
-        </div>
-
-        {/* Sidebar — vellum */}
-        <aside className="flex flex-col min-h-0 border-l border-rule bg-vellum">
-          <div className="px-6 py-4 border-b border-rule">
-            <p className="font-mono text-[11px] text-ink-faint tracking-widest uppercase">Prompt</p>
-            <p className="text-sm mt-1 text-ink">{gen.prompt}</p>
-          </div>
-
-          {gen.status === 'done' && gen.code && (
-            <>
-              <div className="px-6 py-4 border-b border-rule">
-                <p className="font-mono text-[11px] text-ink-faint tracking-widest uppercase mb-2">Refine</p>
-                <SuggestionChips
-                  suggestions={gen.suggestions}
-                  onSelect={s => void submit(`${gen.prompt}\n\nNow: ${s}`)}
-                  disabled={isBusy}
-                />
-              </div>
-              <div className="flex-1 min-h-0">
-                <CodePane code={gen.code} />
-              </div>
-            </>
-          )}
-
-          {(gen.status === 'llm_failed' ||
-            gen.status === 'eval_failed' ||
-            gen.status === 'timeout') && (
-            <div className="p-6">
-              <ErrorPanel
-                code={gen.status}
-                message={gen.diagnostics?.message ?? 'Unknown failure'}
-                originalPrompt={gen.prompt}
-                onRefine={p => void submit(p)}
-                busy={isBusy}
-              />
-            </div>
-          )}
-
-          {gen.status === 'running' && (
-            <div className="p-6 text-ink-soft font-mono text-sm">Still running…</div>
-          )}
-        </aside>
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/studio/routes/p.$slug.tsx
+++ b/src/studio/routes/p.$slug.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
-import { FunnelViewer } from '../../funnel/components/FunnelViewer';
-import { CodePane } from '../../funnel/components/CodePane';
+import App from '../App';
 import { ExportButtons } from '../../funnel/components/ExportButtons';
 import { SignInButton } from '../../funnel/components/SignInButton';
 import { useSession } from '../../funnel/hooks/useSession';
@@ -36,51 +35,27 @@ function ProjectPage() {
     );
   }
 
-  const isOwner = session?.user.id === project.owner_id;
-
+  // Full Studio shell with the saved project code preloaded. Floating
+  // overlay carries project metadata + export buttons. The shell's own
+  // Header handles view modes / local project state.
   return (
-    <main className="min-h-screen bg-vellum text-ink font-sans grid grid-rows-[auto_1fr] grid-cols-1">
-      {/* Nav */}
-      <header className="border-b border-rule px-6 py-3 flex items-center justify-between bg-vellum">
-        <a href="/" className="flex items-center gap-2 font-serif text-base font-medium no-underline text-ink">
-          <svg className="w-4 h-4 text-ink" viewBox="0 0 84 84" fill="none" aria-label="kernelCAD">
-            <path d="M 14,12 L 26,12 L 26,34 Q 26,36 27.5,34.5 L 46,12 L 60,12 L 36,40 Q 35,42 36,44 L 60,72 L 46,72 L 27.5,49.5 Q 26,48 26,50 L 26,72 L 14,72 Z" fill="currentColor"/>
-          </svg>
-          <span>kernel<span className="text-blueprint">CAD</span></span>
-        </a>
-        <div className="flex items-center gap-3">
+    <div className="relative w-screen h-screen overflow-hidden">
+      <App initialCode={project.current_code} />
+
+      <div className="pointer-events-none absolute top-3 right-3 z-50 flex items-start gap-3">
+        <div className="pointer-events-auto rounded-lg border border-rule bg-vellum/95 backdrop-blur px-3 py-2 shadow-sm max-w-md">
+          <p className="font-mono text-[10px] text-ink-faint tracking-widest uppercase">
+            Project · {project.privacy}
+          </p>
+          <p className="font-serif text-sm font-medium text-ink mt-0.5 line-clamp-1">
+            {project.title}
+          </p>
+        </div>
+        <div className="pointer-events-auto flex items-center gap-2">
           <ExportButtons slug={project.slug} signedIn={!!session} />
-          {!session && <SignInButton />}
+          {!session && <SignInButton>Sign in</SignInButton>}
         </div>
-      </header>
-
-      <div className="grid grid-cols-1 lg:grid-cols-2 min-h-0">
-        {/* 3D Viewer — dark background matches brand code-bg */}
-        <div className="bg-code-bg min-h-[60vh] lg:min-h-0">
-          <FunnelViewer code={project.current_code} />
-        </div>
-
-        {/* Sidebar — vellum */}
-        <aside className="flex flex-col min-h-0 border-l border-rule bg-vellum">
-          <div className="px-6 py-4 border-b border-rule flex items-start justify-between">
-            <div>
-              <p className="font-mono text-[11px] text-ink-faint tracking-widest uppercase">Project</p>
-              <h1 className="font-serif text-xl font-medium mt-1 text-ink">{project.title}</h1>
-            </div>
-            <span className="font-mono text-[11px] text-ink-faint tracking-widest uppercase mt-1">{project.privacy}</span>
-          </div>
-          <div className="flex-1 min-h-0">
-            <CodePane code={project.current_code} />
-          </div>
-          {isOwner && (
-            <div className="px-6 py-3 border-t border-rule">
-              <p className="font-mono text-[11px] text-ink-faint tracking-wide">
-                Editing via /studio for now. Refine-prompt in /p/&lt;slug&gt; arrives in slice 1.1.
-              </p>
-            </div>
-          )}
-        </aside>
       </div>
-    </main>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
The funnel viewer was a stripped 2-column layout (3D canvas + prompt/refine sidebar) — none of the Studio's toolbar, inspector, agent rail, bottom drawer, status bar, or export header was reachable from /g/\$genId and /p/\$slug. Plumb an optional initialCode prop through App so funnel routes can seed the workbench at mount, then render full-screen \`<App initialCode={code} />\` with a small floating overlay (top-right) carrying gen-specific actions (prompt + Save this) or project metadata (title/privacy + export).

## Test plan
- [ ] Generate a model from /, navigate to /g/<uuid>, verify the full Studio chrome renders with the geometry preloaded
- [ ] Save the gen, /p/<slug> opens in the full Studio with project metadata in the corner
- [ ] /studio still works standalone
- [ ] /demo-player still routes correctly (App early-returns before WorkbenchProvider)