### PR TITLE
feat(mcp): add_nurbs_curve + add_variable_sweep tools (NURBS Slice B Task 11)

### DIFF
--- a/src/agent/mcp/edits/addNurbsCurve.ts
+++ b/src/agent/mcp/edits/addNurbsCurve.ts
@@ -1,0 +1,74 @@
+// src/agent/mcp/edits/addNurbsCurve.ts
+//
+// NURBS Slice B Task 11: insert a `nurbsCurve(controlPoints, opts?)` binding
+// into a .kcad.ts script immediately before the last top-level `return`.
+// Pure string manipulation — mirrors addFeature / addNurbsSurface.
+
+import { addFeature } from './addFeature';
+import type { AddFeatureResult } from './addFeature';
+
+/**
+ * Inputs for `add_nurbs_curve`. `controlPoints` is a list of Vec3 control
+ * points (mm). All other fields are optional NURBS knobs forwarded verbatim
+ * to the `nurbsCurve(controlPoints, opts)` runtime call.
+ */
+export interface AddNurbsCurveInput {
+  code: string;
+  controlPoints: number[][];
+  degree?: number;
+  weights?: number[];
+  knots?: number[];
+  closed?: boolean;
+  binding_name?: string;
+}
+
+/**
+ * Insert `const <binding> = nurbsCurve([...], { ... });` into `input.code`
+ * immediately before the last top-level `return` statement. The resulting
+ * binding has type `Curve3D`; consume it via `variableSweep(spine, ...)`
+ * or downstream Curve3D-accepting features.
+ */
+export function addNurbsCurve(input: AddNurbsCurveInput): AddFeatureResult {
+  if (!Array.isArray(input.controlPoints) || input.controlPoints.length < 2) {
+    return {
+      ok: false,
+      error: 'add_nurbs_curve: controlPoints must be a Vec3[] with at least 2 points.',
+    };
+  }
+  for (const p of input.controlPoints) {
+    if (!Array.isArray(p) || p.length !== 3 || !p.every(n => typeof n === 'number' && Number.isFinite(n))) {
+      return {
+        ok: false,
+        error: 'add_nurbs_curve: every controlPoint must be a [x, y, z] Vec3 of finite numbers.',
+      };
+    }
+  }
+
+  const binding = input.binding_name ?? deriveDefaultBinding(input.code);
+  const optsParts: string[] = [];
+  if (typeof input.degree === 'number') optsParts.push(`degree: ${JSON.stringify(input.degree)}`);
+  if (input.weights) optsParts.push(`weights: ${JSON.stringify(input.weights)}`);
+  if (input.knots) optsParts.push(`knots: ${JSON.stringify(input.knots)}`);
+  if (typeof input.closed === 'boolean') optsParts.push(`closed: ${JSON.stringify(input.closed)}`);
+
+  const controlPointsLiteral = JSON.stringify(input.controlPoints);
+  const feature_code = optsParts.length > 0
+    ? `const ${binding} = nurbsCurve(${controlPointsLiteral}, { ${optsParts.join(', ')} });`
+    : `const ${binding} = nurbsCurve(${controlPointsLiteral});`;
+
+  return addFeature(input.code, feature_code);
+}
+
+/**
+ * Pick the next available `_curve_<N>` binding by scanning the source for
+ * existing `const _curve_<N> = ` declarations. Independent counter from
+ * surfaces / sweeps / features.
+ */
+function deriveDefaultBinding(code: string): string {
+  let max = 0;
+  for (const m of code.matchAll(/const\s+_curve_(\d+)\s*=/g)) {
+    const n = parseInt(m[1], 10);
+    if (n > max) max = n;
+  }
+  return `_curve_${max + 1}`;
+}

