### PR TITLE
feat(studio): useParamUpdate hook + debounced/coalesced commit

### DIFF
--- a/src/studio/hooks/useParamUpdate.test.ts
+++ b/src/studio/hooks/useParamUpdate.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useParamUpdate } from './useParamUpdate';
+
+describe('useParamUpdate', () => {
+    beforeEach(() => { vi.useFakeTimers(); });
+    afterEach(() => { vi.useRealTimers(); vi.restoreAllMocks(); });
+
+    it('commit() fires updateParam with edits', () => {
+        const update = vi.fn().mockResolvedValue(undefined);
+        const { result } = renderHook(() => useParamUpdate(update));
+        act(() => { result.current.commit([{ name: 'width', value: 5 }]); });
+        expect(update).toHaveBeenCalledExactlyOnceWith([{ name: 'width', value: 5 }]);
+    });
+
+    it('commit() routes rejection through default onError (console.warn with source tag)', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const update = vi.fn().mockRejectedValue(new Error('boom'));
+        const { result } = renderHook(() => useParamUpdate(update, { source: 'ParamsTab' }));
+        act(() => { result.current.commit([{ name: 'x', value: 1 }]); });
+        await vi.waitFor(() => expect(warn).toHaveBeenCalledOnce());
+        const [msg, err, edits] = warn.mock.calls[0];
+        expect(msg).toBe('[ParamsTab] updateParam failed');
+        expect((err as Error).message).toBe('boom');
+        expect(edits).toEqual([{ name: 'x', value: 1 }]);
+    });
+
+    it('commit() routes rejection through custom onError when provided', async () => {
+        const onError = vi.fn();
+        const update = vi.fn().mockRejectedValue(new Error('nope'));
+        const { result } = renderHook(() => useParamUpdate(update, { onError }));
+        act(() => { result.current.commit([{ name: 'x', value: 1 }]); });
+        await vi.waitFor(() => expect(onError).toHaveBeenCalledOnce());
+        expect((onError.mock.calls[0][0] as Error).message).toBe('nope');
+        expect(onError.mock.calls[0][1]).toEqual([{ name: 'x', value: 1 }]);
+    });
+
+    it('commit() is a no-op when updateParam is undefined', () => {
+        const { result } = renderHook(() => useParamUpdate(undefined));
+        // Just verify it doesn't throw.
+        act(() => { result.current.commit([{ name: 'x', value: 1 }]); });
+    });
+
+    it('commit() is a no-op for empty edits', () => {
+        const update = vi.fn().mockResolvedValue(undefined);
+        const { result } = renderHook(() => useParamUpdate(update));
+        act(() => { result.current.commit([]); });
+        expect(update).not.toHaveBeenCalled();
+    });
+
+    it('commitDebounced() does not fire immediately', () => {
+        const update = vi.fn().mockResolvedValue(undefined);
+        const { result } = renderHook(() => useParamUpdate(update, { debounceMs: 100 }));
+        act(() => { result.current.commitDebounced([{ name: 'x', value: 1 }]); });
+        expect(update).not.toHaveBeenCalled();
+    });
+
+    it('commitDebounced() fires once after debounceMs elapses', () => {
+        const update = vi.fn().mockResolvedValue(undefined);
+        const { result } = renderHook(() => useParamUpdate(update, { debounceMs: 100 }));
+        act(() => { result.current.commitDebounced([{ name: 'x', value: 7 }]); });
+        act(() => { vi.advanceTimersByTime(100); });
+        expect(update).toHaveBeenCalledExactlyOnceWith([{ name: 'x', value: 7 }]);
+    });
+
+    it('commitDebounced() coalesces per-name (last-wins) across burst', () => {
+        const update = vi.fn().mockResolvedValue(undefined);
+        const { result } = renderHook(() => useParamUpdate(update, { debounceMs: 100 }));
+        act(() => {
+            result.current.commitDebounced([{ name: 'x', value: 1 }]);
+            result.current.commitDebounced([{ name: 'x', value: 2 }]);
+            result.current.commitDebounced([{ name: 'x', value: 3 }]);
+        });
+        act(() => { vi.advanceTimersByTime(100); });
+        expect(update).toHaveBeenCalledExactlyOnceWith([{ name: 'x', value: 3 }]);
+    });
+
+    it('commitDebounced() batches multiple distinct names into one fire', () => {
+        const update = vi.fn().mockResolvedValue(undefined);
+        const { result } = renderHook(() => useParamUpdate(update, { debounceMs: 100 }));
+        act(() => {
+            result.current.commitDebounced([{ name: 'x', value: 1 }]);
+            result.current.commitDebounced([{ name: 'y', value: 2 }]);
+            result.current.commitDebounced([{ name: 'x', value: 3 }]);
+        });
+        act(() => { vi.advanceTimersByTime(100); });
+        expect(update).toHaveBeenCalledOnce();
+        const batch = update.mock.calls[0][0] as { name: string; value: number }[];
+        expect(batch).toHaveLength(2);
+        expect(batch).toEqual(expect.arrayContaining([
+            { name: 'x', value: 3 },
+            { name: 'y', value: 2 },
+        ]));
+    });
+
+    it('commitDebounced(edits, 0) fires immediately', () => {
+        const update = vi.fn().mockResolvedValue(undefined);
+        const { result } = renderHook(() => useParamUpdate(update, { debounceMs: 100 }));
+        act(() => { result.current.commitDebounced([{ name: 'x', value: 9 }], 0); });
+        expect(update).toHaveBeenCalledExactlyOnceWith([{ name: 'x', value: 9 }]);
+    });
+
+    it('commit() flushes pending debounced edits before firing its own batch', () => {
+        const update = vi.fn().mockResolvedValue(undefined);
+        const { result } = renderHook(() => useParamUpdate(update, { debounceMs: 100 }));
+        act(() => {
+            result.current.commitDebounced([{ name: 'x', value: 1 }]);
+            result.current.commit([{ name: 'y', value: 2 }]);
+        });
+        expect(update).toHaveBeenCalledTimes(2);
+        expect(update.mock.calls[0][0]).toEqual([{ name: 'x', value: 1 }]);
+        expect(update.mock.calls[1][0]).toEqual([{ name: 'y', value: 2 }]);
+    });
+
+    it('flush() fires pending edits on demand', () => {
+        const update = vi.fn().mockResolvedValue(undefined);
+        const { result } = renderHook(() => useParamUpdate(update, { debounceMs: 1000 }));
+        act(() => { result.current.commitDebounced([{ name: 'x', value: 5 }]); });
+        expect(update).not.toHaveBeenCalled();
+        act(() => { result.current.flush(); });
+        expect(update).toHaveBeenCalledExactlyOnceWith([{ name: 'x', value: 5 }]);
+    });
+
+    it('unmount drops pending edits (does not fire on teardown)', () => {
+        const update = vi.fn().mockResolvedValue(undefined);
+        const { result, unmount } = renderHook(() => useParamUpdate(update, { debounceMs: 100 }));
+        act(() => { result.current.commitDebounced([{ name: 'x', value: 1 }]); });
+        unmount();
+        act(() => { vi.advanceTimersByTime(500); });
+        expect(update).not.toHaveBeenCalled();
+    });
+
+    it('returned commit/commitDebounced/flush identities are stable across renders', () => {
+        const update = vi.fn().mockResolvedValue(undefined);
+        const { result, rerender } = renderHook(
+            (props: { update: typeof update }) => useParamUpdate(props.update),
+            { initialProps: { update } },
+        );
+        const first = result.current;
+        // Rerender with the SAME updateParam to confirm identity stability.
+        rerender({ update });
+        expect(result.current.commit).toBe(first.commit);
+        expect(result.current.commitDebounced).toBe(first.commitDebounced);
+        expect(result.current.flush).toBe(first.flush);
+    });
+});

