### PR TITLE
fix(render): headless determinism — strip dev chrome, gray bg, full-canvas viewer

### DIFF
--- a/scripts/renderStlMatchingKernelcad.html
+++ b/scripts/renderStlMatchingKernelcad.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>html,body{margin:0;background:#0a0a0a;}canvas{display:block;}</style>
+</head>
+<body>
+<script type="importmap">
+{ "imports": { "three": "/node_modules/three/build/three.module.js", "three/addons/": "/node_modules/three/examples/jsm/" } }
+</script>
+<script type="module">
+import * as THREE from 'three';
+import { STLLoader } from 'three/addons/loaders/STLLoader.js';
+
+const params = new URLSearchParams(window.location.search);
+const stlUrls = params.getAll('stl');
+const azDeg = Number(params.get('az') ?? '30');
+const elDeg = Number(params.get('el') ?? '15');
+const size = Number(params.get('size') ?? '1024');
+const fovDeg = Number(params.get('fov') ?? '50');
+// Rotate STL geometry to align with kernelCAD's coord convention (Y=depth, Z=up).
+// Most STLs use Z=up natively; some use Y=up. Override via ?rotate=xdeg,ydeg,zdeg
+const rotateStr = params.get('rotate') ?? '-90,0,0';
+const [rotX, rotY, rotZ] = rotateStr.split(',').map(Number);
+
+const renderer = new THREE.WebGLRenderer({ antialias: true, preserveDrawingBuffer: true });
+renderer.setSize(size, size);
+renderer.outputColorSpace = THREE.SRGBColorSpace;
+document.body.appendChild(renderer.domElement);
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x909090);
+scene.add(new THREE.AmbientLight(0xffffff, 0.5));
+const key = new THREE.DirectionalLight(0xffffff, 1.5); key.position.set(1, -2, 2.5); scene.add(key);
+const fill = new THREE.DirectionalLight(0xffffff, 0.8); fill.position.set(-1.5, -1, 0.5); scene.add(fill);
+
+const camera = new THREE.PerspectiveCamera(fovDeg, 1, 0.1, 10000);
+
+const loader = new STLLoader();
+const group = new THREE.Group();
+scene.add(group);
+
+async function loadAll() {
+  for (const url of stlUrls) {
+    const geom = await new Promise((res, rej) => loader.load(url, res, undefined, rej));
+    geom.computeVertexNormals();
+    const mat = new THREE.MeshPhysicalMaterial({ color: 0x6c6c6c, metalness: 0, roughness: 0.15, clearcoat: 0.8, clearcoatRoughness: 0.05 });
+    const mesh = new THREE.Mesh(geom, mat);
+    group.add(mesh);
+  }
+  // Apply orientation rotation (degrees → radians) — maps STL's coord system to kernelCAD's.
+  group.rotation.set((rotX * Math.PI) / 180, (rotY * Math.PI) / 180, (rotZ * Math.PI) / 180);
+  group.updateMatrixWorld(true);
+  // Center group at origin (so framing math matches kernelCAD's "center at origin" assumption)
+  const bbox = new THREE.Box3().setFromObject(group);
+  const center = bbox.getCenter(new THREE.Vector3());
+  group.position.sub(center);
+  // Recompute bbox of the centered group
+  const bbox2 = new THREE.Box3().setFromObject(group);
+  const dx = bbox2.max.x - bbox2.min.x;
+  const dy = bbox2.max.y - bbox2.min.y;
+  const dz = bbox2.max.z - bbox2.min.z;
+  const maxExtent = Math.max(dx, dy, dz);
+  // EXACT same math as DemoPlayerPage.tsx setRenderPose
+  const fov = camera.fov * (Math.PI / 180);
+  const distance = (maxExtent / 2 / Math.tan(fov / 2)) * 0.95;
+  const az = (azDeg * Math.PI) / 180;
+  const el = (elDeg * Math.PI) / 180;
+  const cosEl = Math.cos(el);
+  const x = distance * Math.sin(az) * cosEl;
+  const y = -distance * Math.cos(az) * cosEl;
+  const z = distance * Math.sin(el);
+  camera.up.set(0, 0, 1);
+  camera.position.set(x, y, z);
+  camera.lookAt(0, 0, 0);
+  camera.near = Math.max(0.1, distance / 100);
+  camera.far = distance * 20;
+  camera.updateProjectionMatrix();
+  renderer.render(scene, camera);
+  // Signal ready
+  window.__stlReady = true;
+  window.__bbox = { dx, dy, dz, maxExtent, distance };
+}
+loadAll().catch((e) => { window.__stlError = String(e); });
+</script>
+</body>
+</html>

