### PR TITLE
fix(occt): sweep defaults forceProfileSpineOrthogonality=true

### DIFF
--- a/src/kernel/backends/occt/occtBackend.ts
+++ b/src/kernel/backends/occt/occtBackend.ts
@@ -507,8 +507,15 @@ export class OcctBackend implements ShapeBackend {
     // Lift via the shared helper (handles sketch-kind check + multi-face guard).
     const { face } = OcctBackend.liftSketchToFace(sketch, 'XY');
     const profileWire = face().outerWire();
-    // Sweep.
-    const swept = replicad.genericSweep(profileWire, spineWire, { frenet: opts.frenet ?? false });
+    // Sweep. Default `forceProfileSpineOthogonality: true` (replicad's typo'd
+    // spelling preserved on-wire) — without it, a perpendicular profile on a
+    // planar rail silently collapses to a flat shape because the spine's
+    // tangent is co-planar with the profile. Replicad's own `Sketch.sweepSketch`
+    // sets this to true by default for the same reason.
+    const swept = replicad.genericSweep(profileWire, spineWire, {
+      frenet: opts.frenet ?? false,
+      forceProfileSpineOthogonality: true,
+    });
     return new OcctBackend(swept);
   }
 

--- a/tests/unit/backends/occt/sweepFromSketch.test.ts
+++ b/tests/unit/backends/occt/sweepFromSketch.test.ts
@@ -70,6 +70,37 @@ describe('OcctBackend.sweepFromSketch', () => {
     expect(swept.volume()).toBeGreaterThan(0);
   });
 
+  it('planar XY rail with XY-lifted profile produces a non-degenerate tube (regression: Exp-A cqe-task10)', () => {
+    // Without `forceProfileSpineOthogonality: true`, a perpendicular profile
+    // swept along a planar rail (both in XY) silently collapses to a flat
+    // band: the profile plane never rotates with the spine tangent. Exp-A
+    // cqe-task10 surfaced this — agent tried Sketch.sweep with a 64-point
+    // XY half-circle rail and got Z extent = 0, had to fall back to revolve.
+    // The default flip means the profile now twists with the spine tangent,
+    // producing the expected tube cross-section.
+    const sketch = OcctBackend.fromSketchCommands(square2x2);
+    // Half-circle rail in the XY plane: 16 points sampling x = 10·cos(θ),
+    // y = 10·sin(θ) for θ ∈ [0, π]. Profile lies in XY (perpendicular to the
+    // rail's tangent at θ=0); the orthogonality flag rotates it with the spine.
+    const rail: [number, number, number][] = [];
+    const N = 16;
+    for (let i = 0; i <= N; i++) {
+      const t = (i / N) * Math.PI;
+      rail.push([10 * Math.cos(t), 10 * Math.sin(t), 0]);
+    }
+    const swept = OcctBackend.sweepFromSketch(sketch, rail);
+    // The swept tube must have positive volume AND non-trivial Z extent.
+    // Profile height is 2mm (from y=-1 to y=+1 in the 2×2 square lifted to
+    // XY); after orthogonality-rotation that maps to Z extent ≈ 2mm.
+    expect(swept.volume()).toBeGreaterThan(0);
+    const bbox = (swept.getReplicadShape() as unknown as {
+      boundingBox: { bounds: [[number, number, number], [number, number, number]] };
+    }).boundingBox.bounds;
+    const zExtent = bbox[1][2] - bbox[0][2];
+    expect(zExtent).toBeGreaterThan(1.5);
+    expect(zExtent).toBeLessThan(3);
+  });
+
   it('throws on rail with fewer than 2 points', () => {
     const sketch = OcctBackend.fromSketchCommands(square2x2);
     expect(() => OcctBackend.sweepFromSketch(sketch, [[0, 0, 0]]))


### PR DESCRIPTION
## Summary
- Pass `forceProfileSpineOthogonality: true` (replicad's typo'd spelling preserved on-wire) by default in `OcctBackend.sweepFromSketch`
- Mirrors replicad's own `Sketch.sweepSketch` default — without it, a perpendicular profile on a planar rail silently collapses to a flat shape
- Regression test asserts the planar-rail tube has expected ~2mm Z extent

## Why
Exp-A surfaced this on cqe-task10: an agent built the natural form (square profile + 64-point XY half-circle rail), got Z extent = 0, and had to fall back to a partial revolve. One-line default change closes the gap.

## Test plan
- [x] `tests/unit/backends/occt/sweepFromSketch.test.ts` — 6 tests including new planar-rail regression
- [x] `tests/unit/backends/occt/sweepDiagnostics.test.ts` — 3 tests
- [x] Full OCCT backend suite: 234/234 pass