### PR TITLE
feat(nurbs): Slice C kickoff — OCCT symbol audit + types + diagnostic codes

### DIFF
--- a/docs/audit/2026-05-18-slice-c-occt-symbols.md
+++ b/docs/audit/2026-05-18-slice-c-occt-symbols.md
@@ -1,0 +1,140 @@
+# Slice C OCCT symbol audit (2026-05-18)
+
+Source of truth: `node_modules/replicad-opencascadejs/src/replicad_single.d.ts`
+(the bundle currently shipped with kernelCAD-web). Audit performed during the
+Slice C kickoff (`feat/nurbs-slice-c-audit-and-types`) before any capture-side
+or lowerer code is written, so that Tasks 3-11 can branch on the actual
+binding shape rather than the plan's optimistic guesses.
+
+## surfaceFromBoundary
+
+- **`BRepFill_Filling`: MISSING.** No `BRepFill_*` class is exported beyond
+  `BRepFill_TypeOfContact` (an enum used by `BRepOffsetAPI_MakePipeShell`).
+  The plan's name does not exist in this bundle.
+- **`BRepOffsetAPI_MakeFilling`: PRESENT** (line 7630 of `replicad_single.d.ts`).
+  This is the same algorithm under a different class name and exposes
+  everything Slice C needs:
+  - Single constructor (no `_N` variants) with the full 10-arg signature
+    matching the plan's intended call:
+    ```
+    constructor(Degree, NbPtsOnCur, NbIter, Anisotropie, Tol2d, Tol3d,
+                TolAng, TolCurv, MaxDeg, MaxSegments)
+    ```
+  - **Add overloads (5 variants):**
+    - `Add_1(Constr: TopoDS_Edge, Order: GeomAbs_Shape, IsBound: Standard_Boolean): number`
+      — the variant Slice C wants (boundary edge with continuity flag).
+    - `Add_2(Constr: TopoDS_Edge, Support: TopoDS_Face, Order, IsBound)`
+      — adds an edge that lies on an existing support face (for tangent
+      continuity to a neighbour patch).
+    - `Add_3(Support: TopoDS_Face, Order)` — adds a whole face as a tangency
+      constraint.
+    - `Add_4(Point: gp_Pnt)` — adds an interior pass-through point.
+    - `Add_5(U, V, Support, Order)` — UV-parameter constraint.
+  - `Build(theRange: Message_ProgressRange): void`, `IsDone(): boolean`.
+  - `G0Error_1()`, `G1Error_1()`, `G2Error_1()` — actual achieved error per
+    continuity grade, useful for Slice C diagnostics.
+  - Inherited `Shape(): TopoDS_Shape` from `BRepBuilderAPI_MakeShape` (the
+    plan's `.Face()` does not exist; cast the shape via `TopoDS.Face_1(...)`
+    or `TopExp_Explorer` on the result).
+- **`GeomAbs_Shape`: PRESENT** as an enum-style namespace (line 6504) with
+  the full set required for the C0/C1/C2 + G1/G2 mapping:
+  - `GeomAbs_C0`, `GeomAbs_G1`, `GeomAbs_C1`, `GeomAbs_G2`, `GeomAbs_C2`,
+    `GeomAbs_C3`, `GeomAbs_CN`.
+- **`BRepBuilderAPI_MakeFace`: PRESENT** (not strictly needed; Filling already
+  returns a `TopoDS_Shape` containing a face). Re-wrapping is not required for
+  Slice C.
+
+**Verdict:** Slice C surfaceFromBoundary is **GREEN**, with one trivial
+rename: the plan's `BRepFill_Filling` references all need to be rewritten as
+`BRepOffsetAPI_MakeFilling`, the `Add_2(edge, order, isBound)` call becomes
+`Add_1(edge, order, isBound)`, and `.Face()` becomes `TopoDS.Face_1(.Shape())`.
+
+## G1/G2 fillet
+
+- **`BRepFilletAPI_MakeFillet`: PRESENT** (line 3349). Constructor:
+  ```
+  constructor(S: TopoDS_Shape, FShape: ChFi3d_FilletShape)
+  ```
+  Accepts a `ChFi3d_FilletShape` value at construction (so Slice C can pass
+  the continuity-flavoured enum directly without a follow-up `SetFilletShape`
+  call).
+- **`SetFilletShape(FShape: ChFi3d_FilletShape)`: PRESENT** (line 3372) —
+  also reachable post-construction.
+- **`SetContinuity(InternalContinuity: GeomAbs_Shape, AngularTolerance)`:
+  PRESENT** (line 3352) — a parallel knob for setting the internal blend
+  surface continuity to `GeomAbs_G2` directly. This is a stronger guarantee
+  than `SetFilletShape` and is the right call when the plan asks for
+  `continuity: 'G2'`. Bonus: orthogonal to the rational/polynomial choice.
+- **`ChFi3d_FilletShape`: PRESENT** (line 7039) with all three OCCT values:
+  - `ChFi3d_Rational` — rational Bezier blend surface (G2-capable).
+  - `ChFi3d_QuasiAngular` — quasi-angular polynomial.
+  - `ChFi3d_Polynomial` — polynomial Bezier (G1-only).
+  - (The plan's Case-C contingency — "ChFi3d_Rational missing" — does not
+    apply; the binding ships all three values.)
+
+**Verdict:** Slice C G1/G2 fillet is **GREEN**, with one note: prefer
+`SetContinuity(oc.GeomAbs_Shape.GeomAbs_G2, tol)` for the user-visible
+guarantee, and use `ChFi3d_Rational` (set at constructor time) as the
+matching surface form. The plan's `if (anyG2 && oc.ChFi3d?.ChFi3d_Rational
+!== undefined)` runtime guard becomes dead code (always true) but is cheap
+to keep as a defence-in-depth check.
+
+## hermiteG2
+
+- **`Geom_BSplineCurve` degree=5 path: VERIFIED.** Slice B's
+  `src/modeling/backends/occt/curve3dLowerer.ts` already passes `m.degree`
+  directly to `new oc.Geom_BSplineCurve_1(...)` / `_2(...)` without any
+  branch on degree. The shared `clampedUniformKnots(n, degree)` helper that
+  Slice B introduced produces a correctly-clamped knot vector for any
+  `(n, degree)` pair where `n >= degree + 1` — a 6-control-point quintic
+  matches `n = 6`, `degree = 5`, and the resulting Bezier-style knot
+  vector `[0,0,0,0,0,0,1,1,1,1,1,1]` is exactly what a single-segment
+  quintic Bezier needs.
+- **No new OCCT symbols required.** Task 5 is pure JS arithmetic
+  (the quintic Hermite -> 6-Bezier-control-point conversion in the plan's
+  §Task 5 Step 2) feeding into Slice B's existing `addCurve3D(...)`. No
+  WASM rebuild, no symbol guards.
+
+**Verdict:** Slice C hermiteG2 is **GREEN**.
+
+## Conclusions
+
+- **Task 4 (surfaceFromBoundary): GREEN** — `BRepOffsetAPI_MakeFilling` is
+  the actual class name (plan said `BRepFill_Filling`); identical behaviour.
+- **Task 6 (G1/G2 fillet): GREEN** — `ChFi3d_Rational` and the
+  `SetContinuity(GeomAbs_G2, tol)` knob are both available. The plan's Case-C
+  "G2 missing → downgrade with warning" contingency is unnecessary; Slice C
+  can ship full G2 directly.
+- **Task 5 (hermiteG2): GREEN** — solved entirely on top of Slice B; no new
+  OCCT plumbing.
+
+**Recommended workarounds for RED items:** none — there are no RED items.
+
+**Recommended plan-text amendments** (to be folded into the Slice C plan
+before Tasks 3-11 dispatch):
+
+1. Replace every `BRepFill_Filling` occurrence with `BRepOffsetAPI_MakeFilling`
+   in the plan and any forthcoming lowerer skeleton.
+2. Replace the `.Face()` accessor with `.Shape()` plus a `TopoDS.Face_1(...)`
+   downcast.
+3. Use `Add_1(edge, order, isBound)` (not `Add_2`) for the boundary-edge
+   constraint variant. `Add_2` exists but takes a `Support` face — irrelevant
+   for the Coons-patch boundary, useful only if a future iteration adds
+   tangency to an existing neighbour surface.
+4. In `OcctBackend.filletVariable`, set the rational-surface form at
+   construction (`new BRepFilletAPI_MakeFillet(shape, ChFi3d_Rational)` when
+   any group requests `'G2'`) AND call
+   `mkFillet.SetContinuity(GeomAbs_G2, 1e-6)` for the corresponding internal
+   continuity guarantee. The `oc.ChFi3d?.ChFi3d_Rational !== undefined`
+   runtime guard can be dropped — the symbol is always present in the
+   current bundle — but the cost of keeping it as a defence-in-depth fallback
+   is negligible.
+5. Drop the Slice C Case-C diagnostic
+   `feature.fillet.continuity-not-applicable` from the "downgrade-with-warning"
+   role. The audit shows the symbol is always present, so the code becomes
+   reserved for a different recovery path: it should fire when a user passes
+   `continuity: 'G2'` on a fillet whose adjacent faces are themselves only G1
+   (e.g. fillet across a polyline edge of an extrusion), where requesting G2
+   is geometrically meaningless. The hint should redirect to applying a
+   smaller radius or a different blend strategy rather than implying the
+   kernel can't do G2.

--- a/src/shared/diagnostics/codes.ts
+++ b/src/shared/diagnostics/codes.ts
@@ -92,7 +92,16 @@ export type DiagnosticCode =
   | 'feature.variable-sweep.spine-too-short'
   | 'feature.variable-sweep.profile-not-planar'
   | 'feature.variable-sweep.profile-empty'
-  | 'feature.variable-sweep.frenet-degenerate';
+  | 'feature.variable-sweep.frenet-degenerate'
+  // NURBS Slice C (6) — surfaceFromBoundary (Coons patch) + G2 fillet.
+  // surfaceFromBoundary lowers to BRepOffsetAPI_MakeFilling per the
+  // 2026-05-18 OCCT symbol audit (docs/audit/2026-05-18-slice-c-occt-symbols.md).
+  | 'feature.surface-from-boundary.corner-mismatch'
+  | 'feature.surface-from-boundary.too-few-curves'
+  | 'feature.surface-from-boundary.too-many-curves'
+  | 'feature.surface-from-boundary.continuity-orphan'
+  | 'feature.surface-from-boundary.degenerate-patch'
+  | 'feature.fillet.continuity-not-applicable';
 
 export const DIAGNOSTIC_CODES: readonly DiagnosticCode[] = [
   'feature.invalid-args',
@@ -152,6 +161,12 @@ export const DIAGNOSTIC_CODES: readonly DiagnosticCode[] = [
   'feature.variable-sweep.profile-not-planar',
   'feature.variable-sweep.profile-empty',
   'feature.variable-sweep.frenet-degenerate',
+  'feature.surface-from-boundary.corner-mismatch',
+  'feature.surface-from-boundary.too-few-curves',
+  'feature.surface-from-boundary.too-many-curves',
+  'feature.surface-from-boundary.continuity-orphan',
+  'feature.surface-from-boundary.degenerate-patch',
+  'feature.fillet.continuity-not-applicable',
 ] as const;
 
 export interface HintTemplate {
@@ -282,6 +297,18 @@ function buildHintTemplates(): Record<DiagnosticCode, HintTemplate> {
       'variableSweep profile sketch is empty. Close the path() before passing it as a profile.',
     'feature.variable-sweep.frenet-degenerate':
       'Frenet orientation is undefined where the spine curvature vanishes (straight segments). Pass orientation: { up: Vec3 } or "corrected-frenet" for spines with straight stretches.',
+    'feature.surface-from-boundary.corner-mismatch':
+      'surfaceFromBoundary requires adjacent boundary curves to share endpoints within 1e-6 mm (c1.end == c2.start, c2.end == c3.start, c3.end == c4.start, c4.end == c1.start). Snap the endpoints or rebuild the boundary curves so they form a closed loop.',
+    'feature.surface-from-boundary.too-few-curves':
+      'surfaceFromBoundary requires exactly 4 boundary curves. Pass an array of 4 Curve3D refs in walk order (bottom, right, top, left).',
+    'feature.surface-from-boundary.too-many-curves':
+      'surfaceFromBoundary requires exactly 4 boundary curves. Pass an array of 4 Curve3D refs in walk order — if the loop has more than 4 sides, split the patch into adjacent quads.',
+    'feature.surface-from-boundary.continuity-orphan':
+      "surfaceFromBoundary continuity 'C1' / 'C2' requires the neighbors map to identify which existing surface to be tangent (or curvature-continuous) to on each side. Either drop the continuity flag or supply opts.neighbors so the kernel can resolve the tangency target.",
+    'feature.surface-from-boundary.degenerate-patch':
+      'BRepOffsetAPI_MakeFilling could not produce a face. The boundary curves are likely coincident, self-intersecting, or topologically invalid. Inspect the curve sequence with list_features and visualize each Curve3D before retrying.',
+    'feature.fillet.continuity-not-applicable':
+      "continuity: 'G2' was requested but the adjacent faces along the target edge are themselves only G1-continuous, so the resulting blend can be no smoother than G1. Either accept the G1 result, refit the upstream faces as NURBS so they are G2 internally, or apply a smaller fillet that fits inside a single smooth region.",
   };
   const out = {} as Record<DiagnosticCode, HintTemplate>;
   for (const code of DIAGNOSTIC_CODES) {

--- a/src/shared/diagnostics/nextAction.ts
+++ b/src/shared/diagnostics/nextAction.ts
@@ -80,4 +80,10 @@ export const NEXT_ACTIONS: Record<DiagnosticCode, NextAction> = {
   'feature.variable-sweep.profile-not-planar':    { kind: 'rewrite-feature', guidance: 'use a planar path().close() sketch for each section' },
   'feature.variable-sweep.profile-empty':         { kind: 'rewrite-feature', guidance: 'close the path() before passing as a profile' },
   'feature.variable-sweep.frenet-degenerate':     { kind: 'fix-arg', field: 'orientation' },
+  'feature.surface-from-boundary.corner-mismatch':   { kind: 'fix-arg', field: 'curveRefs' },
+  'feature.surface-from-boundary.too-few-curves':    { kind: 'fix-arg', field: 'curveRefs' },
+  'feature.surface-from-boundary.too-many-curves':   { kind: 'fix-arg', field: 'curveRefs' },
+  'feature.surface-from-boundary.continuity-orphan': { kind: 'fix-arg', field: 'neighbors' },
+  'feature.surface-from-boundary.degenerate-patch':  { kind: 'rewrite-feature', guidance: 'rebuild the 4 boundary curves so they form a non-self-intersecting closed loop, then retry surfaceFromBoundary' },
+  'feature.fillet.continuity-not-applicable':        { kind: 'rewrite-feature', guidance: "drop continuity: 'G2' (adjacent faces are only G1) or refit the upstream faces as NURBS surfaces" },
 };

--- a/src/shared/intent/coonsPatchRecord.ts
+++ b/src/shared/intent/coonsPatchRecord.ts
@@ -1,0 +1,92 @@
+import type { FeatureRef } from './types';
+
+/**
+ * Capture-time metadata for a `surfaceFromBoundary` feature (a Coons patch).
+ * A Coons patch fills the interior of 4 boundary curves to produce a NURBS
+ * surface, lowered via OCCT's `BRepOffsetAPI_MakeFilling` (audited 2026-05-18
+ * — see `docs/audit/2026-05-18-slice-c-occt-symbols.md`; the plan's
+ * `BRepFill_Filling` is not exposed by the current bundle but
+ * `BRepOffsetAPI_MakeFilling` is identical in behaviour).
+ *
+ * The 4 boundary curves must form a closed loop with endpoints coincident
+ * within `1e-6` mm: `curveRefs[0].end === curveRefs[1].start`,
+ * `curveRefs[1].end === curveRefs[2].start`, and so on round to
+ * `curveRefs[3].end === curveRefs[0].start`. Corner-coincidence is checked
+ * lazily during the corresponding Task 3 capture step; this record only
+ * enforces that the array has exactly 4 entries, every entry is a
+ * structurally valid `FeatureRef`, and the optional continuity / degree /
+ * neighbour fields are well-typed.
+ *
+ * Continuity flag is `'C0' | 'C1' | 'C2'` and maps to
+ * `GeomAbs_C0 | GeomAbs_C1 | GeomAbs_C2` at lower time. `'G1'` and `'G2'`
+ * are intentionally NOT accepted here — the OCCT `GeomAbs_Shape` enum
+ * exposes them, but for a Coons patch on free-floating boundary curves
+ * G-continuity is geometrically indistinguishable from C-continuity
+ * (there is no neighbour surface to be tangent to). Future iterations
+ * may surface a `'G1' | 'G2'` flag when `neighbors` is populated — the
+ * `neighbors` field is reserved here so the record shape does not need
+ * to break later.
+ *
+ * `uvDegree` defaults to `{ u: 3, v: 3 }` (bi-cubic) at lower time when
+ * absent. Valid degrees are `1..8` per OCCT's `MaxDeg` ceiling.
+ */
+export interface CoonsPatchMetadata {
+  /** 4 boundary curves in walk order (bottom, right, top, left). */
+  curveRefs: [FeatureRef, FeatureRef, FeatureRef, FeatureRef];
+  /** Continuity grade at the boundary curves. Default C0. */
+  continuity: 'C0' | 'C1' | 'C2';
+  /** Optional u/v polynomial degree for the fitted NURBS surface. */
+  uvDegree?: { u: number; v: number };
+  /** Optional per-side neighbour surface refs for future tangency
+   *  constraints (Task 3 does not consume them; reserved for a follow-up
+   *  iteration when surfaceFromBoundary stitches into an existing patch). */
+  neighbors?: {
+    bottom?: FeatureRef;
+    right?: FeatureRef;
+    top?: FeatureRef;
+    left?: FeatureRef;
+  };
+}
+
+function isFeatureRef(v: unknown): v is FeatureRef {
+  if (typeof v !== 'object' || v === null) return false;
+  const k = (v as { kind?: unknown }).kind;
+  return typeof k === 'string';
+}
+
+function isDegreePair(v: unknown): boolean {
+  if (typeof v !== 'object' || v === null) return false;
+  const o = v as { u?: unknown; v?: unknown };
+  if (typeof o.u !== 'number' || !Number.isInteger(o.u) || o.u < 1 || o.u > 8) return false;
+  if (typeof o.v !== 'number' || !Number.isInteger(o.v) || o.v < 1 || o.v > 8) return false;
+  return true;
+}
+
+function isNeighbourMap(v: unknown): boolean {
+  if (typeof v !== 'object' || v === null) return false;
+  const o = v as Record<string, unknown>;
+  const allowed = ['bottom', 'right', 'top', 'left'];
+  for (const key of Object.keys(o)) {
+    if (!allowed.includes(key)) return false;
+    const val = o[key];
+    if (val !== undefined && !isFeatureRef(val)) return false;
+  }
+  return true;
+}
+
+export function isCoonsPatchMetadata(value: unknown): value is CoonsPatchMetadata {
+  if (typeof value !== 'object' || value === null) return false;
+  const m = value as CoonsPatchMetadata;
+
+  if (!Array.isArray(m.curveRefs) || m.curveRefs.length !== 4) return false;
+  for (const ref of m.curveRefs) {
+    if (!isFeatureRef(ref)) return false;
+  }
+
+  if (m.continuity !== 'C0' && m.continuity !== 'C1' && m.continuity !== 'C2') return false;
+
+  if (m.uvDegree !== undefined && !isDegreePair(m.uvDegree)) return false;
+  if (m.neighbors !== undefined && !isNeighbourMap(m.neighbors)) return false;
+
+  return true;
+}

--- a/src/shared/intent/filletContinuityRecord.ts
+++ b/src/shared/intent/filletContinuityRecord.ts
@@ -1,0 +1,30 @@
+/**
+ * Discriminator for the per-group continuity grade on `Shape.fillet` and
+ * `Shape.chamfer` requests. Threaded through to the OCCT backend in Task 6
+ * where it dispatches to `BRepFilletAPI_MakeFillet`:
+ *
+ * - `'G1'` (default): tangent-continuous blend surface.
+ *   Maps to `ChFi3d_Polynomial` at construction + no
+ *   `SetContinuity` call (OCCT's default internal continuity is already G1).
+ * - `'G2'`: curvature-continuous blend surface.
+ *   Maps to `ChFi3d_Rational` at construction +
+ *   `SetContinuity(GeomAbs_G2, 1e-6)` to force the internal blend surface
+ *   to G2.
+ *
+ * The 2026-05-18 audit (`docs/audit/2026-05-18-slice-c-occt-symbols.md`)
+ * confirmed that both `ChFi3d_Rational` and the `GeomAbs_G2` enum value
+ * are exposed by the current `replicad-opencascadejs` bundle, so the plan's
+ * "downgrade-with-warning" contingency is not needed — Slice C ships full
+ * G2 by direct OCCT dispatch.
+ *
+ * The matching diagnostic code `feature.fillet.continuity-not-applicable`
+ * (Task 2) is reserved for a different failure: requesting `'G2'` on an
+ * edge whose adjacent faces are themselves only G1-continuous (e.g. a
+ * polygonal extrusion edge), where the kernel can construct the blend
+ * surface but the geometric outcome is no smoother than G1.
+ */
+export type FilletContinuity = 'G1' | 'G2';
+
+export function isFilletContinuity(value: unknown): value is FilletContinuity {
+  return value === 'G1' || value === 'G2';
+}

--- a/src/shared/intent/hermiteG2Record.ts
+++ b/src/shared/intent/hermiteG2Record.ts
@@ -1,0 +1,69 @@
+import type { Vec3 } from './types';
+
+/**
+ * Endpoint constraint for a `hermiteG2(a, b)` quintic Hermite transition
+ * curve. Captures the G2-continuous boundary data the agent supplies at
+ * each end of the curve: position, tangent, and (optionally) curvature
+ * second-derivative vector plus a tangent-magnitude weight.
+ *
+ * Validation rules:
+ * - `point` and `tangent` are required and must be finite Vec3.
+ * - `curvature` defaults to `[0, 0, 0]` (geometric line / G1-only).
+ * - `weight` defaults to `1.0` (no rescale on the tangent). Must be
+ *   strictly positive; zero would degenerate the quintic to a cubic by
+ *   collapsing the B1/B4 control points onto B0/B5 (which the math still
+ *   handles, but it's a malformed input from the agent's standpoint).
+ */
+export interface HermiteG2Endpoint {
+  point: Vec3;
+  tangent: Vec3;
+  curvature?: Vec3;
+  weight?: number;
+}
+
+/**
+ * Capture-time metadata for a `hermiteG2(a, b)` feature.
+ *
+ * Lowering is purely JS-side: the quintic Hermite system at both endpoints
+ * is solved analytically into 6 Bezier control points (`buildHermiteG2-
+ * ControlPoints` in Task 5), and the result is forwarded to Slice B's
+ * `addCurve3D({ controlPoints, degree: 5, closed: false })` which builds a
+ * `Geom_BSplineCurve` with degree=5 and a single-segment clamped knot
+ * vector. The audit (2026-05-18) confirmed the curve3dLowerer happily
+ * accepts degree=5 with 6 control points.
+ *
+ * Storing the original `(a, b)` endpoint data on the metadata record (rather
+ * than just the 6 control points) is deliberate: it lets the recompute
+ * pipeline re-run the quintic solver when an upstream Param changes one of
+ * the endpoint tangents / curvatures, without having to invert the Bezier
+ * representation back to Hermite form.
+ */
+export interface HermiteG2Metadata {
+  /** Start-point constraint. */
+  endA: HermiteG2Endpoint;
+  /** End-point constraint. */
+  endB: HermiteG2Endpoint;
+}
+
+function isVec3(v: unknown): v is Vec3 {
+  if (!Array.isArray(v) || v.length !== 3) return false;
+  return v.every((c) => typeof c === 'number' && Number.isFinite(c));
+}
+
+export function isHermiteG2Endpoint(value: unknown): value is HermiteG2Endpoint {
+  if (typeof value !== 'object' || value === null) return false;
+  const e = value as HermiteG2Endpoint;
+  if (!isVec3(e.point)) return false;
+  if (!isVec3(e.tangent)) return false;
+  if (e.curvature !== undefined && !isVec3(e.curvature)) return false;
+  if (e.weight !== undefined) {
+    if (typeof e.weight !== 'number' || !Number.isFinite(e.weight) || e.weight <= 0) return false;
+  }
+  return true;
+}
+
+export function isHermiteG2Metadata(value: unknown): value is HermiteG2Metadata {
+  if (typeof value !== 'object' || value === null) return false;
+  const m = value as HermiteG2Metadata;
+  return isHermiteG2Endpoint(m.endA) && isHermiteG2Endpoint(m.endB);
+}

--- a/src/shared/intent/types.ts
+++ b/src/shared/intent/types.ts
@@ -149,7 +149,12 @@ export type FeatureKind =
   // NURBS Slice B: 3D parametric curve (Geom_BSplineCurve under the hood)
   //   and multi-section sweep (BRepOffsetAPI_MakePipeShell).
   | 'curve3d'
-  | 'variableSweep';
+  | 'variableSweep'
+  // NURBS Slice C: Coons patch from 4 boundary curves (BRepOffsetAPI_MakeFilling
+  //   per 2026-05-18 audit) and quintic Hermite transition curve (degree-5
+  //   nurbsCurve via JS-side Bezier control-point math).
+  | 'surfaceFromBoundary'
+  | 'hermiteG2';
 
 /**
  * Runtime guard for PlaneSpec. Returns true for cardinal strings

--- a/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
+++ b/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
@@ -66,15 +66,19 @@ function emittedCodes(): Set<string> {
 describe('every diagnostic code emitted in src/ is in the catalogue', () => {
   const catalogue = new Set<string>(DIAGNOSTIC_CODES);
 
-  it('catalogue has exactly 46 codes', () => {
-    expect(catalogue.size).toBe(46);
+  it('catalogue has exactly 63 codes', () => {
+    // 46 baseline (milestone-C diagnostic-vocab spec)
+    //  + 11 Slice B (Curve3D + variableSweep capture validation)
+    //  +  6 Slice C (surfaceFromBoundary + G2 fillet)
+    // = 63.
+    expect(catalogue.size).toBe(63);
   });
 
   it('no emit site uses a code outside the catalogue', () => {
     const stale = [...emittedCodes()].filter((c) => !catalogue.has(c)).sort();
     expect(
       stale,
-      `Stale codes still emitted in src/: ${JSON.stringify(stale)}.\nMigration policy: every code must be one of the 43 in DIAGNOSTIC_CODES.`,
+      `Stale codes still emitted in src/: ${JSON.stringify(stale)}.\nMigration policy: every code must be one of the 63 in DIAGNOSTIC_CODES.`,
     ).toEqual([]);
   });
 });

--- a/tests/unit/intent/coonsPatch.test.ts
+++ b/tests/unit/intent/coonsPatch.test.ts
@@ -1,0 +1,117 @@
+// tests/unit/intent/coonsPatch.test.ts
+//
+// NURBS Slice C Task 1: type-level guard for the surfaceFromBoundary (Coons
+// patch) capture metadata. Mirrors the Slice B guard tests in spirit — the
+// guard never touches OCCT; it just fences malformed agent inputs before
+// the lazy lowerer touches the WASM bindings.
+
+import { describe, it, expect } from 'vitest';
+import {
+  isCoonsPatchMetadata,
+  type CoonsPatchMetadata,
+} from '../../../src/shared/intent/coonsPatchRecord';
+import {
+  isFilletContinuity,
+} from '../../../src/shared/intent/filletContinuityRecord';
+import type { FeatureId } from '../../../src/shared/intent/types';
+
+const fid = (s: string) => s as FeatureId;
+const fref = (id: string) => ({ kind: 'feature' as const, id: fid(id) });
+
+describe('CoonsPatchMetadata', () => {
+  it('accepts a minimal 4-curve patch with default C0 continuity', () => {
+    const m: CoonsPatchMetadata = {
+      curveRefs: [fref('c1'), fref('c2'), fref('c3'), fref('c4')],
+      continuity: 'C0',
+    };
+    expect(isCoonsPatchMetadata(m)).toBe(true);
+  });
+
+  it('accepts uvDegree + neighbors', () => {
+    const m: CoonsPatchMetadata = {
+      curveRefs: [fref('c1'), fref('c2'), fref('c3'), fref('c4')],
+      continuity: 'C2',
+      uvDegree: { u: 3, v: 5 },
+      neighbors: { bottom: fref('s_below'), top: fref('s_above') },
+    };
+    expect(isCoonsPatchMetadata(m)).toBe(true);
+  });
+
+  it('rejects fewer or more than 4 curve refs', () => {
+    expect(isCoonsPatchMetadata({
+      curveRefs: [fref('c1'), fref('c2'), fref('c3')],
+      continuity: 'C0',
+    })).toBe(false);
+    expect(isCoonsPatchMetadata({
+      curveRefs: [fref('c1'), fref('c2'), fref('c3'), fref('c4'), fref('c5')],
+      continuity: 'C0',
+    })).toBe(false);
+  });
+
+  it('rejects malformed FeatureRef entries', () => {
+    expect(isCoonsPatchMetadata({
+      curveRefs: ['c1', 'c2', 'c3', 'c4'],
+      continuity: 'C0',
+    })).toBe(false);
+    expect(isCoonsPatchMetadata({
+      curveRefs: [fref('c1'), null, fref('c3'), fref('c4')],
+      continuity: 'C0',
+    })).toBe(false);
+  });
+
+  it('rejects unknown continuity values', () => {
+    expect(isCoonsPatchMetadata({
+      curveRefs: [fref('c1'), fref('c2'), fref('c3'), fref('c4')],
+      continuity: 'C5',
+    })).toBe(false);
+    // G-grades belong on Shape.fillet, not on Coons-patch boundaries
+    // (no neighbour surface = G/C indistinguishable).
+    expect(isCoonsPatchMetadata({
+      curveRefs: [fref('c1'), fref('c2'), fref('c3'), fref('c4')],
+      continuity: 'G2',
+    })).toBe(false);
+  });
+
+  it('rejects out-of-range or non-integer uvDegree entries', () => {
+    const base = {
+      curveRefs: [fref('c1'), fref('c2'), fref('c3'), fref('c4')],
+      continuity: 'C0' as const,
+    };
+    expect(isCoonsPatchMetadata({ ...base, uvDegree: { u: 0, v: 3 } })).toBe(false);
+    expect(isCoonsPatchMetadata({ ...base, uvDegree: { u: 3, v: 9 } })).toBe(false);
+    expect(isCoonsPatchMetadata({ ...base, uvDegree: { u: 2.5, v: 3 } })).toBe(false);
+    expect(isCoonsPatchMetadata({ ...base, uvDegree: { u: 3 } })).toBe(false);
+  });
+
+  it('rejects unknown neighbour keys', () => {
+    const base = {
+      curveRefs: [fref('c1'), fref('c2'), fref('c3'), fref('c4')],
+      continuity: 'C0' as const,
+    };
+    expect(isCoonsPatchMetadata({
+      ...base,
+      neighbors: { sideways: fref('s_side') },
+    })).toBe(false);
+  });
+
+  it('rejects non-object input', () => {
+    expect(isCoonsPatchMetadata(null)).toBe(false);
+    expect(isCoonsPatchMetadata('coons')).toBe(false);
+    expect(isCoonsPatchMetadata(42)).toBe(false);
+  });
+});
+
+describe('isFilletContinuity', () => {
+  it('accepts G1 and G2', () => {
+    expect(isFilletContinuity('G1')).toBe(true);
+    expect(isFilletContinuity('G2')).toBe(true);
+  });
+
+  it('rejects C-grades, lowercase, undefined, and non-string input', () => {
+    expect(isFilletContinuity('C2')).toBe(false);
+    expect(isFilletContinuity('g2')).toBe(false);
+    expect(isFilletContinuity(undefined)).toBe(false);
+    expect(isFilletContinuity(null)).toBe(false);
+    expect(isFilletContinuity(2)).toBe(false);
+  });
+});

--- a/tests/unit/intent/hermiteG2.test.ts
+++ b/tests/unit/intent/hermiteG2.test.ts
@@ -1,0 +1,93 @@
+// tests/unit/intent/hermiteG2.test.ts
+//
+// NURBS Slice C Task 1: type-level guards for the hermiteG2(a, b) endpoint
+// + container metadata. The lowerer for hermiteG2 ships in Task 5 — it
+// solves the quintic Hermite system in JS and forwards 6 control points to
+// Slice B's existing curve3d lowerer, so this guard fences the agent input
+// before any math runs.
+
+import { describe, it, expect } from 'vitest';
+import {
+  isHermiteG2Endpoint,
+  isHermiteG2Metadata,
+  type HermiteG2Endpoint,
+  type HermiteG2Metadata,
+} from '../../../src/shared/intent/hermiteG2Record';
+
+describe('HermiteG2Endpoint', () => {
+  it('accepts the minimal { point, tangent } pair', () => {
+    const e: HermiteG2Endpoint = { point: [0, 0, 0], tangent: [1, 0, 0] };
+    expect(isHermiteG2Endpoint(e)).toBe(true);
+  });
+
+  it('accepts curvature + weight', () => {
+    const e: HermiteG2Endpoint = {
+      point: [0, 0, 0],
+      tangent: [1, 0, 0],
+      curvature: [0, 1, 0],
+      weight: 1.2,
+    };
+    expect(isHermiteG2Endpoint(e)).toBe(true);
+  });
+
+  it('rejects non-3D or non-finite vectors', () => {
+    expect(isHermiteG2Endpoint({ point: [0, 0], tangent: [1, 0, 0] })).toBe(false);
+    expect(isHermiteG2Endpoint({ point: [0, 0, NaN], tangent: [1, 0, 0] })).toBe(false);
+    expect(isHermiteG2Endpoint({ point: [0, 0, 0], tangent: [1, 0, Infinity] })).toBe(false);
+    expect(isHermiteG2Endpoint({
+      point: [0, 0, 0], tangent: [1, 0, 0], curvature: [0, 0],
+    })).toBe(false);
+  });
+
+  it('rejects non-positive or non-finite weight', () => {
+    const base = { point: [0, 0, 0] as [number, number, number], tangent: [1, 0, 0] as [number, number, number] };
+    expect(isHermiteG2Endpoint({ ...base, weight: 0 })).toBe(false);
+    expect(isHermiteG2Endpoint({ ...base, weight: -1 })).toBe(false);
+    expect(isHermiteG2Endpoint({ ...base, weight: NaN })).toBe(false);
+  });
+
+  it('rejects missing required fields', () => {
+    expect(isHermiteG2Endpoint({ point: [0, 0, 0] })).toBe(false);
+    expect(isHermiteG2Endpoint({ tangent: [1, 0, 0] })).toBe(false);
+  });
+
+  it('rejects non-object input', () => {
+    expect(isHermiteG2Endpoint(null)).toBe(false);
+    expect(isHermiteG2Endpoint('endpoint')).toBe(false);
+    expect(isHermiteG2Endpoint([0, 0, 0])).toBe(false);
+  });
+});
+
+describe('HermiteG2Metadata', () => {
+  it('accepts a well-formed pair of endpoints', () => {
+    const m: HermiteG2Metadata = {
+      endA: { point: [0, 0, 0], tangent: [1, 0, 0] },
+      endB: { point: [10, 0, 0], tangent: [1, 0, 0] },
+    };
+    expect(isHermiteG2Metadata(m)).toBe(true);
+  });
+
+  it('accepts endpoints with mismatched curvature + weight', () => {
+    const m: HermiteG2Metadata = {
+      endA: { point: [0, 0, 0], tangent: [1, 0, 0], curvature: [0, 1, 0], weight: 1 },
+      endB: { point: [10, 0, 0], tangent: [0, 1, 0], curvature: [-1, 0, 0], weight: 2.5 },
+    };
+    expect(isHermiteG2Metadata(m)).toBe(true);
+  });
+
+  it('rejects when either endpoint is malformed', () => {
+    expect(isHermiteG2Metadata({
+      endA: { point: [0, 0, 0], tangent: [1, 0, 0] },
+      endB: { point: [10, 0], tangent: [1, 0, 0] },
+    })).toBe(false);
+    expect(isHermiteG2Metadata({
+      endA: { tangent: [1, 0, 0] },
+      endB: { point: [10, 0, 0], tangent: [1, 0, 0] },
+    })).toBe(false);
+  });
+
+  it('rejects non-object input', () => {
+    expect(isHermiteG2Metadata(null)).toBe(false);
+    expect(isHermiteG2Metadata('hermite')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Tight kickoff slice for **NURBS Slice C** (Coons patch + G1/G2 fillet + hermiteG2). Two pieces only — Tasks 3-11 ship in follow-on dispatches:

- **OCCT symbol audit** (`docs/audit/2026-05-18-slice-c-occt-symbols.md`) — confirms the current `replicad-opencascadejs` bundle exposes everything Slice C needs. All three tasks GREEN. Key correction to the plan: the class is `BRepOffsetAPI_MakeFilling`, NOT `BRepFill_Filling` (which is absent); identical behaviour, trivial rename. `ChFi3d_Rational` and `GeomAbs_G2` are both present, so the plan's downgrade-with-warning contingency is unnecessary.
- **Task 1: capture-time type records** — `CoonsPatchMetadata`, `HermiteG2Endpoint` + `HermiteG2Metadata`, `FilletContinuity` ('G1' | 'G2') discriminator. Mirrors Slice B's `curve3dRecord` / `variableSweepRecord` patterns. `FeatureKind` extended with `'surfaceFromBoundary'` and `'hermiteG2'`.
- **Task 2: 6 diagnostic codes** — `feature.surface-from-boundary.{corner-mismatch, too-few-curves, too-many-curves, continuity-orphan, degenerate-patch}` + `feature.fillet.continuity-not-applicable`. Each ships a `HINT_TEMPLATES` entry and a `NEXT_ACTIONS` entry. Catalogue size 57 → 63.

## Test plan

- [x] `tests/unit/intent/coonsPatch.test.ts` — 10 guard tests pass
- [x] `tests/unit/intent/hermiteG2.test.ts` — 10 guard tests pass
- [x] `tests/integration/diagnostics/hint-mandatory.test.ts` — wire sentinel green (all 6 new codes carry hints)
- [x] `tests/integration/diagnostics/next-action-mandatory.test.ts` — wire sentinel green (all 6 new codes carry nextAction)
- [x] `tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts` — catalogue-size bumped 46 (stale pre-Slice-B baseline) → 63
- [x] `npx tsc --noEmit` clean

## Audit verdict

| Task | Status | Note |
|------|--------|------|
| Task 4 surfaceFromBoundary | GREEN | use `BRepOffsetAPI_MakeFilling`, `Add_1(edge, order, isBound)`, `.Shape()` + `TopoDS.Face_1(...)` |
| Task 5 hermiteG2           | GREEN | reuses Slice B curve3d at degree=5 |
| Task 6 G1/G2 fillet        | GREEN | `ChFi3d_Rational` + `SetContinuity(GeomAbs_G2, tol)` both present |

## Concerning gaps (for Tasks 3-11 design)

1. The plan's `.Face()` accessor on the filling builder does not exist — must downcast `.Shape()` via `TopoDS.Face_1(...)`. Affects Task 4 lowerer skeleton.
2. `continuity-not-applicable` repurposed: the audit removed its original "G2 not available in bundle" role; reused for the geometrically-meaningful "G2 requested on G1-only adjacent faces" failure. Task 7 (MCP) wording should follow suit.
3. The `BRepOffsetAPI_MakeFilling.Add_1` returns a contour index — useful for emitting per-edge `corner-mismatch` diagnostics with edge IDs in Task 4.