--- a/src/agent/mcp/edits/addVariableSweep.ts
+++ b/src/agent/mcp/edits/addVariableSweep.ts
@@ -1,0 +1,117 @@
+// src/agent/mcp/edits/addVariableSweep.ts
+//
+// NURBS Slice B Task 11: insert a `variableSweep(spine, sections, opts?)`
+// binding into a .kcad.ts script immediately before the last top-level
+// `return`. Pure string manipulation — mirrors addFeature / addNurbsCurve.
+
+import { addFeature } from './addFeature';
+import type { AddFeatureResult } from './addFeature';
+
+/**
+ * One varying section reference: `t` is the spine parameter in [0, 1];
+ * `profile_binding` is the variable name of an existing Sketch declared
+ * earlier in the script.
+ */
+export interface VariableSweepSectionInput {
+  t: number;
+  profile_binding: string;
+}
+
+/**
+ * Inputs for `add_variable_sweep`. `spine_binding` is the variable name of
+ * an existing Curve3D / Sketch / Vec3[] declared earlier in the script.
+ */
+export interface AddVariableSweepInput {
+  code: string;
+  spine_binding: string;
+  sections: VariableSweepSectionInput[];
+  closed?: boolean;
+  continuity?: 'C0' | 'C1' | 'C2';
+  binding_name?: string;
+}
+
+/**
+ * Insert `const <binding> = variableSweep(<spine>, [...], { ... });` into
+ * `input.code` immediately before the last top-level `return`.
+ *
+ * Validates that `spine_binding` and every `section.profile_binding` are
+ * already bound in the source (simple regex scan over `const <name>` and
+ * `let <name>` declarations) — agents that pass undefined references get
+ * a fast structured error instead of a confusing capture-time stack trace.
+ */
+export function addVariableSweep(input: AddVariableSweepInput): AddFeatureResult {
+  if (!Array.isArray(input.sections) || input.sections.length < 2) {
+    return {
+      ok: false,
+      error: 'add_variable_sweep: sections must contain at least 2 { t, profile_binding } entries.',
+    };
+  }
+  for (const s of input.sections) {
+    if (typeof s?.t !== 'number' || !Number.isFinite(s.t)) {
+      return { ok: false, error: 'add_variable_sweep: every section.t must be a finite number.' };
+    }
+    if (typeof s?.profile_binding !== 'string' || !isValidIdentifier(s.profile_binding)) {
+      return {
+        ok: false,
+        error: `add_variable_sweep: profile_binding must be a JS identifier; got ${JSON.stringify(s?.profile_binding)}.`,
+      };
+    }
+  }
+  if (typeof input.spine_binding !== 'string' || !isValidIdentifier(input.spine_binding)) {
+    return {
+      ok: false,
+      error: `add_variable_sweep: spine_binding must be a JS identifier; got ${JSON.stringify(input.spine_binding)}.`,
+    };
+  }
+
+  if (!bindingExists(input.code, input.spine_binding)) {
+    return {
+      ok: false,
+      error: `add_variable_sweep: spine_binding "${input.spine_binding}" is not declared in the source.`,
+    };
+  }
+  for (const s of input.sections) {
+    if (!bindingExists(input.code, s.profile_binding)) {
+      return {
+        ok: false,
+        error: `add_variable_sweep: profile_binding "${s.profile_binding}" is not declared in the source.`,
+      };
+    }
+  }
+
+  const binding = input.binding_name ?? deriveDefaultBinding(input.code);
+  const sectionsLiteral = '[' + input.sections
+    .map(s => `{ t: ${JSON.stringify(s.t)}, profile: ${s.profile_binding} }`)
+    .join(', ') + ']';
+
+  const optsParts: string[] = [];
+  if (typeof input.closed === 'boolean') optsParts.push(`closed: ${JSON.stringify(input.closed)}`);
+  if (input.continuity) optsParts.push(`continuity: ${JSON.stringify(input.continuity)}`);
+
+  const feature_code = optsParts.length > 0
+    ? `const ${binding} = variableSweep(${input.spine_binding}, ${sectionsLiteral}, { ${optsParts.join(', ')} });`
+    : `const ${binding} = variableSweep(${input.spine_binding}, ${sectionsLiteral});`;
+
+  return addFeature(input.code, feature_code);
+}
+
+const IDENTIFIER_RE = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+function isValidIdentifier(s: string): boolean {
+  return IDENTIFIER_RE.test(s);
+}
+
+/** Regex check for `const <name>` or `let <name>` declaration anywhere in source. */
+function bindingExists(code: string, name: string): boolean {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`(?:^|[^A-Za-z0-9_$])(?:const|let|var)\\s+${escaped}\\b`);
+  return re.test(code);
+}
+
+function deriveDefaultBinding(code: string): string {
+  let max = 0;
+  for (const m of code.matchAll(/const\s+_sweep_(\d+)\s*=/g)) {
+    const n = parseInt(m[1], 10);
+    if (n > max) max = n;
+  }
+  return `_sweep_${max + 1}`;
+}

