### PR TITLE
feat(diagnostics): assembly.mates-ignored-by-model-call info code

### DIFF
--- a/eval/oracle/kernelcad-client.ts
+++ b/eval/oracle/kernelcad-client.ts
@@ -44,9 +44,16 @@ export async function evaluateScript(scriptPath: string): Promise<EvaluateResult
   // The CLI may print the JSON to stdout regardless of exit code; try to parse.
   try {
     const parsed = JSON.parse(r.stdout);
+    // Info-severity diagnostics are advisory (e.g. assembly.placement-ignored-
+    // by-mate-fk, assembly.mates-ignored-by-model-call); they don't fail the
+    // evaluate. Only warn/error severity should flip `ok` to false.
+    const diagnostics: Array<{ severity?: string }> = Array.isArray(parsed.diagnostics)
+      ? parsed.diagnostics
+      : [];
+    const blocking = diagnostics.filter((d) => d.severity !== 'info');
     return {
-      ok: !!parsed.ok && Array.isArray(parsed.diagnostics) && parsed.diagnostics.length === 0,
-      diagnostics: Array.isArray(parsed.diagnostics) ? parsed.diagnostics : [],
+      ok: !!parsed.ok && blocking.length === 0,
+      diagnostics,
       featureCount: parsed.featureCount,
     };
   } catch {

--- a/src/modeling/backends/occt/occtLowerer.ts
+++ b/src/modeling/backends/occt/occtLowerer.ts
@@ -1849,8 +1849,27 @@ export class OcctLowerer implements FeatureLowerer {
         const meta = r.metadata as {
           assemblyName?: string;
           partIds?: FeatureId[];
+          declaredMateCount?: number;
         } | undefined;
         const partIds = meta?.partIds ?? [];
+        // Exp-D four-bolt-flange-v2 surfaced this: an agent declared mates
+        // on the assembly, then ended the script with arm.model() (not
+        // solvedModel({})). model() skips mate FK entirely — parts stack
+        // at local-frame origin and downstream interference / scoring
+        // gates lie. Emit an info diag at the model() lowering so the
+        // mate-FK skip surfaces explicitly, not via downstream symptoms.
+        const declaredMateCount = meta?.declaredMateCount ?? 0;
+        if (declaredMateCount > 0) {
+          const assemblyName = meta?.assemblyName ?? '<unnamed>';
+          diagnostics.push({
+            target: this.target,
+            code: 'assembly.mates-ignored-by-model-call',
+            featureId: r.id,
+            severity: 'info',
+            message: `assembly '${assemblyName}' declared ${declaredMateCount} mate(s) but the script returned arm.model() (which skips mate FK); parts will pose at their local-frame origin, not their mate-derived world positions.`,
+            hint: 'Replace `arm.model()` with `arm.solvedModel({})` (or `arm.solvedModel(poses)`) so the mate solver runs and parts pose correctly. arm.model() is the unposed view — useful only when the assembly declares no mates.',
+          });
+        }
         if (partEntries.length !== partIds.length) {
           diagnostics.push({
             target: this.target,

--- a/src/modeling/capture/assembly.ts
+++ b/src/modeling/capture/assembly.ts
@@ -1333,7 +1333,13 @@ export class Assembly {
         'Call assembly.part(name, shape, opts?) before assembly.model().',
       );
     }
-    const sceneShape = this.session.assemblyModel(this.name, this.parts);
+    // Stash the mate count so the lowerer can emit the
+    // `assembly.mates-ignored-by-model-call` info diagnostic when
+    // model() is used in lieu of solvedModel() on a mate-bearing
+    // assembly. Without this, mates declared on `arm` never reach the
+    // FK pipeline — parts stack at local-frame origin and downstream
+    // interferences/scoring lies. Surfaced by Exp-D four-bolt-flange-v2.
+    const sceneShape = this.session.assemblyModel(this.name, this.parts, this.mates.length);
     return this.makeScene(sceneShape);
   }
 

--- a/src/modeling/capture/captureSession.ts
+++ b/src/modeling/capture/captureSession.ts
@@ -554,7 +554,7 @@ export class CaptureSession {
     });
   }
 
-  assemblyModel(assemblyName: string, parts: readonly AssemblyPartRef[]): Shape {
+  assemblyModel(assemblyName: string, parts: readonly AssemblyPartRef[], declaredMateCount: number = 0): Shape {
     if (parts.length === 0) {
       throw new Error('assembly.model requires at least one part');
     }
@@ -574,6 +574,11 @@ export class CaptureSession {
       metadata: {
         assemblyName,
         partIds: parts.map(part => part.id),
+        // Non-zero when the Assembly had `arm.mate(...)` calls but the
+        // script ended with `arm.model()` (not `solvedModel()`). The
+        // lowerer reads this and emits the info diag so the agent
+        // notices the mate FK is being skipped.
+        ...(declaredMateCount > 0 ? { declaredMateCount } : {}),
       },
     });
   }

--- a/src/shared/diagnostics/codes.ts
+++ b/src/shared/diagnostics/codes.ts
@@ -76,7 +76,11 @@ export type DiagnosticCode =
   // placement is silently dropped when the part is reached by mate FK.
   // Info-severity so the agent learns about the override before the Gate 2
   // axis-mismatch error path (two reasoning steps removed from root cause).
-  | 'assembly.placement-ignored-by-mate-fk';
+  | 'assembly.placement-ignored-by-mate-fk'
+  // Assembly UX (1) — Exp-D four-bolt-flange-v2 surfaced: agent declared
+  // mates then ended with arm.model() (not solvedModel), so mate FK never
+  // runs and parts stack at local origin. Same shape as placement-ignored.
+  | 'assembly.mates-ignored-by-model-call';
 
 export const DIAGNOSTIC_CODES: readonly DiagnosticCode[] = [
   'feature.invalid-args',
@@ -124,6 +128,7 @@ export const DIAGNOSTIC_CODES: readonly DiagnosticCode[] = [
   'feature.material.value-clamped',
   'feature.edge-feature.short-edges-skipped',
   'assembly.placement-ignored-by-mate-fk',
+  'assembly.mates-ignored-by-model-call',
 ] as const;
 
 export interface HintTemplate {
@@ -230,6 +235,8 @@ function buildHintTemplates(): Record<DiagnosticCode, HintTemplate> {
       'OCCT blend solver rejects fillet/chamfer radii larger than half the target edge length. Some edges were below 2 × radius and got skipped so the rest could chamfer. Either reduce the radius, refactor upstream booleans so target edges are longer, or scope your fillet/chamfer to a face/edge query that only matches the long edges.',
     'assembly.placement-ignored-by-mate-fk':
       "The part's `at:` placement was dropped because it is positioned by mate FK from its mate parent. Either remove the `at:` and let the mate decide the pose, or place the part's local frame so it sits at the intended pose with its mate connector at the origin (mate FK composes parent_world ∘ trans(parent_conn) ∘ joint ∘ trans(-child_conn)).",
+    'assembly.mates-ignored-by-model-call':
+      "The assembly declared mates but the script ended with arm.model() (which skips mate FK). Replace with arm.solvedModel({}) so the mate solver runs and parts pose correctly.",
   };
   const out = {} as Record<DiagnosticCode, HintTemplate>;
   for (const code of DIAGNOSTIC_CODES) {

--- a/src/shared/diagnostics/nextAction.ts
+++ b/src/shared/diagnostics/nextAction.ts
@@ -68,4 +68,5 @@ export const NEXT_ACTIONS: Record<DiagnosticCode, NextAction> = {
   'feature.material.value-clamped':           { kind: 'fix-arg', field: 'see-message' },
   'feature.edge-feature.short-edges-skipped': { kind: 'fix-arg', field: 'radius-or-distance' },
   'assembly.placement-ignored-by-mate-fk':    { kind: 'fix-arg', field: 'at' },
+  'assembly.mates-ignored-by-model-call':     { kind: 'rewrite-feature', guidance: 'replace arm.model() with arm.solvedModel({}) so the mate solver runs' },
 };

--- a/tests/integration/mcp/reviewCad.test.ts
+++ b/tests/integration/mcp/reviewCad.test.ts
@@ -394,7 +394,11 @@ describe('review_cad MCP tool', () => {
 
     expect(r.ok).toBe(false);
     if (!r.ok) {
-      expect(r.diagnostics).toEqual([]);
+      // Filter out info-level advisories (assembly.mates-ignored-by-model-call
+      // fires here because the fixture intentionally returns arm.model() on a
+      // mate-bearing assembly to test the fitness-repair flow). The fitness
+      // failure is what's being asserted, not the absence of info diags.
+      expect(r.diagnostics.filter((d) => d.severity !== 'info')).toEqual([]);
       expect(r.fitness?.blockingReasons.map((reason) => reason.code)).toEqual([
         'assembly.mechanism.no-tracked-workspace',
         'assembly.mechanism.no-tracked-travel',

--- a/tests/unit/assemblies/matesIgnoredByModelCall.test.ts
+++ b/tests/unit/assemblies/matesIgnoredByModelCall.test.ts
@@ -1,0 +1,75 @@
+// tests/unit/assemblies/matesIgnoredByModelCall.test.ts
+//
+// Regression test for the `assembly.mates-ignored-by-model-call`
+// diagnostic. Surfaced by Exp-D four-bolt-flange-v2: when an agent
+// declares mates then ends the script with `arm.model()` (not
+// `solvedModel({})`), mate FK never runs and parts stack at their local
+// origin. The downstream symptom is bolt-bolt interferences; the root
+// cause (model() skips FK) is two reasoning steps removed.
+//
+// The diagnostic fires at the `assemblyModel` lowering when the captured
+// metadata carries `declaredMateCount > 0`.
+
+import { describe, expect, it, beforeAll } from 'vitest';
+import { buildModel } from '../../../src/modeling/buildModel';
+import { initOcct } from '../../../src/kernel/backends/occt/occtBackend';
+
+describe('assembly.mates-ignored-by-model-call diagnostic', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('fires when arm.model() is used on a mate-bearing assembly', async () => {
+    const model = await buildModel({
+      fileName: 'model-with-mates.kcad.ts',
+      code: `
+        const arm = assembly('test');
+        arm.part('base', box(10, 10, 10))
+           .connector('p', { type: 'frame', origin: { kind: 'vec3', value: [5, 0, 0] } });
+        arm.part('child', box(10, 10, 10))
+           .connector('q', { type: 'frame', origin: { kind: 'vec3', value: [-5, 0, 0] } });
+        arm.mate('m', 'base.p', 'child.q', 'fastened');
+        // Footgun: ends with arm.model(), not arm.solvedModel({})
+        return arm.model();
+      `,
+    });
+    const matesIgnored = model.diagnostics.filter(
+      (d) => d.code === 'assembly.mates-ignored-by-model-call',
+    );
+    expect(matesIgnored.length).toBe(1);
+    expect(matesIgnored[0].severity).toBe('info');
+    expect(matesIgnored[0].message).toContain('1 mate');
+    expect(matesIgnored[0].hint).toMatch(/solvedModel/i);
+  });
+
+  it('does NOT fire when arm.model() is used on a mate-free assembly', async () => {
+    const model = await buildModel({
+      fileName: 'model-no-mates.kcad.ts',
+      code: `
+        const arm = assembly('test');
+        arm.part('a', box(10, 10, 10));
+        arm.part('b', box(10, 10, 10), { at: [20, 0, 0] });
+        return arm.model();
+      `,
+    });
+    expect(
+      model.diagnostics.some((d) => d.code === 'assembly.mates-ignored-by-model-call'),
+    ).toBe(false);
+  });
+
+  it('does NOT fire when arm.solvedModel({}) is used', async () => {
+    const model = await buildModel({
+      fileName: 'solvedmodel-with-mates.kcad.ts',
+      code: `
+        const arm = assembly('test');
+        arm.part('base', box(10, 10, 10))
+           .connector('p', { type: 'frame', origin: { kind: 'vec3', value: [5, 0, 0] } });
+        arm.part('child', box(10, 10, 10))
+           .connector('q', { type: 'frame', origin: { kind: 'vec3', value: [-5, 0, 0] } });
+        arm.mate('m', 'base.p', 'child.q', 'fastened');
+        return arm.solvedModel({});
+      `,
+    });
+    expect(
+      model.diagnostics.some((d) => d.code === 'assembly.mates-ignored-by-model-call'),
+    ).toBe(false);
+  });
+});

--- a/tests/unit/diagnostics/codes.test.ts
+++ b/tests/unit/diagnostics/codes.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from 'vitest';
 import { DIAGNOSTIC_CODES, HINT_TEMPLATES } from '../../../src/shared/diagnostics/codes';
 
 describe('diagnostic catalogue invariants', () => {
-  it('emits exactly 45 codes', () => {
-    expect(DIAGNOSTIC_CODES).toHaveLength(45);
-    expect(new Set(DIAGNOSTIC_CODES).size).toBe(45);
+  it('emits exactly 46 codes', () => {
+    expect(DIAGNOSTIC_CODES).toHaveLength(46);
+    expect(new Set(DIAGNOSTIC_CODES).size).toBe(46);
   });
 
   it('every code has a non-empty hint template', () => {

--- a/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
+++ b/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
@@ -66,8 +66,8 @@ function emittedCodes(): Set<string> {
 describe('every diagnostic code emitted in src/ is in the catalogue', () => {
   const catalogue = new Set<string>(DIAGNOSTIC_CODES);
 
-  it('catalogue has exactly 45 codes', () => {
-    expect(catalogue.size).toBe(45);
+  it('catalogue has exactly 46 codes', () => {
+    expect(catalogue.size).toBe(46);
   });
 
   it('no emit site uses a code outside the catalogue', () => {

--- a/tests/unit/mcp/tools/listDiagnosticCodes.test.ts
+++ b/tests/unit/mcp/tools/listDiagnosticCodes.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { listDiagnosticCodesTool } from '../../../../src/agent/mcp/tools/listDiagnosticCodes';
 
 describe('list_diagnostic_codes', () => {
-  it('returns all 45 codes with non-empty hint templates', async () => {
+  it('returns all 46 codes with non-empty hint templates', async () => {
     const result = await listDiagnosticCodesTool({});
     expect(result.ok).toBe(true);
-    expect(result.codes).toHaveLength(45);
+    expect(result.codes).toHaveLength(46);
     for (const entry of result.codes) {
       expect(entry.hint_template.trim().length).toBeGreaterThan(0);
     }
@@ -13,6 +13,6 @@ describe('list_diagnostic_codes', () => {
 
   it('every code is unique', async () => {
     const result = await listDiagnosticCodesTool({});
-    expect(new Set(result.codes.map((c) => c.code)).size).toBe(45);
+    expect(new Set(result.codes.map((c) => c.code)).size).toBe(46);
   });
 });


### PR DESCRIPTION
## Summary
- New 46th diagnostic code: fires when an assembly declares mates but ends with `arm.model()` instead of `arm.solvedModel({})`
- Adjacent silent-footgun to `assembly.placement-ignored-by-mate-fk` (#197) — same shape, same fix pattern
- Surfaced by Exp-D four-bolt-flange-v2: agent avoided the `at:` footgun cleanly thanks to the prior diag's hint, then bit by this adjacent one (bolts stacked at local origin → 6 spurious interferences)

## Why
`arm.model()` is the unposed-view path: it skips mate FK entirely. When an agent declares mates and uses `model()`, the script "works" (no errors) but produces geometry where every part poses at its local-frame origin instead of its mate-derived world position. Downstream gates (interference, scoring) catch the symptom — but two reasoning steps removed from "use solvedModel instead". An info-severity diag at the actual model() lowering point gives the agent the direct answer.

## Implementation
- `Assembly.model()` passes `this.mates.length` through to capture
- Session stashes it in the assemblyModel record's metadata as `declaredMateCount` (only when > 0)
- The lowerer's assemblyModel case emits the diag when present

## Test plan
- [x] `tests/unit/assemblies/matesIgnoredByModelCall.test.ts` — 3 cases: fires on conflict, doesn't fire on mate-free `model()`, doesn't fire on `solvedModel({})`
- [x] All 217 tests in `tests/unit/{assemblies,diagnostics,mcp,mates}` pass