### PR TITLE
feat(intent): Curve3DMetadata + curve3d/variableSweep FeatureKinds (NURBS Slice B Task 1)

### DIFF
--- a/src/shared/intent/curve3dRecord.ts
+++ b/src/shared/intent/curve3dRecord.ts
@@ -1,0 +1,62 @@
+import type { Vec3 } from './types';
+
+/**
+ * Capture-time metadata for a Curve3D feature. A Curve3D is a 3D parametric
+ * curve produced by `nurbsCurve(controlPoints, opts)` (and convenience peers
+ * like `spline3d`). It is captured as a `FeatureRecord` of kind `'curve3d'`
+ * and lowered to a `TopoDS_Edge` backed by `Geom_BSplineCurve` (direct
+ * OCCT — no replicad wrapper). The proxy exposes synchronous `sample`,
+ * `pointAt`, `tangentAt`, `length`, `domain` via a lazy-lower-on-first-call
+ * pattern; the lower stores the edge on `session.importedGeometry` so it
+ * survives subsequent capture calls.
+ *
+ * Validation rules (mirrored by `isCurve3DMetadata` below):
+ * - `controlPoints` must have at least `degree + 1` entries, each a 3D
+ *   point with finite coordinates.
+ * - `degree` must be a positive integer.
+ * - `weights`, when supplied, must have exactly `controlPoints.length`
+ *   entries and every weight must be finite and strictly positive (a zero
+ *   weight collapses the basis; a negative weight is geometrically
+ *   meaningless for B-spline curves).
+ * - `knots`, when supplied, must have exactly
+ *   `controlPoints.length + degree + 1` entries (the standard non-periodic
+ *   B-spline knot count). A monotonicity check is deferred to the lowerer
+ *   so that the JS guard stays cheap.
+ * - `closed` defaults to `false`; the lowerer reads it to decide whether
+ *   to call `BRepBuilderAPI_MakeEdge` against a periodic curve.
+ */
+export interface Curve3DMetadata {
+  controlPoints: Vec3[];
+  degree: number;
+  weights?: number[];
+  knots?: number[];
+  closed?: boolean;
+}
+
+export function isCurve3DMetadata(value: unknown): value is Curve3DMetadata {
+  if (typeof value !== 'object' || value === null) return false;
+  const m = value as Curve3DMetadata;
+
+  if (!Array.isArray(m.controlPoints)) return false;
+  if (typeof m.degree !== 'number' || !Number.isInteger(m.degree) || m.degree < 1) return false;
+  if (m.controlPoints.length < m.degree + 1) return false;
+  for (const p of m.controlPoints) {
+    if (!Array.isArray(p) || p.length !== 3) return false;
+    if (!p.every((c) => typeof c === 'number' && Number.isFinite(c))) return false;
+  }
+
+  if (m.weights !== undefined) {
+    if (!Array.isArray(m.weights) || m.weights.length !== m.controlPoints.length) return false;
+    if (!m.weights.every((w) => typeof w === 'number' && Number.isFinite(w) && w > 0)) return false;
+  }
+
+  if (m.knots !== undefined) {
+    const expectedKnots = m.controlPoints.length + m.degree + 1;
+    if (!Array.isArray(m.knots) || m.knots.length !== expectedKnots) return false;
+    if (!m.knots.every((k) => typeof k === 'number' && Number.isFinite(k))) return false;
+  }
+
+  if (m.closed !== undefined && typeof m.closed !== 'boolean') return false;
+
+  return true;
+}

