### PR TITLE
fix(validator): validateAssembly is v0.6 mate-aware

### DIFF
--- a/src/modeling/mates/validator.ts
+++ b/src/modeling/mates/validator.ts
@@ -138,6 +138,13 @@ export interface ValidateAssemblyInput {
 export function validateAssembly(input: ValidateAssemblyInput): ValidatorResult {
   const parts = collectParts(input.records);
   const joints = collectJoints(input.records);
+  // v0.6 mates flow into the record stream via solvedAssembly metadata
+  // (Assembly.solvedModel records its mate list there for the lowerer). Walk
+  // those so the floating-part gate sees mate-only assemblies as connected.
+  // Without this, Exp-B/C/D agents repeatedly saw spurious "floating"
+  // warnings on otherwise-correct mate-only graphs (ball-joint, gear-pair,
+  // robotic-arm, screw-in-block — surfaced 4× in the agent eval batches).
+  const mateEdges = collectMateEdges(input.records);
   const diagnostics: ValidatorDiagnostic[] = [];
 
   // Build an undirected adjacency map: part name -> set of neighbour names.
@@ -148,6 +155,11 @@ export function validateAssembly(input: ValidateAssemblyInput): ValidatorResult 
     if (!a || !b) continue;
     adj.get(a)?.add(b);
     adj.get(b)?.add(a);
+  }
+  for (const [a, b] of mateEdges) {
+    if (!adj.has(a) || !adj.has(b)) continue;
+    adj.get(a)!.add(b);
+    adj.get(b)!.add(a);
   }
 
   // Check 1 — floating parts (zero joints).
@@ -229,6 +241,29 @@ function collectParts(records: readonly FeatureRecord[]): PartInfo[] {
     const meta = r.metadata as { partName?: string } | undefined;
     const partName = meta?.partName;
     if (typeof partName === 'string') out.push({ partName, recordId: r.id });
+  }
+  return out;
+}
+
+/**
+ * Walk `solvedAssembly` records and pull v0.6 mate edges into a flat list
+ * of `[aPartName, bPartName]` pairs. Mate refs are `'partName.connectorName'`
+ * strings; we slice off the connector and keep the part. Returns [] when no
+ * solvedAssembly record carries mates (v0.5-only assemblies or pre-solve
+ * record streams).
+ */
+function collectMateEdges(records: readonly FeatureRecord[]): readonly (readonly [string, string])[] {
+  const out: [string, string][] = [];
+  for (const r of records) {
+    if (r.kind !== 'solvedAssembly') continue;
+    const meta = r.metadata as { mates?: ReadonlyArray<{ a: string; b: string }> } | undefined;
+    const mates = meta?.mates;
+    if (!Array.isArray(mates)) continue;
+    for (const m of mates) {
+      const a = typeof m.a === 'string' ? m.a.split('.')[0] : undefined;
+      const b = typeof m.b === 'string' ? m.b.split('.')[0] : undefined;
+      if (a && b) out.push([a, b]);
+    }
   }
   return out;
 }

