### PR TITLE
docs(skills): kernelcad-from-reference rewrite based on Round 1-6 findings

### DIFF
--- a/src/agent/skills/kernelcad-from-reference/SKILL.md
+++ b/src/agent/skills/kernelcad-from-reference/SKILL.md
@@ -10,12 +10,42 @@ kernelCAD primitives. This is an orchestrator skill that names sub-skills and
 their order. Read this first; then load each sub-skill in sequence as you
 work through the stages.
 
-## Required reading order
+## Decision tree (1 screen — start here)
 
-1. `prepare-prompt/SKILL.md` — turn the user's ask into a Real Object Brief.
-2. `blockout-model/SKILL.md` — coarse parametric blockout in canonical views.
-3. `use-the-available-kernel/SKILL.md` — hard rules for which kernelCAD primitives to reach for. **The most important sub-skill.**
-4. `image-replicator/SKILL.md` — the render→score→iterate loop.
+```
+Have a written spec with numeric dimensions? → just read kernelcad-authoring
+                                                + use-the-available-kernel,
+                                                build single-pass, score.
+Have a reference photo only? ──┬─ Extract numeric dimensions FIRST
+                               │  (measure visually OR if STL available
+                               │   use trimesh to extract bbox+landmarks),
+                               │  then proceed as if you had a spec.
+                               │
+                               └─ Don't iterate against the 2D-photo scorer —
+                                  R5/R16/R18 empirical: it's gameable. Use
+                                  the geometric scorer (scripts/scoreMeshVsMesh.ts)
+                                  if an STL reference is shipped.
+
+Building an organic-curve outline (brow, grip, sneaker)?
+   → use path().smoothSpline() — chained sagittaArc hits solver cliffs.
+
+Building an acetate-bevel-style chamfer on post-cut topology?
+   → just call .chamfer(d). The kernel auto-skips edges shorter than 2×d
+     and emits a clean warning. Do NOT "skip and document."
+
+Iteration mode: visual > scored > spec+photo (R1-R6 empirical).
+   Single-pass with a detailed spec OUTPERFORMS visual or scored iteration.
+   Adding the photo to a good spec REGRESSES (R3). Closed-loop scorer-only
+   iteration plateaus FAR below single-pass (R2 / R16). Only iterate when
+   you have a CLEAR signal pointing at a SPECIFIC defect.
+```
+
+## Required reading order (only if the decision tree didn't tell you what to do)
+
+1. `use-the-available-kernel/SKILL.md` — **the most important sub-skill.** Hard rules for which primitive to reach for.
+2. `prepare-prompt/SKILL.md` — turn the user's ask into a Real Object Brief.
+3. `blockout-model/SKILL.md` — coarse parametric blockout in canonical views.
+4. `image-replicator/SKILL.md` — the render→score→iterate loop (caveat: see Rule 9).
 5. `render-inspect/SKILL.md` — interpret diagnostic hints from `kernelcad evaluate`.
 
 ## Hard rules across all sub-skills

--- a/src/agent/skills/kernelcad-from-reference/use-the-available-kernel/SKILL.md
+++ b/src/agent/skills/kernelcad-from-reference/use-the-available-kernel/SKILL.md
@@ -60,22 +60,31 @@ Do NOT uniform-extrude a single silhouette. The resulting slab is what the
 scorer detects as a "fake" body — the silhouette gate passes, but the SSIM gate
 fails because the depth profile is wrong.
 
-## Rule 4 — Organic curves → NURBS curve or chained arcs
+## Rule 4 — Organic curves → smoothSpline
 
-For silhouettes with smooth, non-arc transitions (Wayfarer brows, handle curves),
-use NURBS curve authoring when available in a follow-up slice. Until then,
-chain at most 3 `tangentArc` / `sagittaArc` segments and keep tangent
-reachability conservative:
+For silhouettes with smooth, non-arc transitions (Wayfarer brows, ergonomic
+grips, sneaker silhouettes), USE the C1-smooth spline:
 
 ```ts
 const brow = path()
   .moveTo(-28, 0)
-  .sagittaArc(-14, 5, 3)
-  .sagittaArc(0, 6, 2)
-  .sagittaArc(14, 5, 3)
-  .sagittaArc(28, 0, 3)
+  .smoothSpline(-14, 5)
+  .smoothSpline(0, 6)
+  .smoothSpline(14, 5)
+  .smoothSpline(28, 0)
   .close();
 ```
+
+Each `smoothSpline(x, y)` inherits its start tangent from the previous segment,
+so chained calls interpolate smoothly through many points without C0 kinks.
+
+**Why this matters:** chained `sagittaArc` segments hit OCCT BlendChain solver
+cliffs at sub-arc joins — the tangent discontinuity at each join becomes a
+sub-mm coplanar edge that breaks downstream fillet/chamfer. Round-6 empirical:
+Agent D found the operating window for chained sagittaArcs is sagitta=0..2.9
+mm, with a hard cliff at 2.95; Agent R15 had to fall back to ellipse-shaped
+lens openings because their multi-arc brow kept failing. smoothSpline does
+not have this failure mode.
 
 Do NOT fake a curved brow with a single long arc — the chord bulge is visible
 in the top view. Do NOT use lineTo for organic curves — the SSIM score tanks.
