### PR TITLE
feat(sketch): path-level smoothSpline() for organic 2D outlines

### DIFF
--- a/src/agent/mcp/tools/listApi.ts
+++ b/src/agent/mcp/tools/listApi.ts
@@ -131,6 +131,7 @@ export const PATH_BUILDER_METHODS: ApiEntry[] = [
   { name: 'sagittaArc', signature: '(x: Editable<number>, y: Editable<number>, sagitta: Editable<number>) => PathBuilder', description: 'Arc by chord + perpendicular bulge height. Sign chooses bulge side. All scalars accept ParamRef for parametric authoring.' },
   { name: 'bulgeArc', signature: '(x: Editable<number>, y: Editable<number>, bulge: Editable<number>) => PathBuilder', description: 'Arc by chord + DXF bulge factor (tan(angle/4)). All scalars accept ParamRef for parametric authoring.' },
   { name: 'radiusArc', signature: '(x: Editable<number>, y: Editable<number>, radius: Editable<number>) => PathBuilder', description: 'Arc by chord + explicit radius. Always minor arc; sign chooses bulge side. All scalars accept ParamRef for parametric authoring.' },
+  { name: 'smoothSpline', signature: '(x: Editable<number>, y: Editable<number>) => PathBuilder', description: 'C1-smooth spline segment from current position to (x, y); inherits start tangent from prior segment. Chain multiple calls for organic outlines (eyewear brow, ergonomic grips, sneaker silhouettes). Coords accept ParamRef for parametric authoring.' },
   { name: 'label', signature: '(name: string) => PathBuilder', description: 'Tag the previous segment so it can be referenced later in fillet/chamfer/shell as `{face: name}`.' },
   { name: 'close', signature: '() => Sketch', description: 'Close the path; returns a Sketch that can be extruded/revolved/swept.' },
 ];

--- a/src/kernel/backends/occt/cutoutLowerer.ts
+++ b/src/kernel/backends/occt/cutoutLowerer.ts
@@ -117,6 +117,7 @@ function drawingFromCommands(commands: readonly SketchCommand[]): replicad.Drawi
       const sagitta = (cr >= 0 ? 1 : -1) * (r - Math.sqrt(r * r - halfChord * halfChord));
       pen = pen.sagittaArcTo([cx, cy], sagitta);
     }
+    else if (c.kind === 'smoothSpline') pen = pen.smoothSplineTo([c.x.evaluated, c.y.evaluated]);
   }
   return pen.close();
 }

--- a/src/kernel/backends/occt/occtBackend.ts
+++ b/src/kernel/backends/occt/occtBackend.ts
@@ -356,6 +356,8 @@ export class OcctBackend implements ShapeBackend {
         const sagittaMagnitude = Math.abs(cr) - Math.sqrt(cr * cr - halfChord * halfChord);
         const signedSagitta = Math.sign(cr) * sagittaMagnitude;
         pen = pen.sagittaArcTo([cx, cy], signedSagitta) as typeof pen;
+      } else if (c.kind === 'smoothSpline') {
+        pen = pen.smoothSplineTo([c.x.evaluated, c.y.evaluated]) as typeof pen;
       }
       // Update position after every non-close command (all have explicit x/y endpoint)
       if ('x' in c && 'y' in c) {

--- a/src/modeling/capture/sketch.ts
+++ b/src/modeling/capture/sketch.ts
@@ -281,6 +281,14 @@ export class Sketch {
           const [x, y] = reflectXY(cmd.x, cmd.y);
           return { ...cmd, x, y, radius: negateScalar(cmd.radius) };
         }
+        case 'smoothSpline': {
+          // smoothSpline inherits its start tangent from the prior segment
+          // (which is also reflected here), so we only flip the endpoint.
+          // The end tangent is auto-chosen by replicad; reflection of the
+          // surrounding context picks the correct mirrored tangent.
+          const [x, y] = reflectXY(cmd.x, cmd.y);
+          return { ...cmd, x, y };
+        }
         case 'close':
           return cmd;
         default: {
@@ -447,6 +455,28 @@ export class PathBuilder {
       y: toParam(y, 'mm'),
       radius: toParam(radius, 'mm'),
     });
+    return this;
+  }
+
+  /**
+   * C1-smooth spline segment from current pen position to (x, y). Replicad's
+   * `smoothSplineTo` underneath. The start tangent is inherited from the
+   * prior segment (smooth join); the end tangent is auto-chosen.
+   *
+   * Pick this for organic outlines (eyewear brow, ergonomic grips, sneaker
+   * silhouettes) where chained sagittaArcs hit OCCT BlendChain solver
+   * cliffs at sub-arc joins. Chain several `smoothSpline` calls to
+   * interpolate through many points; each segment joins the previous one
+   * smoothly.
+   *
+   * Throws at lowering time if called as the first command — no prior
+   * tangent to inherit.
+   *
+   * @param x endpoint X
+   * @param y endpoint Y
+   */
+  smoothSpline(x: Editable<number>, y: Editable<number>): PathBuilder {
+    this.commands.push({ kind: 'smoothSpline', x: toParam(x, 'mm'), y: toParam(y, 'mm') });
     return this;
   }
 

