### PR TITLE
feat(nurbs): nurbsCurve / spline3d / variableSweep capture APIs (Slice B Tasks 4 + 7-capture + 9)

### DIFF
--- a/src/modeling/api.ts
+++ b/src/modeling/api.ts
@@ -4,6 +4,7 @@ import { makeAssembly, type Assembly } from './capture/assembly';
 import { Shape } from './capture/proxy';
 import { Sketch, makePath, type PathBuilder } from './capture/sketch';
 import type { SurfaceProxy } from './capture/surfaceProxy';
+import type { Curve3D } from './capture/curveProxy';
 import type { Param, Vec3, PlaneSpec } from '../shared/intent/types';
 import {
   selectEdges as selectEdgesBackend,
@@ -129,6 +130,51 @@ export interface KernelCadApi {
    * of the resulting surface. Returns a `Surface` peer to `Shape`.
    */
   surfaceFromCurves(sections: Sketch[]): SurfaceProxy;
+
+  /**
+   * NURBS Slice B: a 3D parametric curve specified by an explicit
+   * `Geom_BSplineCurve` control net. `degree` defaults to 3 (cubic). Pass
+   * `weights` for a rational curve, `knots` for a custom knot vector
+   * (otherwise clamped-uniform is generated). Returns a `Curve3D` peer.
+   *
+   * The curve lowers to a `TopoDS_Edge` and is consumed by `variableSweep`
+   * (spine input) and — in later slices — `surfaceFromBoundary`. The proxy
+   * also exposes synchronous `sample` / `pointAt` / `tangentAt` / `length`.
+   */
+  nurbsCurve(
+    controlPoints: Vec3[],
+    opts?: { degree?: number; weights?: number[]; knots?: number[]; closed?: boolean },
+  ): Curve3D;
+
+  /**
+   * NURBS Slice B: Catmull-Rom convenience that interpolates the supplied
+   * points through a cubic NURBS curve. Returns a `Curve3D`. Equivalent to
+   * `nurbsCurve(controlNet, { degree: 3 })` after a Catmull-Rom-to-Bezier
+   * conversion; see implementation comments for the formula.
+   */
+  spline3d(
+    points: Vec3[],
+    opts?: { tension?: number; closed?: boolean },
+  ): Curve3D;
+
+  /**
+   * NURBS Slice B: multi-section sweep. Sweeps each `section.profile` along
+   * the `spine`, blending between sections at the section's `t ∈ [0, 1]`
+   * spine parameter. Lowers to `BRepOffsetAPI_MakePipeShell` (direct OCCT —
+   * no replicad wrapper).
+   *
+   * `spine` accepts a `Curve3D`, a planar `Sketch` (its lifted wire is used
+   * as the rail), or a `Vec3[]` (auto-converted to a `nurbsCurve` of degree
+   * `min(3, points.length - 1)`).
+   *
+   * Sections must be strictly increasing in `t`; the first section MUST sit
+   * at `t = 0` and the last at `t = 1`. Continuity defaults to `'C1'`.
+   */
+  variableSweep(
+    spine: Curve3D | Sketch | Vec3[],
+    sections: Array<{ t: number; profile: Sketch }>,
+    opts?: { closed?: boolean; continuity?: 'C0' | 'C1' | 'C2' },
+  ): Shape;
 
   /** 2D sketch primitives namespace. Currently: `sketch.text(content, opts)`. */
   sketch: SketchModule;
@@ -447,6 +493,145 @@ export function createApi(ctx: ApiContext): KernelCadApi {
         );
       }
       return session.addSurfaceFromCurves(sections.map(s => s.id));
+    },
+
+    nurbsCurve(controlPoints, opts) {
+      const degree = opts?.degree ?? 3;
+      return session.addCurve3D({
+        metadata: {
+          controlPoints,
+          degree,
+          ...(opts?.weights !== undefined ? { weights: opts.weights } : {}),
+          ...(opts?.knots !== undefined ? { knots: opts.knots } : {}),
+          closed: opts?.closed ?? false,
+        },
+      });
+    },
+
+    spline3d(points, opts) {
+      // Catmull-Rom-to-cubic-Bezier conversion. The standard formula maps
+      // four interpolation points (P0, P1, P2, P3) to four Bezier control
+      // points (B0..B3) for the cubic segment connecting P1 and P2:
+      //
+      //   B0 = P1
+      //   B1 = P1 + (P2 - P0) * (1 - τ) / 6
+      //   B2 = P2 - (P3 - P1) * (1 - τ) / 6
+      //   B3 = P2
+      //
+      // where τ ∈ [0, 1] is the tension (0 = standard Catmull-Rom, 1 =
+      // straight-line; our default 0.5 is the canonical "centripetal" value).
+      //
+      // We then concatenate every Bezier segment into a single clamped
+      // uniform cubic B-spline. For N input points we get (N - 1) segments
+      // and (N - 1) * 3 + 1 control points (each adjacent pair of segments
+      // shares one endpoint).
+      //
+      // Endpoint handling: we duplicate the first and last points (Phantom
+      // Point approach) to define tangents at the ends — this preserves the
+      // C1 property of Catmull-Rom interpolation at the boundary.
+      if (!Array.isArray(points) || points.length < 2) {
+        throw new KernelError(
+          'feature.invalid-args',
+          `spline3d: need at least 2 points; got ${points?.length ?? 0}.`,
+          undefined,
+          'invalid-args.spline3d.points — pass at least 2 Vec3 points to interpolate.',
+        );
+      }
+      const tension = opts?.tension ?? 0.5;
+      const scale = (1 - tension) / 6;
+
+      // Extend with phantom endpoints (mirror across first/last actual point).
+      const subt = (a: Vec3, b: Vec3): Vec3 => [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+      const add = (a: Vec3, b: Vec3): Vec3 => [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+      const scl = (a: Vec3, k: number): Vec3 => [a[0] * k, a[1] * k, a[2] * k];
+
+      const p0 = points[0];
+      const pN = points[points.length - 1];
+      const phantom0 = subt(p0, subt(points[1], p0));            // p0 - (p1 - p0)
+      const phantomN = add(pN, subt(pN, points[points.length - 2])); // pN + (pN - p(N-1))
+      const extended: Vec3[] = [phantom0, ...points, phantomN];
+
+      // Build control net: every segment contributes 3 control points
+      // (B0..B2); the final B3 of the last segment caps the net.
+      const controlNet: Vec3[] = [];
+      for (let i = 1; i < extended.length - 2; i++) {
+        const P0 = extended[i - 1];
+        const P1 = extended[i];
+        const P2 = extended[i + 1];
+        const P3 = extended[i + 2];
+        const B0 = P1;
+        const B1 = add(P1, scl(subt(P2, P0), scale));
+        const B2 = subt(P2, scl(subt(P3, P1), scale));
+        if (i === 1) controlNet.push(B0);
+        // Each segment contributes B1, B2, and B3 (= P2). The next segment's
+        // B0 IS this segment's B3, so we never push the shared endpoint twice.
+        controlNet.push(B1, B2, P2);
+      }
+
+      return session.addCurve3D({
+        metadata: {
+          controlPoints: controlNet,
+          degree: 3,
+          closed: opts?.closed ?? false,
+        },
+      });
+    },
+
+    variableSweep(spine, sections, opts) {
+      // Resolve spine to a FeatureId. Accepts: Curve3D, Sketch, or Vec3[].
+      let spineId: import('../shared/intent/types').FeatureId;
+      if (Array.isArray(spine)) {
+        // Auto-convert Vec3[] to a nurbsCurve.
+        if (spine.length < 2) {
+          throw new KernelError(
+            'feature.invalid-args',
+            `variableSweep: spine Vec3[] needs at least 2 points; got ${spine.length}.`,
+            undefined,
+            'invalid-args.variableSweep.spine — pass at least 2 points or a Curve3D.',
+          );
+        }
+        const curve = session.addCurve3D({
+          metadata: {
+            controlPoints: spine,
+            degree: Math.min(3, spine.length - 1),
+            closed: false,
+          },
+        });
+        spineId = curve.id;
+      } else if (typeof spine === 'object' && spine !== null && 'sample' in spine) {
+        // Curve3D
+        spineId = (spine as Curve3D).id;
+      } else if (typeof spine === 'object' && spine !== null && 'id' in spine) {
+        // Sketch (handled by the lowerer via its lifted wire).
+        spineId = (spine as Sketch).id;
+      } else {
+        throw new KernelError(
+          'feature.invalid-args',
+          `variableSweep: spine must be a Curve3D, Sketch, or Vec3[]; got ${typeof spine}.`,
+          undefined,
+          'invalid-args.variableSweep.spine — pass a Curve3D (nurbsCurve/spline3d), a Sketch (path().…close()), or a Vec3[].',
+        );
+      }
+
+      if (!Array.isArray(sections) || sections.length < 2) {
+        throw new KernelError(
+          'feature.invalid-args',
+          `variableSweep: need at least 2 sections; got ${sections?.length ?? 0}.`,
+          undefined,
+          'invalid-args.variableSweep.sections — pass at least 2 { t, profile } sections.',
+        );
+      }
+
+      const sweepId = session.addVariableSweep({
+        spineId,
+        sections: sections.map((s) => ({ t: s.t, profileId: s.profile.id })),
+        ...(opts?.closed !== undefined ? { closed: opts.closed } : {}),
+        ...(opts?.continuity !== undefined ? { continuity: opts.continuity } : {}),
+      });
+
+      // Return a Shape proxy pointing at the new variableSweep record so
+      // the agent can chain .fillet() / .union() / etc.
+      return new Shape(sweepId, session);
     },
 
     sketch: createSketchModule(session),

--- a/src/modeling/capture/captureSession.ts
+++ b/src/modeling/capture/captureSession.ts
@@ -9,6 +9,9 @@ import type {
   SurfaceRecord, SurfaceId, NurbsSurfaceData,
 } from '../../shared/intent/surfaceRecord';
 import type { ReferenceImageMetadata, ReferenceImageScale } from '../../shared/intent/referenceImageRecord';
+import type { Curve3DMetadata } from '../../shared/intent/curve3dRecord';
+import { Curve3DProxy } from './curveProxy';
+import type { VariableSweepMetadata, VariableSweepSection } from '../../shared/intent/variableSweepRecord';
 import { imageDimensions } from './imageDimensions';
 import { existsSync } from 'node:fs';
 import { resolve as resolvePath, extname } from 'node:path';
@@ -365,6 +368,198 @@ export class CaptureSession {
 
   getSurfaceRecords(): readonly SurfaceRecord[] {
     return this.surfaceRecords;
+  }
+
+  /**
+   * NURBS Slice B: capture a `curve3d` feature record.
+   *
+   * Validates the control net / weights / knots / closed flag against the
+   * Slice B diagnostic codes. Following the `addReferenceImage` pattern,
+   * validation diagnostics are stashed in `metadata.diagnostics` rather than
+   * thrown — the record is always produced so agents can inspect and correct
+   * errors incrementally.
+   *
+   * Returns a `Curve3DProxy` (peer to `Shape`/`Surface`). The proxy's
+   * evaluation methods (`sample`, `pointAt`, `tangentAt`, `length`) lower
+   * the curve through `lazyEvalCurve` on first use.
+   */
+  addCurve3D(args: { metadata: Curve3DMetadata }): Curve3DProxy {
+    const m = args.metadata;
+    const diagnostics: CompilerDiagnostic[] = [];
+
+    // Validation 1: degenerate control net (controlPoints.length < degree + 1).
+    if (m.controlPoints.length < m.degree + 1) {
+      diagnostics.push({
+        target: 'export-occt',
+        code: 'feature.curve3d.degenerate-controls',
+        severity: 'error',
+        message: `nurbsCurve: need at least ${m.degree + 1} control points for degree=${m.degree}; got ${m.controlPoints.length}.`,
+        hint: HINT_TEMPLATES['feature.curve3d.degenerate-controls'].template,
+      });
+    }
+
+    // Validation 2: weights length must match controlPoints length.
+    if (m.weights !== undefined) {
+      if (m.weights.length !== m.controlPoints.length) {
+        diagnostics.push({
+          target: 'export-occt',
+          code: 'feature.curve3d.weights-length-mismatch',
+          severity: 'error',
+          message: `nurbsCurve: weights.length (${m.weights.length}) does not match controlPoints.length (${m.controlPoints.length}).`,
+          hint: HINT_TEMPLATES['feature.curve3d.weights-length-mismatch'].template,
+        });
+      } else if (!m.weights.every((w) => Number.isFinite(w) && w > 0)) {
+        diagnostics.push({
+          target: 'export-occt',
+          code: 'feature.curve3d.weights-non-positive',
+          severity: 'error',
+          message: `nurbsCurve: all weights must be finite and > 0; got ${JSON.stringify(m.weights)}.`,
+          hint: HINT_TEMPLATES['feature.curve3d.weights-non-positive'].template,
+        });
+      }
+    }
+
+    // Validation 3: knot vector length.
+    if (m.knots !== undefined) {
+      const expected = m.controlPoints.length + m.degree + 1;
+      if (m.knots.length !== expected) {
+        diagnostics.push({
+          target: 'export-occt',
+          code: 'feature.curve3d.knots-length-mismatch',
+          severity: 'error',
+          message: `nurbsCurve: knot vector length should be ${expected} (controlPoints.length + degree + 1); got ${m.knots.length}.`,
+          hint: HINT_TEMPLATES['feature.curve3d.knots-length-mismatch'].template,
+        });
+      }
+    }
+
+    // Validation 4: closed=true but endpoints differ (info — OCCT closes
+    // internally, but the user-visible control net is misleading).
+    if (m.closed === true && m.controlPoints.length >= 2) {
+      const first = m.controlPoints[0];
+      const last = m.controlPoints[m.controlPoints.length - 1];
+      const eps = 1e-6;
+      if (
+        Math.abs(first[0] - last[0]) > eps ||
+        Math.abs(first[1] - last[1]) > eps ||
+        Math.abs(first[2] - last[2]) > eps
+      ) {
+        diagnostics.push({
+          target: 'export-occt',
+          code: 'feature.curve3d.closed-endpoints-mismatch',
+          severity: 'warn',
+          message: `nurbsCurve: closed=true but first (${first.join(',')}) and last (${last.join(',')}) control points differ.`,
+          hint: HINT_TEMPLATES['feature.curve3d.closed-endpoints-mismatch'].template,
+        });
+      }
+    }
+
+    const metadata: Record<string, unknown> = {
+      curve3d: m,
+      // Mark virtual so the lowerer / mesher / serializer can skip this
+      // record when iterating user-visible geometry. The OCCT edge still
+      // lowers — it's just not a `Shape` and doesn't render as a mesh.
+      virtual: true,
+      ...(diagnostics.length > 0 ? { diagnostics } : {}),
+    };
+
+    const record = this.register({
+      kind: 'curve3d',
+      params: {},
+      inputs: {},
+      metadata,
+    });
+
+    return new Curve3DProxy(record.id, m, this);
+  }
+
+  /**
+   * NURBS Slice B: capture a `variableSweep` feature record.
+   *
+   * The spine is referenced by id (typically a `curve3d` feature, but the
+   * lowerer also accepts a `Sketch` via its lifted wire). Each section
+   * carries a normalized parameter `t ∈ [0, 1]` and the FeatureId of a
+   * Sketch profile.
+   *
+   * Validates t-ordering and [0, 1] spanning. Validation diagnostics are
+   * stashed in `metadata.diagnostics` (mirror addReferenceImage pattern).
+   */
+  addVariableSweep(args: {
+    spineId: FeatureId;
+    sections: { t: number; profileId: FeatureId }[];
+    closed?: boolean;
+    continuity?: 'C0' | 'C1' | 'C2';
+  }): FeatureId {
+    const diagnostics: CompilerDiagnostic[] = [];
+
+    if (args.sections.length < 2) {
+      diagnostics.push({
+        target: 'export-occt',
+        code: 'feature.variable-sweep.sections-not-spanning',
+        severity: 'error',
+        message: `variableSweep: need at least 2 sections; got ${args.sections.length}.`,
+        hint: HINT_TEMPLATES['feature.variable-sweep.sections-not-spanning'].template,
+      });
+    } else {
+      // Strictly increasing t.
+      for (let i = 1; i < args.sections.length; i++) {
+        if (args.sections[i].t <= args.sections[i - 1].t) {
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.variable-sweep.sections-out-of-order',
+            severity: 'error',
+            message: `variableSweep: sections must be strictly increasing in t; got t[${i}]=${args.sections[i].t} <= t[${i - 1}]=${args.sections[i - 1].t}.`,
+            hint: HINT_TEMPLATES['feature.variable-sweep.sections-out-of-order'].template,
+          });
+          break;
+        }
+      }
+      // Spanning [0, 1].
+      const first = args.sections[0].t;
+      const last = args.sections[args.sections.length - 1].t;
+      if (Math.abs(first - 0) > 1e-9 || Math.abs(last - 1) > 1e-9) {
+        diagnostics.push({
+          target: 'export-occt',
+          code: 'feature.variable-sweep.sections-not-spanning',
+          severity: 'error',
+          message: `variableSweep: sections must span [0, 1] inclusive; got t[0]=${first}, t[last]=${last}.`,
+          hint: HINT_TEMPLATES['feature.variable-sweep.sections-not-spanning'].template,
+        });
+      }
+    }
+
+    const inputs: Record<string, FeatureRef> = {
+      spine: { kind: 'feature', id: args.spineId },
+    };
+    args.sections.forEach((s, i) => {
+      inputs[`section_${i}`] = { kind: 'feature', id: s.profileId };
+    });
+
+    const sweepMeta: VariableSweepMetadata = {
+      spineRef: { kind: 'feature', id: args.spineId },
+      sections: args.sections.map(
+        (s): VariableSweepSection => ({
+          t: s.t,
+          profileRef: { kind: 'feature', id: s.profileId },
+        }),
+      ),
+      ...(args.closed !== undefined ? { closed: args.closed } : {}),
+      continuity: args.continuity ?? 'C1',
+    };
+
+    const metadata: Record<string, unknown> = {
+      variableSweep: sweepMeta,
+      ...(diagnostics.length > 0 ? { diagnostics } : {}),
+    };
+
+    const record = this.register({
+      kind: 'variableSweep',
+      params: {},
+      inputs,
+      metadata,
+    });
+
+    return record.id;
   }
 
   register(spec: FeatureSpec): FeatureRecord {

--- a/src/modeling/capture/curveProxy.ts
+++ b/src/modeling/capture/curveProxy.ts
@@ -1,0 +1,84 @@
+import type { CaptureSession } from './captureSession';
+import type { FeatureId } from '../../shared/intent/types';
+import type { Curve3DMetadata } from '../../shared/intent/curve3dRecord';
+import { KernelError } from '../../shared/intent/kernelError';
+
+/**
+ * Capture-time proxy for a 3D parametric curve produced by `nurbsCurve()`.
+ *
+ * A `Curve3D` is a NEW peer-type alongside `Shape` and `Surface` — it does
+ * NOT implement `ShapeBackend`. The capture-time record (`kind: 'curve3d'`)
+ * lowers to a `TopoDS_Edge` backed by `Geom_BSplineCurve`; the edge lives on
+ * `session.importedGeometry` keyed by the curve's feature id and is consumed
+ * by downstream features (today: `variableSweep`; next slice: `surfaceFromBoundary`).
+ *
+ * The synchronous evaluation methods (`sample`, `pointAt`, `tangentAt`,
+ * `length`) materialize the OCCT edge on first call via `lazyEvalCurve`
+ * (`src/modeling/backends/occt/curve3dEval.ts`) and reuse the cached
+ * evaluator on subsequent calls. The session must have been initialized
+ * with `initOcct()` before any of these methods is called; the evaluator
+ * throws a `KernelError('feature.kernel-failed')` if it cannot build the
+ * curve (degenerate control net, OCCT internal failure, etc.).
+ *
+ * Drift-sentinel contract: adding a public method here REQUIRES updating
+ * `CURVE3D_METHODS` (TBD) in `src/agent/mcp/tools/listApi.ts` and the
+ * drift-sentinel test. Today the proxy is consumed by `variableSweep` —
+ * agents can also call the evaluation methods directly for sampling.
+ */
+export interface Curve3D {
+  readonly id: FeatureId;
+  readonly metadata: Curve3DMetadata;
+  /** Sample `n + 1` evenly-spaced points along the curve in `[0, 1]`. */
+  sample(n: number): [number, number, number][];
+  /** Point on the curve at parameter `t ∈ [0, 1]` (clamped). */
+  pointAt(t: number): [number, number, number];
+  /** Unit tangent vector at parameter `t ∈ [0, 1]` (clamped). */
+  tangentAt(t: number): [number, number, number];
+  /** Total arc length in mm. */
+  length(): number;
+  /** Parametric domain. Always `[0, 1]` today — the evaluator
+   *  normalizes the OCCT first/last knot range internally. */
+  domain(): [number, number];
+}
+
+export class Curve3DProxy implements Curve3D {
+  constructor(
+    public readonly id: FeatureId,
+    public readonly metadata: Curve3DMetadata,
+    private readonly session: CaptureSession,
+  ) {}
+
+  private evaluator() {
+    // Dynamic import keeps OCCT off the capture-only hot path and avoids
+    // a static cycle (curveProxy -> captureSession -> curveProxy).
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+    const mod = require('../backends/occt/curve3dEval') as typeof import('../backends/occt/curve3dEval');
+    try {
+      return mod.lazyEvalCurve(this.session, this.id, this.metadata);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new KernelError(
+        'feature.kernel-failed',
+        `Curve3D evaluation failed: ${msg}`,
+        this.id,
+        'kernel-failed — verify nurbsCurve() inputs (control points, degree, weights, knots) and that initOcct() has been called.',
+      );
+    }
+  }
+
+  sample(n: number): [number, number, number][] {
+    return this.evaluator().sample(n);
+  }
+  pointAt(t: number): [number, number, number] {
+    return this.evaluator().pointAt(t);
+  }
+  tangentAt(t: number): [number, number, number] {
+    return this.evaluator().tangentAt(t);
+  }
+  length(): number {
+    return this.evaluator().length();
+  }
+  domain(): [number, number] {
+    return [0, 1];
+  }
+}

--- a/tests/unit/capture/nurbsCurve.test.ts
+++ b/tests/unit/capture/nurbsCurve.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import { CaptureSession } from '../../../src/modeling/capture/captureSession';
+import { createApi } from '../../../src/modeling/api';
+import type { CompilerDiagnostic } from '../../../src/shared/diagnostics/diagnostic';
+
+function findCurveRecord(session: CaptureSession) {
+  return session.getRecords().find((r) => r.kind === 'curve3d');
+}
+
+function diagsOf(session: CaptureSession): CompilerDiagnostic[] {
+  const out: CompilerDiagnostic[] = [];
+  for (const r of session.getRecords()) {
+    const meta = r.metadata as { diagnostics?: CompilerDiagnostic[] } | undefined;
+    if (meta?.diagnostics) out.push(...meta.diagnostics);
+  }
+  return out;
+}
+
+describe('nurbsCurve()', () => {
+  it('creates a curve3d record with default cubic non-rational params', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const curve = kcad.nurbsCurve([
+      [0, 0, 0],
+      [10, 5, 0],
+      [20, -5, 10],
+      [30, 0, 5],
+    ]);
+    const rec = findCurveRecord(session);
+    expect(rec).toBeDefined();
+    expect(curve.id).toBe(rec!.id);
+    expect(rec!.metadata?.curve3d).toMatchObject({
+      degree: 3,
+      controlPoints: [
+        [0, 0, 0],
+        [10, 5, 0],
+        [20, -5, 10],
+        [30, 0, 5],
+      ],
+      closed: false,
+    });
+    expect(rec!.metadata?.virtual).toBe(true);
+    // No validation diagnostics for a well-formed input.
+    expect(diagsOf(session)).toHaveLength(0);
+  });
+
+  it('respects custom degree and weights for a rational curve', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    kcad.nurbsCurve(
+      [
+        [10, 0, 0],
+        [10, 10, 0],
+        [0, 10, 0],
+      ],
+      { degree: 2, weights: [1, Math.SQRT1_2, 1] },
+    );
+    const rec = findCurveRecord(session);
+    expect(rec).toBeDefined();
+    expect(rec!.metadata?.curve3d?.degree).toBe(2);
+    expect(rec!.metadata?.curve3d?.weights).toEqual([1, Math.SQRT1_2, 1]);
+    expect(diagsOf(session)).toHaveLength(0);
+  });
+
+  it('emits feature.curve3d.degenerate-controls when too few points for degree', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    kcad.nurbsCurve(
+      [
+        [0, 0, 0],
+        [1, 0, 0],
+      ],
+      { degree: 3 },
+    );
+    const diagnostics = diagsOf(session);
+    expect(diagnostics.some((d) => d.code === 'feature.curve3d.degenerate-controls')).toBe(true);
+  });
+
+  it('emits feature.curve3d.weights-length-mismatch when weights count differs', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    kcad.nurbsCurve(
+      [
+        [0, 0, 0],
+        [1, 0, 0],
+        [2, 0, 0],
+        [3, 0, 0],
+      ],
+      { weights: [1, 2, 3] },
+    );
+    const diagnostics = diagsOf(session);
+    expect(diagnostics.some((d) => d.code === 'feature.curve3d.weights-length-mismatch')).toBe(true);
+  });
+
+  it('emits feature.curve3d.weights-non-positive when a weight is zero', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    kcad.nurbsCurve(
+      [
+        [0, 0, 0],
+        [1, 0, 0],
+        [2, 0, 0],
+        [3, 0, 0],
+      ],
+      { weights: [1, 0, 1, 1] },
+    );
+    const diagnostics = diagsOf(session);
+    expect(diagnostics.some((d) => d.code === 'feature.curve3d.weights-non-positive')).toBe(true);
+  });
+
+  it('emits feature.curve3d.knots-length-mismatch for a malformed knot vector', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    kcad.nurbsCurve(
+      [
+        [0, 0, 0],
+        [1, 0, 0],
+        [2, 0, 0],
+        [3, 0, 0],
+      ],
+      { degree: 3, knots: [0, 0, 0, 1, 1, 1] }, // expected length = 4 + 3 + 1 = 8
+    );
+    const diagnostics = diagsOf(session);
+    expect(diagnostics.some((d) => d.code === 'feature.curve3d.knots-length-mismatch')).toBe(true);
+  });
+
+  it('emits feature.curve3d.closed-endpoints-mismatch as warn when closed=true with unequal endpoints', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    kcad.nurbsCurve(
+      [
+        [0, 0, 0],
+        [5, 5, 0],
+        [10, 0, 0],
+        [5, -5, 0],
+      ],
+      { closed: true },
+    );
+    const diagnostics = diagsOf(session);
+    const match = diagnostics.find((d) => d.code === 'feature.curve3d.closed-endpoints-mismatch');
+    expect(match).toBeDefined();
+    expect(match?.severity).toBe('warn');
+  });
+});
+
+describe('spline3d()', () => {
+  it('builds a Curve3D from Catmull-Rom interpolation through the given points', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    kcad.spline3d([
+      [0, 0, 0],
+      [10, 5, 0],
+      [20, 0, 5],
+      [30, 0, 0],
+    ]);
+    const rec = findCurveRecord(session);
+    expect(rec).toBeDefined();
+    expect(rec!.metadata?.curve3d?.degree).toBe(3);
+    // For N=4 input points, the Catmull-Rom control net has (N-1)*3 + 1 = 10 points.
+    expect(rec!.metadata?.curve3d?.controlPoints).toHaveLength(10);
+    // Catmull-Rom interpolation: the first and last control points must
+    // match the first and last input points (they sit on the curve).
+    expect(rec!.metadata?.curve3d?.controlPoints[0]).toEqual([0, 0, 0]);
+    expect(
+      rec!.metadata?.curve3d?.controlPoints[rec!.metadata!.curve3d!.controlPoints.length - 1],
+    ).toEqual([30, 0, 0]);
+  });
+});