--- a/scripts/renderStlMatchingKernelcad.mjs
+++ b/scripts/renderStlMatchingKernelcad.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// scripts/renderStlMatchingKernelcad.mjs
+//
+// Render an STL (or multiple) using the SAME camera math as kernelCAD's
+// DemoPlayerPage.tsx setRenderPose. Goal: produce a reference image at the
+// identical framing convention agent builds are rendered with, so scoring
+// builds against this reference uses an apples-to-apples comparison.
+//
+// Usage:
+//   node scripts/renderStlMatchingKernelcad.mjs \
+//     --stl /path/a.stl --stl /path/b.stl \
+//     --pose 30,15 --size 1024 --out /tmp/ref.png
+
+import { chromium } from 'playwright';
+import { resolve, isAbsolute, join } from 'node:path';
+import { existsSync, copyFileSync, mkdirSync } from 'node:fs';
+
+function arg(name, dflt) {
+  const i = process.argv.indexOf('--' + name);
+  if (i < 0) return dflt;
+  return process.argv[i + 1];
+}
+function args(name) {
+  const out = [];
+  for (let i = 0; i < process.argv.length; i++) {
+    if (process.argv[i] === '--' + name) out.push(process.argv[i + 1]);
+  }
+  return out;
+}
+
+const stlPaths = args('stl');
+const pose = arg('pose', '30,15');
+const size = Number(arg('size', '1024'));
+const out = arg('out', '/tmp/stl-render.png');
+const baseUrl = arg('base-url', 'http://localhost:5173');
+const rotate = arg('rotate', '-90,0,0');
+
+if (stlPaths.length === 0) {
+  console.error('usage: renderStlMatchingKernelcad.mjs --stl <path> [--stl <path>] [--pose 30,15] [--size 1024] [--out <png>]');
+  process.exit(2);
+}
+
+const [azStr, elStr] = pose.split(',').map(s => s.trim());
+
+// Copy STLs into the worktree's public/ so vite serves them at /tmp-stls/<name>
+const worktreeRoot = resolve(import.meta.dirname, '..');
+const publicStaticDir = join(worktreeRoot, 'public', 'tmp-stls');
+mkdirSync(publicStaticDir, { recursive: true });
+const servedUrls = [];
+for (const p of stlPaths) {
+  const abs = isAbsolute(p) ? p : resolve(p);
+  if (!existsSync(abs)) {
+    console.error(`STL not found: ${abs}`);
+    process.exit(2);
+  }
+  const base = abs.split('/').pop();
+  const dest = join(publicStaticDir, base);
+  copyFileSync(abs, dest);
+  servedUrls.push(`/tmp-stls/${base}`);
+}
+
+const stlQueryParams = servedUrls.map(u => `stl=${encodeURIComponent(u)}`).join('&');
+const url = `${baseUrl}/renderStlMatchingKernelcad.html?${stlQueryParams}&az=${azStr}&el=${elStr}&size=${size}&rotate=${encodeURIComponent(rotate)}`;
+
+const browser = await chromium.launch({ args: ['--disable-dev-shm-usage'] });
+const ctx = await browser.newContext({ viewport: { width: size, height: size } });
+const page = await ctx.newPage();
+page.on('pageerror', (e) => console.error('page error:', e));
+page.on('console', (m) => { if (m.type() === 'error') console.error('console:', m.text()); });
+
+await page.goto(url);
+try {
+  await page.waitForFunction(() => window.__stlReady === true || window.__stlError, { timeout: 30000 });
+  const err = await page.evaluate(() => window.__stlError);
+  if (err) {
+    console.error('STL load error:', err);
+    await browser.close();
+    process.exit(3);
+  }
+  const bbox = await page.evaluate(() => window.__bbox);
+  console.error('rendered bbox:', JSON.stringify(bbox));
+  // Wait for renderer to settle
+  await page.waitForTimeout(500);
+  await page.screenshot({ path: out, type: 'png' });
+  console.log(`Wrote ${out}`);
+} finally {
+  await browser.close();
+}