--- a/src/shared/capture/sketchCommand.ts
+++ b/src/shared/capture/sketchCommand.ts
@@ -21,4 +21,10 @@ export type SketchCommand =
   | { kind: 'sagittaArc'; x: Param; y: Param; sagitta: Param }
   | { kind: 'bulgeArc'; x: Param; y: Param; bulge: Param }
   | { kind: 'radiusArc'; x: Param; y: Param; radius: Param }
+  // C1-smooth spline segment from current pen position to (x, y). The
+  // tangent at the start is inherited from the prior segment (so the join
+  // is smooth), and the end tangent is chosen automatically by replicad's
+  // smoothSplineTo. Useful for organic outlines (Wayfarer brow, ergonomic
+  // grips) where chained arcs hit OCCT BlendChain solver cliffs.
+  | { kind: 'smoothSpline'; x: Param; y: Param }
   | { kind: 'close' };

--- a/tests/unit/capture/sketch.test.ts
+++ b/tests/unit/capture/sketch.test.ts
@@ -267,6 +267,51 @@ describe('path() builder + Sketch capture', () => {
     });
   });
 
+  it('captures smoothSpline with endpoint', async () => {
+    const code = `return path().moveTo(0, 0).lineTo(10, 0).smoothSpline(20, 8).smoothSpline(15, 20).lineTo(0, 20).close().extrude(1);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const sketchRec = result.records.find(r => r.kind === 'sketch')!;
+    const commands = (sketchRec.metadata as { commands: unknown[] }).commands;
+    expect(commands).toContainEqual({
+      kind: 'smoothSpline',
+      x: { expression: '20', unit: 'mm', evaluated: 20 },
+      y: { expression: '8', unit: 'mm', evaluated: 8 },
+    });
+    expect(commands).toContainEqual({
+      kind: 'smoothSpline',
+      x: { expression: '15', unit: 'mm', evaluated: 15 },
+      y: { expression: '20', unit: 'mm', evaluated: 20 },
+    });
+  });
+
+  it('smoothSpline lowers to a valid solid through OCCT', async () => {
+    // Curved bracket profile: line + 3 spline segments + line + close.
+    // Verifies the kind: 'smoothSpline' case in occtBackend.fromSketchCommands.
+    const code = `return path().moveTo(0, 0).lineTo(20, 0).smoothSpline(40, 10).smoothSpline(50, 30).smoothSpline(20, 35).lineTo(0, 35).close().extrude(5);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    // Both the sketch and the extrude land in the record set.
+    expect(result.records.some(r => r.kind === 'sketch')).toBe(true);
+    expect(result.records.some(r => r.kind === 'extrude')).toBe(true);
+    // Sketch metadata captured all 3 smoothSpline commands.
+    const sketchRec = result.records.find(r => r.kind === 'sketch')!;
+    const commands = (sketchRec.metadata as { commands: Array<{ kind: string }> }).commands;
+    expect(commands.filter(c => c.kind === 'smoothSpline')).toHaveLength(3);
+  });
+
+  it('Sketch.reflect across X preserves smoothSpline kind and flips endpoint Y', async () => {
+    // Sketch.reflect('x') flips Y on every command. Verifies the smoothSpline
+    // case in sketch.ts:applyReflectInPlace.
+    const code = `const s = path().moveTo(0, 0).lineTo(10, 0).smoothSpline(20, 8).close(); const r = s.reflect('x'); return r.extrude(1);`;
+    const result = await runScript({ code, fileName: 'test.kcad.ts' });
+    const sketches = result.records.filter(r => r.kind === 'sketch');
+    expect(sketches.length).toBeGreaterThanOrEqual(2);
+    const reflected = sketches[sketches.length - 1];
+    const reflectedCommands = (reflected.metadata as { commands: Array<{ kind: string; y?: { evaluated: number } }> }).commands;
+    const spline = reflectedCommands.find(c => c.kind === 'smoothSpline');
+    expect(spline).toBeDefined();
+    expect(spline!.y!.evaluated).toBe(-8);  // Y flipped by reflect('x')
+  });
+
   it('emits feature.sketch.degenerate-arc when radiusArc has invalid radius', async () => {
     const { RecomputeEngine } = await import('../../../src/modeling/compute/recomputeEngine');
     const { OcctLowerer } = await import('../../../src/modeling/backends/occt/occtLowerer');


### PR DESCRIPTION
**Stacks on #184 → #183 → develop.** Merge in order.

## Summary

Sketches only exposed `sagittaArc` / `tangentArc` / `threePointsArc` / `radiusArc` / `bulgeArc` at the `path()` level. There was NO C1-smooth multi-point curve primitive. Organic outlines (Wayfarer brow, ergonomic grips, sneaker silhouettes, instrument-panel cutouts) had to chain small sagittaArcs that hit OCCT `BRepFilletAPI` BlendChain solver cliffs at sub-arc joins.

Round-6 agent eval (R15, R17) confirmed the gap empirically — agents attempting brow-curve outlines either fell back to single oversized sagittaArc segments (operating window from sagitta=0 to ~2.95, cliff at 2.95) or had to model the entire front face as a NURBS surface + thicken (which breaks separately on concave silhouettes — R17 hit non-watertight + fell back to polygon extrude).

## API

```ts
path()
  .moveTo(0, 0)
  .lineTo(20, 0)
  .smoothSpline(40, 10)   // C1-smooth from (20,0), through tangent
  .smoothSpline(50, 30)   //   chain to interpolate through many points
  .smoothSpline(20, 35)
  .lineTo(0, 35)
  .close()
  .extrude(5);
```

The start tangent is inherited from the prior segment (smooth join); the end tangent is auto-chosen by replicad's `smoothSplineTo`. Chain multiple calls to interpolate through many points; each segment joins smoothly. Throws at lowering if called as the first command (no prior tangent).

## Files

- `src/shared/capture/sketchCommand.ts` — add `{kind: 'smoothSpline'}` variant
- `src/modeling/capture/sketch.ts` — `PathBuilder.smoothSpline()` + reflect support
- `src/kernel/backends/occt/cutoutLowerer.ts` — lower for cutout subtractions
- `src/kernel/backends/occt/occtBackend.ts` — lower in main path (`fromSketchCommands`)
- `src/agent/mcp/tools/listApi.ts` — drift sentinel + `list_api` MCP discoverability
- `tests/unit/capture/sketch.test.ts` — 3 new tests (capture, lower, reflect)

## Test plan

- [x] 3 new unit tests pass (`smoothSpline` capture / lower / reflect-flip)
- [x] `npx tsc -b --noEmit` passes
- [x] `npx vitest run tests/integration/mcp/listApi.driftSentinel.test.ts` (drift sentinel) passes
- [x] End-to-end smoke: 5-segment curved bracket script renders cleanly

## Part of the ship sprint

This is PR 3 of 3 in the renderer-determinism + author-API ship:
- #183 `fix(render): headless determinism — strip dev chrome, gray bg`
- #184 `fix(render): auto-framer uses bbox-corner projection`
- this PR `feat(sketch): path-level smoothSpline for organic outlines`