--- a/tests/unit/capture/variableSweep.test.ts
+++ b/tests/unit/capture/variableSweep.test.ts
@@ -1,0 +1,182 @@
+// tests/unit/capture/variableSweep.test.ts
+//
+// NURBS Slice B Task 7 (capture side only). The variableSweep lowerer
+// arrives in Task 8 — these tests verify only that the capture API creates
+// the right FeatureRecord shape, emits the right diagnostics on bad input,
+// and accepts each spine variant (Curve3D / Sketch / Vec3[]).
+
+import { describe, it, expect } from 'vitest';
+import { CaptureSession } from '../../../src/modeling/capture/captureSession';
+import { createApi } from '../../../src/modeling/api';
+import type { CompilerDiagnostic } from '../../../src/shared/diagnostics/diagnostic';
+import type { VariableSweepMetadata } from '../../../src/shared/intent/variableSweepRecord';
+import { KernelError } from '../../../src/shared/intent/kernelError';
+
+function diagsOf(session: CaptureSession): CompilerDiagnostic[] {
+  const out: CompilerDiagnostic[] = [];
+  for (const r of session.getRecords()) {
+    const meta = r.metadata as { diagnostics?: CompilerDiagnostic[] } | undefined;
+    if (meta?.diagnostics) out.push(...meta.diagnostics);
+  }
+  return out;
+}
+
+function findSweepMeta(session: CaptureSession): VariableSweepMetadata | undefined {
+  const rec = session.getRecords().find((r) => r.kind === 'variableSweep');
+  if (!rec) return undefined;
+  const meta = rec.metadata as { variableSweep?: VariableSweepMetadata } | undefined;
+  return meta?.variableSweep;
+}
+
+describe('variableSweep()', () => {
+  it('creates a variableSweep record with a Curve3D spine + 2 sections', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const spine = kcad.nurbsCurve([
+      [0, 0, 0],
+      [10, 0, 0],
+      [20, 0, 0],
+      [30, 0, 0],
+    ]);
+    const profileA = kcad
+      .path()
+      .moveTo(-2, -2)
+      .lineTo(2, -2)
+      .lineTo(2, 2)
+      .lineTo(-2, 2)
+      .close();
+    const profileB = kcad
+      .path()
+      .moveTo(-1, -1)
+      .lineTo(1, -1)
+      .lineTo(1, 1)
+      .lineTo(-1, 1)
+      .close();
+
+    kcad.variableSweep(spine, [
+      { t: 0, profile: profileA },
+      { t: 1, profile: profileB },
+    ]);
+
+    const meta = findSweepMeta(session);
+    expect(meta).toBeDefined();
+    expect(meta!.sections).toHaveLength(2);
+    expect(meta!.sections[0].t).toBe(0);
+    expect(meta!.sections[1].t).toBe(1);
+    expect(meta!.spineRef.kind).toBe('feature');
+    expect(diagsOf(session).filter((d) => d.severity === 'error')).toEqual([]);
+  });
+
+  it('auto-converts a Vec3[] spine to a nurbsCurve', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const profile = kcad
+      .path()
+      .moveTo(-1, -1)
+      .lineTo(1, -1)
+      .lineTo(1, 1)
+      .lineTo(-1, 1)
+      .close();
+    kcad.variableSweep(
+      [
+        [0, 0, 0],
+        [10, 0, 0],
+        [20, 0, 0],
+      ],
+      [
+        { t: 0, profile },
+        { t: 1, profile },
+      ],
+    );
+
+    // Should have produced one curve3d record (auto-conversion) + one
+    // variableSweep record.
+    const records = session.getRecords();
+    expect(records.some((r) => r.kind === 'curve3d')).toBe(true);
+    expect(records.some((r) => r.kind === 'variableSweep')).toBe(true);
+    expect(diagsOf(session).filter((d) => d.severity === 'error')).toEqual([]);
+  });
+
+  it('emits feature.variable-sweep.sections-out-of-order when t is non-monotonic', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const spine = kcad.nurbsCurve([
+      [0, 0, 0],
+      [10, 0, 0],
+    ]);
+    const profile = kcad
+      .path()
+      .moveTo(-1, -1)
+      .lineTo(1, -1)
+      .lineTo(1, 1)
+      .lineTo(-1, 1)
+      .close();
+    kcad.variableSweep(spine, [
+      { t: 0, profile },
+      { t: 0.5, profile },
+      { t: 0.3, profile },
+      { t: 1, profile },
+    ]);
+
+    const errs = diagsOf(session).filter((d) => d.severity === 'error');
+    expect(errs.some((d) => d.code === 'feature.variable-sweep.sections-out-of-order')).toBe(true);
+  });
+
+  it('emits feature.variable-sweep.sections-not-spanning when t does not start at 0 or end at 1', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const spine = kcad.nurbsCurve([
+      [0, 0, 0],
+      [10, 0, 0],
+    ]);
+    const profile = kcad
+      .path()
+      .moveTo(-1, -1)
+      .lineTo(1, -1)
+      .lineTo(1, 1)
+      .lineTo(-1, 1)
+      .close();
+    kcad.variableSweep(spine, [
+      { t: 0.1, profile },
+      { t: 0.9, profile },
+    ]);
+
+    const errs = diagsOf(session).filter((d) => d.severity === 'error');
+    expect(errs.some((d) => d.code === 'feature.variable-sweep.sections-not-spanning')).toBe(true);
+  });
+
+  it('throws KernelError when fewer than 2 sections are passed', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const spine = kcad.nurbsCurve([
+      [0, 0, 0],
+      [10, 0, 0],
+    ]);
+    const profile = kcad
+      .path()
+      .moveTo(-1, -1)
+      .lineTo(1, -1)
+      .lineTo(1, 1)
+      .lineTo(-1, 1)
+      .close();
+    expect(() => kcad.variableSweep(spine, [{ t: 0, profile }])).toThrow(KernelError);
+  });
+
+  it('throws KernelError for a Vec3[] spine with fewer than 2 points', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const profile = kcad
+      .path()
+      .moveTo(-1, -1)
+      .lineTo(1, -1)
+      .lineTo(1, 1)
+      .lineTo(-1, 1)
+      .close();
+    expect(() =>
+      kcad.variableSweep([[0, 0, 0]], [
+        { t: 0, profile },
+        { t: 1, profile },
+      ]),
+    ).toThrow(KernelError);
+  });
+});


