### PR TITLE
refactor(studio): migrate ParamsTab + JointsTab to useParamUpdate

### DIFF
--- a/src/studio/tabs/JointsTab.tsx
+++ b/src/studio/tabs/JointsTab.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from 'react';
 import { useRecomputeResult } from '../hooks/useRecomputeResult';
+import { useParamUpdate } from '../hooks/useParamUpdate';
 import { NumericScrubInput } from '../components/inputs/NumericScrubInput';
 import type { JointPoseSnapshot } from '../adapters/featureRecordsToMates';
 
@@ -18,6 +19,10 @@ const ROTATIONAL_TYPES = new Set(['revolute', 'cylindrical', 'pin_slot', 'ball']
 
 export function JointsTab(): JSX.Element {
     const { joints, updateParam } = useRecomputeResult();
+    // Joint sliders are the heaviest scrub UI (one drag → full record-chain
+    // relower per pointer-move on a 50+ part assembly). Route through the
+    // debounced commit so 60 FPS drag becomes 10 commits/sec.
+    const updater = useParamUpdate(updateParam, { source: 'JointsTab' });
     const posed = joints ?? [];
 
     if (posed.length === 0) {
@@ -32,7 +37,6 @@ export function JointsTab(): JSX.Element {
     }
 
     const handleReset = (): void => {
-        if (!updateParam) return;
         const edits: { name: string; value: number }[] = [];
         for (const j of posed) {
             for (const pname of j.poseParamNames) {
@@ -40,7 +44,7 @@ export function JointsTab(): JSX.Element {
             }
         }
         if (edits.length === 0) return;
-        updateParam(edits)?.catch((err) => console.warn('[JointsTab] reset failed', err));
+        updater.commit(edits);
     };
 
     const partCount = new Set(posed.flatMap((j) => [j.mate.a.split('.')[0], j.mate.b.split('.')[0]])).size;
@@ -54,9 +58,7 @@ export function JointsTab(): JSX.Element {
                         key={snap.mate.name}
                         snap={snap}
                         onChange={(name, value) => {
-                            updateParam?.([{ name, value }])?.catch((err) =>
-                                console.warn('[JointsTab] updateParam failed', err),
-                            );
+                            updater.commitDebounced([{ name, value }]);
                         }}
                     />
                 ))}

--- a/src/studio/tabs/ParamsTab.tsx
+++ b/src/studio/tabs/ParamsTab.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from 'react';
 import { useRecomputeResult } from '../hooks/useRecomputeResult';
+import { useParamUpdate, type ParamUpdater } from '../hooks/useParamUpdate';
 import type { ParamEntry } from '../../shared/runtime/paramTable';
 import { NumericScrubInput } from '../components/inputs/NumericScrubInput';
 
@@ -13,6 +14,11 @@ import { NumericScrubInput } from '../components/inputs/NumericScrubInput';
  */
 export function ParamsTab(): JSX.Element {
     const { paramTable, joints, updateParam } = useRecomputeResult();
+    // Single shared updater for every row in this tab. Numeric scrubs get
+    // a debounced send so slider drag doesn't fire one POST + one full
+    // relower per pointer-move; boolean toggles are single high-intent
+    // clicks, so they fire immediately via `commit`.
+    const updater = useParamUpdate(updateParam, { source: 'ParamsTab' });
 
     // Slice 2C: hide params that are surfaced as joint poses in JointsTab so
     // the same scalar isn't edited from two places. `poseParamNames` may
@@ -43,7 +49,7 @@ export function ParamsTab(): JSX.Element {
         <div className="flex flex-col" data-testid="params-tab">
             <ul className="flex flex-col divide-y divide-[#1f1f1f]">
                 {entries.map((entry) => (
-                    <ParamRow key={entry.name} entry={entry} updateParam={updateParam} />
+                    <ParamRow key={entry.name} entry={entry} updater={updater} />
                 ))}
             </ul>
         </div>
@@ -52,12 +58,10 @@ export function ParamsTab(): JSX.Element {
 
 interface ParamRowProps {
     readonly entry: ParamEntry;
-    readonly updateParam?: (
-        edits: { name: string; value: number | boolean }[],
-    ) => Promise<void>;
+    readonly updater: ParamUpdater;
 }
 
-function ParamRow({ entry, updateParam }: ParamRowProps): JSX.Element {
+function ParamRow({ entry, updater }: ParamRowProps): JSX.Element {
     if (entry.type === 'boolean') {
         return (
             <li
@@ -71,8 +75,7 @@ function ParamRow({ entry, updateParam }: ParamRowProps): JSX.Element {
                     type="checkbox"
                     checked={entry.value as boolean}
                     onChange={(e) => {
-                        updateParam?.([{ name: entry.name, value: e.target.checked }])
-                            ?.catch((err) => console.warn('[ParamsTab] updateParam failed', err));
+                        updater.commit([{ name: entry.name, value: e.target.checked }]);
                     }}
                     aria-label={`${entry.name} value`}
                     data-testid={`param-checkbox-${entry.name}`}
@@ -96,8 +99,7 @@ function ParamRow({ entry, updateParam }: ParamRowProps): JSX.Element {
                 min={min}
                 max={max}
                 onChange={(next) => {
-                    updateParam?.([{ name: entry.name, value: next }])
-                        ?.catch((err) => console.warn('[ParamsTab] updateParam failed', err));
+                    updater.commitDebounced([{ name: entry.name, value: next }]);
                 }}
             />
         </li>


### PR DESCRIPTION
## Summary

Carryover cleanup from #212. The three Slice 2 tab PRs (#206/#208/#209) shipped before the `useParamUpdate` hook landed, so their onChange handlers still inline `updateParam?.([...])?.catch((err) => console.warn(...))` in **4 call-sites** across two tabs. This PR migrates all of them.

## Migration

| Site | Before | After | Rationale |
|---|---|---|---|
| `ParamsTab` numeric scrub | inline `.catch` per pointer-move | `commitDebounced` (100 ms trailing) | Slider drag at 60 FPS → 10 commits/sec instead of one full record-chain relower per pointer-move |
| `ParamsTab` boolean checkbox | inline `.catch` per toggle | `commit` (immediate) | Single high-intent click; no debounce needed |
| `JointsTab` joint slider | inline `.catch` per pointer-move | `commitDebounced` | Heaviest scrub UI; was recomputing 50-record assembly per pointer-move |
| `JointsTab` handleReset | inline `.catch` per click | `commit` | Single high-intent click |

Hook call is hoisted to each tab's root so a shared updater **coalesces edits across rows** (per-name last-wins). Error policy now lives in one place — the default `console.warn` is preserved with the `[ParamsTab]` / `[JointsTab]` source tag, so log noise is unchanged. Swap `onError` when the team picks the long-term UX (toast vs rollback).

## Verification

- `pnpm typecheck` — clean (0 errors)
- `pnpm lint src/studio/tabs/*.tsx` — 0 errors, 0 new warnings
- Full studio + integration suite: **246/246 green** (52 test files). The existing `paramsTabScrub` (5 tests) + `jointsTabSweep` (4 tests) tolerate the 100 ms debounce via their existing `waitFor(...)` blocks — no test changes needed.

## Test plan

- [ ] Drag a slider in ParamsTab — confirm 3D view doesn't stall (debounce caps relower at 10 FPS)
- [ ] Drag a joint slider in JointsTab on a 50-record assembly — confirm same
- [ ] Hit "↻ reset all to rest" — confirm joints zero out and the kernel relower fires once with the full batch
- [ ] Toggle a boolean param — confirm immediate response (no debounce)