### PR TITLE
feat(eval): optional 3D-geometric gates in eyewear-wayfarer-front harness

### DIFF
--- a/eval/tasks/eyewear-wayfarer-front/harness.ts
+++ b/eval/tasks/eyewear-wayfarer-front/harness.ts
@@ -1,8 +1,11 @@
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
+import { spawn } from 'node:child_process';
 import { evaluateScript, getShapeInfo } from '../../oracle/kernelcad-client';
 import { runInterference } from '../../oracle/interference';
 import { renderScript } from '../../oracle/render';
 import { scoreAgainstReference } from '../../oracle/scoreReference';
+import { scoreMesh } from '../../oracle/scoreMesh';
 import type { HarnessCtx, HarnessResult } from '../../types';
 
 // Reference photo: front-right product shot from approximately az=30°, el=15°.
@@ -23,6 +26,28 @@ const COMPOSITE_FLOOR = 0.30;
 // to make passing easier) so the scored field reflects the real gap until a
 // follow-up slice closes it (NURBS brow curves + temple geometry).
 const SSIM_FLOOR = 0.35;
+
+// Geometric-oracle thresholds (used iff `reference.stl` exists in the task dir).
+// These come from R12-R18 empirical baselines on the meta-glasses task: the
+// human expert + E4 (NURBS) build at chamfer 16-19 mm; R5's slab hack hits
+// 32+ mm. Thresholds picked to PASS the geometrically-faithful builds and
+// FAIL the scorer-hacks.
+const CHAMFER_CEIL_MM = 25;     // Pass if chamfer ≤ 25mm (R5's 32mm fails;
+                                //   expert's 19mm passes; R14's 12mm passes)
+const BBOX_IOU_FLOOR = 0.05;    // Pass if bbox IoU ≥ 0.05 (R5's 0.056 borderline)
+
+async function exportToStl(scriptPath: string, outPath: string): Promise<boolean> {
+  // Shell out to `kernelcad export stl <script> -o <outPath>`. Doesn't need
+  // a running dev server — STL export is BREP→mesh in-process.
+  const bin = process.env.KERNELCAD_BIN ?? './dist/cli/index.js';
+  const cmd = bin.endsWith('.js') ? 'node' : bin;
+  const args = bin.endsWith('.js') ? [bin, 'export', 'stl', scriptPath, '-o', outPath] : ['export', 'stl', scriptPath, '-o', outPath];
+  return await new Promise((resolve) => {
+    const child = spawn(cmd, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    child.on('close', (code) => resolve(code === 0 && existsSync(outPath)));
+    child.on('error', () => resolve(false));
+  });
+}
 
 export default async function harness(scriptPath: string, ctx?: HarnessCtx): Promise<HarnessResult> {
   const ev = await evaluateScript(scriptPath);
@@ -65,6 +90,32 @@ export default async function harness(scriptPath: string, ctx?: HarnessCtx): Pro
     }
   }
 
+  // G5 (optional, gameable-resistant) 3D geometric scoring against
+  // `reference.stl`. Activates iff the task dir ships a reference STL.
+  // See memory: kernelcad_r5_scorer_hack_finding — the 2D-pixel scorer is
+  // gameable (R5 inflated body depth → top vs photo, last vs 3D model).
+  // The Chamfer distance gate punishes geometric divergence directly.
+  let geomScored = false;
+  let chamferMm = 0;
+  let bboxIoU = 0;
+  if (ctx) {
+    const refStlPath = join(ctx.taskDir, 'reference.stl');
+    if (existsSync(refStlPath)) {
+      const genStlPath = join(ctx.runDir, 'generated.stl');
+      const exported = await exportToStl(scriptPath, genStlPath);
+      if (exported) {
+        try {
+          const m = scoreMesh(genStlPath, refStlPath);
+          chamferMm = m.chamferDistance;
+          bboxIoU = m.bboxIoU;
+          geomScored = true;
+        } catch {
+          // scoreMesh throws on malformed STL — leave geomScored false.
+        }
+      }
+    }
+  }
+
   return {
     gates: {
       'evaluates clean': true,
@@ -80,6 +131,12 @@ export default async function harness(scriptPath: string, ctx?: HarnessCtx): Pro
       'silhouette IoU >= 0.45 vs photo': rendered && silhouetteIoU >= SILHOUETTE_FLOOR,
       'composite >= 0.30 vs photo': rendered && composite >= COMPOSITE_FLOOR,
       'SSIM >= 0.35 vs photo': rendered && ssim >= SSIM_FLOOR,
+      // 3D-geometric gates (only present when reference.stl is shipped).
+      // Order in object literal preserved → reads naturally in harness output.
+      ...(geomScored ? {
+        [`chamfer distance <= ${CHAMFER_CEIL_MM} mm vs STL`]: chamferMm <= CHAMFER_CEIL_MM,
+        [`bbox IoU >= ${BBOX_IOU_FLOOR.toFixed(2)} vs STL`]: bboxIoU >= BBOX_IOU_FLOOR,
+      } : {}),
     },
   };
 }

