### PR TITLE
fix(css): allow body to scroll so landing-page gallery is reachable

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -39,8 +39,11 @@
 body {
     margin: 0;
     padding: 0;
-    width: 100vw;
-    height: 100vh;
-    overflow: hidden;
     background-color: #000;
 }
+
+/* Studio workbench routes (StudioShell, DemoPlayerPage, AnonGenPage,
+ * ProjectPage) provide their own h-screen overflow-hidden container, so the
+ * body no longer needs the global viewport lock. Removing it lets the
+ * landing route (/) scroll past the fold so users can reach the "Built with
+ * kernelCAD" gallery and the "Get notified" email signup below the prompt. */


### PR DESCRIPTION
## Summary
\`src/index.css\` pinned \`body { height: 100vh; overflow: hidden }\` globally — correct for the Studio workbench routes (/studio, /g, /p, /dev-lab), but it also locked the landing route (/) into a single viewport. Users couldn't scroll past the prompt to reach the new "Built with kernelCAD" gallery or the "Get notified when we ship" email signup.

Studio routes already provide their own \`h-screen overflow-hidden\` container (\`StudioShell\`, \`DemoPlayerPage\`, \`AnonGenPage\`, \`ProjectPage\`), so removing the global body lock doesn't change their behavior.

## Test plan
- [x] Local smoke test: \`scrollY = 800\` of \`scrollHeight = 1975\` confirms the landing page scrolls past the prompt into the gallery + signup.
- [ ] Live: kernelcad.com scrolls; "Built with kernelCAD" gallery + "Get notified" form reachable.