--- a/tests/unit/mates/validateAssemblyMateAwareness.test.ts
+++ b/tests/unit/mates/validateAssemblyMateAwareness.test.ts
@@ -1,0 +1,83 @@
+// tests/unit/mates/validateAssemblyMateAwareness.test.ts
+//
+// Regression test for the v0.6 mate-graph awareness of the synchronous
+// `validateAssembly` function (the path `kernelcad validate` CLI uses).
+//
+// Surfaced 4× across Exp-B/C/D agent runs (ball-joint, gear-pair,
+// robotic-arm, screw-in-block): the v0.5 floating-part walk doesn't see
+// v0.6 mate edges, so otherwise-correct mate-only assemblies trip
+// `assembly.part.floating` warnings on every part. Fix: read mate edges
+// from solvedAssembly records' metadata.mates and fold them into the
+// adjacency map.
+
+import { describe, expect, it, beforeAll } from 'vitest';
+import { buildModel } from '../../../src/modeling/buildModel';
+import { initOcct } from '../../../src/kernel/backends/occt/occtBackend';
+import { validateAssembly } from '../../../src/modeling/mates/validator';
+
+describe('validateAssembly is v0.6 mate-aware', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('does NOT flag floating for a part connected only via a v0.6 mate', async () => {
+    const model = await buildModel({
+      fileName: 'mate-only.kcad.ts',
+      code: `
+        const arm = assembly('test');
+        arm.part('base', box(10, 10, 10))
+           .connector('p', { type: 'frame', origin: { kind: 'vec3', value: [5, 0, 0] } });
+        arm.part('child', box(10, 10, 10))
+           .connector('q', { type: 'frame', origin: { kind: 'vec3', value: [-5, 0, 0] } });
+        // Only a v0.6 mate. No legacy joints. Pre-fix: validateAssembly
+        // would flag both parts as floating.
+        arm.mate('m', 'base.p', 'child.q', 'fastened');
+        return arm.solvedModel({});
+      `,
+    });
+    const result = validateAssembly({ records: model.records });
+    const floating = result.diagnostics.filter((d) => d.code === 'assembly.part.floating');
+    expect(floating).toHaveLength(0);
+  });
+
+  it('still flags floating for parts that are genuinely disconnected', async () => {
+    const model = await buildModel({
+      fileName: 'one-floating.kcad.ts',
+      code: `
+        const arm = assembly('test');
+        arm.part('base', box(10, 10, 10))
+           .connector('p', { type: 'frame', origin: { kind: 'vec3', value: [5, 0, 0] } });
+        arm.part('child', box(10, 10, 10))
+           .connector('q', { type: 'frame', origin: { kind: 'vec3', value: [-5, 0, 0] } });
+        // 'lonely' has no mate at all — should still get floating warning.
+        arm.part('lonely', box(5, 5, 5));
+        arm.mate('m', 'base.p', 'child.q', 'fastened');
+        return arm.solvedModel({});
+      `,
+    });
+    const result = validateAssembly({ records: model.records });
+    const floating = result.diagnostics.filter((d) => d.code === 'assembly.part.floating');
+    expect(floating).toHaveLength(1);
+    expect(floating[0].partName).toBe('lonely');
+  });
+
+  it('handles a 3-part chain wired entirely by mates (no floating warnings)', async () => {
+    const model = await buildModel({
+      fileName: 'mate-chain.kcad.ts',
+      code: `
+        const arm = assembly('chain');
+        arm.part('a', box(10, 10, 10))
+           .connector('out', { type: 'axis', origin: { kind: 'vec3', value: [5, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('b', box(10, 10, 10))
+           .connector('in',  { type: 'axis', origin: { kind: 'vec3', value: [-5, 0, 0] }, axis: [0, 0, 1] })
+           .connector('out', { type: 'axis', origin: { kind: 'vec3', value: [5, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('c', box(10, 10, 10))
+           .connector('in',  { type: 'axis', origin: { kind: 'vec3', value: [-5, 0, 0] }, axis: [0, 0, 1] });
+        arm.mate('m1', 'a.out', 'b.in', 'revolute', { limitsDeg: [0, 90] });
+        arm.mate('m2', 'b.out', 'c.in', 'revolute', { limitsDeg: [0, 90] });
+        return arm.solvedModel({});
+      `,
+    });
+    const result = validateAssembly({ records: model.records });
+    expect(result.diagnostics.filter((d) => d.code === 'assembly.part.floating')).toHaveLength(0);
+    expect(result.diagnostics.filter((d) => d.code === 'assembly.part.orphan')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- `validateAssembly` (CLI's sync path) now reads v0.6 mate edges from `solvedAssembly` record metadata, not just legacy `assemblyJoint` records
- Closes the spurious floating-part warnings on mate-only assemblies surfaced **4× across Exp-B/C/D agent runs**

## Why
v0.6 mates (`arm.mate(...)`) don't create `assemblyJoint` records — they're carried as in-memory state on the Assembly handle and only reach the record stream via `solvedAssembly.metadata.mates`. The validator's adjacency walk was joint-record-only, so a mate-only assembly looked entirely disconnected and every part tripped `assembly.part.floating`. Agents saw it on:
- ball-joint-linkage (Exp-B)
- gear-pair-meshing (Exp-C)
- robotic-arm-chain (Exp-C)
- screw-in-block (Exp-D)

## Test plan
- [x] `tests/unit/mates/validateAssemblyMateAwareness.test.ts` — 3 cases:
  - 2-part mate-only assembly: no floating warnings (was 2 before fix)
  - 3-part `lonely+mated-pair` mix: floating warning fires ONLY on the genuinely disconnected part
  - 3-part mate chain: no floating, no orphan
- [x] All 90 tests in `tests/unit/{mates,assemblies,diagnostics}` pass