--- a/src/shared/intent/featureRecord.ts
+++ b/src/shared/intent/featureRecord.ts
@@ -5,6 +5,7 @@ import type {
 export type { CanonicalFace };
 import type { FaceQuery } from './queryTypes';
 import type { PBRMaterial } from './material';
+import type { Curve3DMetadata } from './curve3dRecord';
 
 export type ShapeTransform =
   | { op: 'translate'; vec: Vec3Param }
@@ -27,6 +28,9 @@ export interface FeatureMetadata {
   /** true for capture-graph nodes that produce no OcctBackend geometry
    *  (referenceImage today; future construction-only feature kinds may set this). */
   virtual?: boolean;
+  /** NURBS Slice B: control-net spec for a `curve3d` feature. Read by the
+   *  Curve3D lowerer to build a `Geom_BSplineCurve`. */
+  curve3d?: Curve3DMetadata;
   /**
    * Catch-all for feature-kind-specific keys (commands, poses, partIds,
    * bendRecord, etc.) accessed via cast in individual lowerers. Promote a

--- a/src/shared/intent/types.ts
+++ b/src/shared/intent/types.ts
@@ -145,7 +145,11 @@ export type FeatureKind =
   // W1.3 NURBS surfaces — escape paths from a `Surface` into the Shape pipeline.
   | 'surfaceThicken' | 'surfaceToShape'
   // Slice A: reference-image overlay node (capture-only, no OCCT output).
-  | 'referenceImage';
+  | 'referenceImage'
+  // NURBS Slice B: 3D parametric curve (Geom_BSplineCurve under the hood)
+  //   and multi-section sweep (BRepOffsetAPI_MakePipeShell).
+  | 'curve3d'
+  | 'variableSweep';
 
 /**
  * Runtime guard for PlaneSpec. Returns true for cardinal strings

--- a/tests/unit/intent/curve3d.test.ts
+++ b/tests/unit/intent/curve3d.test.ts
@@ -1,0 +1,74 @@
+// tests/unit/intent/curve3d.test.ts
+//
+// NURBS Slice B Task 1: type-level guard for Curve3D control-net metadata.
+// Curve3D is a new peer-type alongside Shape/Surface and is captured as a
+// FeatureRecord with metadata.curve3d. Lowering to a Geom_BSplineCurve
+// happens in a later task; this file only covers the JS-level shape.
+
+import { describe, it, expect } from 'vitest';
+import { isCurve3DMetadata, type Curve3DMetadata } from '../../../src/shared/intent/curve3dRecord';
+
+describe('Curve3DMetadata', () => {
+  it('accepts a cubic non-rational curve', () => {
+    const c: Curve3DMetadata = {
+      controlPoints: [
+        [0, 0, 0],
+        [10, 5, 0],
+        [20, -5, 10],
+        [30, 0, 5],
+      ],
+      degree: 3,
+      closed: false,
+    };
+    expect(isCurve3DMetadata(c)).toBe(true);
+  });
+
+  it('accepts a rational curve with weights + knots', () => {
+    const c: Curve3DMetadata = {
+      controlPoints: [
+        [10, 0, 0],
+        [10, 10, 0],
+        [0, 10, 0],
+      ],
+      degree: 2,
+      weights: [1, Math.SQRT1_2, 1],
+      knots: [0, 0, 0, 1, 1, 1],
+      closed: false,
+    };
+    expect(isCurve3DMetadata(c)).toBe(true);
+  });
+
+  it('rejects a control-net with fewer than degree+1 points', () => {
+    expect(isCurve3DMetadata({ controlPoints: [[0, 0, 0]], degree: 3 })).toBe(false);
+  });
+
+  it('rejects non-finite or non-3D control points', () => {
+    expect(isCurve3DMetadata({ controlPoints: [[0, 0]], degree: 1 })).toBe(false);
+    expect(isCurve3DMetadata({ controlPoints: [[0, 0, NaN], [1, 1, 1]], degree: 1 })).toBe(false);
+  });
+
+  it('rejects degree < 1 or non-integer degree', () => {
+    expect(isCurve3DMetadata({ controlPoints: [[0, 0, 0], [1, 1, 1]], degree: 0 })).toBe(false);
+    expect(isCurve3DMetadata({ controlPoints: [[0, 0, 0], [1, 1, 1]], degree: 1.5 })).toBe(false);
+  });
+
+  it('rejects weights with wrong length or non-positive entries', () => {
+    const base = { controlPoints: [[0, 0, 0], [1, 1, 1], [2, 0, 0]], degree: 2 };
+    expect(isCurve3DMetadata({ ...base, weights: [1, 1] })).toBe(false);
+    expect(isCurve3DMetadata({ ...base, weights: [1, 0, 1] })).toBe(false);
+    expect(isCurve3DMetadata({ ...base, weights: [1, -1, 1] })).toBe(false);
+  });
+
+  it('rejects knots with wrong length', () => {
+    const base = { controlPoints: [[0, 0, 0], [1, 1, 1], [2, 0, 0]], degree: 2 };
+    // Required length = controlPoints.length + degree + 1 = 3 + 2 + 1 = 6
+    expect(isCurve3DMetadata({ ...base, knots: [0, 0, 0, 1, 1] })).toBe(false);
+    expect(isCurve3DMetadata({ ...base, knots: [0, 0, 0, 1, 1, 1] })).toBe(true);
+  });
+
+  it('rejects non-object input', () => {
+    expect(isCurve3DMetadata(null)).toBe(false);
+    expect(isCurve3DMetadata('curve')).toBe(false);
+    expect(isCurve3DMetadata(42)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- New `Curve3DMetadata` type + `isCurve3DMetadata` guard in `src/shared/intent/curve3dRecord.ts`
- `'curve3d'` and `'variableSweep'` appended to the `FeatureKind` union
- `curve3d?: Curve3DMetadata` field added to `FeatureMetadata` (`variableSweep?` field deferred to Slice B Task 2 where the metadata type lands)

Foundational types for NURBS Slice B. A `Curve3D` is captured as a `FeatureRecord` of kind `'curve3d'` whose `metadata.curve3d` holds a B-spline control net (control points, degree, optional rational weights, optional knot vector, closed flag). The lowerer in Task 5 will materialize it as a `Geom_BSplineCurve` bound directly to OpenCascade.js (no replicad wrapper). The `variableSheep` kind is added to the union now so later tasks can refer to it; its metadata schema lives with the lowerer in Task 2.

## Validation rules (mirrored by `isCurve3DMetadata`)

- `controlPoints`: ≥ `degree + 1` entries, each finite 3D point
- `degree`: positive integer
- `weights` (optional): same length as `controlPoints`, strictly positive
- `knots` (optional): length = `controlPoints.length + degree + 1`
- `closed`: defaults to `false`

Knot monotonicity is left to the lowerer to keep the JS guard cheap.

## Test plan

- [x] `npx vitest run tests/unit/intent/curve3d.test.ts` — 8 tests pass
- [x] `npx tsc --noEmit` — clean