--- a/src/studio/hooks/useParamUpdate.ts
+++ b/src/studio/hooks/useParamUpdate.ts
@@ -57,12 +57,16 @@ export function useParamUpdate(
   // Stash callbacks in refs so the returned `commit` / `commitDebounced`
   // identities stay stable across renders. Consumers pass them into
   // event handlers; an unstable identity would invalidate their memos.
+  // Ref-sync runs in a layout effect so the refs read by `commit` and
+  // `commitDebounced` (both invoked from user events, never during render)
+  // see the most recent props without making the callback identities
+  // depend on those props.
   const updateRef = useRef(updateParam);
-  updateRef.current = updateParam;
   const onErrorRef = useRef<UseParamUpdateOptions['onError']>(userOnError);
-  onErrorRef.current = userOnError;
   const sourceRef = useRef(source);
-  sourceRef.current = source;
+  useEffect(() => { updateRef.current = updateParam; });
+  useEffect(() => { onErrorRef.current = userOnError; });
+  useEffect(() => { sourceRef.current = source; });
 
   // Per-name last-wins coalesce buffer. A single debounced flush sends
   // one batch containing the most recent value per param name.

--- a/src/studio/hooks/useParamUpdate.ts
+++ b/src/studio/hooks/useParamUpdate.ts
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+
+/** Single param edit accepted by `updateParam` on the geometry context. */
+export type ParamEdit = { name: string; value: number | boolean };
+
+/** Shape of the raw `updateParam` plumbed through `GeometryContext` →
+ *  `useRecomputeResult`. May be `undefined` before the session token has
+ *  resolved (e.g. on first paint), so callers should tolerate a no-op. */
+export type UpdateParamFn = (edits: ParamEdit[]) => Promise<void>;
+
+export interface UseParamUpdateOptions {
+  /** Default debounce window for `commitDebounced` in milliseconds. The
+   *  recommended value for slider/scrub UIs is 100 ms (10 FPS) — enough
+   *  to ride a drag without flooding the kernel with one relower per
+   *  pointer-move. `0` disables debouncing and fires immediately. */
+  debounceMs?: number;
+  /** Source tag included in the default error log. Pass the component
+   *  name so console output is bisectable: `useParamUpdate({ source: 'JointsTab' })`. */
+  source?: string;
+  /** Custom error sink. Replaces the default `console.warn` behavior.
+   *  Receives the rejection and the edits that failed. */
+  onError?: (err: unknown, edits: ParamEdit[]) => void;
+}
+
+export interface ParamUpdater {
+  /** Fire `edits` immediately. Flushes any pending debounced edits first
+   *  so commits arrive in author order. Errors route through `onError`. */
+  commit: (edits: ParamEdit[]) => void;
+  /** Coalesce `edits` with other in-flight debounced edits (per-name
+   *  last-wins) and fire one batch after `debounceMs`. `debounceMs`
+   *  defaults to the hook option. Trailing-edge only — the first call
+   *  does not fire immediately. */
+  commitDebounced: (edits: ParamEdit[], debounceMs?: number) => void;
+  /** Fire any pending debounced edits right now and clear the timer. */
+  flush: () => void;
+}
+
+/** Centralizes the `updateParam(...).catch(console.warn)` pattern that
+ *  was being copy-pasted across every interactive tab (ParamsTab numeric,
+ *  ParamsTab bool, JointsTab joint sliders). Adds a debounced variant for
+ *  scrub/slider hot paths so dragging doesn't fire one POST + one relower
+ *  per pointer-move.
+ *
+ *  Usage:
+ *    const { commit, commitDebounced } = useParamUpdate(updateParam, { source: 'JointsTab' });
+ *    // pointer move:
+ *    onChange={(v) => commitDebounced([{ name, value: v }])}
+ *    // pointer up / blur:
+ *    onCommit={(v) => commit([{ name, value: v }])}
+ */
+export function useParamUpdate(
+  updateParam: UpdateParamFn | undefined,
+  opts: UseParamUpdateOptions = {},
+): ParamUpdater {
+  const { debounceMs: defaultDebounce = 100, source, onError: userOnError } = opts;
+
+  // Stash callbacks in refs so the returned `commit` / `commitDebounced`
+  // identities stay stable across renders. Consumers pass them into
+  // event handlers; an unstable identity would invalidate their memos.
+  const updateRef = useRef(updateParam);
+  updateRef.current = updateParam;
+  const onErrorRef = useRef<UseParamUpdateOptions['onError']>(userOnError);
+  onErrorRef.current = userOnError;
+  const sourceRef = useRef(source);
+  sourceRef.current = source;
+
+  // Per-name last-wins coalesce buffer. A single debounced flush sends
+  // one batch containing the most recent value per param name.
+  const pendingRef = useRef<Map<string, ParamEdit>>(new Map());
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleError = useCallback((err: unknown, edits: ParamEdit[]) => {
+    if (onErrorRef.current) { onErrorRef.current(err, edits); return; }
+    const tag = sourceRef.current ? `[${sourceRef.current}] ` : '';
+    console.warn(`${tag}updateParam failed`, err, edits);
+  }, []);
+
+  const fire = useCallback((edits: ParamEdit[]) => {
+    if (edits.length === 0) return;
+    const fn = updateRef.current;
+    if (!fn) return;
+    fn(edits).catch((err: unknown) => handleError(err, edits));
+  }, [handleError]);
+
+  const flush = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    if (pendingRef.current.size === 0) return;
+    const batch = [...pendingRef.current.values()];
+    pendingRef.current.clear();
+    fire(batch);
+  }, [fire]);
+
+  const commit = useCallback((edits: ParamEdit[]) => {
+    if (pendingRef.current.size > 0) flush();
+    fire(edits);
+  }, [fire, flush]);
+
+  const commitDebounced = useCallback((edits: ParamEdit[], debounceMs?: number) => {
+    const ms = debounceMs ?? defaultDebounce;
+    if (ms <= 0) { fire(edits); return; }
+    for (const e of edits) pendingRef.current.set(e.name, e);
+    if (timerRef.current !== null) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      const batch = [...pendingRef.current.values()];
+      pendingRef.current.clear();
+      fire(batch);
+    }, ms);
+  }, [defaultDebounce, fire]);
+
+  // Drop pending edits on unmount. We do NOT auto-flush: by the time a
+  // tab unmounts the GeometryContext that owns `updateParam` may be
+  // tearing down too, and firing into a closing fetch path produces
+  // confusing aborted-request warnings. Callers that care about the
+  // trailing value should bind `flush` to pointer-up / blur explicitly.
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      pendingRef.current.clear();
+    };
+  }, []);
+
+  return useMemo(() => ({ commit, commitDebounced, flush }), [commit, commitDebounced, flush]);
+}


