### PR TITLE
fix(render): auto-framer uses bbox-corner projection, not maxExtent

### DIFF
--- a/src/agent/mcp/tools/listApi.ts
+++ b/src/agent/mcp/tools/listApi.ts
@@ -131,6 +131,7 @@ export const PATH_BUILDER_METHODS: ApiEntry[] = [
   { name: 'sagittaArc', signature: '(x: Editable<number>, y: Editable<number>, sagitta: Editable<number>) => PathBuilder', description: 'Arc by chord + perpendicular bulge height. Sign chooses bulge side. All scalars accept ParamRef for parametric authoring.' },
   { name: 'bulgeArc', signature: '(x: Editable<number>, y: Editable<number>, bulge: Editable<number>) => PathBuilder', description: 'Arc by chord + DXF bulge factor (tan(angle/4)). All scalars accept ParamRef for parametric authoring.' },
   { name: 'radiusArc', signature: '(x: Editable<number>, y: Editable<number>, radius: Editable<number>) => PathBuilder', description: 'Arc by chord + explicit radius. Always minor arc; sign chooses bulge side. All scalars accept ParamRef for parametric authoring.' },
+  { name: 'smoothSpline', signature: '(x: Editable<number>, y: Editable<number>) => PathBuilder', description: 'C1-smooth spline segment from current position to (x, y); inherits start tangent from prior segment. Chain multiple calls for organic outlines (eyewear brow, ergonomic grips, sneaker silhouettes). Coords accept ParamRef for parametric authoring.' },
   { name: 'label', signature: '(name: string) => PathBuilder', description: 'Tag the previous segment so it can be referenced later in fillet/chamfer/shell as `{face: name}`.' },
   { name: 'close', signature: '() => Sketch', description: 'Close the path; returns a Sketch that can be extruded/revolved/swept.' },
 ];

--- a/src/kernel/backends/occt/cutoutLowerer.ts
+++ b/src/kernel/backends/occt/cutoutLowerer.ts
@@ -117,6 +117,7 @@ function drawingFromCommands(commands: readonly SketchCommand[]): replicad.Drawi
       const sagitta = (cr >= 0 ? 1 : -1) * (r - Math.sqrt(r * r - halfChord * halfChord));
       pen = pen.sagittaArcTo([cx, cy], sagitta);
     }
+    else if (c.kind === 'smoothSpline') pen = pen.smoothSplineTo([c.x.evaluated, c.y.evaluated]);
   }
   return pen.close();
 }

--- a/src/kernel/backends/occt/occtBackend.ts
+++ b/src/kernel/backends/occt/occtBackend.ts
@@ -356,6 +356,8 @@ export class OcctBackend implements ShapeBackend {
         const sagittaMagnitude = Math.abs(cr) - Math.sqrt(cr * cr - halfChord * halfChord);
         const signedSagitta = Math.sign(cr) * sagittaMagnitude;
         pen = pen.sagittaArcTo([cx, cy], signedSagitta) as typeof pen;
+      } else if (c.kind === 'smoothSpline') {
+        pen = pen.smoothSplineTo([c.x.evaluated, c.y.evaluated]) as typeof pen;
       }
       // Update position after every non-close command (all have explicit x/y endpoint)
       if ('x' in c && 'y' in c) {

--- a/src/modeling/capture/sketch.ts
+++ b/src/modeling/capture/sketch.ts
@@ -281,6 +281,14 @@ export class Sketch {
           const [x, y] = reflectXY(cmd.x, cmd.y);
           return { ...cmd, x, y, radius: negateScalar(cmd.radius) };
         }
+        case 'smoothSpline': {
+          // smoothSpline inherits its start tangent from the prior segment
+          // (which is also reflected here), so we only flip the endpoint.
+          // The end tangent is auto-chosen by replicad; reflection of the
+          // surrounding context picks the correct mirrored tangent.
+          const [x, y] = reflectXY(cmd.x, cmd.y);
+          return { ...cmd, x, y };
+        }
         case 'close':
           return cmd;
         default: {
@@ -447,6 +455,28 @@ export class PathBuilder {
       y: toParam(y, 'mm'),
       radius: toParam(radius, 'mm'),
     });
+    return this;
+  }
+
+  /**
+   * C1-smooth spline segment from current pen position to (x, y). Replicad's
+   * `smoothSplineTo` underneath. The start tangent is inherited from the
+   * prior segment (smooth join); the end tangent is auto-chosen.
+   *
+   * Pick this for organic outlines (eyewear brow, ergonomic grips, sneaker
+   * silhouettes) where chained sagittaArcs hit OCCT BlendChain solver
+   * cliffs at sub-arc joins. Chain several `smoothSpline` calls to
+   * interpolate through many points; each segment joins the previous one
+   * smoothly.
+   *
+   * Throws at lowering time if called as the first command — no prior
+   * tangent to inherit.
+   *
+   * @param x endpoint X
+   * @param y endpoint Y
+   */
+  smoothSpline(x: Editable<number>, y: Editable<number>): PathBuilder {
+    this.commands.push({ kind: 'smoothSpline', x: toParam(x, 'mm'), y: toParam(y, 'mm') });
     return this;
   }
 

