### PR TITLE
cleanup: knock down 6 of the 8 high-slop audit findings

### DIFF
--- a/src/agent/render/headlessRender.ts
+++ b/src/agent/render/headlessRender.ts
@@ -106,13 +106,16 @@ export async function headlessRender(opts: HeadlessRenderOpts): Promise<Headless
       await page.evaluate(() => window.__demoPlayer?.setReferenceImagesVisible(false));
     }
 
-    // Belt-and-suspenders: nuke ANY dev chrome before each screenshot. The
-    // headless URL param + __root.tsx suppression doesn't always catch the
-    // TanStack Router devtools badge — it gets re-injected by HMR or React
-    // double-render after mesh load. Removing the offending DOM nodes here
-    // guarantees zero badge pixels in the screenshot.
-    const stripDevChrome = `
-      () => {
+    // Belt-and-suspenders: nuke ANY dev chrome AFTER mesh load and BEFORE the
+    // first screenshot. The headless URL param + __root.tsx suppression doesn't
+    // always catch the TanStack Router devtools badge — it can get re-injected
+    // by React StrictMode double-render at mount. We run this once, post-load:
+    // by then any mount-time re-injection has settled, and there is no HMR in
+    // headless production (no file watcher). If a late re-injection ever bites
+    // again, wire this through a MutationObserver — don't re-add the per-frame
+    // scan.
+    await page.evaluate(`
+      (() => {
         const sels = [
           '[data-testid="tsr-devtools"]',
           '.TanStackRouterDevtools',
@@ -127,14 +130,13 @@ export async function headlessRender(opts: HeadlessRenderOpts): Promise<Headless
             el.remove();
           }
         });
-      }
-    `;
+      })()
+    `);
 
     // 4. Per-view: snap camera, screenshot, collect.
     const pngsByView: Partial<Record<RenderView, Buffer>> = {};
     for (const view of views) {
       await page.evaluate((v) => window.__demoPlayer!.setRenderView(v), view);
-      await page.evaluate(stripDevChrome);
       const buf = await page.screenshot({ type: 'png' });
       pngsByView[view] = buf;
     }
@@ -153,7 +155,6 @@ export async function headlessRender(opts: HeadlessRenderOpts): Promise<Headless
           ({ a, e }) => window.__demoPlayer!.setRenderPose(a, e),
           { a: az, e: el },
         );
-        await page.evaluate(stripDevChrome);
         const buf = await page.screenshot({ type: 'png' });
         pngsByPose[poseKey] = buf;
       }

--- a/src/funnel/hooks/useGeneration.ts
+++ b/src/funnel/hooks/useGeneration.ts
@@ -1,11 +1,23 @@
 import { useCallback, useState } from 'react';
 import { parseSseStream, startGeneration, type Artifact, type GenerateEvent } from '../lib/generateClient';
 
+/** Codes emitted by the client when generation fails outside the server's
+ *  own error stream. Server-relayed `error` events carry their own codes
+ *  (relayed through verbatim), so the wire shape stays open. */
+export type FunnelClientErrorCode =
+  | 'network'
+  | 'rate_limited'
+  | 'no_body'
+  | 'missing_generation_id'
+  | 'stream_closed';
+
+export type FunnelErrorCode = FunnelClientErrorCode | `http_${number}` | (string & {});
+
 export type GenerationPhase =
   | { state: 'idle' }
   | { state: 'running'; generationId?: string; anonId?: string; lastEvent: GenerateEvent }
   | { state: 'done'; generationId: string; anonId: string; artifact: Artifact }