--- a/src/agent/mcp/toolRegistry.ts
+++ b/src/agent/mcp/toolRegistry.ts
@@ -1,8 +1,10 @@
 import { addConnectorTool } from './tools/addConnector';
 import { addConstraintTool, listConstraintsTool, solveSketchTool } from './tools/constraints';
 import { addFeatureTool } from './tools/addFeature';
+import { addNurbsCurveTool } from './tools/addNurbsCurve';
 import { addNurbsSurfaceTool } from './tools/addNurbsSurface';
 import { addPatternFeatureTool } from './tools/addPatternFeature';
+import { addVariableSweepTool } from './tools/addVariableSweep';
 import { addSketchTextTool } from './tools/addSketchText';
 import { addMateTool } from './tools/addMate';
 import { evaluateScriptTool } from './tools/evaluateScript';
@@ -283,6 +285,70 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
       },
     },
     handler: input => addNurbsSurfaceTool(input as unknown as Parameters<typeof addNurbsSurfaceTool>[0]),
+  },
+  {
+    definition: {
+      name: 'add_nurbs_curve',
+      description:
+        "Insert a `nurbsCurve(controlPoints, opts?)` declaration into the user's .kcad.ts immediately before the last top-level return. The returned binding has type Curve3D (peer to Shape / Surface) — consume it via `add_variable_sweep` (spine input) or downstream Curve3D-accepting features. Pass `controlPoints` as a Vec3[] (mm, at least 2 points). Optional NURBS knobs: `degree` (default 3), rational `weights`, explicit `knots`, `closed`. Returns the modified code + diagnostics from re-evaluating. Side-effect-free.",
+      inputSchema: {
+        type: 'object',
+        properties: {
+          code: { type: 'string', description: 'The .kcad.ts source code.' },
+          controlPoints: {
+            type: 'array',
+            description: 'Control points as Vec3 triples in mm; at least 2 entries.',
+            items: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+          },
+          degree: { type: 'integer', minimum: 1, description: 'Curve degree; default 3 (cubic).' },
+          weights: {
+            type: 'array',
+            description: 'Optional rational weights, one per control point (same length as controlPoints).',
+            items: { type: 'number' },
+          },
+          knots: {
+            type: 'array',
+            description: 'Optional explicit knot vector; missing => clamped-uniform inferred.',
+            items: { type: 'number' },
+          },
+          closed: { type: 'boolean', description: 'Optional periodic/closed-curve flag.' },
+          binding_name: { type: 'string', description: 'JS const name for the new Curve3D binding (default: _curve_<N>).' },
+        },
+        required: ['code', 'controlPoints'],
+      },
+    },
+    handler: input => addNurbsCurveTool(input as unknown as Parameters<typeof addNurbsCurveTool>[0]),
+  },
+  {
+    definition: {
+      name: 'add_variable_sweep',
+      description:
+        "Insert a `variableSweep(spine, sections, opts?)` declaration into the user's .kcad.ts immediately before the last top-level return. The result is a Shape — chain `.translate(...)`, `.union(...)`, etc. via `add_feature`. `spine_binding` references an existing variable (Curve3D / Sketch / Vec3[]) in the source; each `sections[i].profile_binding` references an existing Sketch. Sections must be strictly increasing in `t` and span [0, 1]; first t=0, last t=1. Validates every binding exists in the source via regex before inserting (fast structured error vs capture-time stack). Returns the modified code + diagnostics. Side-effect-free.",
+      inputSchema: {
+        type: 'object',
+        properties: {
+          code: { type: 'string', description: 'The .kcad.ts source code.' },
+          spine_binding: { type: 'string', description: 'Existing variable name for a Curve3D / Sketch / Vec3[] declared earlier in the source.' },
+          sections: {
+            type: 'array',
+            description: 'Varying cross-sections along the spine; at least 2 entries, strictly increasing in `t`.',
+            items: {
+              type: 'object',
+              properties: {
+                t: { type: 'number', description: 'Spine parameter in [0, 1].' },
+                profile_binding: { type: 'string', description: 'Existing Sketch variable name for this section.' },
+              },
+              required: ['t', 'profile_binding'],
+            },
+          },
+          closed: { type: 'boolean', description: 'Optional closed-sweep flag.' },
+          continuity: { type: 'string', enum: ['C0', 'C1', 'C2'], description: "Inter-section continuity; default 'C1'." },
+          binding_name: { type: 'string', description: 'JS const name for the new Shape binding (default: _sweep_<N>).' },
+        },
+        required: ['code', 'spine_binding', 'sections'],
+      },
+    },
+    handler: input => addVariableSweepTool(input as unknown as Parameters<typeof addVariableSweepTool>[0]),
   },
   {
     definition: {

--- a/src/agent/mcp/tools/addNurbsCurve.ts
+++ b/src/agent/mcp/tools/addNurbsCurve.ts
@@ -1,0 +1,32 @@
+// src/agent/mcp/tools/addNurbsCurve.ts
+//
+// MCP tool wrapper for `add_nurbs_curve`. Inserts a `nurbsCurve(...)`
+// binding into a .kcad.ts script, then re-evaluates the result so the
+// caller sees capture-time validation failures inline.
+
+import { addNurbsCurve } from '../edits/addNurbsCurve';
+import type { AddNurbsCurveInput } from '../edits/addNurbsCurve';
+import { evaluateScriptTool } from './evaluateScript';
+import type { CompilerDiagnostic } from '../../../shared/diagnostics/diagnostic';
+
+export type { AddNurbsCurveInput };
+
+export interface AddNurbsCurveOutput {
+  ok: boolean;
+  new_code?: string;
+  diagnostics?: CompilerDiagnostic[];
+  error?: string;
+}
+
+export async function addNurbsCurveTool(input: AddNurbsCurveInput): Promise<AddNurbsCurveOutput> {
+  const edit = addNurbsCurve(input);
+  if (!edit.ok || !edit.new_code) {
+    return { ok: false, error: edit.error };
+  }
+  const evalResult = await evaluateScriptTool({ code: edit.new_code });
+  return {
+    ok: true,
+    new_code: edit.new_code,
+    diagnostics: evalResult.diagnostics,
+  };
+}

--- a/src/agent/mcp/tools/addVariableSweep.ts
+++ b/src/agent/mcp/tools/addVariableSweep.ts
@@ -1,0 +1,32 @@
+// src/agent/mcp/tools/addVariableSweep.ts
+//
+// MCP tool wrapper for `add_variable_sweep`. Inserts a `variableSweep(...)`
+// binding into a .kcad.ts script, then re-evaluates the result so the
+// caller sees capture-time validation failures inline.
+
+import { addVariableSweep } from '../edits/addVariableSweep';
+import type { AddVariableSweepInput } from '../edits/addVariableSweep';
+import { evaluateScriptTool } from './evaluateScript';
+import type { CompilerDiagnostic } from '../../../shared/diagnostics/diagnostic';
+
+export type { AddVariableSweepInput };
+
+export interface AddVariableSweepOutput {
+  ok: boolean;
+  new_code?: string;
+  diagnostics?: CompilerDiagnostic[];
+  error?: string;
+}
+
+export async function addVariableSweepTool(input: AddVariableSweepInput): Promise<AddVariableSweepOutput> {
+  const edit = addVariableSweep(input);
+  if (!edit.ok || !edit.new_code) {
+    return { ok: false, error: edit.error };
+  }
+  const evalResult = await evaluateScriptTool({ code: edit.new_code });
+  return {
+    ok: true,
+    new_code: edit.new_code,
+    diagnostics: evalResult.diagnostics,
+  };
+}

--- a/tests/integration/mcp/addNurbsCurve.test.ts
+++ b/tests/integration/mcp/addNurbsCurve.test.ts
@@ -1,0 +1,74 @@
+// tests/integration/mcp/addNurbsCurve.test.ts
+//
+// NURBS Slice B Task 11: integration test for the `add_nurbs_curve` MCP tool.
+// Covers minimal insertion, explicit binding_name, malformed inputs, and a
+// full evaluateScript round-trip so the inserted code actually parses through
+// the capture pipeline.
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { initOcct } from '../../../src/kernel/backends/occt/occtBackend';
+import { addNurbsCurveTool } from '../../../src/agent/mcp/tools/addNurbsCurve';
+
+const SEED_CODE = [
+  'const base = box(20, 20, 5);',
+  'return base;',
+].join('\n');
+
+describe('add_nurbs_curve MCP tool', () => {
+  beforeAll(async () => { await initOcct(); }, 60000);
+
+  it('inserts a minimal nurbsCurve declaration before the return', async () => {
+    const r = await addNurbsCurveTool({
+      code: SEED_CODE,
+      controlPoints: [
+        [0, 0, 0], [10, 0, 0], [20, 0, 0], [30, 0, 0],
+      ],
+    });
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toMatch(/const _curve_1 = nurbsCurve\(/);
+    expect(r.new_code).toContain('return base;');
+    expect(r.diagnostics?.filter(d => d.severity === 'error') ?? []).toEqual([]);
+  });
+
+  it('honors explicit binding_name and serializes opts', async () => {
+    const r = await addNurbsCurveTool({
+      code: SEED_CODE,
+      controlPoints: [[0, 0, 0], [10, 0, 0], [20, 0, 0], [30, 0, 0]],
+      degree: 3,
+      closed: false,
+      binding_name: 'brow',
+    });
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toContain('const brow = nurbsCurve(');
+    expect(r.new_code).toContain('degree: 3');
+    expect(r.new_code).toContain('closed: false');
+  });
+
+  it('rejects controlPoints with bad shape', async () => {
+    const r = await addNurbsCurveTool({
+      code: SEED_CODE,
+      controlPoints: [[0, 0], [10, 0, 0]] as number[][],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Vec3/);
+  });
+
+  it('rejects fewer than 2 control points', async () => {
+    const r = await addNurbsCurveTool({
+      code: SEED_CODE,
+      controlPoints: [[0, 0, 0]],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/at least 2/);
+  });
+
+  it('auto-numbers consecutive bindings (_curve_2 follows _curve_1)', async () => {
+    const codeWithOne = `const _curve_1 = nurbsCurve([[0,0,0],[1,0,0]]);\n${SEED_CODE}`;
+    const r = await addNurbsCurveTool({
+      code: codeWithOne,
+      controlPoints: [[0, 0, 0], [10, 0, 0]],
+    });
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toMatch(/const _curve_2 = nurbsCurve\(/);
+  });
+});

--- a/tests/integration/mcp/addVariableSweep.test.ts
+++ b/tests/integration/mcp/addVariableSweep.test.ts
@@ -1,0 +1,95 @@
+// tests/integration/mcp/addVariableSweep.test.ts
+//
+// NURBS Slice B Task 11: integration test for the `add_variable_sweep` MCP
+// tool. Covers minimal insertion with two sections, binding-resolution
+// errors (spine and profile), and a full evaluateScript round-trip so the
+// inserted code actually parses through the capture pipeline.
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { initOcct } from '../../../src/kernel/backends/occt/occtBackend';
+import { addVariableSweepTool } from '../../../src/agent/mcp/tools/addVariableSweep';
+
+// Use a Sketch spine — the curve3d-spine path is gated on a future
+// recompute-engine change (see occtLowerer.ts comment at the variableSweep
+// arm). Sketch spines lower end-to-end today, which is what this integration
+// test exercises through evaluateScript.
+const SEED_CODE = [
+  'const spineSketch = path().moveTo(0, 0).lineTo(10, 0).lineTo(20, 0).lineTo(30, 0).close();',
+  'const profileA = path().moveTo(-2, -2).lineTo(2, -2).lineTo(2, 2).lineTo(-2, 2).close();',
+  'const profileB = path().moveTo(-1, -1).lineTo(1, -1).lineTo(1, 1).lineTo(-1, 1).close();',
+  'const base = box(1, 1, 1);',
+  'return base;',
+].join('\n');
+
+describe('add_variable_sweep MCP tool', () => {
+  beforeAll(async () => { await initOcct(); }, 60000);
+
+  it('inserts a minimal variableSweep declaration with two sections', async () => {
+    const r = await addVariableSweepTool({
+      code: SEED_CODE,
+      spine_binding: 'spineSketch',
+      sections: [
+        { t: 0, profile_binding: 'profileA' },
+        { t: 1, profile_binding: 'profileB' },
+      ],
+    });
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toMatch(/const _sweep_1 = variableSweep\(spineSketch, \[/);
+    expect(r.new_code).toContain('{ t: 0, profile: profileA }');
+    expect(r.new_code).toContain('{ t: 1, profile: profileB }');
+    expect(r.new_code).toContain('return base;');
+    expect(r.diagnostics?.filter(d => d.severity === 'error') ?? []).toEqual([]);
+  });
+
+  it('serializes optional continuity + binding_name', async () => {
+    const r = await addVariableSweepTool({
+      code: SEED_CODE,
+      spine_binding: 'spineSketch',
+      sections: [
+        { t: 0, profile_binding: 'profileA' },
+        { t: 1, profile_binding: 'profileB' },
+      ],
+      continuity: 'C2',
+      binding_name: 'body',
+    });
+    expect(r.ok).toBe(true);
+    expect(r.new_code).toContain('const body = variableSweep(spineSketch,');
+    expect(r.new_code).toContain('continuity: "C2"');
+  });
+
+  it('rejects when spine_binding is not declared in the source', async () => {
+    const r = await addVariableSweepTool({
+      code: SEED_CODE,
+      spine_binding: 'nonexistentSpine',
+      sections: [
+        { t: 0, profile_binding: 'profileA' },
+        { t: 1, profile_binding: 'profileB' },
+      ],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/spine_binding "nonexistentSpine" is not declared/);
+  });
+
+  it('rejects when any profile_binding is not declared in the source', async () => {
+    const r = await addVariableSweepTool({
+      code: SEED_CODE,
+      spine_binding: 'spineSketch',
+      sections: [
+        { t: 0, profile_binding: 'profileA' },
+        { t: 1, profile_binding: 'ghostProfile' },
+      ],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/profile_binding "ghostProfile" is not declared/);
+  });
+
+  it('rejects fewer than 2 sections', async () => {
+    const r = await addVariableSweepTool({
+      code: SEED_CODE,
+      spine_binding: 'spineSketch',
+      sections: [{ t: 0, profile_binding: 'profileA' }],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/at least 2/);
+  });
+});


### PR DESCRIPTION
## Summary

Two side-effect-free MCP tools that insert Curve3D + variableSweep declarations into a .kcad.ts script's source via string manipulation (brace-depth-tracked insertion before the last top-level return — same pattern as add_feature / add_nurbs_surface).

- add_nurbs_curve(code, controlPoints, degree?, weights?, knots?, closed?, binding_name?) — emits const _curve_N = nurbsCurve([...], { ... });
- add_variable_sweep(code, spine_binding, sections, closed?, continuity?, binding_name?) — emits const _sweep_N = variableSweep(<spine>, [...], { ... }); validates spine_binding and every section.profile_binding exist in source via regex before inserting (fast structured error vs capture-time stack).

Each tool re-evaluates the resulting script via evaluateScriptTool so capture-pipeline diagnostics surface inline.

## Test plan

- [x] tests/integration/mcp/addNurbsCurve.test.ts — minimal insert, explicit binding_name + opts, bad Vec3 shape rejection, <2 controlPoints rejection, auto-numbering through evaluateScript round-trip (5 cases).
- [x] tests/integration/mcp/addVariableSweep.test.ts — minimal insert with two Sketch sections, optional continuity + binding_name, missing spine_binding rejection, missing profile_binding rejection, <2 sections rejection (5 cases).
- [x] npx tsc --noEmit clean.
- [x] All 10 new tests pass.

Notes:
- Drift sentinel listApi.driftSentinel.test.ts already fails on base for missing nurbsCurve/spline3d/variableSweep entries in listApi.ts GLOBALS — that's Task 12 territory, intentionally out of scope here.
- variableSweep integration test uses a Sketch spine because the curve3d-spine recompute wiring is gated on a future engine change (see comment at occtLowerer.ts variableSweep arm).