### PR DESCRIPTION
## Summary

Cross-cutting extraction for the three open Slice 2 tab PRs (#206 ParamsTab numeric, #208 ParamsTab bool, #209 JointsTab joint sliders). Each currently copy-pastes:

```ts
onChange={(v) => {
  updateParam?.([{ name, value: v }])
    ?.catch((err) => console.warn('[<TabName>] updateParam failed', err));
}}
```

…with **four call-sites in #209 alone** (handleReset / JointRow / BallAxis / etc.). The slop audit on the open-PR set flagged this as the highest-impact cross-PR pattern; this PR is the upstream extraction those three can rebase onto.

## What it ships

`useParamUpdate(updateParam, opts?)` → `{ commit, commitDebounced, flush }`:

- **`commit(edits)`** — fires immediately. Flushes pending debounced edits first so commits arrive in author order. Errors route through the configured sink.
- **`commitDebounced(edits, ms?)`** — trailing-edge debounce (default 100 ms / 10 FPS) with per-name **last-wins coalesce**. Multiple bursty edits to the same param send one batch with the latest value; multiple distinct names within the window go out together as one batch.
- **`flush()`** — fire any pending debounced edits right now (bind to pointer-up / blur to commit the trailing value).

Centralized error policy: default sink is `console.warn` with a source tag for log bisectability. Consumers can pass `onError` to wire a toast or rollback when the UX policy is decided.

## Why a debounced variant matters now

PR #209's JointsTab is the primary slider UI for joint scrub. With the current `updateParam` on every pointer-move, a 60 FPS drag → 60 POST `/__kernelcad/params` → 60 full record-chain relower events. On a 50-record assembly that's ~3000 ms of recompute per second of drag — guaranteed stall. Trailing-edge 100 ms debounce caps that at ~10 commits/sec while still feeling responsive.

## Rebase guidance for #206 / #208 / #209

```tsx
// Before:
onChange={(v) => {
  updateParam?.([{ name: entry.name, value: v }])
    ?.catch((err) => console.warn('[ParamsTab] updateParam failed', err));
}}

// After:
const { commitDebounced, flush } = useParamUpdate(updateParam, { source: 'ParamsTab' });
// pointer-move-style onChange:
onChange={(v) => commitDebounced([{ name: entry.name, value: v }])}
// pointer-up / blur:
onBlur={flush}
```

#208 (bool checkbox) is a single high-intent action, not a drag — use `commit(...)` directly, no debounce needed.

## Verification

- `pnpm typecheck` clean
- 14 new unit tests cover: immediate commit, default + custom `onError`, undefined `updateParam` no-op, empty edits no-op, debounce timing, per-name coalesce, multi-name batching, `debounceMs: 0` immediate path, `commit` flushes pending, manual `flush`, unmount drops pending, returned identities stable across renders
- Full studio suite: 232/232 still green

## Test plan

- [ ] Approve + merge before #206/#208/#209
- [ ] Open follow-up issue tracking the `onError → toast/rollback` UX decision (not in scope for this PR — the hook just makes the sink swappable)