### PR TITLE
fix(build): regenerate route tree before vite build

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "scripts": {
     "dev": "vite",
+    "prebuild": "tsr generate",
     "build": "tsc -b && vite build",
     "build:cli": "tsc --noEmit -p tsconfig.cli.json && node scripts/build-cli.mjs",
     "eval": "npx tsx eval/run.ts",


### PR DESCRIPTION
## Summary
- The TanStack Router \`routeTree.gen.ts\` is gitignored and only generated by the \`pretypecheck\` hook. CI fresh checkouts have no route tree, so \`tsc -b && vite build\` fails with \"Cannot find module './routeTree.gen'\".
- This has been silently breaking the \`deploy-cloudflare\` workflow since #178 — three consecutive deploys to develop failed without us noticing.
- Add a \`prebuild: tsr generate\` hook so \`npm run build\` is reproducible from a clean tree.

## Test plan
- [x] Local: \`rm src/studio/routeTree.gen.ts && npm run build\` succeeds
- [ ] CI deploy-cloudflare workflow turns green
- [ ] kernelcad.com / app.kernelcad.com reflect the funnel-chrome + KISS-tile changes