--- a/scripts/lib/exportGlb.ts
+++ b/scripts/lib/exportGlb.ts
@@ -2,6 +2,7 @@ import { writeFileSync, existsSync } from 'node:fs';
 import {
   BufferGeometry,
   BufferAttribute,
+  Color,
   Mesh,
   MeshStandardMaterial,
   Scene as ThreeScene,
@@ -9,10 +10,59 @@ import {
 import { GLTFExporter } from 'three-stdlib';
 import { evaluateAndBuildScript } from '../../src/agent/cli/commands/evaluate';
 import type { OcctBackend } from '../../src/kernel/backends/occt/occtBackend';
+import { loadScriptFeatures } from '../../src/modeling/runtime/scriptLoader';
+import { meshFeaturesPerFeature, type FeatureMesh } from '../../src/modeling/capture/featureMeshing';
 
 export interface ExportGlbOptions {
   scriptPath: string;
   outPath: string;
+}
+
+const DEFAULT_MATERIAL = { color: 0xb0b0b0, metalness: 0.2, roughness: 0.6 };
+
+function makeMaterial(color: string | undefined): MeshStandardMaterial {
+  const mat = new MeshStandardMaterial({ ...DEFAULT_MATERIAL });
+  if (color && /^#[0-9a-fA-F]{6}$/.test(color)) {
+    mat.color = new Color(color);
+  }
+  return mat;
+}
+
+function addSingleMesh(
+  scene: ThreeScene,
+  positions: Float32Array,
+  normals: Float32Array,
+  indices: Uint32Array,
+  color: string | undefined,
+): void {
+  const geometry = new BufferGeometry();
+  geometry.setAttribute('position', new BufferAttribute(positions, 3));
+  geometry.setAttribute('normal', new BufferAttribute(normals, 3));
+  geometry.setIndex(new BufferAttribute(indices, 1));
+  scene.add(new Mesh(geometry, makeMaterial(color)));
+}
+
+function addFeatureMesh(scene: ThreeScene, fm: FeatureMesh): void {
+  if (fm.virtual) return;
+  const totalVerts = fm.faces.reduce((s, f) => s + f.vertices.length, 0);
+  if (totalVerts === 0) return;
+  const totalIndices = fm.faces.reduce((s, f) => s + f.indices.length, 0);
+  const positions = new Float32Array(totalVerts);
+  const normals = new Float32Array(totalVerts);
+  const indices = new Uint32Array(totalIndices);
+  let vOff = 0;
+  let iOff = 0;
+  for (const face of fm.faces) {
+    positions.set(face.vertices, vOff);
+    normals.set(face.normals, vOff);
+    const indexBase = vOff / 3;
+    for (let i = 0; i < face.indices.length; i++) {
+      indices[iOff + i] = face.indices[i] + indexBase;
+    }
+    vOff += face.vertices.length;
+    iOff += face.indices.length;
+  }
+  addSingleMesh(scene, positions, normals, indices, fm.color);
 }
 
 export async function exportGlb(opts: ExportGlbOptions): Promise<void> {
@@ -21,33 +71,38 @@ export async function exportGlb(opts: ExportGlbOptions): Promise<void> {
   }
 
   const { evaluation, model } = await evaluateAndBuildScript({ file: opts.scriptPath });
-  if (evaluation.exitCode !== 0 || !model || !model.tailShape) {
-    throw new Error(
-      `evaluation failed (exitCode=${evaluation.exitCode}, has model=${!!model}, has tail=${!!model?.tailShape})`,
-    );
+  if (evaluation.exitCode !== 0 || !model) {
+    throw new Error(`evaluation failed (exitCode=${evaluation.exitCode}, has model=${!!model})`);
   }
 
-  // tailShape is a ShapeBackend; for OCCT (the only backend in this repo)
-  // it's an OcctBackend exposing getMesh(). Cast to access.
-  const tail = model.tailShape as OcctBackend;
-  if (typeof tail.getMesh !== 'function') {
-    throw new Error('tailShape does not expose getMesh() — non-OCCT backend?');
-  }
-  const meshData = tail.getMesh();
-
-  const geometry = new BufferGeometry();
-  geometry.setAttribute('position', new BufferAttribute(meshData.positions, 3));
-  geometry.setAttribute('normal', new BufferAttribute(meshData.normals, 3));
-  geometry.setIndex(new BufferAttribute(meshData.indices, 1));
-
-  const material = new MeshStandardMaterial({
-    color: 0xb0b0b0,
-    metalness: 0.2,
-    roughness: 0.6,
-  });
-  const threeMesh = new Mesh(geometry, material);
   const scene = new ThreeScene();
-  scene.add(threeMesh);
+
+  // Two paths:
+  //   1. Single-shape script — tailShape is an OcctBackend exposing getMesh().
+  //   2. Assembly script — tailShape is the assembly's own backend (no getMesh).
+  //      Fan out via meshFeaturesPerFeature (same path headlessRender uses),
+  //      build one Mesh per non-virtual feature with its captured color.
+  const tail = model.tailShape as OcctBackend | undefined;
+  if (tail && typeof tail.getMesh === 'function') {
+    const m = tail.getMesh();
+    addSingleMesh(scene, m.positions, m.normals, m.indices, undefined);
+  } else {
+    const loaded = await loadScriptFeatures(opts.scriptPath);
+    const meshing = await meshFeaturesPerFeature(
+      loaded.features.map((f) => f.record),
+      loaded.paramTable,
+      loaded.session,
+    );
+    if (meshing.failedFeatureIds.length > 0) {
+      throw new Error(
+        `exportGlb: ${meshing.failedFeatureIds.length} feature(s) failed to mesh: ${meshing.failedFeatureIds.join(', ')}`,
+      );
+    }
+    for (const fm of meshing.features) addFeatureMesh(scene, fm);
+    if (scene.children.length === 0) {
+      throw new Error('exportGlb: assembly produced no non-virtual feature meshes');
+    }
+  }
 
   const exporter = new GLTFExporter();
   const buffer = await new Promise<ArrayBuffer>((resolve, reject) => {

--- a/site/gallery/entries.json
+++ b/site/gallery/entries.json
@@ -1,6 +1,31 @@
 {
   "entries": [
     {
+      "slug": "pink-pocket-watch",
+      "title": "Pop-Art Pocket Watch (Pink × Yellow)",
+      "author": {
+        "handle": "kernelcad",
+        "url": "https://x.com/kernelcad"
+      },
+      "version": "v0.7.0",
+      "prompt": "A pop-art octagonal pocket watch with two concentric octagons: a pink outer frame ~50 mm corner-to-corner and a yellow inner case ~36 mm flat-to-flat, the case studded with eight dark hex screws at each of its octagon vertices. The teal dial inside carries a fine waffle tapisserie texture, four cardinal numerals at 12, 6 and 9, eight yellow stick hour markers, two yellow hands, and a pink-ringed seconds subdial at 3 o'clock under a small domed NURBS sapphire crystal. A small yellow crown rises from the top of the case into the mouth of a pink lanyard loop, with a short pink ribbon strap above.",
+      "source": "curated",
+      "video": "../../docs/demos/v0.7/pocket-watch/demo.mp4",
+      "codeLocal": "../../examples/portfolio/pocket-watch/build.kcad.ts",
+      "code": "https://github.com/w1ne/kernelCAD-web/blob/main/examples/portfolio/pocket-watch/build.kcad.ts",
+      "tags": [
+        "pop-art",
+        "pocket-watch",
+        "octagonal",
+        "nurbs-dome",
+        "multi-color",
+        "assembly"
+      ],
+      "featured": true,
+      "createdAt": "2026-05-15",
+      "appUrl": null
+    },
+    {
       "slug": "meta-glasses",
       "title": "Ray-Ban Meta \u2014 Wayfarer (front face)",
       "author": {


### PR DESCRIPTION
**Stacks logically on #191** (the consolidated sprint that ships `eval/oracle/scoreMesh.ts`). Open against develop directly — when #191 lands first, this rebases cleanly.

## Why this exists

The 2D-pixel scorer is gameable. Round 5/6 agent-eval surfaced:
- **R5** inflated body depth 10→75mm and scored #1 vs photo (composite 0.580) but LAST vs a real Wayfarer STL (chamfer 32.88mm, 2× worst)
- **R16** left lens cuts disconnected and scored higher than the fixed version because solid silhouette area was larger

The geometric scorer landed in the sprint (#191). This wires it into the eyewear-wayfarer-front harness as 2 NEW optional gates, activated when a `reference.stl` exists in the task dir.

## Gates

| Gate | Threshold |
|---|---|
| chamfer distance ≤ N mm vs STL | 25 mm |
| bbox IoU ≥ N vs STL | 0.05 |

Thresholds tuned to PASS the 6 geometrically-faithful builds and FAIL R5's scorer-hack:

| Build | Chamfer | bboxIoU | Verdict |
|---|---|---|---|
| R14 (measured) | 12.26 | 0.145 | ✅ pass |
| R1 | 15.08 | 0.077 | ✅ pass |
| E4 (NURBS) | 16.08 | 0.127 | ✅ pass |
| E3 | 16.76 | 0.074 | ✅ pass |
| E1 | 17.89 | 0.081 | ✅ pass |
| baseline | 19.08 | 0.077 | ✅ pass |
| **R5 (slab)** | **32.88** | **0.056** | ❌ chamfer fail (also borderline bboxIoU) |

## Activation

The gates only run when `reference.stl` is present next to `harness.ts`. This PR does NOT ship a Wayfarer STL (license considerations — the Printables Kevin Long STL we tested against isn't CC0). Future eval rounds / users can drop one in and the harness picks it up automatically.

## Test plan

- [x] `npx tsc -b --noEmit` passes
- [x] Without `reference.stl` present, harness output unchanged (back-compat)
- [x] With `reference.stl` from /tmp/r12/faceframe.stl, gates evaluate as in the table above