@@ -130,6 +139,63 @@ referenceImage('./reference.jpg', {
 
 The eval scorer automatically excludes reference images during scoring
 (`--hide-reference-images` flag). They do not pollute the score.
+
+## Rule 8 — Trust the chamfer/fillet auto-skip; don't pre-disable
+
+When you call `.chamfer(d)` or `.fillet(r)` on a body with post-cut topology
+(e.g., front-face perimeter after lens openings were subtracted), the kernel
+will auto-skip any target edges shorter than 2 × d (or 2 × r) and emit a
+warning naming the skipped count. The chamfer **succeeds** on the long edges.
+
+Pre-empirical pattern (BAD — leaves the acetate bevel off entirely):
+
+```ts
+// "OCCT will reject this, skip and document" — DO NOT do this
+const bodyFinished = bodyWithBores;  // chamfer skipped
+```
+
+Post-fix pattern (GOOD — accept partial chamfer, agent gets a clear warn):
+
+```ts
+const bodyFinished = bodyWithBores.chamfer(0.6);
+// You'll get a warning like:
+//   WARN [feature.edge-feature.short-edges-skipped] chamfer_3:
+//   chamfer skipped 8 of 24 target edges shorter than 2 × distance = 1.20 mm;
+//   chamfering the remaining 16.
+// The 16 long edges are correctly chamfered. The 8 short ones (lens-corner
+// transitions) were never going to chamfer at d=0.6 anyway.
+```
+
+If you want only the LONG edges chamfered with no warning, scope the edge
+query: `chamfer(0.6, { face: 'top', minEdgeLength: 1.5 })` (when query
+extensions ship). Until then, accept the auto-skip; the warning is
+informational, not an error.
+
+## Rule 9 — Score against 3D geometry, not photos (when available)
+
+Round-6 agent eval revealed the 2D-pixel scorer (`scoreRenderVsReference`)
+is gameable. R5 inflated body depth 10→75mm and scored #1 vs photo (composite
+0.580); R16 left lens cuts disconnected and scored higher than the fixed
+version; R18 added a floating bbox-extending box outside the body and gained
++0.5 silhouette IoU. All three "hacks" optimize against render artifacts,
+not against geometry.
+
+If the eval task ships a reference STL (check `eval/tasks/<task>/reference.stl`),
+USE the geometric scorer:
+
+```bash
+kernelcad export stl my-build.kcad.ts -o build.stl
+npx tsx scripts/scoreMeshVsMesh.ts \
+  --generated build.stl \
+  --reference eval/tasks/<task>/reference.stl --json
+```
+
+Output: chamfer distance (mm), Hausdorff 99p, bbox IoU. These are pure
+geometric metrics; there is no render artifact to exploit. Optimize against
+THIS, not the photo composite, when you have an STL to compare against.
+
+The 2D-photo scorer remains useful as a sanity check (does it look like the
+photo?) but should not be the primary optimization target.
 
 ## When NOT to apply a rule
 


### PR DESCRIPTION
**Stacks on #188 → #186 → #185 → #184 → #183 → develop.**

## Why this exists

E1 agent retrospective (Round 1, full-stack skill build): *"by the time I'd read all 5 sub-skills my context was 30K tokens deep just on process. A 1-screen decision tree would beat the current 200-line orchestrator."*

Round 1-6 agent-eval surfaced:
- Skills predate `smoothSpline()` (just shipped in #185) — Rule 4 still says "NURBS in a follow-up slice"
- Skills predate chamfer/fillet auto-skip (just shipped in #188) — agents kept "skipping and documenting" the front-face bevel
- Skills predate geometric scorer (just shipped in #186) — agents iterated against the gameable photo scorer

## Updates

### `kernelcad-from-reference/SKILL.md`
Added a **Decision tree (1 screen)** at the top that maps the most common from-reference entry points to ONE concrete recommendation each:

```
Have a spec? → kernelcad-authoring + use-the-available-kernel, build single-pass.
Photo only?  → extract numeric dimensions FIRST, then proceed as if spec.
Organic curve? → use path().smoothSpline()
Chamfer on post-cut topology? → just call it, accept the auto-skip warning.
Iteration mode: visual > scored > spec+photo (R1-R6 empirical).
```

Required reading order kept below, gated on "only if the decision tree didn't tell you what to do."

### `use-the-available-kernel/SKILL.md`

- **Rule 4** rewritten: switch from "chain sagittaArcs, NURBS in a follow-up slice" to `path().smoothSpline()`. Cites Agent D's empirical operating window (sagitta=0..2.9, hard cliff at 2.95) and R15's fallback to ellipse-shaped lens openings.

- **Rule 8 NEW**: trust the chamfer/fillet auto-skip. E3/R6/R19 all "skipped and documented"; new pattern is to call it, accept the partial-success warn, ship the bevel.

- **Rule 9 NEW**: score against 3D geometry not photos when STL available. R5 inflated body depth (top vs photo / last vs STL); R16 left lens cuts disconnected; R18 added floating bbox-extender. M1 closed this scorer-hack class.

## Test plan

- [x] Drift sentinel `tests/unit/skill/skillPathBuilderMethodsDrift.test.ts` passes
- [x] Skills reference shipped APIs (smoothSpline from #185, edge-feature.short-edges-skipped diagnostic from #188, scoreMesh from #186)
- [ ] Real validation: future agent build against eyewear-wayfarer-front, using these updated skills — confirm Rule 4 / 8 / 9 are actionable

## Ship sprint position

- #183 fix(render): headless determinism
- #184 fix(render): auto-framer bbox-corner projection
- #185 feat(sketch): path-level smoothSpline
- #186 feat(eval): geometric scorer
- #188 feat(kernel): edge-length-aware chamfer/fillet
- **this PR** docs(skills): rewrite based on Round 1-6 empirical