### PR TITLE
Inject funnel chrome into Studio Header

### DIFF
--- a/src/studio/App.tsx
+++ b/src/studio/App.tsx
@@ -5,9 +5,10 @@ import { useShellStore } from './store/useShellStore';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { DevLab } from './devlab/DevLab';
 import { devLabScenarios } from './devlab/scenarios';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { parseCode } from '../shared/codeGeneration/ast';
 import { DemoPlayerPage } from './components/demoPlayer/DemoPlayerPage';
+import { StudioChromeProvider } from './context/StudioChromeContext';
 
 function isCodeParsable(code: string): boolean {
   try {
@@ -120,9 +121,15 @@ interface AppProps {
    * routes (/g/$genId, /p/$slug) to open generated/saved artifacts inside
    * the full Studio shell rather than a stripped viewer. */
   initialCode?: string;
+  /** Funnel-route chrome injected into the Studio Header (left of toolbar).
+   * Use for prompt context or saved-project metadata pills. */
+  headerLeft?: ReactNode;
+  /** Funnel-route chrome injected into the Studio Header (right cluster).
+   * Use for Save / Sign-in / per-project actions. */
+  headerRight?: ReactNode;
 }
 
-export default function App({ initialCode: initialCodeProp }: AppProps = {}) {
+export default function App({ initialCode: initialCodeProp, headerLeft, headerRight }: AppProps = {}) {
   if (isDemoPlayerRoute()) {
     return <DemoPlayerPage />;
   }
@@ -133,9 +140,11 @@ export default function App({ initialCode: initialCodeProp }: AppProps = {}) {
 
   return (
     <WorkbenchProvider initialCode={initialCode}>
-      <ErrorBoundary>
-        <AppContent isDevLab={isDevLab} />
-      </ErrorBoundary>
+      <StudioChromeProvider value={{ headerLeft, headerRight }}>
+        <ErrorBoundary>
+          <AppContent isDevLab={isDevLab} />
+        </ErrorBoundary>
+      </StudioChromeProvider>
     </WorkbenchProvider>
   );
 }

--- a/src/studio/components/Layout/Header.tsx
+++ b/src/studio/components/Layout/Header.tsx
@@ -3,8 +3,10 @@ import { Loader2, Download, FileDown, Code, Monitor, Undo2, Redo2, Box, Grid as 
 import { exportSTEP, exportSTL } from '../../../shared/worker/geometryEngine';
 import { formatTooltip, SHORTCUT_HINTS } from '../../../shared/constants/shortcuts';
 import { useProject } from '../../context/ProjectContext';
+import { useStudioChrome } from '../../context/StudioChromeContext';
 
 export function Header() {
+    const { headerLeft, headerRight } = useStudioChrome();
     const {
         viewMode, setViewMode, viewMode3D, setViewMode3D,
         isComputing, code, commandManager, setActiveDialog
@@ -35,7 +37,7 @@ export function Header() {
 
     return (
         <div className="h-10 bg-[#111] border-b border-[#333] flex items-center px-4 justify-between select-none shrink-0" data-testid="header">
-            <div className="flex items-center gap-4">
+            <div className="flex items-center gap-3 min-w-0">
                 <button
                     onClick={() => setActiveDialog('projectManager')}
                     aria-label="Open project manager"
@@ -47,9 +49,21 @@ export function Header() {
                         <FolderOpen size={12} className="text-gray-500 group-hover:text-blue-400" />
                     </span>
                 </button>
+                {headerLeft && (
+                    <>
+                        <div className="h-6 w-px bg-[#333]" />
+                        <div className="flex items-center gap-2 min-w-0">{headerLeft}</div>
+                    </>
+                )}
             </div>
 
             <div className="flex gap-2 items-center">
+                {headerRight && (
+                    <>
+                        <div className="flex items-center gap-2">{headerRight}</div>
+                        <div className="h-6 w-px bg-[#333] mx-2" />
+                    </>
+                )}
                 {/* Mode Toggle */}
                 <div className="flex bg-[#222] rounded p-0.5 mr-2" data-testid="mode-toggle">
                     <button

--- a/src/studio/context/StudioChromeContext.tsx
+++ b/src/studio/context/StudioChromeContext.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, type ReactNode } from 'react';
+
+export interface StudioChromeValue {
+  /** Extra chrome injected into the Header's left cluster, after the
+   * project-manager button. Used by funnel routes to show prompt context
+   * or saved-project metadata inline with the Studio chrome. */
+  headerLeft?: ReactNode;
+  /** Extra chrome injected into the Header's right cluster, before the
+   * built-in toolbar group. Used by funnel routes for Save / Sign in. */
+  headerRight?: ReactNode;
+}
+
+const StudioChromeContext = createContext<StudioChromeValue>({});
+
+export function StudioChromeProvider({
+  value,
+  children,
+}: {
+  value: StudioChromeValue;
+  children: ReactNode;
+}) {
+  return <StudioChromeContext.Provider value={value}>{children}</StudioChromeContext.Provider>;
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useStudioChrome(): StudioChromeValue {
+  return useContext(StudioChromeContext);
+}

--- a/src/studio/routes/g.$genId.tsx
+++ b/src/studio/routes/g.$genId.tsx
@@ -79,37 +79,34 @@ function AnonGenPage() {
     );
   }
 
-  // Full Studio shell with the generated code preloaded. Floating overlay
-  // gives one-click save + prompt context without taking real estate from
-  // the workbench. The shell's own Header handles export / view modes /
-  // local project management.
-  return (
-    <div className="relative w-screen h-screen overflow-hidden">
-      <App initialCode={gen.code} />
-
-      <div className="pointer-events-none absolute top-3 right-3 z-50 flex items-start gap-3">
-        <div className="pointer-events-auto rounded-lg border border-rule bg-vellum/95 backdrop-blur px-3 py-2 shadow-sm max-w-md">
-          <p className="font-mono text-[10px] text-ink-faint tracking-widest uppercase">Prompt</p>
-          <p className="text-xs text-ink mt-0.5 line-clamp-2">{gen.prompt}</p>
-        </div>
-        <div className="pointer-events-auto flex items-center gap-2">
-          <button
-            type="button"
-            onClick={() => void handleSave()}
-            disabled={savingState === 'saving'}
-            className="rounded-lg bg-blueprint hover:bg-blueprint-hover text-white px-4 py-2 text-sm font-medium disabled:opacity-50 transition-colors font-sans shadow-sm"
-          >
-            {session
-              ? savingState === 'saving'
-                ? 'Saving…'
-                : savingState === 'error'
-                  ? 'Retry save'
-                  : 'Save this'
-              : 'Sign in to save'}
-          </button>
-          {!session && <SignInButton redirectTo={window.location.href}>Sign in</SignInButton>}
-        </div>
-      </div>
+  const headerLeft = (
+    <div className="flex items-center gap-2 min-w-0">
+      <span className="text-[10px] uppercase tracking-widest text-gray-500 font-mono shrink-0">
+        Prompt
+      </span>
+      <span className="text-xs text-gray-300 truncate max-w-[420px]" title={gen.prompt}>
+        {gen.prompt}
+      </span>
     </div>
   );
+
+  const headerRight = session ? (
+    <button
+      type="button"
+      onClick={() => void handleSave()}
+      disabled={savingState === 'saving'}
+      className="px-3 py-1 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 transition-colors"
+    >
+      {savingState === 'saving' ? 'Saving…' : savingState === 'error' ? 'Retry save' : 'Save'}
+    </button>
+  ) : (
+    <SignInButton
+      redirectTo={typeof window !== 'undefined' ? window.location.href : undefined}
+      className="inline-flex items-center gap-1.5 px-3 py-1 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 transition-colors"
+    >
+      Sign in to save
+    </SignInButton>
+  );
+
+  return <App initialCode={gen.code} headerLeft={headerLeft} headerRight={headerRight} />;
 }

--- a/src/studio/routes/p.$slug.tsx
+++ b/src/studio/routes/p.$slug.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 import App from '../App';
-import { ExportButtons } from '../../funnel/components/ExportButtons';
 import { SignInButton } from '../../funnel/components/SignInButton';
 import { useSession } from '../../funnel/hooks/useSession';
 import { fetchProjectBySlug, type ProjectRow } from '../../funnel/lib/apiClient';
@@ -35,27 +34,31 @@ function ProjectPage() {
     );
   }
 
-  // Full Studio shell with the saved project code preloaded. Floating
-  // overlay carries project metadata + export buttons. The shell's own
-  // Header handles view modes / local project state.
-  return (
-    <div className="relative w-screen h-screen overflow-hidden">
-      <App initialCode={project.current_code} />
-
-      <div className="pointer-events-none absolute top-3 right-3 z-50 flex items-start gap-3">
-        <div className="pointer-events-auto rounded-lg border border-rule bg-vellum/95 backdrop-blur px-3 py-2 shadow-sm max-w-md">
-          <p className="font-mono text-[10px] text-ink-faint tracking-widest uppercase">
-            Project · {project.privacy}
-          </p>
-          <p className="font-serif text-sm font-medium text-ink mt-0.5 line-clamp-1">
-            {project.title}
-          </p>
-        </div>
-        <div className="pointer-events-auto flex items-center gap-2">
-          <ExportButtons slug={project.slug} signedIn={!!session} />
-          {!session && <SignInButton>Sign in</SignInButton>}
-        </div>
-      </div>
+  const headerLeft = (
+    <div className="flex items-center gap-2 min-w-0">
+      <span className="text-xs text-gray-200 font-medium truncate max-w-[280px]" title={project.title}>
+        {project.title}
+      </span>
+      <span className="text-[10px] uppercase tracking-widest text-gray-500 font-mono px-1.5 py-0.5 rounded border border-[#333]">
+        {project.privacy}
+      </span>
     </div>
+  );
+
+  const headerRight = !session ? (
+    <SignInButton
+      redirectTo={typeof window !== 'undefined' ? window.location.href : undefined}
+      className="inline-flex items-center gap-1.5 px-3 py-1 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 transition-colors"
+    >
+      Sign in
+    </SignInButton>
+  ) : null;
+
+  return (
+    <App
+      initialCode={project.current_code}
+      headerLeft={headerLeft}
+      headerRight={headerRight ?? undefined}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- Replace the floating top-right overlay panel on /g/\$genId and /p/\$slug with chrome integrated directly into the Studio Header (alongside the existing project name, mode toggle, view modes, undo/redo, export).
- New \`StudioChromeContext\` lets App accept optional \`headerLeft\` and \`headerRight\` ReactNode props and pipe them to the Header.
- /g shows the prompt as an inline pill on the left and a dark-themed \`Save\` / \`Sign in to save\` button on the right of the Header.
- /p shows the project title + privacy badge on the left and a \`Sign in\` button on the right; the disabled Phase-4 ExportButtons stub is dropped (the Header's working STEP/STL export covers this).

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint\` clean for touched files
- [x] \`npm run build\` succeeds
- [ ] Live: navigate to /g/<uuid> — verify prompt pill + Save/Sign-in render inside the Header bar, no floating overlay over the workbench
- [ ] Live: navigate to /p/<slug> — verify project title + privacy badge render inside the Header bar