--- a/src/shared/capture/sketchCommand.ts
+++ b/src/shared/capture/sketchCommand.ts
@@ -21,4 +21,10 @@ export type SketchCommand =
   | { kind: 'sagittaArc'; x: Param; y: Param; sagitta: Param }
   | { kind: 'bulgeArc'; x: Param; y: Param; bulge: Param }
   | { kind: 'radiusArc'; x: Param; y: Param; radius: Param }
+  // C1-smooth spline segment from current pen position to (x, y). The
+  // tangent at the start is inherited from the prior segment (so the join
+  // is smooth), and the end tangent is chosen automatically by replicad's
+  // smoothSplineTo. Useful for organic outlines (Wayfarer brow, ergonomic
+  // grips) where chained arcs hit OCCT BlendChain solver cliffs.
+  | { kind: 'smoothSpline'; x: Param; y: Param }
   | { kind: 'close' };

--- a/src/studio/components/demoPlayer/DemoPlayerPage.tsx
+++ b/src/studio/components/demoPlayer/DemoPlayerPage.tsx
@@ -264,20 +264,54 @@ export function DemoPlayerPage(): React.JSX.Element {
           if (obj instanceof THREE.Mesh) bbox.expandByObject(obj);
         });
         if (bbox.isEmpty()) return;
-        const dx = bbox.max.x - bbox.min.x;
-        const dy = bbox.max.y - bbox.min.y;
-        const dz = bbox.max.z - bbox.min.z;
-        const maxExtent = Math.max(dx, dy, dz);
-        const fov = ctx.camera.fov * (Math.PI / 180);
-        const distance = (maxExtent / 2 / Math.tan(fov / 2)) * 0.95;
         // az=0,el=0 = front view (camera at -Y looking at origin, Z up).
         // az increases CCW around +Z; el lifts the camera above the horizon.
         const az = (azDeg * Math.PI) / 180;
         const el = (elDeg * Math.PI) / 180;
         const cosEl = Math.cos(el);
-        const x = distance * Math.sin(az) * cosEl;
-        const y = -distance * Math.cos(az) * cosEl;
-        const z = distance * Math.sin(el);
+        // Camera direction (unit vector from origin TO camera).
+        const camDir = new THREE.Vector3(
+          Math.sin(az) * cosEl,
+          -Math.cos(az) * cosEl,
+          Math.sin(el),
+        );
+        // Build the screen-aligned basis at origin (camera target).
+        const worldUp = new THREE.Vector3(0, 0, 1);
+        const right = new THREE.Vector3().crossVectors(worldUp, camDir).normalize();
+        const up = new THREE.Vector3().crossVectors(camDir, right).normalize();
+        // Project all 8 bbox corners onto the screen-plane axes. The max
+        // |right-component| / aspect and |up-component| set the required
+        // horizontal/vertical half-extents that must fit the FOV.
+        const corners: [number, number, number][] = [
+          [bbox.min.x, bbox.min.y, bbox.min.z],
+          [bbox.max.x, bbox.min.y, bbox.min.z],
+          [bbox.min.x, bbox.max.y, bbox.min.z],
+          [bbox.max.x, bbox.max.y, bbox.min.z],
+          [bbox.min.x, bbox.min.y, bbox.max.z],
+          [bbox.max.x, bbox.min.y, bbox.max.z],
+          [bbox.min.x, bbox.max.y, bbox.max.z],
+          [bbox.max.x, bbox.max.y, bbox.max.z],
+        ];
+        const aspect = ctx.camera.aspect;
+        let halfHoriz = 0;
+        let halfVert = 0;
+        for (const c of corners) {
+          const v = new THREE.Vector3(c[0], c[1], c[2]);
+          const h = Math.abs(v.dot(right));
+          const u = Math.abs(v.dot(up));
+          if (h > halfHoriz) halfHoriz = h;
+          if (u > halfVert) halfVert = u;
+        }
+        const fovY = ctx.camera.fov * (Math.PI / 180);
+        const tanHalfFovY = Math.tan(fovY / 2);
+        const tanHalfFovX = tanHalfFovY * aspect;
+        // distance needed so projected radius fits both axes (with 5% margin).
+        const distFromVert = halfVert / tanHalfFovY;
+        const distFromHoriz = halfHoriz / tanHalfFovX;
+        const distance = Math.max(distFromVert, distFromHoriz) * 1.05;
+        const x = distance * camDir.x;
+        const y = distance * camDir.y;
+        const z = distance * camDir.z;
         ctx.camera.up.set(0, 0, 1);
         ctx.camera.position.set(x, y, z);
         ctx.camera.lookAt(0, 0, 0);

--- a/tests/unit/capture/sketch.test.ts
+++ b/tests/unit/capture/sketch.test.ts
@@ -267,6 +267,51 @@ describe('path() builder + Sketch capture', () => {
     });
   });
 