-  | { state: 'error'; code: string; message: string; generationId?: string };
+  | { state: 'error'; code: FunnelErrorCode; message: string; generationId?: string };
 
 export function useGeneration() {
   const [phase, setPhase] = useState<GenerationPhase>({ state: 'idle' });
@@ -30,7 +42,7 @@ export function useGeneration() {
     if (!res.ok) {
       setPhase({
         state: 'error',
-        code: res.status === 429 ? 'rate_limited' : 'http_' + res.status,
+        code: res.status === 429 ? 'rate_limited' : `http_${res.status}`,
         message: await res.text().catch(() => `HTTP ${res.status}`),
       });
       return;

--- a/src/modeling/backends/occt/occtLowerer.ts
+++ b/src/modeling/backends/occt/occtLowerer.ts
@@ -67,6 +67,63 @@ function drainResolvedWarnings(
   }
 }
 
+/** Pre-filter edges below `minLength` (2 × radius for fillet, 2 × distance for
+ *  chamfer). OCCT's BlendChain solver rejects radii larger than half the target
+ *  edge length, so historically a single sub-2×r edge would fail the whole
+ *  operation. Filtering pre-call lets long edges proceed and surfaces a clean
+ *  info diagnostic naming the skipped count. Used by both fillet and chamfer. */
+function filterEdgesByMinLength(
+  edges: readonly import('replicad').Edge[],
+  minLength: number,
+  ctx: {
+    op: 'fillet' | 'chamfer';
+    paramName: 'radius' | 'distance';
+    featureId: FeatureId;
+  },
+): {
+  kept: import('replicad').Edge[];
+  diagnostic: CompilerDiagnostic | undefined;
+} {
+  const kept: import('replicad').Edge[] = [];
+  let skipped = 0;
+  for (const e of edges) {
+    // Edge.length is the arc length via BRepAdaptor_Curve; safe on straight,
+    // arc, and spline edges. Throws if the edge has no underlying curve
+    // (degenerate); skip those defensively.
+    let len: number;
+    try { len = e.length; } catch { skipped++; continue; }
+    if (len >= minLength) kept.push(e); else skipped++;
+  }
+  if (skipped === 0) return { kept, diagnostic: undefined };
+  const minLenStr = minLength.toFixed(2);
+  const hint = HINT_TEMPLATES['feature.edge-feature.short-edges-skipped'].template;
+  if (kept.length === 0) {
+    return {
+      kept,
+      diagnostic: {
+        target: 'export-occt',
+        code: 'feature.edge-feature.short-edges-skipped',
+        featureId: ctx.featureId,
+        severity: 'error',
+        message: `${ctx.op} skipped: all ${skipped} target edges are shorter than 2 × ${ctx.paramName} = ${minLenStr} mm`,
+        hint,
+      },
+    };
+  }
+  const gerund = ctx.op === 'fillet' ? 'filleting' : 'chamfering';
+  return {
+    kept,
+    diagnostic: {
+      target: 'export-occt',
+      code: 'feature.edge-feature.short-edges-skipped',
+      featureId: ctx.featureId,
+      severity: 'warn',
+      message: `${ctx.op} skipped ${skipped} of ${edges.length} target edges shorter than 2 × ${ctx.paramName} = ${minLenStr} mm; ${gerund} the remaining ${kept.length}.`,
+      hint,
+    },
+  };
+}
+
 
 /** Read a Vec3Param to a numeric Vec3 by picking the `evaluated` field of each
  *  component. The recompute engine pre-resolves every Param-shaped node in the
@@ -1243,51 +1300,15 @@ export class OcctLowerer implements FeatureLowerer {
         } else {
           edgesForFillet = sharpEdges;
         }
-        // M2: pre-filter edges below 2 × radius. The OCCT BlendChain solver
-        // rejects fillet radii larger than half the target edge length;
-        // historically this caused the WHOLE fillet operation to fail (see
-        // E3, R6, R19 in the agent-eval rounds — they all had to "skip and
-        // document" their front-face perimeter fillet/chamfer because the
-        // R=3 lens-cutout corner edges were sub-1mm). Filtering pre-call
-        // means the long edges get filleted and the agent gets a clean
-        // info diagnostic naming the skipped count.
-        const filletMinEdgeLength = 2 * radius;
-        const longFilletEdges: import('replicad').Edge[] = [];
-        let skippedFilletEdges = 0;
-        for (const e of edgesForFillet) {
-          // Edge.length is the arc length via BRepAdaptor_Curve; safe on
-          // straight, arc, and spline edges. Throws if the edge has no
-          // underlying curve (degenerate); skip those defensively.
-          let len: number;
-          try { len = e.length; } catch { skippedFilletEdges++; continue; }
-          if (len >= filletMinEdgeLength) longFilletEdges.push(e); else skippedFilletEdges++;
-        }
-        if (skippedFilletEdges > 0 && longFilletEdges.length === 0) {
-          // All target edges shorter than 2×radius — the fillet didn't run at
-          // all. Surface as `error` (not `warn`) so the chain walker reports
-          // the feature as failed; agent should retry with a smaller radius.
-          diagnostics.push({
-            target: 'export-occt',
-            code: 'feature.edge-feature.short-edges-skipped',
-            featureId: r.id,
-            severity: 'error',
-            message: `fillet skipped: all ${skippedFilletEdges} target edges are shorter than 2 × radius = ${filletMinEdgeLength.toFixed(2)} mm`,
-            hint: 'OCCT blend solver rejects fillet/chamfer radii larger than half the target edge length. Some edges were below 2 × radius and got skipped so the rest could chamfer. Either reduce the radius, refactor upstream booleans so target edges are longer, or scope your fillet/chamfer to a face/edge query that only matches the long edges.',
-          });
+        const filletFilter = filterEdgesByMinLength(edgesForFillet, 2 * radius, {
+          op: 'fillet', paramName: 'radius', featureId: r.id,
+        });
+        if (filletFilter.diagnostic) diagnostics.push(filletFilter.diagnostic);
+        if (filletFilter.diagnostic?.severity === 'error') {
           shape = base;
           break;
         }
-        if (skippedFilletEdges > 0) {
-          diagnostics.push({
-            target: 'export-occt',
-            code: 'feature.edge-feature.short-edges-skipped',
-            featureId: r.id,
-            severity: 'warn',
-            message: `fillet skipped ${skippedFilletEdges} of ${edgesForFillet.length} target edges shorter than 2 × radius = ${filletMinEdgeLength.toFixed(2)} mm; chamfering the remaining ${longFilletEdges.length}.`,
-            hint: 'OCCT blend solver rejects fillet/chamfer radii larger than half the target edge length. Some edges were below 2 × radius and got skipped so the rest could chamfer. Either reduce the radius, refactor upstream booleans so target edges are longer, or scope your fillet/chamfer to a face/edge query that only matches the long edges.',
-          });
-          edgesForFillet = longFilletEdges;
-        }
+        edgesForFillet = filletFilter.kept;
         try {
           // Convert replicad Edge[] → EdgeRefForFilleting[] by hashing each
           // edge's underlying TopoDS_Edge handle.
@@ -1380,44 +1401,17 @@ export class OcctLowerer implements FeatureLowerer {
           return { shape: base, diagnostics };
         }
         drainResolvedWarnings(r, diagnostics);
-        // M2: pre-filter edges below 2 × distance. Same rationale as fillet:
-        // OCCT blend solver rejects chamfer distances larger than half the
-        // target edge length. Filter pre-call so long edges get chamfered
-        // and the agent gets a clean diagnostic naming the skipped count.
-        const chamferMinEdgeLength = 2 * distance;
-        const longChamferEdges: import('replicad').Edge[] = [];
-        let skippedChamferEdges = 0;
-        for (const e of edgesResult as import('replicad').Edge[]) {
-          let len: number;
-          try { len = e.length; } catch { skippedChamferEdges++; continue; }
-          if (len >= chamferMinEdgeLength) longChamferEdges.push(e); else skippedChamferEdges++;
-        }
-        if (skippedChamferEdges > 0 && longChamferEdges.length === 0) {
-          // All target edges shorter than 2×distance — chamfer didn't run.
-          // `error` so the chain walker flags the feature as failed.
-          diagnostics.push({
-            target: 'export-occt',
-            code: 'feature.edge-feature.short-edges-skipped',
-            featureId: r.id,
-            severity: 'error',
-            message: `chamfer skipped: all ${skippedChamferEdges} target edges are shorter than 2 × distance = ${chamferMinEdgeLength.toFixed(2)} mm`,
-            hint: 'OCCT blend solver rejects fillet/chamfer radii larger than half the target edge length. Some edges were below 2 × radius and got skipped so the rest could chamfer. Either reduce the radius, refactor upstream booleans so target edges are longer, or scope your fillet/chamfer to a face/edge query that only matches the long edges.',
-          });
+        const chamferFilter = filterEdgesByMinLength(
+          edgesResult as import('replicad').Edge[],
+          2 * distance,
+          { op: 'chamfer', paramName: 'distance', featureId: r.id },
+        );
+        if (chamferFilter.diagnostic) diagnostics.push(chamferFilter.diagnostic);
+        if (chamferFilter.diagnostic?.severity === 'error') {
           shape = base;
           break;
         }
-        let edgesForChamfer: import('replicad').Edge[] = edgesResult as import('replicad').Edge[];
-        if (skippedChamferEdges > 0) {
-          diagnostics.push({
-            target: 'export-occt',
-            code: 'feature.edge-feature.short-edges-skipped',
-            featureId: r.id,
-            severity: 'warn',
-            message: `chamfer skipped ${skippedChamferEdges} of ${(edgesResult as import('replicad').Edge[]).length} target edges shorter than 2 × distance = ${chamferMinEdgeLength.toFixed(2)} mm; chamfering the remaining ${longChamferEdges.length}.`,
-            hint: 'OCCT blend solver rejects fillet/chamfer radii larger than half the target edge length. Some edges were below 2 × radius and got skipped so the rest could chamfer. Either reduce the radius, refactor upstream booleans so target edges are longer, or scope your fillet/chamfer to a face/edge query that only matches the long edges.',
-          });
-          edgesForChamfer = longChamferEdges;
-        }
+        const edgesForChamfer = chamferFilter.kept;
         try {
           // Convert replicad Edge[] → EdgeRefForFilleting[] by hashing each
           // edge's underlying TopoDS_Edge handle.

--- a/src/modeling/capture/assembly.ts
+++ b/src/modeling/capture/assembly.ts
@@ -407,12 +407,8 @@ export class Assembly {
     //    prepending the prefix, leaving the connectorName intact. Mate
     //    names are also prefixed so name-uniqueness within `this` holds.
     const remapRef = (ref: string): string => {
-      const dot = ref.indexOf('.');
-      // parseConnectorRef will throw on a bad ref upstream; defensively
-      // pass through anything we can't split (the upstream throw is the
-      // canonical surface — we don't want to invent diagnostics here).
-      if (dot < 1) return ref;
-      return `${prefix}${ref.slice(0, dot)}.${ref.slice(dot + 1)}`;
+      const { partName, connectorName } = parseConnectorRef(ref);
+      return `${prefix}${partName}.${connectorName}`;
     };
     for (const om of other.__mates()) {
       this.mates.push({
@@ -425,33 +421,29 @@ export class Assembly {
         ...(om.limitsMm !== undefined ? { limitsMm: om.limitsMm } : {}),
       });
     }
+    const requireImportedPart = (origPartName: string, method: 'ref' | 'part'): AssemblyPartRef => {
+      const ref = importedByOriginalName.get(origPartName);
+      if (ref) return ref;
+      const known = [...importedByOriginalName.keys()].join(', ') || '(none)';
+      const extraHint = method === 'ref'
+        ? ' Use sub.part(name) to grab the imported AssemblyPartRef.'
+        : '';
+      throw new KernelError(
+        'feature.invalid-args',
+        `subAssembly('${name}').${method}: '${origPartName}' is not a part of the imported assembly '${other.name}'. Known parts: ${known}.`,
+        undefined,
+        `Pass the ORIGINAL part name (before prefixing).${extraHint}`,
+      );
+    };
     return {
       prefix,
       ref: (origPartName: string, connectorName?: string): string => {
-        if (!importedByOriginalName.has(origPartName)) {
-          throw new KernelError(
-            'feature.invalid-args',
-            `subAssembly('${name}').ref: '${origPartName}' is not a part of the imported assembly '${other.name}'. Known parts: ${[...importedByOriginalName.keys()].join(', ') || '(none)'}.`,
-            undefined,
-            "Pass the ORIGINAL part name (before prefixing). Use sub.part(name) to grab the imported AssemblyPartRef.",
-          );
-        }
+        requireImportedPart(origPartName, 'ref');
         return connectorName !== undefined
           ? `${prefix}${origPartName}.${connectorName}`
           : `${prefix}${origPartName}`;
       },
-      part: (origPartName: string): AssemblyPartRef => {
-        const ref = importedByOriginalName.get(origPartName);
-        if (!ref) {
-          throw new KernelError(
-            'feature.invalid-args',
-            `subAssembly('${name}').part: '${origPartName}' is not a part of the imported assembly '${other.name}'. Known parts: ${[...importedByOriginalName.keys()].join(', ') || '(none)'}.`,
-            undefined,
-            'Pass the ORIGINAL part name (before prefixing).',
-          );
-        }
-        return ref;
-      },
+      part: (origPartName: string): AssemblyPartRef => requireImportedPart(origPartName, 'part'),
     };
   }
 

--- a/src/studio/components/demoPlayer/DemoPlayerPage.tsx
+++ b/src/studio/components/demoPlayer/DemoPlayerPage.tsx
@@ -281,24 +281,19 @@ export function DemoPlayerPage(): React.JSX.Element {
         const up = new THREE.Vector3().crossVectors(camDir, right).normalize();
         // Project all 8 bbox corners onto the screen-plane axes. The max
         // |right-component| / aspect and |up-component| set the required
-        // horizontal/vertical half-extents that must fit the FOV.
-        const corners: [number, number, number][] = [
-          [bbox.min.x, bbox.min.y, bbox.min.z],
-          [bbox.max.x, bbox.min.y, bbox.min.z],
-          [bbox.min.x, bbox.max.y, bbox.min.z],
-          [bbox.max.x, bbox.max.y, bbox.min.z],
-          [bbox.min.x, bbox.min.y, bbox.max.z],
-          [bbox.max.x, bbox.min.y, bbox.max.z],
-          [bbox.min.x, bbox.max.y, bbox.max.z],
-          [bbox.max.x, bbox.max.y, bbox.max.z],
-        ];
+        // horizontal/vertical half-extents that must fit the FOV. Operate on
+        // raw min/max components so we don't allocate 8 Vector3s per call.
         const aspect = ctx.camera.aspect;
+        const rx = right.x, ry = right.y, rz = right.z;
+        const ux = up.x, uy = up.y, uz = up.z;
+        const xs = [bbox.min.x, bbox.max.x];
+        const ys = [bbox.min.y, bbox.max.y];
+        const zs = [bbox.min.z, bbox.max.z];
         let halfHoriz = 0;
         let halfVert = 0;
-        for (const c of corners) {
-          const v = new THREE.Vector3(c[0], c[1], c[2]);
-          const h = Math.abs(v.dot(right));
-          const u = Math.abs(v.dot(up));
+        for (const cx of xs) for (const cy of ys) for (const cz of zs) {
+          const h = Math.abs(cx * rx + cy * ry + cz * rz);
+          const u = Math.abs(cx * ux + cy * uy + cz * uz);
           if (h > halfHoriz) halfHoriz = h;
           if (u > halfVert) halfVert = u;
         }


### PR DESCRIPTION
## Summary

Closes 6 of the 8 high-impact findings from the develop-branch slop audit (v0.8.0..develop, 73 files / +2983/-280). The two skipped findings are explained inline.

## What landed

- **Fix #3 — `parseConnectorRef`**: `subAssembly().remapRef` was hand-rolling `indexOf('.') / slice` instead of using the helper `src/modeling/mates/mate.ts:74` already exports.
- **Fix #5 — subAssembly handle dedup**: `.ref()` and `.part()` each independently threw a near-identical `KernelError`; extracted `requireImportedPart()`.
- **Fix #2 + #1 (high part) — fillet/chamfer extraction**: two near-identical 50-line edge-length filter blocks in `occtLowerer.ts` collapsed into one `filterEdgesByMinLength()` helper. Pulled the 4× inlined 150-char hint string from `HINT_TEMPLATES['feature.edge-feature.short-edges-skipped']`. Also fixed a pre-existing copy-paste typo: fillet warn message said `'chamfering the remaining N'` → now `'filleting the remaining N'`.
- **Fix #4 — funnel error-code union**: `GenerationPhase.error.code` was typed as raw `string`. Introduced `FunnelClientErrorCode` (closed) + `FunnelErrorCode = ClientCode | \`http_\${number}\` | (string & {})` to keep server-relayed codes open while gaining autocomplete for the client vocabulary.
- **Fix #6 — single-pass dev-chrome scrub**: `stripDevChrome` walked `document.querySelectorAll('*')` per view AND per pose. The "HMR / React double-render after mesh load" justification doesn't hold in headless production playwright. Moved to one call after `forceFullOpacity()`.
- **Fix #8 — drop 8 Vector3 allocations per `setRenderPose`**: bbox-corner projection now uses raw `bbox.min/max` component math instead of allocating 8 `THREE.Vector3` instances per call.

## What I did NOT do (and why)

- **Fix #1 structural — diagnostic-code 4-source-of-truth**: the codes are listed in 4 places (`DiagnosticCode` union + `DIAGNOSTIC_CODES` array + `NEXT_ACTIONS` record + hint templates). Consolidating to one entry-per-code requires a non-trivial refactor of the diagnostic system and the structural debt is **pre-existing**, not new in v0.8.0..develop. Deserves its own spec. The high-impact part of the finding (4× inlined hints in the lowerer) IS fixed here via `HINT_TEMPLATES`.
- **Fix #7 — parallelize headless screenshot loop**: false-positive audit finding. Screenshots share a single Page's WebGL state; `setRenderView → screenshot` is mutate-then-snap, not independent. `Promise.all` would race the camera state and produce duplicate frames. Multi-page parallelization would cost more in browser memory/warmup than it saves for 4 views.

## Verification

- `pnpm typecheck` — clean
- `pnpm build:cli` — `dist/cli/index.js` builds clean
- Full vitest run: **400 files / 2254 tests pass, 21 skipped, 0 failed** (~3.5 min)
- The 5 failures in the initial run were all pre-existing build-prerequisite failures (CLI bundle tests + NURBS integration tests both need `dist/cli/index.js`); resolved by running `build:cli` first per the in-test comment.

## Test plan

- [ ] Skim the diagnostic-message change in `occtLowerer.ts` — the fillet warn gerund went from `chamfering` to `filleting`. SKILL.md `kernelcad-from-reference/use-the-available-kernel/SKILL.md` discusses only the chamfer message, so no doc update needed.
- [ ] Confirm headless render still strips devtools — visually inspect a `kernelcad render` output before merge.
- [ ] Confirm SubAssembly + composition still works — `tests/integration/assemblies/subAssembly.test.ts` exercises this (passing).