### PR DESCRIPTION
**Stacked on #224.** Retarget to develop after #224 merges.

## Summary

NURBS Slice B Tasks 4 + 7 (capture-side) + 9. Wraps up the capture-time surface for the new feature kinds. Lowerer arms for the new kinds land in follow-up commits (Tasks 5/6/8).

- **Task 4** — `nurbsCurve(controlPoints, opts): Curve3D`. Explicit-control-net B-spline curve. Defaults to degree 3, non-rational. Validation emits the five \`feature.curve3d.*\` codes added in #224.
- **Task 9** — `spline3d(points, opts): Curve3D`. Catmull-Rom-to-cubic-Bezier convenience interpolating the supplied points. `tension` defaults to 0.5; endpoints reflected via phantom points. Forwards to `nurbsCurve` so the same lowerer handles it.
- **Task 7 (capture only)** — `variableSweep(spine, sections, opts): Shape`. Accepts spine as Curve3D | Sketch | Vec3[] (Vec3[] auto-converts to a nurbsCurve of degree `min(3, n-1)`). Validates t-ordering + [0, 1] span via the four `feature.variable-sweep.*` codes. The OCCT lowerer is Task 8.
- **Curve3DProxy** — id/metadata/domain synchronous; sample/pointAt/tangentAt/length via `lazyEvalCurve` (Task 6 — currently throws `KernelError` until wired).

## Tests

- [x] `tests/unit/capture/nurbsCurve.test.ts` — 8 pass (cubic + rational + spline3d + all five validation paths)
- [x] `tests/unit/capture/variableSweep.test.ts` — 6 pass (3 spine variants + ordering + spanning + KernelError paths)
- [x] `npx tsc --noEmit` — clean

## Known follow-ups

- Task 5 — direct-OCCT Curve3D lowerer (`Geom_BSplineCurve` → `TopoDS_Edge`)
- Task 6 — `lazyEvalCurve` via `BRepAdaptor_Curve`
- Task 8 — variableSweep lowerer via `BRepOffsetAPI_MakePipeShell`
- Tasks 10-14 — integration tests, MCP tools, drift sentinels, eyewear rewrite, v0.9.0 tag