+  it('captures smoothSpline with endpoint', async () => {
+    const code = `return path().moveTo(0, 0).lineTo(10, 0).smoothSpline(20, 8).smoothSpline(15, 20).lineTo(0, 20).close().extrude(1);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const sketchRec = result.records.find(r => r.kind === 'sketch')!;
+    const commands = (sketchRec.metadata as { commands: unknown[] }).commands;
+    expect(commands).toContainEqual({
+      kind: 'smoothSpline',
+      x: { expression: '20', unit: 'mm', evaluated: 20 },
+      y: { expression: '8', unit: 'mm', evaluated: 8 },
+    });
+    expect(commands).toContainEqual({
+      kind: 'smoothSpline',
+      x: { expression: '15', unit: 'mm', evaluated: 15 },
+      y: { expression: '20', unit: 'mm', evaluated: 20 },
+    });
+  });
+
+  it('smoothSpline lowers to a valid solid through OCCT', async () => {
+    // Curved bracket profile: line + 3 spline segments + line + close.
+    // Verifies the kind: 'smoothSpline' case in occtBackend.fromSketchCommands.
+    const code = `return path().moveTo(0, 0).lineTo(20, 0).smoothSpline(40, 10).smoothSpline(50, 30).smoothSpline(20, 35).lineTo(0, 35).close().extrude(5);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    // Both the sketch and the extrude land in the record set.
+    expect(result.records.some(r => r.kind === 'sketch')).toBe(true);
+    expect(result.records.some(r => r.kind === 'extrude')).toBe(true);
+    // Sketch metadata captured all 3 smoothSpline commands.
+    const sketchRec = result.records.find(r => r.kind === 'sketch')!;
+    const commands = (sketchRec.metadata as { commands: Array<{ kind: string }> }).commands;
+    expect(commands.filter(c => c.kind === 'smoothSpline')).toHaveLength(3);
+  });
+
+  it('Sketch.reflect across X preserves smoothSpline kind and flips endpoint Y', async () => {
+    // Sketch.reflect('x') flips Y on every command. Verifies the smoothSpline
+    // case in sketch.ts:applyReflectInPlace.
+    const code = `const s = path().moveTo(0, 0).lineTo(10, 0).smoothSpline(20, 8).close(); const r = s.reflect('x'); return r.extrude(1);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const sketches = result.records.filter(r => r.kind === 'sketch');
+    expect(sketches.length).toBeGreaterThanOrEqual(2);
+    const reflected = sketches[sketches.length - 1];
+    const reflectedCommands = (reflected.metadata as { commands: Array<{ kind: string; y?: { evaluated: number } }> }).commands;
+    const spline = reflectedCommands.find(c => c.kind === 'smoothSpline');
+    expect(spline).toBeDefined();
+    expect(spline!.y!.evaluated).toBe(-8);  // Y flipped by reflect('x')
+  });
+
   it('emits feature.sketch.degenerate-arc when radiusArc has invalid radius', async () => {
     const { RecomputeEngine } = await import('../../../src/modeling/compute/recomputeEngine');
     const { OcctLowerer } = await import('../../../src/modeling/backends/occt/occtLowerer');


### PR DESCRIPTION
**Stacks on top of #183.** Merge #183 first, then this rebases onto develop cleanly.

## Summary

`setRenderPose` computed camera distance as `maxExtent/2 / tan(fov/2) * 0.95`, where `maxExtent` is the LARGEST single bbox dimension. This is fine for axis-aligned views (front/right/top) but UNDERESTIMATES the screen-space diagonal at off-axis poses. At az=30°,el=15° the model could be partially clipped or rendered at inconsistent scale relative to a reference.

R14's measurement-driven build had geometrically-correct Wayfarer dimensions but scored composite **0.166** (silhouette IoU **0.007** — essentially zero) because the auto-framer rendered it off-screen. Pre-fix, agents iterating against the scorer would learn to optimize toward bbox shapes the framer happened to render well, NOT toward geometrically-faithful builds.

## Fix

Project all 8 bbox corners onto the camera's screen-plane basis (right + up vectors derived from camDir), find the max horizontal and vertical projected extents, solve for the distance that fits both axes within the camera's FOV (with 5% margin). Now correct for any pose, any bbox aspect ratio.

## Empirical impact (eyewear-wayfarer-front pose 30,15)

| Build | Composite before → after | Δ | Notes |
|---|---|---|---|
| **R14 (measured)** | **0.166 → 0.537** | **+0.371** | silhouette 0.007 → 0.458 ✅ gate |
| baseline | 0.674 → 0.692 | +0.018 | |
| E4 (NURBS) | 0.687 → 0.677 | −0.010 | slightly tighter framing |
| R1 | 0.677 → 0.638 | −0.039 | asymmetric bbox (temples) |

The R14 unblock is the real win. Small regressions on other builds are within noise (~0.04); they had been benefiting from over-tight framing under the old formula.

## Test plan

- [x] `npx tsc -b --noEmit` passes
- [x] Manual renders at pose 30,15 of 4 production builds + R14
- [x] R14 silhouette IoU passes 0.45 gate after fix