### PR TITLE
feat(intent): VariableSweepMetadata + t-ordering guard (NURBS Slice B Task 2)

### DIFF
--- a/src/shared/intent/featureRecord.ts
+++ b/src/shared/intent/featureRecord.ts
@@ -6,6 +6,7 @@ export type { CanonicalFace };
 import type { FaceQuery } from './queryTypes';
 import type { PBRMaterial } from './material';
 import type { Curve3DMetadata } from './curve3dRecord';
+import type { VariableSweepMetadata } from './variableSweepRecord';
 
 export type ShapeTransform =
   | { op: 'translate'; vec: Vec3Param }
@@ -31,6 +32,9 @@ export interface FeatureMetadata {
   /** NURBS Slice B: control-net spec for a `curve3d` feature. Read by the
    *  Curve3D lowerer to build a `Geom_BSplineCurve`. */
   curve3d?: Curve3DMetadata;
+  /** NURBS Slice B: multi-section sweep spec consumed by the variableSweep
+   *  lowerer (BRepOffsetAPI_MakePipeShell). */
+  variableSweep?: VariableSweepMetadata;
   /**
    * Catch-all for feature-kind-specific keys (commands, poses, partIds,
    * bendRecord, etc.) accessed via cast in individual lowerers. Promote a

--- a/src/shared/intent/variableSweepRecord.ts
+++ b/src/shared/intent/variableSweepRecord.ts
@@ -1,0 +1,89 @@
+import type { FeatureRef, Vec3 } from './types';
+
+/**
+ * Capture-time metadata for a `variableSweep` feature. A variable-section
+ * sweep blends N profile sketches along a 3D spine curve, parameterized by
+ * `t ∈ [0, 1]` along the spine. Lowering hands the spine + each section to
+ * `BRepOffsetAPI_MakePipeShell::Add(profile, location)` and calls
+ * `Build()` — direct OCCT, bypassing replicad.
+ *
+ * Section authoring rules (enforced by `isVariableSweepMetadata`):
+ * - At least two sections (a one-section sweep is just a regular sweep).
+ * - Sections in strictly increasing `t` order (so the lowerer can walk
+ *   them without sorting).
+ * - The first section must sit at `t === 0`; the last at `t === 1`.
+ *   Intermediate sections may live anywhere in (0, 1). This anchors the
+ *   sweep to the full spine extent — partial-coverage sweeps would
+ *   require a spine sub-range parameter that we don't model today.
+ * - Profile refs must point at a Sketch feature; the lowerer resolves
+ *   them through the existing sketch lifter.
+ *
+ * `closed` / `continuity` / `orientation` are optional knobs the lowerer
+ * reads when building the pipe shell. `'frenet'` rotates the profile
+ * with the curve's tangent + curvature; `{ up: Vec3 }` keeps a fixed
+ * up-vector reference frame; `'discrete'` and `'corrected-frenet'` are
+ * OCCT escape hatches for fast-twisting spines.
+ */
+
+export interface VariableSweepSection {
+  t: number;
+  profileRef: FeatureRef;
+}
+
+export type SweepOrientation =
+  | 'frenet'
+  | 'corrected-frenet'
+  | 'discrete'
+  | { up: Vec3 };
+
+export interface VariableSweepMetadata {
+  spineRef: FeatureRef;
+  sections: VariableSweepSection[];
+  closed?: boolean;
+  continuity?: 'C0' | 'C1' | 'C2';
+  orientation?: SweepOrientation;
+}
+
+function isOrientation(v: unknown): v is SweepOrientation {
+  if (v === 'frenet' || v === 'corrected-frenet' || v === 'discrete') return true;
+  if (typeof v === 'object' && v !== null) {
+    const o = v as { up?: unknown };
+    if (!Array.isArray(o.up) || o.up.length !== 3) return false;
+    return o.up.every((c) => typeof c === 'number' && Number.isFinite(c));
+  }
+  return false;
+}
+
+function isSection(v: unknown): v is VariableSweepSection {
+  if (typeof v !== 'object' || v === null) return false;
+  const s = v as VariableSweepSection;
+  if (typeof s.t !== 'number' || !Number.isFinite(s.t)) return false;
+  if (typeof s.profileRef !== 'object' || s.profileRef === null) return false;
+  if (typeof (s.profileRef as { kind?: unknown }).kind !== 'string') return false;
+  return true;
+}
+
+export function isVariableSweepMetadata(value: unknown): value is VariableSweepMetadata {
+  if (typeof value !== 'object' || value === null) return false;
+  const m = value as VariableSweepMetadata;
+
+  if (typeof m.spineRef !== 'object' || m.spineRef === null) return false;
+  if (typeof (m.spineRef as { kind?: unknown }).kind !== 'string') return false;
+
+  if (!Array.isArray(m.sections) || m.sections.length < 2) return false;
+  for (const s of m.sections) {
+    if (!isSection(s)) return false;
+  }
+  for (let i = 1; i < m.sections.length; i++) {
+    if (m.sections[i].t <= m.sections[i - 1].t) return false;
+  }
+  if (Math.abs(m.sections[0].t - 0) > 1e-9) return false;
+  if (Math.abs(m.sections[m.sections.length - 1].t - 1) > 1e-9) return false;
+
+  if (m.closed !== undefined && typeof m.closed !== 'boolean') return false;
+  if (m.continuity !== undefined &&
+      m.continuity !== 'C0' && m.continuity !== 'C1' && m.continuity !== 'C2') return false;
+  if (m.orientation !== undefined && !isOrientation(m.orientation)) return false;
+
+  return true;
+}

--- a/tests/unit/intent/curve3d.test.ts
+++ b/tests/unit/intent/curve3d.test.ts
@@ -1,12 +1,17 @@
 // tests/unit/intent/curve3d.test.ts
 //
-// NURBS Slice B Task 1: type-level guard for Curve3D control-net metadata.
-// Curve3D is a new peer-type alongside Shape/Surface and is captured as a
-// FeatureRecord with metadata.curve3d. Lowering to a Geom_BSplineCurve
-// happens in a later task; this file only covers the JS-level shape.
+// NURBS Slice B Task 1 + Task 2: type-level guards for Curve3D control-net
+// metadata and VariableSweep section-list metadata. Both are JS-side guards
+// that fence the public capture API against malformed inputs before they
+// reach the OCCT lowerer.
 
 import { describe, it, expect } from 'vitest';
 import { isCurve3DMetadata, type Curve3DMetadata } from '../../../src/shared/intent/curve3dRecord';
+import { isVariableSweepMetadata, type VariableSweepMetadata } from '../../../src/shared/intent/variableSweepRecord';
+import type { FeatureId } from '../../../src/shared/intent/types';
+
+const fid = (s: string) => s as FeatureId;
+const fref = (id: string) => ({ kind: 'feature' as const, id: fid(id) });
 
 describe('Curve3DMetadata', () => {
   it('accepts a cubic non-rational curve', () => {
@@ -70,5 +75,147 @@ describe('Curve3DMetadata', () => {
     expect(isCurve3DMetadata(null)).toBe(false);
     expect(isCurve3DMetadata('curve')).toBe(false);
     expect(isCurve3DMetadata(42)).toBe(false);
+  });
+});
+
+describe('VariableSweepMetadata', () => {
+  it('accepts a minimal 2-section sweep at t=0 and t=1', () => {
+    const m: VariableSweepMetadata = {
+      spineRef: fref('curve3d_1'),
+      sections: [
+        { t: 0, profileRef: fref('sketch_1') },
+        { t: 1, profileRef: fref('sketch_2') },
+      ],
+      closed: false,
+    };
+    expect(isVariableSweepMetadata(m)).toBe(true);
+  });
+
+  it('accepts intermediate sections and full optional knobs', () => {
+    const m: VariableSweepMetadata = {
+      spineRef: fref('curve3d_1'),
+      sections: [
+        { t: 0, profileRef: fref('sketch_1') },
+        { t: 0.3, profileRef: fref('sketch_2') },
+        { t: 0.7, profileRef: fref('sketch_3') },
+        { t: 1, profileRef: fref('sketch_4') },
+      ],
+      continuity: 'C2',
+      orientation: { up: [0, 0, 1] },
+    };
+    expect(isVariableSweepMetadata(m)).toBe(true);
+  });
+
+  it('accepts every cardinal orientation', () => {
+    const base = {
+      spineRef: fref('curve3d_1'),
+      sections: [
+        { t: 0, profileRef: fref('a') },
+        { t: 1, profileRef: fref('b') },
+      ],
+    };
+    expect(isVariableSweepMetadata({ ...base, orientation: 'frenet' })).toBe(true);
+    expect(isVariableSweepMetadata({ ...base, orientation: 'corrected-frenet' })).toBe(true);
+    expect(isVariableSweepMetadata({ ...base, orientation: 'discrete' })).toBe(true);
+    expect(isVariableSweepMetadata({ ...base, orientation: { up: [0, 0, 1] } })).toBe(true);
+  });
+
+  it('rejects sections out of order', () => {
+    expect(isVariableSweepMetadata({
+      spineRef: fref('curve3d_1'),
+      sections: [
+        { t: 0, profileRef: fref('a') },
+        { t: 0.5, profileRef: fref('b') },
+        { t: 0.3, profileRef: fref('c') },
+        { t: 1, profileRef: fref('d') },
+      ],
+    })).toBe(false);
+  });
+
+  it('rejects duplicate t values', () => {
+    expect(isVariableSweepMetadata({
+      spineRef: fref('curve3d_1'),
+      sections: [
+        { t: 0, profileRef: fref('a') },
+        { t: 0.5, profileRef: fref('b') },
+        { t: 0.5, profileRef: fref('c') },
+        { t: 1, profileRef: fref('d') },
+      ],
+    })).toBe(false);
+  });
+
+  it('rejects sections that do not span [0, 1]', () => {
+    // Starts past 0:
+    expect(isVariableSweepMetadata({
+      spineRef: fref('curve3d_1'),
+      sections: [
+        { t: 0.1, profileRef: fref('a') },
+        { t: 0.9, profileRef: fref('b') },
+      ],
+    })).toBe(false);
+    // Ends before 1:
+    expect(isVariableSweepMetadata({
+      spineRef: fref('curve3d_1'),
+      sections: [
+        { t: 0, profileRef: fref('a') },
+        { t: 0.9, profileRef: fref('b') },
+      ],
+    })).toBe(false);
+  });
+
+  it('rejects fewer than 2 sections', () => {
+    expect(isVariableSweepMetadata({
+      spineRef: fref('curve3d_1'),
+      sections: [{ t: 0, profileRef: fref('a') }],
+    })).toBe(false);
+    expect(isVariableSweepMetadata({
+      spineRef: fref('curve3d_1'),
+      sections: [],
+    })).toBe(false);
+  });
+
+  it('rejects malformed spineRef / profileRef / orientation', () => {
+    const base = {
+      sections: [
+        { t: 0, profileRef: fref('a') },
+        { t: 1, profileRef: fref('b') },
+      ],
+    };
+    expect(isVariableSweepMetadata({ ...base, spineRef: 'curve_1' })).toBe(false);
+    expect(isVariableSweepMetadata({ ...base, spineRef: null })).toBe(false);
+    expect(isVariableSweepMetadata({
+      spineRef: fref('curve3d_1'),
+      sections: [
+        { t: 0, profileRef: 'sketch_1' },
+        { t: 1, profileRef: fref('b') },
+      ],
+    })).toBe(false);
+    expect(isVariableSweepMetadata({
+      spineRef: fref('curve3d_1'),
+      sections: base.sections,
+      orientation: { up: [0, 0] },
+    })).toBe(false);
+    expect(isVariableSweepMetadata({
+      spineRef: fref('curve3d_1'),
+      sections: base.sections,
+      orientation: 'tornado',
+    })).toBe(false);
+  });
+
+  it('rejects invalid continuity / closed types', () => {
+    const base = {
+      spineRef: fref('curve3d_1'),
+      sections: [
+        { t: 0, profileRef: fref('a') },
+        { t: 1, profileRef: fref('b') },
+      ],
+    };
+    expect(isVariableSweepMetadata({ ...base, continuity: 'C5' })).toBe(false);
+    expect(isVariableSweepMetadata({ ...base, closed: 'maybe' })).toBe(false);
+  });
+
+  it('rejects non-object input', () => {
+    expect(isVariableSweepMetadata(null)).toBe(false);
+    expect(isVariableSweepMetadata('sweep')).toBe(false);
   });
 });


### PR DESCRIPTION
**Stacked on #217.** Retarget to \`develop\` after #217 merges.

## Summary

\`VariableSweepMetadata\` is the section-list metadata for the future \`variableSweep\` lowerer (\`BRepOffsetAPI_MakePipeShell\`). Sections are anchored to the full spine extent:

- \`t = 0\` at the head, \`t = 1\` at the tail (guard rejects partial-coverage sweeps).
- Strictly increasing \`t\` between sections (so the lowerer can walk without sorting).
- \`profileRef\` is a \`FeatureRef\` pointing at a Sketch feature.

Optional knobs the lowerer will read: \`closed\`, \`continuity: 'C0'|'C1'|'C2'\`, and \`orientation: 'frenet' | 'corrected-frenet' | 'discrete' | { up: Vec3 }\`.

The \`variableSweep\` \`FeatureKind\` itself was already added to the union in Slice B Task 1; this PR fills in the metadata schema and the \`variableSweep?: VariableSweepMetadata\` field on \`FeatureMetadata\`.

## Test plan

- [x] \`npx vitest run tests/unit/intent/curve3d.test.ts\` — 18 tests pass (8 Curve3D + 10 VariableSweep)
- [x] \`npx tsc --noEmit\` — clean