--- a/src/agent/render/headlessRender.ts
+++ b/src/agent/render/headlessRender.ts
@@ -106,10 +106,35 @@ export async function headlessRender(opts: HeadlessRenderOpts): Promise<Headless
       await page.evaluate(() => window.__demoPlayer?.setReferenceImagesVisible(false));
     }
 
+    // Belt-and-suspenders: nuke ANY dev chrome before each screenshot. The
+    // headless URL param + __root.tsx suppression doesn't always catch the
+    // TanStack Router devtools badge — it gets re-injected by HMR or React
+    // double-render after mesh load. Removing the offending DOM nodes here
+    // guarantees zero badge pixels in the screenshot.
+    const stripDevChrome = `
+      () => {
+        const sels = [
+          '[data-testid="tsr-devtools"]',
+          '.TanStackRouterDevtools',
+          '[data-tanstack-router-devtools]',
+          'vite-error-overlay',
+        ];
+        for (const sel of sels) document.querySelectorAll(sel).forEach((n) => n.remove());
+        // Heuristic: any fixed-position element with "TanStack" in text content.
+        document.querySelectorAll('*').forEach((el) => {
+          const cs = (el instanceof Element) ? getComputedStyle(el) : null;
+          if (cs && cs.position === 'fixed' && /TanStack/i.test(el.textContent || '') && el.children.length < 8) {
+            el.remove();
+          }
+        });
+      }
+    `;
+
     // 4. Per-view: snap camera, screenshot, collect.
     const pngsByView: Partial<Record<RenderView, Buffer>> = {};
     for (const view of views) {
       await page.evaluate((v) => window.__demoPlayer!.setRenderView(v), view);
+      await page.evaluate(stripDevChrome);
       const buf = await page.screenshot({ type: 'png' });
       pngsByView[view] = buf;
     }
@@ -128,6 +153,7 @@ export async function headlessRender(opts: HeadlessRenderOpts): Promise<Headless
           ({ a, e }) => window.__demoPlayer!.setRenderPose(a, e),
           { a: az, e: el },
         );
+        await page.evaluate(stripDevChrome);
         const buf = await page.screenshot({ type: 'png' });
         pngsByPose[poseKey] = buf;
       }

--- a/src/studio/components/demoPlayer/DemoPlayerPage.tsx
+++ b/src/studio/components/demoPlayer/DemoPlayerPage.tsx
@@ -667,6 +667,12 @@ export function DemoPlayerPage(): React.JSX.Element {
     };
   }, [isDemoApiReady]);
 
+  // Headless renders (kernelcad render, scoreReference) navigate with
+  // ?headless=1. Suppress the TerminalPane so the ViewerPane (and its model)
+  // fills the entire viewport. Without this, TerminalPane's 640px sidebar eats
+  // half the canvas at 1024×1024 capture → silhouette IoU bimodality.
+  const isHeadless = typeof window !== 'undefined'
+    && new URLSearchParams(window.location.search).get('headless') === '1';
   return (
     <div
       data-testid="demo-player"
@@ -678,15 +684,17 @@ export function DemoPlayerPage(): React.JSX.Element {
         overflow: 'hidden',
       }}
     >
-      <TerminalPane
-        lines={terminalLines}
-        width={TERMINAL_W}
-        height={TERMINAL_H}
-        getElapsedMs={() => Math.max(0, elapsedMsRef.current - terminalOriginRef.current)}
-      />
+      {!isHeadless && (
+        <TerminalPane
+          lines={terminalLines}
+          width={TERMINAL_W}
+          height={TERMINAL_H}
+          getElapsedMs={() => Math.max(0, elapsedMsRef.current - terminalOriginRef.current)}
+        />
+      )}
       <ViewerPane
         version={version}
-        width={VIEWER_W}
+        width={isHeadless ? VIEWER_W + TERMINAL_W : VIEWER_W}
         height={VIEWER_H}
         onSceneReady={handleSceneReady}
       />

--- a/src/studio/components/demoPlayer/ViewerPane.tsx
+++ b/src/studio/components/demoPlayer/ViewerPane.tsx
@@ -16,7 +16,12 @@ export function ViewerPane({ version, onSceneReady, width, height }: ViewerPaneP
     if (!mountRef.current) return;
     const mount = mountRef.current;
     const scene = new THREE.Scene();
-    scene.background = new THREE.Color(0x0a0a0a);
+    // Background luma 144 (#909090). Chosen to match the eval reference photos'
+    // typical studio-gray backdrop so SSIM doesn't get dominated by background
+    // pixel mismatch. Flat gray (no ground plane) keeps all 4 corners at the
+    // same luma so silhouetteMask's corner-bg sample stays consistent — see
+    // memory/kernelcad_silhouette_iou_bg_pitfall.md.
+    scene.background = new THREE.Color(0x909090);
     const camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 5000);
     camera.position.set(120, 80, 120);
     camera.lookAt(0, 0, 0);

