### PR TITLE
fix(funnel): /g/$genId displays fetched artifact, not localStorage

### DIFF
--- a/src/studio/context/ProjectContext.funnel.test.tsx
+++ b/src/studio/context/ProjectContext.funnel.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { ProjectProvider, useProject } from './ProjectContext';
+
+vi.mock('../../shared/worker/geometryEngine', () => ({
+  defaultCode: '// DEFAULT_PLACEHOLDER_CODE — must never reach funnel routes',
+}));
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+const Probe = () => {
+  const { activeProject, activeProjectId } = useProject();
+  return (
+    <>
+      <span data-testid="id">{activeProjectId ?? 'null'}</span>
+      <span data-testid="code">{activeProject?.code ?? 'null'}</span>
+      <span data-testid="name">{activeProject?.name ?? 'null'}</span>
+    </>
+  );
+};
+
+/**
+ * Funnel-route contract (regression guard for the 2026-05-17 prod loop bug):
+ *
+ * When ProjectProvider is mounted with `initialCode` (i.e. /g/$genId or
+ * /p/$slug), it MUST:
+ *   1. expose that code as activeProject.code immediately (no localStorage hop)
+ *   2. NEVER fall back to defaultCode from geometryEngine
+ *   3. NEVER read kernelcad_last_project_id from localStorage
+ *   4. NEVER write the funnel project into kernelcad_project_index
+ *
+ * If this test fails, share links like https://kernelcad.com/g/<id> will once
+ * again display the visitor's last local Studio project instead of the
+ * generation they followed the link to see.
+ */
+describe('ProjectProvider — funnel route (initialCode)', () => {
+  const funnelCode = 'const cube = box(20, 20, 20);\nreturn cube;';
+
+  beforeEach(() => {
+    // Seed localStorage with a stale "last project" that the old code path
+    // would have hydrated and displayed instead of funnelCode.
+    localStorage.setItem('kernelcad_last_project_id', 'stale-1');
+    localStorage.setItem(
+      'kernelcad_project_index',
+      JSON.stringify([{ id: 'stale-1', name: 'Stale Local', lastUpdated: '2020-01-01' }]),
+    );
+    localStorage.setItem(
+      'kernelcad_project_stale-1',
+      JSON.stringify({
+        version: 1,
+        name: 'Stale Local',
+        code: '// STALE_LOCALSTORAGE_CODE',
+        viewState: { viewMode: 'code', viewMode3D: 'shadedWithEdges', sidePanelVisible: true, showSketches: true },
+        lastUpdated: '2020-01-01',
+      }),
+    );
+  });
+
+  it('exposes initialCode as activeProject.code, ignoring localStorage', async () => {
+    render(
+      <ProjectProvider initialCode={funnelCode} projectName="Generated">
+        <Probe />
+      </ProjectProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('code').textContent).toBe(funnelCode);
+    });
+
+    expect(screen.getByTestId('code').textContent).not.toContain('STALE_LOCALSTORAGE_CODE');
+    expect(screen.getByTestId('code').textContent).not.toContain('DEFAULT_PLACEHOLDER_CODE');
+    expect(screen.getByTestId('name').textContent).toBe('Generated');
+  });
+
+  it('uses ephemeral id so funnel project is not persisted', async () => {
+    render(
+      <ProjectProvider initialCode={funnelCode}>
+        <Probe />
+      </ProjectProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('id').textContent).toBe('__funnel_ephemeral__');
+    });
+
+    // The funnel project must not leak into the persisted project index.
+    const index = JSON.parse(localStorage.getItem('kernelcad_project_index') ?? '[]');
+    expect(index.find((p: { id: string }) => p.id === '__funnel_ephemeral__')).toBeUndefined();
+  });
+
+  it('falls back to localStorage hydration when initialCode is absent', async () => {
+    render(
+      <ProjectProvider>
+        <Probe />
+      </ProjectProvider>,
+    );
+
+    // The non-funnel path must NOT pick the ephemeral id — it has to hydrate
+    // from localStorage like before. We don't assert the exact code here
+    // (projectService schema-validation is its own concern); just that the
+    // funnel sentinel was not used.
+    await waitFor(() => {
+      expect(screen.getByTestId('id').textContent).not.toBe('__funnel_ephemeral__');
+    });
+  });
+});

