### PR TITLE
feat(kernel): edge-length-aware chamfer/fillet (auto-skip tiny edges)

### DIFF
--- a/src/modeling/backends/occt/occtLowerer.ts
+++ b/src/modeling/backends/occt/occtLowerer.ts
@@ -1243,6 +1243,48 @@ export class OcctLowerer implements FeatureLowerer {
         } else {
           edgesForFillet = sharpEdges;
         }
+        // M2: pre-filter edges below 2 × radius. The OCCT BlendChain solver
+        // rejects fillet radii larger than half the target edge length;
+        // historically this caused the WHOLE fillet operation to fail (see
+        // E3, R6, R19 in the agent-eval rounds — they all had to "skip and
+        // document" their front-face perimeter fillet/chamfer because the
+        // R=3 lens-cutout corner edges were sub-1mm). Filtering pre-call
+        // means the long edges get filleted and the agent gets a clean
+        // info diagnostic naming the skipped count.
+        const filletMinEdgeLength = 2 * radius;
+        const longFilletEdges: import('replicad').Edge[] = [];
+        let skippedFilletEdges = 0;
+        for (const e of edgesForFillet) {
+          // Edge.length is the arc length via BRepAdaptor_Curve; safe on
+          // straight, arc, and spline edges. Throws if the edge has no
+          // underlying curve (degenerate); skip those defensively.
+          let len: number;
+          try { len = e.length; } catch { skippedFilletEdges++; continue; }
+          if (len >= filletMinEdgeLength) longFilletEdges.push(e); else skippedFilletEdges++;
+        }
+        if (skippedFilletEdges > 0 && longFilletEdges.length === 0) {
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.edge-feature.short-edges-skipped',
+            featureId: r.id,
+            severity: 'warn',
+            message: `fillet skipped: all ${skippedFilletEdges} target edges are shorter than 2 × radius = ${filletMinEdgeLength.toFixed(2)} mm`,
+            hint: 'OCCT blend solver rejects fillet/chamfer radii larger than half the target edge length. Some edges were below 2 × radius and got skipped so the rest could chamfer. Either reduce the radius, refactor upstream booleans so target edges are longer, or scope your fillet/chamfer to a face/edge query that only matches the long edges.',
+          });
+          shape = base;
+          break;
+        }
+        if (skippedFilletEdges > 0) {
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.edge-feature.short-edges-skipped',
+            featureId: r.id,
+            severity: 'warn',
+            message: `fillet skipped ${skippedFilletEdges} of ${edgesForFillet.length} target edges shorter than 2 × radius = ${filletMinEdgeLength.toFixed(2)} mm; chamfering the remaining ${longFilletEdges.length}.`,
+            hint: 'OCCT blend solver rejects fillet/chamfer radii larger than half the target edge length. Some edges were below 2 × radius and got skipped so the rest could chamfer. Either reduce the radius, refactor upstream booleans so target edges are longer, or scope your fillet/chamfer to a face/edge query that only matches the long edges.',
+          });
+          edgesForFillet = longFilletEdges;
+        }
         try {
           // Convert replicad Edge[] → EdgeRefForFilleting[] by hashing each
           // edge's underlying TopoDS_Edge handle.
@@ -1335,11 +1377,47 @@ export class OcctLowerer implements FeatureLowerer {
           return { shape: base, diagnostics };
         }
         drainResolvedWarnings(r, diagnostics);
+        // M2: pre-filter edges below 2 × distance. Same rationale as fillet:
+        // OCCT blend solver rejects chamfer distances larger than half the
+        // target edge length. Filter pre-call so long edges get chamfered
+        // and the agent gets a clean diagnostic naming the skipped count.
+        const chamferMinEdgeLength = 2 * distance;
+        const longChamferEdges: import('replicad').Edge[] = [];
+        let skippedChamferEdges = 0;
+        for (const e of edgesResult as import('replicad').Edge[]) {
+          let len: number;
+          try { len = e.length; } catch { skippedChamferEdges++; continue; }
+          if (len >= chamferMinEdgeLength) longChamferEdges.push(e); else skippedChamferEdges++;
+        }
+        if (skippedChamferEdges > 0 && longChamferEdges.length === 0) {
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.edge-feature.short-edges-skipped',
+            featureId: r.id,
+            severity: 'warn',
+            message: `chamfer skipped: all ${skippedChamferEdges} target edges are shorter than 2 × distance = ${chamferMinEdgeLength.toFixed(2)} mm`,
+            hint: 'OCCT blend solver rejects fillet/chamfer radii larger than half the target edge length. Some edges were below 2 × radius and got skipped so the rest could chamfer. Either reduce the radius, refactor upstream booleans so target edges are longer, or scope your fillet/chamfer to a face/edge query that only matches the long edges.',
+          });
+          shape = base;
+          break;
+        }
+        let edgesForChamfer: import('replicad').Edge[] = edgesResult as import('replicad').Edge[];
+        if (skippedChamferEdges > 0) {
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.edge-feature.short-edges-skipped',
+            featureId: r.id,
+            severity: 'warn',
+            message: `chamfer skipped ${skippedChamferEdges} of ${(edgesResult as import('replicad').Edge[]).length} target edges shorter than 2 × distance = ${chamferMinEdgeLength.toFixed(2)} mm; chamfering the remaining ${longChamferEdges.length}.`,
+            hint: 'OCCT blend solver rejects fillet/chamfer radii larger than half the target edge length. Some edges were below 2 × radius and got skipped so the rest could chamfer. Either reduce the radius, refactor upstream booleans so target edges are longer, or scope your fillet/chamfer to a face/edge query that only matches the long edges.',
+          });
+          edgesForChamfer = longChamferEdges;
+        }
         try {
           // Convert replicad Edge[] → EdgeRefForFilleting[] by hashing each
           // edge's underlying TopoDS_Edge handle.
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const edgeRefs: EdgeRefForFilleting[] = edgesResult.map((e: any) => ({
+          const edgeRefs: EdgeRefForFilleting[] = edgesForChamfer.map((e: any) => ({
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             hash: ((e.wrapped ?? e._wrapped ?? e) as any).HashCode(2147483647).toString(16),
           }));

--- a/src/shared/diagnostics/codes.ts
+++ b/src/shared/diagnostics/codes.ts
@@ -69,7 +69,9 @@ export type DiagnosticCode =
   | 'feature.reference-image.format-unsupported'
   // Material (2) — Slice A
   | 'feature.material.invalid-base-color'
-  | 'feature.material.value-clamped';
+  | 'feature.material.value-clamped'
+  // Edge-feature partial success (1) — M2
+  | 'feature.edge-feature.short-edges-skipped';
 
 export const DIAGNOSTIC_CODES: readonly DiagnosticCode[] = [
   'feature.invalid-args',
@@ -115,6 +117,7 @@ export const DIAGNOSTIC_CODES: readonly DiagnosticCode[] = [
   'feature.reference-image.format-unsupported',
   'feature.material.invalid-base-color',
   'feature.material.value-clamped',
+  'feature.edge-feature.short-edges-skipped',
 ] as const;
 
 export interface HintTemplate {
@@ -217,6 +220,8 @@ function buildHintTemplates(): Record<DiagnosticCode, HintTemplate> {
       'Pass a CSS color string or a registered role token to baseColor.',
     'feature.material.value-clamped':
       'Numeric PBR fields are clamped to [0, 1] (ior to [1.0, 2.5]).',
+    'feature.edge-feature.short-edges-skipped':
+      'OCCT blend solver rejects fillet/chamfer radii larger than half the target edge length. Some edges were below 2 × radius and got skipped so the rest could chamfer. Either reduce the radius, refactor upstream booleans so target edges are longer, or scope your fillet/chamfer to a face/edge query that only matches the long edges.',
   };
   const out = {} as Record<DiagnosticCode, HintTemplate>;
   for (const code of DIAGNOSTIC_CODES) {

--- a/src/shared/diagnostics/nextAction.ts
+++ b/src/shared/diagnostics/nextAction.ts
@@ -66,4 +66,5 @@ export const NEXT_ACTIONS: Record<DiagnosticCode, NextAction> = {
   'feature.reference-image.format-unsupported': { kind: 'fix-arg', field: 'path' },
   'feature.material.invalid-base-color':      { kind: 'fix-arg', field: 'baseColor' },
   'feature.material.value-clamped':           { kind: 'fix-arg', field: 'see-message' },
+  'feature.edge-feature.short-edges-skipped': { kind: 'fix-arg', field: 'radius-or-distance' },
 };

--- a/tests/unit/diagnostics/codes.test.ts
+++ b/tests/unit/diagnostics/codes.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from 'vitest';
 import { DIAGNOSTIC_CODES, HINT_TEMPLATES } from '../../../src/shared/diagnostics/codes';
 
 describe('diagnostic catalogue invariants', () => {
-  it('emits exactly 43 codes', () => {
-    expect(DIAGNOSTIC_CODES).toHaveLength(43);
-    expect(new Set(DIAGNOSTIC_CODES).size).toBe(43);
+  it('emits exactly 44 codes', () => {
+    expect(DIAGNOSTIC_CODES).toHaveLength(44);
+    expect(new Set(DIAGNOSTIC_CODES).size).toBe(44);
   });
 
   it('every code has a non-empty hint template', () => {

--- a/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
+++ b/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
@@ -66,8 +66,8 @@ function emittedCodes(): Set<string> {
 describe('every diagnostic code emitted in src/ is in the catalogue', () => {
   const catalogue = new Set<string>(DIAGNOSTIC_CODES);
 
-  it('catalogue has exactly 43 codes', () => {
-    expect(catalogue.size).toBe(43);
+  it('catalogue has exactly 44 codes', () => {
+    expect(catalogue.size).toBe(44);
   });
 
   it('no emit site uses a code outside the catalogue', () => {

--- a/tests/unit/mcp/tools/listDiagnosticCodes.test.ts
+++ b/tests/unit/mcp/tools/listDiagnosticCodes.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { listDiagnosticCodesTool } from '../../../../src/agent/mcp/tools/listDiagnosticCodes';
 
 describe('list_diagnostic_codes', () => {
-  it('returns all 43 codes with non-empty hint templates', async () => {
+  it('returns all 44 codes with non-empty hint templates', async () => {
     const result = await listDiagnosticCodesTool({});
     expect(result.ok).toBe(true);
-    expect(result.codes).toHaveLength(43);
+    expect(result.codes).toHaveLength(44);
     for (const entry of result.codes) {
       expect(entry.hint_template.trim().length).toBeGreaterThan(0);
     }
@@ -13,6 +13,6 @@ describe('list_diagnostic_codes', () => {
 
   it('every code is unique', async () => {
     const result = await listDiagnosticCodesTool({});
-    expect(new Set(result.codes.map((c) => c.code)).size).toBe(43);
+    expect(new Set(result.codes.map((c) => c.code)).size).toBe(44);
   });
 });


### PR DESCRIPTION
**Stacks on #186 → #185 → #184 → #183 → develop.**

## Why this exists

OCCT `BRepFilletAPI`'s BlendChain solver rejects fillet radii (and chamfer distances) larger than half the target edge length. When an agent calls `.chamfer(0.6)` on a body whose post-cut topology has sub-1mm edges — typical Wayfarer case: R=3 lens-opening corners create R=5 transition edges that become sub-1mm coplanar fragments after the lens-cutout boolean — the **whole** chamfer fails. Agent gets a generic kernel-failed and gives up.

In Round 1-6 agent-eval, this caused **E3, R6, R19** to all explicitly "skip and document" the front-face perimeter chamfer/fillet — leaving the diagnostic Wayfarer acetate bevel off the build even though most target edges were chamferable.

## Fix

Pre-filter edges by `Edge.length` (true arc length via `BRepAdaptor_Curve`) before passing to the BRepFilletAPI builder. Two graceful-degrade paths:

1. **All edges < 2 × radius**: emit `feature.edge-feature.short-edges-skipped` (warn), return base shape unchanged.
2. **Some edges < 2 × radius**: emit warn naming the skipped count, chamfer the rest.

## Smoke verification

```
$ cat /tmp/test.kcad.ts
return box(6, 6, 6).chamfer(5);  // all 12 edges length=6, but 2×distance=10
$ kernelcad evaluate /tmp/test.kcad.ts
Features: 2
WARN [feature.edge-feature.short-edges-skipped] chamfer_1:
  chamfer skipped: all 12 target edges are shorter than 2 × distance = 10.00 mm
Hint: OCCT blend solver rejects fillet/chamfer radii larger than half the
target edge length. Some edges were below 2 × radius and got skipped so
the rest could chamfer. Either reduce the radius, refactor upstream
booleans so target edges are longer, or scope your fillet/chamfer to a
face/edge query that only matches the long edges.
OK
```

Pre-fix that exact call threw a kernel-failed error and ended the script. Post-fix the script completes; agent decides whether to retry with smaller distance or accept the un-chamfered body.

## Files

- `src/modeling/backends/occt/occtLowerer.ts` — pre-filter logic for both fillet and chamfer cases (+80 lines)
- `src/shared/diagnostics/codes.ts` — new code `feature.edge-feature.short-edges-skipped` + hint template
- `src/shared/diagnostics/nextAction.ts` — `{ kind: 'fix-arg', field: 'radius-or-distance' }`
- Tests: bumped 43→44 in 3 sentinel tests

## Test plan

- [x] `npx tsc -b --noEmit` passes
- [x] `npx vitest run tests/unit/diagnostics/ tests/unit/mcp/tools/listDiagnosticCodes.test.ts` passes (10/10)
- [x] Smoke: box+chamfer larger than half-edge → warn diagnostic, no crash
- [x] Smoke: box+chamfer smaller than half-edge → success, no diagnostic

## Ship sprint position

- #183 fix(render): headless determinism
- #184 fix(render): auto-framer bbox-corner projection
- #185 feat(sketch): path-level smoothSpline
- #186 feat(eval): geometric scorer
- **this PR** feat(kernel): edge-length-aware chamfer/fillet