--- a/src/studio/routes/__root.tsx
+++ b/src/studio/routes/__root.tsx
@@ -33,6 +33,22 @@ function RootLayout() {
   const headless = isHeadlessRender();
   return (
     <>
+      {headless && (
+        // Belt-and-suspenders: even though we don't render TanStackRouterDevtools
+        // when headless, vite HMR or React Strict Mode can briefly mount it.
+        // The badge is injected into <body> via a portal, so a global rule on
+        // any element WITH the data attribute kills it.
+        <style>{`
+          [data-testid="tsr-devtools"],
+          .TanStackRouterDevtools,
+          [data-tanstack-router-devtools] {
+            display: none !important;
+            visibility: hidden !important;
+          }
+          /* Vite error overlay too — never let it bleed into a render. */
+          vite-error-overlay { display: none !important; }
+        `}</style>
+      )}
       <Outlet />
       {!headless && (
         <Suspense fallback={null}>


### PR DESCRIPTION
## Summary

Headless renders (`kernelcad render`, `scoreReference`, eval harness) were systematically contaminated by three pieces of dev chrome bleeding into score PNGs. This made every eval task's scoring noisy or biased.

## What was contaminating renders

1. **TerminalPane sidebar (640 px)** consumed 60% of the 1024 px capture viewport, cropping the model. The persistent 0.50-plateau across 28 agent-eval experiments was partially this bug, not agent limitation.
2. **TanStack Router devtools badge** re-injected by HMR or React double-render despite `?headless=1`. Visible in ~3/5 runs → bimodal silhouette IoU (0.078 vs 0.277 same script).
3. **Black scene background (`#0a0a0a`)** dominated SSIM against gray studio reference photos.

## Empirical impact (eyewear-wayfarer-front, pose 30,15, 1024×1024)

| Build | Before (comp / sil / SSIM) | After (comp / sil / SSIM) |
|---|---|---|
| baseline | 0.487 / 0.675 / 0.165 | 0.674 / 0.765 / 0.544 |
| E3 (spec) | 0.527 / 0.728 / 0.222 | 0.670 / 0.752 / 0.575 |
| R1 (visual iter) | 0.538 / 0.752 / 0.218 | 0.677 / 0.752 / 0.577 |
| E4 (NURBS) | 0.431 / 0.592 / 0.179 | **0.687 / 0.754 / 0.597** |

**Gate pass rate goes from 1/4 to 4/4.** Pre-fix only R5 passed by gaming the photo with a slab hack — geometrically correct builds were being failed by the renderer leaking dev chrome into their PNGs.

## Files

- `src/studio/routes/__root.tsx` — belt-and-suspenders CSS rule hides TanStack devtools + vite-error-overlay in headless mode
- `src/studio/components/demoPlayer/DemoPlayerPage.tsx` — skip TerminalPane when `?headless=1`, ViewerPane expands to fill full canvas
- `src/studio/components/demoPlayer/ViewerPane.tsx` — scene background `0x0a0a0a` → `0x909090` (flat gray matches reference photos, all 4 corners same luma so `silhouetteMask` corner-bg sample stays consistent)
- `src/agent/render/headlessRender.ts` — `stripDevChrome` script removes any residual badge DOM before each screenshot post-mesh-load

## New tool

- `scripts/renderStlMatchingKernelcad.{html,mjs}` — standalone STL→PNG renderer using the EXACT `setRenderPose` camera math from `DemoPlayerPage`. Enables apples-to-apples scoring of agent builds against STL-derived oracles (Python pyrender references had incompatible framing).

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.cli.json` passes
- [x] `npx tsc -b --noEmit` (build mode) passes
- [x] `npx eslint` on touched files passes
- [x] Manual render of `eval/tasks/eyewear-wayfarer-front/solution-expert.kcad.ts` at pose 30,15: clean PNG, no badge, no sidebar
- [x] All 4 production builds (baseline/E3/R1/E4) pass photo gates after fix