### PR TITLE
feat(diagnostics): assembly.placement-ignored-by-mate-fk info code

### DIFF
--- a/src/modeling/backends/occt/occtLowerer.ts
+++ b/src/modeling/backends/occt/occtLowerer.ts
@@ -2177,6 +2177,41 @@ export class OcctLowerer implements FeatureLowerer {
           // FeatureId appears in `connectorsByPartId`.
           for (const [partId, mT] of mateWorldT) {
             if (partId in connectorsByPartId) {
+              // Exp-B four-bolt-flange surfaced this: when a part has an
+              // authored `at:` AND is positioned by mate FK, the `at:` is
+              // silently dropped — the agent only learns about it 2 reasoning
+              // steps later via a Gate 2 axis-mismatch. Emit an info-level
+              // diagnostic so the conflict surfaces at the override point.
+              const partRec = records.find((rec) => rec.id === partId);
+              // `resolvePartPlacement` defaults `at` to [0,0,0] even when the
+              // user passed nothing — so we can't just check for presence.
+              // Only fire the diagnostic when `at` is a non-trivial vec3
+              // (any coord magnitude > 1e-6 mm) AND was authored by the user
+              // (the placedBy/connect path leaves `at` synthesized from the
+              // connector pair — that's not a conflict, it's how connect
+              // was designed; skip those).
+              const partMeta = partRec?.metadata as
+                | { at?: { x?: { evaluated?: number }; y?: { evaluated?: number }; z?: { evaluated?: number } };
+                    placedBy?: unknown;
+                    partName?: string }
+                | undefined;
+              const partAt = partMeta?.at;
+              const ax = partAt?.x?.evaluated ?? 0;
+              const ay = partAt?.y?.evaluated ?? 0;
+              const az = partAt?.z?.evaluated ?? 0;
+              const atIsNonTrivial = Math.abs(ax) + Math.abs(ay) + Math.abs(az) > 1e-6;
+              const placedByConnect = partMeta?.placedBy !== undefined;
+              if (partRec && atIsNonTrivial && !placedByConnect) {
+                const partName = partMeta?.partName ?? partId;
+                diagnostics.push({
+                  target: this.target,
+                  code: 'assembly.placement-ignored-by-mate-fk',
+                  featureId: partRec.id,
+                  severity: 'info',
+                  message: `assembly.part '${partName}' has both an authored \`at:\` placement (${ax.toFixed(2)}, ${ay.toFixed(2)}, ${az.toFixed(2)}) AND a mate-FK-derived pose; the \`at:\` is being ignored.`,
+                  hint: "Remove the `at:` and let the mate decide the pose, or place the part's local frame so its mate connector sits at the origin (mate FK composes parent_world ∘ trans(parent_conn) ∘ joint ∘ trans(-child_conn)).",
+                });
+              }
               worldT.set(partId, mT);
             }
           }

--- a/src/shared/diagnostics/codes.ts
+++ b/src/shared/diagnostics/codes.ts
@@ -71,7 +71,12 @@ export type DiagnosticCode =
   | 'feature.material.invalid-base-color'
   | 'feature.material.value-clamped'
   // Edge-feature partial success (1) — M2
-  | 'feature.edge-feature.short-edges-skipped';
+  | 'feature.edge-feature.short-edges-skipped'
+  // Assembly UX (1) — Exp-B four-bolt-flange surfaced: a part's `at:`
+  // placement is silently dropped when the part is reached by mate FK.
+  // Info-severity so the agent learns about the override before the Gate 2
+  // axis-mismatch error path (two reasoning steps removed from root cause).
+  | 'assembly.placement-ignored-by-mate-fk';
 
 export const DIAGNOSTIC_CODES: readonly DiagnosticCode[] = [
   'feature.invalid-args',
@@ -118,6 +123,7 @@ export const DIAGNOSTIC_CODES: readonly DiagnosticCode[] = [
   'feature.material.invalid-base-color',
   'feature.material.value-clamped',
   'feature.edge-feature.short-edges-skipped',
+  'assembly.placement-ignored-by-mate-fk',
 ] as const;
 
 export interface HintTemplate {
@@ -222,6 +228,8 @@ function buildHintTemplates(): Record<DiagnosticCode, HintTemplate> {
       'Numeric PBR fields are clamped to [0, 1] (ior to [1.0, 2.5]).',
     'feature.edge-feature.short-edges-skipped':
       'OCCT blend solver rejects fillet/chamfer radii larger than half the target edge length. Some edges were below 2 × radius and got skipped so the rest could chamfer. Either reduce the radius, refactor upstream booleans so target edges are longer, or scope your fillet/chamfer to a face/edge query that only matches the long edges.',
+    'assembly.placement-ignored-by-mate-fk':
+      "The part's `at:` placement was dropped because it is positioned by mate FK from its mate parent. Either remove the `at:` and let the mate decide the pose, or place the part's local frame so it sits at the intended pose with its mate connector at the origin (mate FK composes parent_world ∘ trans(parent_conn) ∘ joint ∘ trans(-child_conn)).",
   };
   const out = {} as Record<DiagnosticCode, HintTemplate>;
   for (const code of DIAGNOSTIC_CODES) {

--- a/src/shared/diagnostics/nextAction.ts
+++ b/src/shared/diagnostics/nextAction.ts
@@ -67,4 +67,5 @@ export const NEXT_ACTIONS: Record<DiagnosticCode, NextAction> = {
   'feature.material.invalid-base-color':      { kind: 'fix-arg', field: 'baseColor' },
   'feature.material.value-clamped':           { kind: 'fix-arg', field: 'see-message' },
   'feature.edge-feature.short-edges-skipped': { kind: 'fix-arg', field: 'radius-or-distance' },
+  'assembly.placement-ignored-by-mate-fk':    { kind: 'fix-arg', field: 'at' },
 };

--- a/tests/unit/assemblies/placementIgnoredByMateFk.test.ts
+++ b/tests/unit/assemblies/placementIgnoredByMateFk.test.ts
@@ -1,0 +1,73 @@
+// tests/unit/assemblies/placementIgnoredByMateFk.test.ts
+//
+// Regression test for the `assembly.placement-ignored-by-mate-fk`
+// diagnostic. Surfaced by Exp-B four-bolt-flange — an agent authored a
+// part with both `at:` and a mate that reaches it via FK; the `at:` was
+// silently dropped because mate FK overrides authored placements. The
+// agent only learned about the override two reasoning steps later when
+// the joint-axis-binding gate flagged a BREP mismatch. The new info-
+// severity diagnostic surfaces the conflict at the override point.
+
+import { describe, expect, it, beforeAll } from 'vitest';
+import { buildModel } from '../../../src/modeling/buildModel';
+import { initOcct } from '../../../src/kernel/backends/occt/occtBackend';
+
+describe('assembly.placement-ignored-by-mate-fk diagnostic', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('emits info-severity when a mated part also declares `at:`', async () => {
+    const model = await buildModel({
+      fileName: 'placement-ignored.kcad.ts',
+      code: `
+        const arm = assembly('test');
+        arm.part('base', box(10, 10, 10))
+           .connector('p', { type: 'frame', origin: { kind: 'vec3', value: [5, 0, 0] } });
+        // Part 'child' has BOTH at: AND is mate-positioned. mate FK
+        // will override the at:; the diag flags this conflict.
+        arm.part('child', box(10, 10, 10), { at: [100, 100, 100] })
+           .connector('q', { type: 'frame', origin: { kind: 'vec3', value: [-5, 0, 0] } });
+        arm.mate('m', 'base.p', 'child.q', 'fastened');
+        return arm.solvedModel({});
+      `,
+    });
+    const placementIgnored = model.diagnostics.filter(
+      (d) => d.code === 'assembly.placement-ignored-by-mate-fk',
+    );
+    expect(placementIgnored.length).toBeGreaterThanOrEqual(1);
+    expect(placementIgnored[0].severity).toBe('info');
+    expect(placementIgnored[0].message).toContain('child');
+    expect(placementIgnored[0].hint).toMatch(/mate connector/i);
+  });
+
+  it('does NOT emit when the mated part has no `at:`', async () => {
+    const model = await buildModel({
+      fileName: 'no-at.kcad.ts',
+      code: `
+        const arm = assembly('test');
+        arm.part('base', box(10, 10, 10))
+           .connector('p', { type: 'frame', origin: { kind: 'vec3', value: [5, 0, 0] } });
+        arm.part('child', box(10, 10, 10))
+           .connector('q', { type: 'frame', origin: { kind: 'vec3', value: [-5, 0, 0] } });
+        arm.mate('m', 'base.p', 'child.q', 'fastened');
+        return arm.solvedModel({});
+      `,
+    });
+    expect(
+      model.diagnostics.some((d) => d.code === 'assembly.placement-ignored-by-mate-fk'),
+    ).toBe(false);
+  });
+
+  it('does NOT emit when a part has `at:` but is NOT mated', async () => {
+    const model = await buildModel({
+      fileName: 'at-no-mate.kcad.ts',
+      code: `
+        const arm = assembly('test');
+        arm.part('floating', box(10, 10, 10), { at: [50, 0, 0] });
+        return arm.solvedModel({});
+      `,
+    });
+    expect(
+      model.diagnostics.some((d) => d.code === 'assembly.placement-ignored-by-mate-fk'),
+    ).toBe(false);
+  });
+});

--- a/tests/unit/diagnostics/codes.test.ts
+++ b/tests/unit/diagnostics/codes.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from 'vitest';
 import { DIAGNOSTIC_CODES, HINT_TEMPLATES } from '../../../src/shared/diagnostics/codes';
 
 describe('diagnostic catalogue invariants', () => {
-  it('emits exactly 44 codes', () => {
-    expect(DIAGNOSTIC_CODES).toHaveLength(44);
-    expect(new Set(DIAGNOSTIC_CODES).size).toBe(44);
+  it('emits exactly 45 codes', () => {
+    expect(DIAGNOSTIC_CODES).toHaveLength(45);
+    expect(new Set(DIAGNOSTIC_CODES).size).toBe(45);
   });
 
   it('every code has a non-empty hint template', () => {

--- a/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
+++ b/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
@@ -66,8 +66,8 @@ function emittedCodes(): Set<string> {
 describe('every diagnostic code emitted in src/ is in the catalogue', () => {
   const catalogue = new Set<string>(DIAGNOSTIC_CODES);
 
-  it('catalogue has exactly 44 codes', () => {
-    expect(catalogue.size).toBe(44);
+  it('catalogue has exactly 45 codes', () => {
+    expect(catalogue.size).toBe(45);
   });
 
   it('no emit site uses a code outside the catalogue', () => {

--- a/tests/unit/mcp/tools/listDiagnosticCodes.test.ts
+++ b/tests/unit/mcp/tools/listDiagnosticCodes.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { listDiagnosticCodesTool } from '../../../../src/agent/mcp/tools/listDiagnosticCodes';
 
 describe('list_diagnostic_codes', () => {
-  it('returns all 44 codes with non-empty hint templates', async () => {
+  it('returns all 45 codes with non-empty hint templates', async () => {
     const result = await listDiagnosticCodesTool({});
     expect(result.ok).toBe(true);
-    expect(result.codes).toHaveLength(44);
+    expect(result.codes).toHaveLength(45);
     for (const entry of result.codes) {
       expect(entry.hint_template.trim().length).toBeGreaterThan(0);
     }
@@ -13,6 +13,6 @@ describe('list_diagnostic_codes', () => {
 
   it('every code is unique', async () => {
     const result = await listDiagnosticCodesTool({});
-    expect(new Set(result.codes.map((c) => c.code)).size).toBe(44);
+    expect(new Set(result.codes.map((c) => c.code)).size).toBe(45);
   });
 });


### PR DESCRIPTION
## Summary
- New info-severity diagnostic surfaced at the mate-FK override point in the solvedAssembly lowerer
- Surfaced by Exp-B four-bolt-flange — silent `at:` drop, error path was 2 reasoning steps removed
- 45th code in the catalog; bumps `tests/unit/diagnostics/*` counts and adds 3 regression tests

## Why
Agents authoring multi-mate assemblies (like the four-bolt-flange Exp-B case) naturally place parts with `at:` first, then add mates. Mate FK silently overrides the `at:`, and the conflict only surfaces downstream as a Gate 2 BREP-axis mismatch — two reasoning steps from the root cause. The new info diag fires at the actual override point, names the part, prints the dropped `(x, y, z)`, and points at the recovery (remove `at:` or place the part's local frame so its mate connector sits at the origin).

False-positive avoidance:
- Skips trivial `at: [0,0,0]` (identical to mate FK's identity)
- Skips parts placed via `connect:` (that path synthesizes `at:` from the connector pair by design)

## Test plan
- [x] `tests/unit/assemblies/placementIgnoredByMateFk.test.ts` — 3 cases: fires on conflict, doesn't fire without `at:`, doesn't fire without mate
- [x] All 211 tests across `tests/unit/{assemblies,diagnostics,mcp}` pass