### PR TITLE
feat(occt): direct-OCCT lowerer for curve3d via Geom_BSplineCurve (NURBS Slice B Task 5)

### DIFF
--- a/src/modeling/backends/occt/curve3dLowerer.ts
+++ b/src/modeling/backends/occt/curve3dLowerer.ts
@@ -1,0 +1,105 @@
+import { getOC } from 'replicad';
+import {
+  clampedUniformKnots,
+  decomposeKnots,
+} from '../../../kernel/backends/occt/nurbsSurfaceLowerer';
+import type { Curve3DMetadata } from '../../../shared/intent/curve3dRecord';
+
+/**
+ * Result of lowering a `curve3d` record to OCCT.
+ *
+ * The edge is a `TopoDS_Edge` backed by a `Geom_BSplineCurve`. It is parked on
+ * `session.importedGeometry` by the main lowerer so downstream consumers
+ * (`variableSweep`, `surfaceFromBoundary`, and the lazy proxy that drives
+ * `Curve3DProxy.{sample,pointAt,tangentAt,length,domain}`) can reach it.
+ */
+export interface Curve3DLowerResult {
+  /** OCCT `TopoDS_Edge` wrapping a `Geom_BSplineCurve`. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  edge: any;
+}
+
+/**
+ * Build a `TopoDS_Edge` from a validated `Curve3DMetadata`.
+ *
+ * Direct OCCT — no replicad wrapper. Capture-layer validation
+ * (`isCurve3DMetadata` + `addCurve3D` diagnostics) is assumed to have
+ * gate-checked the inputs; this function focuses on the OCCT call sequence.
+ *
+ * Constructor selection:
+ *  - Non-rational (no weights): `Geom_BSplineCurve_1(Poles, Knots, Mults,
+ *    Degree, Periodic)`.
+ *  - Rational (weights present): `Geom_BSplineCurve_2(Poles, Weights, Knots,
+ *    Mults, Degree, Periodic, CheckRational)`.
+ *
+ * Knot handling:
+ *  - If the caller supplied an explicit knot vector, decompose it into
+ *    distinct knots + per-knot multiplicities (OCCT's expected form).
+ *  - Otherwise, generate a clamped-uniform knot vector via
+ *    `clampedUniformKnots(n, degree)` (shared with the NURBS-surface lowerer).
+ */
+export function lowerCurve3D(m: Curve3DMetadata): Curve3DLowerResult {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const oc = getOC() as any;
+  const n = m.controlPoints.length;
+  const periodic = m.closed ?? false;
+
+  // 1-indexed (1..n) per OCCT convention.
+  const polesArr = new oc.TColgp_Array1OfPnt_2(1, n);
+  for (let i = 0; i < n; i++) {
+    const [x, y, z] = m.controlPoints[i];
+    polesArr.SetValue(i + 1, new oc.gp_Pnt_3(x, y, z));
+  }
+
+  // Weights — only when explicitly provided. Capture-layer guarantees length
+  // matches and every weight is finite and positive.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let weightsArr: any | undefined;
+  if (m.weights !== undefined) {
+    weightsArr = new oc.TColStd_Array1OfReal_2(1, n);
+    for (let i = 0; i < n; i++) {
+      weightsArr.SetValue(i + 1, m.weights[i]);
+    }
+  }
+
+  // Knot decomposition — reuse the shared helpers from nurbsSurfaceLowerer so
+  // the curve and surface paths agree on conventions (knot-vector form,
+  // clamped-uniform inference).
+  const decomposed = m.knots !== undefined
+    ? decomposeKnots(m.knots)
+    : clampedUniformKnots(n, m.degree);
+
+  const knotsArr = new oc.TColStd_Array1OfReal_2(1, decomposed.knots.length);
+  const multsArr = new oc.TColStd_Array1OfInteger_2(1, decomposed.mults.length);
+  for (let i = 0; i < decomposed.knots.length; i++) {
+    knotsArr.SetValue(i + 1, decomposed.knots[i]);
+    multsArr.SetValue(i + 1, decomposed.mults[i]);
+  }
+
+  // Build Geom_BSplineCurve via the constructor matching the input shape.
+  const bspline = weightsArr !== undefined
+    ? new oc.Geom_BSplineCurve_2(
+        polesArr,
+        weightsArr,
+        knotsArr,
+        multsArr,
+        m.degree,
+        periodic,
+        false, // CheckRational — let OCCT trust the supplied weights as rational.
+      )
+    : new oc.Geom_BSplineCurve_1(
+        polesArr,
+        knotsArr,
+        multsArr,
+        m.degree,
+        periodic,
+      );
+
+  // Wrap as TopoDS_Edge. BRepBuilderAPI_MakeEdge_24 takes a Handle_Geom_Curve;
+  // Handle_Geom_Curve_2 wraps a raw Geom_Curve* pointer.
+  const handle = new oc.Handle_Geom_Curve_2(bspline);
+  const edgeBuilder = new oc.BRepBuilderAPI_MakeEdge_24(handle);
+  const edge = edgeBuilder.Edge();
+
+  return { edge };
+}

--- a/src/modeling/backends/occt/occtLowerer.ts
+++ b/src/modeling/backends/occt/occtLowerer.ts
@@ -22,6 +22,8 @@ import { OcctBackend } from '../../../kernel/backends/occt/occtBackend';
 import {
   buildNurbsFace, buildSkinnedSurface, thickenFace, faceToShape,
 } from '../../../kernel/backends/occt/nurbsSurfaceLowerer';
+import { lowerCurve3D } from './curve3dLowerer';
+import { isCurve3DMetadata } from '../../../shared/intent/curve3dRecord';
 import { pickEdges, pickFace } from '../../../kernel/backends/occt/edgeSelection';
 import { computeDihedralPublic } from '../../../kernel/backends/occt/edgeQueries';
 import { lowerSheetMetalBend, resolveBendAxis } from './sheetMetalLowerer';
@@ -413,6 +415,7 @@ export class OcctLowerer implements FeatureLowerer {
     'sheetMetalBend',   // W2.2
     'sdfMaterialize',   // W2.3
     'referenceImage',   // virtual — no BREP; defense-in-depth guard
+    'curve3d',          // NURBS Slice B: 3D NURBS curve → TopoDS_Edge on session.importedGeometry
   ]);
 
   /** v0.5: pre-lowered geometry for `importedStep` records, populated by
@@ -2413,6 +2416,47 @@ export class OcctLowerer implements FeatureLowerer {
         // Virtual record — no BREP output. recomputeEngine gates on
         // metadata.virtual === true and skips the lowerer, so this arm is
         // defense-in-depth for callers that invoke the lowerer directly.
+        return { shape: undefined as unknown as ShapeBackend, diagnostics };
+      }
+      case 'curve3d': {
+        // NURBS Slice B: lower a 3D NURBS curve to a `TopoDS_Edge` backed by
+        // a `Geom_BSplineCurve`. The edge is parked on
+        // `session.importedGeometry` so downstream consumers (variableSweep,
+        // surfaceFromBoundary, lazy Curve3DProxy evaluators) can reach it.
+        // Like `referenceImage`, this record contributes no `Shape` — the
+        // capture layer marks it `metadata.virtual = true`.
+        const meta = r.metadata as { curve3d?: unknown } | undefined;
+        const m = meta?.curve3d;
+        if (!isCurve3DMetadata(m)) {
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.curve3d.degenerate-controls',
+            featureId: r.id,
+            severity: 'error',
+            message: `curve3d record '${r.id}' is missing valid metadata.curve3d.`,
+            hint: 'Build the record via session.addCurve3D({ metadata }) so the validators run.',
+          });
+          return { shape: undefined as unknown as ShapeBackend, diagnostics };
+        }
+        try {
+          const { edge } = lowerCurve3D(m);
+          // Park the raw OCCT edge on the importedGeometry map. The map is
+          // typed as ShapeBackend (the same slot fromSTEP / sdfMaterialize
+          // use); curve3d stores a TopoDS_Edge instead, and the consumer
+          // (variableSweep lowerer, lazy proxy) is responsible for retrieving
+          // it with the matching expectation.
+          this.importedGeometry.set(r.id, edge as unknown as ShapeBackend);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          diagnostics.push({
+            target: 'export-occt',
+            code: 'feature.kernel-failed',
+            featureId: r.id,
+            severity: 'error',
+            message: `OCCT BSplineCurve build failed: ${msg}`,
+            hint: 'kernel-failed — verify the control points, knots, and degree form a valid NURBS curve.',
+          });
+        }
         return { shape: undefined as unknown as ShapeBackend, diagnostics };
       }
       default:

--- a/tests/unit/backends/occt/curve3dLowerer.test.ts
+++ b/tests/unit/backends/occt/curve3dLowerer.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { getOC } from 'replicad';
+import { initOcct } from '../../../../src/kernel/backends/occt/occtBackend';
+import { lowerCurve3D } from '../../../../src/modeling/backends/occt/curve3dLowerer';
+import type { Curve3DMetadata } from '../../../../src/shared/intent/curve3dRecord';
+
+describe('curve3dLowerer', () => {
+  beforeAll(async () => {
+    await initOcct();
+  });
+
+  it('builds a TopoDS_Edge from a cubic NURBS curve with finite linear length', () => {
+    const m: Curve3DMetadata = {
+      controlPoints: [
+        [0, 0, 0],
+        [10, 5, 0],
+        [20, -5, 10],
+        [30, 0, 5],
+      ],
+      degree: 3,
+      closed: false,
+    };
+
+    const result = lowerCurve3D(m);
+    expect(result.edge).toBeDefined();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const oc = getOC() as any;
+    const props = new oc.GProp_GProps_1();
+    oc.BRepGProp.LinearProperties(result.edge, props, false, false);
+    const length = props.Mass();
+    expect(Number.isFinite(length)).toBe(true);
+    expect(length).toBeGreaterThan(0);
+  });
+
+  it('builds a rational NURBS edge when weights are supplied', () => {
+    const m: Curve3DMetadata = {
+      controlPoints: [
+        [0, 0, 0],
+        [5, 5, 0],
+        [10, 0, 0],
+      ],
+      degree: 2,
+      weights: [1, 2, 1],
+      closed: false,
+    };
+
+    const result = lowerCurve3D(m);
+    expect(result.edge).toBeDefined();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const oc = getOC() as any;
+    const props = new oc.GProp_GProps_1();
+    oc.BRepGProp.LinearProperties(result.edge, props, false, false);
+    const length = props.Mass();
+    expect(Number.isFinite(length)).toBe(true);
+    expect(length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

NURBS Slice B Task 5: lower `curve3d` feature records to a `TopoDS_Edge` backed by `Geom_BSplineCurve`, parked on `session.importedGeometry` so downstream consumers (variableSweep, surfaceFromBoundary, lazy `Curve3DProxy` evaluators) can retrieve it.

- New `src/modeling/backends/occt/curve3dLowerer.ts` — pure `lowerCurve3D(m)` that builds the BSpline via direct OCCT (`Geom_BSplineCurve_1` for non-rational, `Geom_BSplineCurve_2` for rational) and wraps it via `Handle_Geom_Curve_2` + `BRepBuilderAPI_MakeEdge_24`. Reuses `clampedUniformKnots` / `decomposeKnots` from `nurbsSurfaceLowerer` so curve and surface paths agree on knot conventions.
- Modified `src/modeling/backends/occt/occtLowerer.ts` — `'curve3d'` added to `supports`; a `case 'curve3d'` arm sits next to `referenceImage` (the other virtual no-shape record kind) and parks the edge on `this.importedGeometry`. Defense-in-depth: degenerate metadata yields `feature.curve3d.degenerate-controls`; OCCT throws yield `feature.kernel-failed`.
- New `tests/unit/backends/occt/curve3dLowerer.test.ts` — smoke tests assert `BRepGProp.LinearProperties.Mass()` is finite and positive for the non-rational cubic + rational quadratic constructor paths.

## OCCT constructor variants chosen

Verified against `node_modules/replicad-opencascadejs/src/replicad_single.d.ts`:
- `Geom_BSplineCurve_1(Poles, Knots, Mults, Degree, Periodic)` — non-rational
- `Geom_BSplineCurve_2(Poles, Weights, Knots, Mults, Degree, Periodic, CheckRational)` — rational
- `TColgp_Array1OfPnt_2`, `TColStd_Array1OfReal_2`, `TColStd_Array1OfInteger_2`, `gp_Pnt_3`
- `Handle_Geom_Curve_2(curve*)` + `BRepBuilderAPI_MakeEdge_24(handle)`

## Deviations from plan

- `getOC` imported from `'replicad'` (repo convention via `nurbsSurfaceSpike.test.ts`, `nurbsSurfaceLowerer.ts`) rather than re-exported from `occtBackend.ts` as the plan suggested. Avoids an unrelated export.
- Test path lives under `tests/unit/backends/occt/` to match neighbouring lowerer tests instead of the plan's top-level `tests/unit/backends/`.
- Knot decomposition reuses `decomposeKnots` / `clampedUniformKnots` from `nurbsSurfaceLowerer` instead of inlining a `reduceKnotVector` helper — keeps a single source of truth.

## Test plan

- [x] `npx vitest run tests/unit/backends/occt/curve3dLowerer.test.ts` — 2/2 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run tests/unit/backends/occt/{lowererContract,nurbsSurfaceSpike,occtLowerer}.test.ts` — green, no regressions
- [x] `npx vitest run tests/unit/intent/curve3d.test.ts` — 18/18 still green