### PR TITLE
hotfix: restore prompt funnel on kernelcad.com + bake VITE_SUPABASE envs

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -1,8 +1,13 @@
 name: Deploy to Cloudflare Pages
 
-# Auto-deploys two Cloudflare Pages projects on every push:
-#   - kernelcad-marketing  ← site/ (kernelcad.com)
-#   - kernelcad-app        ← dist/ (app.kernelcad.com, Vite build with base=/)
+# Auto-deploys two Cloudflare Pages projects on every push.
+#
+# Both projects serve the Studio Vite app (dist/) so the prompt-funnel
+# landing route (/) renders at kernelcad.com AND app.kernelcad.com. The
+# marketing project bundles site/functions/ (CF Pages Functions for the
+# /api/subscribe D1 endpoint) and site/public/ overlays (brand assets,
+# rendered hero demo.mp4) on top of dist/. kernelcad.com is bound to
+# kernelcad-marketing; app.kernelcad.com is bound to kernelcad-app.
 
 on:
   push:
@@ -44,20 +49,34 @@ jobs:
       - name: Install Playwright Chromium (for brand asset rendering)
         run: npx playwright install --with-deps chromium
 
+      - name: Build Vite app (Studio funnel — kernelcad.com landing)
+        env:
+          VITE_BASE_PATH: /
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
+        run: npm run build
+
       - name: Build demo + curated gallery + brand assets
         run: |
           npx tsx site/scripts/build-demo.ts
           npx tsx site/scripts/build-gallery.ts
-          bash site/scripts/link-public.sh
           node site/scripts/render-brand.mjs
+
+      - name: Overlay site/ assets + functions on dist/
+        run: |
+          # CF Pages Functions for /api/subscribe (D1-backed).
+          cp -r site/functions dist/functions
+          # site/public/ has favicon.svg, og-image.png, demo.mp4, brand/,
+          # gallery JSON — overlay onto dist/ so kernelcad.com serves them.
+          cp -r site/public/. dist/
 
       - name: Deploy to Cloudflare Pages (kernelcad-marketing)
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: site
-          command: pages deploy . --project-name=kernelcad-marketing --branch=main --commit-dirty=true
+          command: pages deploy dist --project-name=kernelcad-marketing --branch=main --commit-dirty=true
 
   app:
     name: Deploy visual debugger app
@@ -76,6 +95,9 @@ jobs:
       - name: Build Vite app (root-rooted base path for app.kernelcad.com)
         env:
           VITE_BASE_PATH: /
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
         run: npm run build
 
       - name: Deploy to Cloudflare Pages (kernelcad-app)

--- a/scripts/lib/cloudflareDeployWorkflow.test.ts
+++ b/scripts/lib/cloudflareDeployWorkflow.test.ts
@@ -3,20 +3,38 @@ import { describe, expect, it } from 'vitest';
 import YAML from 'yaml';
 
 describe('Cloudflare Pages deploy workflow', () => {
-  it('runs the marketing Pages deploy from site/ so Pages Functions and wrangler.toml are discovered', () => {
+  it('deploys the Studio dist/ bundle to kernelcad-marketing (so kernelcad.com serves the prompt funnel)', () => {
     const workflow = YAML.parse(readFileSync('.github/workflows/deploy-cloudflare.yml', 'utf8'));
     const marketingSteps = workflow.jobs.marketing.steps as Array<{
       name?: string;
-      with?: { command?: string };
+      with?: { command?: string; workingDirectory?: string };
     }>;
 
     const deployStep = marketingSteps.find((step) =>
       step.name?.includes('Deploy to Cloudflare Pages'),
     );
 
-    expect(deployStep?.with?.workingDirectory).toBe('site');
+    // After hotfix: deploy runs from repo root and uploads dist/ (which gets
+    // site/functions and site/public overlaid by the preceding step). The old
+    // site-as-workingDirectory shape served a static landing without the
+    // prompt funnel.
     expect(deployStep?.with?.command).toBe(
-      'pages deploy . --project-name=kernelcad-marketing --branch=main --commit-dirty=true',
+      'pages deploy dist --project-name=kernelcad-marketing --branch=main --commit-dirty=true',
     );
+  });
+
+  it('passes VITE_SUPABASE_* secrets to both Vite build jobs (otherwise supabaseClient throws on bundle load)', () => {
+    const workflow = YAML.parse(readFileSync('.github/workflows/deploy-cloudflare.yml', 'utf8'));
+    for (const jobName of ['marketing', 'app'] as const) {
+      const steps = workflow.jobs[jobName].steps as Array<{
+        name?: string;
+        env?: Record<string, string>;
+        run?: string;
+      }>;
+      const buildStep = steps.find((s) => s.run?.includes('npm run build'));
+      expect(buildStep, `${jobName}: vite build step exists`).toBeDefined();
+      expect(buildStep?.env?.VITE_SUPABASE_URL, `${jobName}: VITE_SUPABASE_URL`).toMatch(/secrets\.VITE_SUPABASE_URL/);
+      expect(buildStep?.env?.VITE_SUPABASE_ANON_KEY, `${jobName}: VITE_SUPABASE_ANON_KEY`).toMatch(/secrets\.VITE_SUPABASE_ANON_KEY/);
+    }
   });
 });


### PR DESCRIPTION
## Summary
Two production regressions from today's marketing-deploy fix (#182):

1. **kernelcad.com lost the prompt funnel.** kernelcad-marketing was historically serving a Studio Vite bundle some earlier manual deploy had uploaded. #182 finally got the workflow running end-to-end, which replaced it with the actual \`site/\` static landing — killing the \`/\` prompt funnel users had been testing against. Marketing job now builds the Vite Studio bundle like the app job and overlays \`site/functions\` (CF Pages Function for \`/api/subscribe\` + D1 binding) and \`site/public/\` (favicon, og, demo.mp4, brand assets, gallery JSON) on top of \`dist/\` before deploy.

2. **app.kernelcad.com runtime crash.** \"Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY\" at module init — neither build job in deploy-cloudflare.yml was passing the VITE_* secrets to the Vite build, so the bundle hit the supabaseClient throw on load. Pass VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY / VITE_API_BASE_URL from repo secrets to both build steps.

## Test plan
- [ ] CI deploy-cloudflare workflow turns green
- [ ] \`https://app.kernelcad.com/\` loads without console errors (no Supabase env throw)
- [ ] \`https://kernelcad.com/\` shows the prompt landing again (the / route from \`src/studio/routes/index.tsx\`, not the static \`site/index.html\` marketing page)