--- a/src/studio/context/ProjectContext.tsx
+++ b/src/studio/context/ProjectContext.tsx
@@ -17,14 +17,35 @@ interface ProjectContextType {
 // eslint-disable-next-line react-refresh/only-export-components
 export const ProjectContext = createContext<ProjectContextType | undefined>(undefined);
 
-export function ProjectProvider({ children }: { children: React.ReactNode }) {
+const EPHEMERAL_ID = '__funnel_ephemeral__';
+
+export function ProjectProvider({ children, initialCode, projectName }: {
+    children: React.ReactNode;
+    initialCode?: string;
+    projectName?: string;
+}) {
     const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
     const [projects, setProjects] = useState<ProjectMetadata[]>([]);
     const [isSaving, setIsSaving] = useState(false);
     const [projectVersion, setProjectVersion] = useState(0);
+    const [ephemeralProject, setEphemeralProject] = useState<KernelCADProject | null>(null);
 
     // Initial load and migration
     useEffect(() => {
+        if (initialCode !== undefined) {
+            // Funnel route: do NOT hydrate from localStorage. Build an in-memory
+            // project so the editor + header still work, but never persist.
+            const proj = projectService.createProject(initialCode, {
+                viewMode: 'code',
+                viewMode3D: 'shadedWithEdges',
+                sidePanelVisible: true,
+                showSketches: true,
+            }, projectName ?? 'Generated');
+            setEphemeralProject(proj);
+            setActiveProjectId(EPHEMERAL_ID);
+            return;
+        }
+
         const migratedId = projectService.migrateLegacyIfNeeded();
         const list = projectService.listProjects();
         setProjects(list);
@@ -50,11 +71,12 @@ export function ProjectProvider({ children }: { children: React.ReactNode }) {
             setProjects(projectService.listProjects());
             setActiveProjectId(id);
         }
-    }, []);
+    }, [initialCode, projectName]);
 
     // Derive active project data
     const activeProject = useMemo(() => {
         if (!activeProjectId) return null;
+        if (activeProjectId === EPHEMERAL_ID) return ephemeralProject;
         // projectVersion is used to force re-memoization on save
         const proj = projectService.getProject(activeProjectId);
         if (activeProjectId) {
@@ -62,7 +84,7 @@ export function ProjectProvider({ children }: { children: React.ReactNode }) {
         }
         return proj;
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [activeProjectId, projectVersion]);
+    }, [activeProjectId, projectVersion, ephemeralProject]);
 
     const openProject = useCallback((id: string) => {
         setActiveProjectId(id);
@@ -98,6 +120,10 @@ export function ProjectProvider({ children }: { children: React.ReactNode }) {
 
     const renameActiveProject = useCallback((newName: string) => {
         if (!activeProjectId || !activeProject) return;
+        if (activeProjectId === EPHEMERAL_ID) {
+            setEphemeralProject(p => (p ? { ...p, name: newName } : p));
+            return;
+        }
         const updated = { ...activeProject, name: newName };
         projectService.saveProject(activeProjectId, updated);
         setProjects(projectService.listProjects());
@@ -106,6 +132,11 @@ export function ProjectProvider({ children }: { children: React.ReactNode }) {
 
     const saveActiveProject = useCallback((updates: Partial<KernelCADProject>) => {
         if (!activeProjectId || !activeProject) return;
+        if (activeProjectId === EPHEMERAL_ID) {
+            // Funnel route: keep edits in memory; never write to localStorage.
+            setEphemeralProject(p => (p ? { ...p, ...updates } : p));
+            return;
+        }
         setIsSaving(true);
         const updated = { ...activeProject, ...updates };
         projectService.saveProject(activeProjectId, updated);

--- a/src/studio/context/WorkbenchContext.tsx
+++ b/src/studio/context/WorkbenchContext.tsx
@@ -265,7 +265,7 @@ import { ProjectProvider } from './ProjectContext';
  */
 export function WorkbenchProvider({ children, initialCode }: { children: ReactNode; initialCode?: string }) {
     return (
-        <ProjectProvider>
+        <ProjectProvider initialCode={initialCode}>
             <CodeProvider initialCode={initialCode}>
                 <WorkbenchStateProvider>
                     <UIProvider>


### PR DESCRIPTION
## Summary

- `/g/$genId` (and `/p/$slug`) were hydrating the visitor's own `kernelcad_last_project_id` from localStorage and overwriting the funnel-route's `initialCode`. Header pinned the right prompt; editor + viewport showed a stale local project (or the `defaultCode` bracket for first-time visitors).
- Surfaced today via prod smoke against `https://kernelcad.com/g/bdcae169-7a26-4958-9dbc-bdc3e4246b8b` — the SSE-generated cube was in Supabase, but Monaco rendered a 4-hole bracket.
- Fix: `ProjectProvider` now accepts `initialCode`. When present it builds an in-memory ephemeral project (sentinel id `__funnel_ephemeral__`), skips the localStorage hydration path, and treats save/rename as no-ops so funnel edits never leak into the visitor's project index.

## Files

- `src/studio/context/ProjectContext.tsx` — ephemeral-project branch keyed on `initialCode`
- `src/studio/context/WorkbenchContext.tsx` — thread `initialCode` to `ProjectProvider`
- `src/studio/context/ProjectContext.funnel.test.tsx` — 3 contract tests guarding (a) funnel `initialCode` wins over stale localStorage, (b) ephemeral sentinel id is used, (c) non-funnel path still hydrates from localStorage

## Test plan

- [x] `npx vitest run src/studio/context/ src/studio/routes/` — 20/20 green (includes the 3 new funnel tests)
- [x] `npx tsc --noEmit` — clean
- [ ] After merge: open `https://kernelcad.com/g/bdcae169-7a26-4958-9dbc-bdc3e4246b8b` — viewport should render a cube, code panel should read `const size = param("Size", 20, "mm"); ...`, header prompt should read "a simple 20mm cube"
- [ ] After merge: same URL in a clean browser profile (no kernelcad localStorage) — must also render the cube (no `defaultCode` bracket fallback)