### PR TITLE
feat(nurbs): hermiteG2 quintic Hermite transition curve (Slice C Task 5)

### DIFF
--- a/src/modeling/api.ts
+++ b/src/modeling/api.ts
@@ -14,6 +14,7 @@ import {
 } from '../kernel/backends/occt/edgeQueries';
 import type { ReferenceImageHandle, ReferenceImageScale } from '../shared/intent/referenceImageRecord';
 import { helix, type RailPoint, type HelixOptions } from './helix';
+import { solveHermiteG2, type HermiteEndpoint } from './capture/hermiteG2';
 import { createSketchModule, type SketchModule } from './sketch/index';
 import { fontPath, type FontPath } from '../shared/fonts/index';
 import { fromSTEP as libFromSTEP } from './parts/fromSTEP';
@@ -156,6 +157,22 @@ export interface KernelCadApi {
     points: Vec3[],
     opts?: { tension?: number; closed?: boolean },
   ): Curve3D;
+
+  /**
+   * NURBS Slice C: quintic Hermite transition curve between two endpoints
+   * with prescribed tangent and (optional) curvature on each side. Returns
+   * a degree-5 `Curve3D` (6-control-point Bezier under a clamped-uniform
+   * knot vector).
+   *
+   * Use this to build a G2 blend curve between two existing curves — sample
+   * each neighbour's `pointAt(t)`, `tangentAt(t)` (and, if the neighbour is
+   * itself a `Curve3D`, its second-derivative for G2; otherwise omit
+   * `curvature` to fall back to G1).
+   *
+   * Throws `KernelError` on non-finite inputs or a zero-magnitude tangent;
+   * the curve3d record is not registered in that case.
+   */
+  hermiteG2(a: HermiteEndpoint, b: HermiteEndpoint): Curve3D;
 
   /**
    * NURBS Slice B: multi-section sweep. Sweeps each `section.profile` along
@@ -573,6 +590,17 @@ export function createApi(ctx: ApiContext): KernelCadApi {
           controlPoints: controlNet,
           degree: 3,
           closed: opts?.closed ?? false,
+        },
+      });
+    },
+
+    hermiteG2(a, b) {
+      const controlPoints = solveHermiteG2(a, b);
+      return session.addCurve3D({
+        metadata: {
+          controlPoints,
+          degree: 5,
+          closed: false,
         },
       });
     },

--- a/src/modeling/capture/hermiteG2.ts
+++ b/src/modeling/capture/hermiteG2.ts
@@ -1,0 +1,130 @@
+// NURBS Slice C Task 5 — hermiteG2 quintic Hermite transition curve.
+//
+// Pure-JS solver. Given two endpoints with prescribed point, first derivative
+// (tangent), and (optional) second derivative (curvature), produce the 6
+// Bezier control points of the quintic Hermite curve that interpolates both
+// endpoints with matching tangents and matching curvatures (G2 continuity
+// when joined to a neighbour with the same endpoint frame).
+//
+// The quintic-Hermite → Bezier conversion on [0, 1] is:
+//
+//   B0 = P0
+//   B1 = P0 + T0 / 5
+//   B2 = P0 + 2·T0 / 5 + C0 / 20
+//   B3 = P1 - 2·T1 / 5 + C1 / 20
+//   B4 = P1 - T1 / 5
+//   B5 = P1
+//
+// (Curvature defaults to [0, 0, 0]; the result is a quintic-degree curve
+// that is only G1, not G2, in that case — equivalent to a cubic Hermite
+// lifted to degree 5.)
+//
+// The control points are emitted into a degree-5 nurbsCurve via Slice B's
+// addCurve3D; the OCCT lowerer (Geom_BSplineCurve) generates a clamped
+// uniform knot vector `clampedUniformKnots(6, 5)` = [0,0,0,0,0,0,1,1,1,1,1,1].
+
+import type { Vec3 } from '../../shared/intent/types';
+import { KernelError } from '../../shared/intent/kernelError';
+
+/**
+ * One end of a quintic Hermite transition curve.
+ *
+ * `point`     — position in mm.
+ * `tangent`   — first derivative of the curve at this endpoint (NOT the unit
+ *               tangent: magnitude controls how aggressively the curve heads
+ *               out of the endpoint; typical magnitude is in the order of the
+ *               chord length between the two endpoints).
+ * `curvature` — second derivative of the curve at this endpoint. Defaults to
+ *               the zero vector, which makes the curve G1-only.
+ */
+export interface HermiteEndpoint {
+  point: Vec3;
+  tangent: Vec3;
+  curvature?: Vec3;
+}
+
+const ZERO: Vec3 = [0, 0, 0];
+
+function isFiniteVec3(v: Vec3): boolean {
+  return (
+    Array.isArray(v) &&
+    v.length === 3 &&
+    Number.isFinite(v[0]) &&
+    Number.isFinite(v[1]) &&
+    Number.isFinite(v[2])
+  );
+}
+
+function magnitude(v: Vec3): number {
+  return Math.sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+}
+
+/**
+ * Solve the quintic Hermite system at capture time and return the 6 Bezier
+ * control points that interpolate the two endpoints with matching tangent
+ * and curvature.
+ *
+ * Throws `KernelError` on:
+ * - any NaN/Infinity in `point`, `tangent`, or `curvature`
+ *   (`feature.hermite-g2.non-finite-input`);
+ * - a tangent with magnitude < 1e-12 on either endpoint
+ *   (`feature.hermite-g2.degenerate-tangent`).
+ */
+export function solveHermiteG2(a: HermiteEndpoint, b: HermiteEndpoint): Vec3[] {
+  const aC: Vec3 = a.curvature ?? ZERO;
+  const bC: Vec3 = b.curvature ?? ZERO;
+
+  // Validation 1: non-finite inputs.
+  if (
+    !isFiniteVec3(a.point) ||
+    !isFiniteVec3(a.tangent) ||
+    !isFiniteVec3(aC) ||
+    !isFiniteVec3(b.point) ||
+    !isFiniteVec3(b.tangent) ||
+    !isFiniteVec3(bC)
+  ) {
+    throw new KernelError(
+      'feature.hermite-g2.non-finite-input',
+      `hermiteG2: every coord of a.point / a.tangent / a.curvature / b.point / b.tangent / b.curvature must be a finite number. Got a={point:${JSON.stringify(a.point)}, tangent:${JSON.stringify(a.tangent)}, curvature:${JSON.stringify(a.curvature ?? null)}}, b={point:${JSON.stringify(b.point)}, tangent:${JSON.stringify(b.tangent)}, curvature:${JSON.stringify(b.curvature ?? null)}}.`,
+      undefined,
+      'hermite-g2.non-finite-input — replace NaN/Infinity coords with finite numbers, then retry.',
+    );
+  }
+
+  // Validation 2: zero-magnitude tangent on either endpoint.
+  const TANGENT_EPS = 1e-12;
+  const aMag = magnitude(a.tangent);
+  const bMag = magnitude(b.tangent);
+  if (aMag < TANGENT_EPS || bMag < TANGENT_EPS) {
+    throw new KernelError(
+      'feature.hermite-g2.degenerate-tangent',
+      `hermiteG2: tangent magnitude must be > 1e-12 on both endpoints; got |a.tangent|=${aMag}, |b.tangent|=${bMag}.`,
+      undefined,
+      'hermite-g2.degenerate-tangent — supply a tangent with magnitude in the order of the chord length between the two endpoints.',
+    );
+  }
+
+  const [p0x, p0y, p0z] = a.point;
+  const [p1x, p1y, p1z] = b.point;
+  const [t0x, t0y, t0z] = a.tangent;
+  const [t1x, t1y, t1z] = b.tangent;
+  const [c0x, c0y, c0z] = aC;
+  const [c1x, c1y, c1z] = bC;
+
+  const B0: Vec3 = [p0x, p0y, p0z];
+  const B1: Vec3 = [p0x + t0x / 5, p0y + t0y / 5, p0z + t0z / 5];
+  const B2: Vec3 = [
+    p0x + (2 * t0x) / 5 + c0x / 20,
+    p0y + (2 * t0y) / 5 + c0y / 20,
+    p0z + (2 * t0z) / 5 + c0z / 20,
+  ];
+  const B3: Vec3 = [
+    p1x - (2 * t1x) / 5 + c1x / 20,
+    p1y - (2 * t1y) / 5 + c1y / 20,
+    p1z - (2 * t1z) / 5 + c1z / 20,
+  ];
+  const B4: Vec3 = [p1x - t1x / 5, p1y - t1y / 5, p1z - t1z / 5];
+  const B5: Vec3 = [p1x, p1y, p1z];
+
+  return [B0, B1, B2, B3, B4, B5];
+}

--- a/src/shared/diagnostics/codes.ts
+++ b/src/shared/diagnostics/codes.ts
@@ -101,7 +101,11 @@ export type DiagnosticCode =
   | 'feature.surface-from-boundary.too-many-curves'
   | 'feature.surface-from-boundary.continuity-orphan'
   | 'feature.surface-from-boundary.degenerate-patch'
-  | 'feature.fillet.continuity-not-applicable';
+  | 'feature.fillet.continuity-not-applicable'
+  // NURBS Slice C — hermiteG2 quintic transition curve.
+  // Pure-JS solver; emits these on input the math can't fit.
+  | 'feature.hermite-g2.degenerate-tangent'
+  | 'feature.hermite-g2.non-finite-input';
 
 export const DIAGNOSTIC_CODES: readonly DiagnosticCode[] = [
   'feature.invalid-args',
@@ -167,6 +171,8 @@ export const DIAGNOSTIC_CODES: readonly DiagnosticCode[] = [
   'feature.surface-from-boundary.continuity-orphan',
   'feature.surface-from-boundary.degenerate-patch',
   'feature.fillet.continuity-not-applicable',
+  'feature.hermite-g2.degenerate-tangent',
+  'feature.hermite-g2.non-finite-input',
 ] as const;
 
 export interface HintTemplate {
@@ -309,6 +315,10 @@ function buildHintTemplates(): Record<DiagnosticCode, HintTemplate> {
       'BRepOffsetAPI_MakeFilling could not produce a face. The boundary curves are likely coincident, self-intersecting, or topologically invalid. Inspect the curve sequence with list_features and visualize each Curve3D before retrying.',
     'feature.fillet.continuity-not-applicable':
       "continuity: 'G2' was requested but the adjacent faces along the target edge are themselves only G1-continuous, so the resulting blend can be no smoother than G1. Either accept the G1 result, refit the upstream faces as NURBS so they are G2 internally, or apply a smaller fillet that fits inside a single smooth region.",
+    'feature.hermite-g2.degenerate-tangent':
+      'hermiteG2 received a tangent with zero magnitude on one or both endpoints. The quintic Hermite scales the tangent into the inner control points; a zero tangent collapses two control points onto the endpoint, producing a cusp rather than a smooth transition. Supply a non-zero tangent (magnitude in the order of the chord length between the endpoints).',
+    'feature.hermite-g2.non-finite-input':
+      'hermiteG2 received NaN / Infinity in one of point, tangent, or curvature. Validate the endpoints upstream — typically caused by a divide-by-zero in a normal/curvature derivation. Recompute the endpoint with finite inputs before retrying.',
   };
   const out = {} as Record<DiagnosticCode, HintTemplate>;
   for (const code of DIAGNOSTIC_CODES) {

--- a/src/shared/diagnostics/nextAction.ts
+++ b/src/shared/diagnostics/nextAction.ts
@@ -86,4 +86,6 @@ export const NEXT_ACTIONS: Record<DiagnosticCode, NextAction> = {
   'feature.surface-from-boundary.continuity-orphan': { kind: 'fix-arg', field: 'neighbors' },
   'feature.surface-from-boundary.degenerate-patch':  { kind: 'rewrite-feature', guidance: 'rebuild the 4 boundary curves so they form a non-self-intersecting closed loop, then retry surfaceFromBoundary' },
   'feature.fillet.continuity-not-applicable':        { kind: 'rewrite-feature', guidance: "drop continuity: 'G2' (adjacent faces are only G1) or refit the upstream faces as NURBS surfaces" },
+  'feature.hermite-g2.degenerate-tangent':           { kind: 'fix-arg', field: 'tangent' },
+  'feature.hermite-g2.non-finite-input':             { kind: 'fix-arg', field: 'see-message' },
 };

--- a/tests/unit/capture/hermiteG2.test.ts
+++ b/tests/unit/capture/hermiteG2.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { CaptureSession } from '../../../src/modeling/capture/captureSession';
+import { createApi } from '../../../src/modeling/api';
+import { initOcct } from '../../../src/kernel/backends/occt/occtBackend';
+import { solveHermiteG2 } from '../../../src/modeling/capture/hermiteG2';
+import { KernelError } from '../../../src/shared/intent/kernelError';
+
+const EPS_TIGHT = 1e-6;
+const EPS_LOOSE = 1e-3;
+
+function approxEq(a: number, b: number, eps = EPS_TIGHT): boolean {
+  return Math.abs(a - b) <= eps;
+}
+
+describe('solveHermiteG2 (pure-JS solver)', () => {
+  it('returns 6 control points; B0 == a.point, B5 == b.point', () => {
+    const cps = solveHermiteG2(
+      { point: [0, 0, 0], tangent: [10, 0, 0] },
+      { point: [10, 0, 0], tangent: [10, 0, 0] },
+    );
+    expect(cps).toHaveLength(6);
+    expect(cps[0]).toEqual([0, 0, 0]);
+    expect(cps[5]).toEqual([10, 0, 0]);
+  });
+
+  it('applies the quintic Hermite-to-Bezier formula with zero curvature', () => {
+    // B1 = P0 + T0/5; B4 = P1 - T1/5; B2/B3 fold in curvature/20 (zero here).
+    const cps = solveHermiteG2(
+      { point: [0, 0, 0], tangent: [5, 0, 0] },
+      { point: [10, 0, 0], tangent: [5, 0, 0] },
+    );
+    expect(cps[1]).toEqual([1, 0, 0]);     // 0 + 5/5
+    expect(cps[2]).toEqual([2, 0, 0]);     // 0 + 2·5/5 + 0/20
+    expect(cps[3]).toEqual([8, 0, 0]);     // 10 - 2·5/5 + 0/20
+    expect(cps[4]).toEqual([9, 0, 0]);     // 10 - 5/5
+  });
+
+  it('throws non-finite-input when a coord is NaN', () => {
+    let caught: unknown = null;
+    try {
+      solveHermiteG2(
+        { point: [Number.NaN, 0, 0], tangent: [1, 0, 0] },
+        { point: [10, 0, 0], tangent: [1, 0, 0] },
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(KernelError);
+    expect((caught as KernelError).code).toBe('feature.hermite-g2.non-finite-input');
+  });
+
+  it('throws non-finite-input when a curvature coord is Infinity', () => {
+    let caught: unknown = null;
+    try {
+      solveHermiteG2(
+        { point: [0, 0, 0], tangent: [1, 0, 0], curvature: [0, Number.POSITIVE_INFINITY, 0] },
+        { point: [10, 0, 0], tangent: [1, 0, 0] },
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(KernelError);
+    expect((caught as KernelError).code).toBe('feature.hermite-g2.non-finite-input');
+  });
+
+  it('throws degenerate-tangent when |a.tangent| == 0', () => {
+    let caught: unknown = null;
+    try {
+      solveHermiteG2(
+        { point: [0, 0, 0], tangent: [0, 0, 0] },
+        { point: [10, 0, 0], tangent: [1, 0, 0] },
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(KernelError);
+    expect((caught as KernelError).code).toBe('feature.hermite-g2.degenerate-tangent');
+  });
+
+  it('throws degenerate-tangent when |b.tangent| == 0', () => {
+    let caught: unknown = null;
+    try {
+      solveHermiteG2(
+        { point: [0, 0, 0], tangent: [1, 0, 0] },
+        { point: [10, 0, 0], tangent: [0, 0, 0] },
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(KernelError);
+    expect((caught as KernelError).code).toBe('feature.hermite-g2.degenerate-tangent');
+  });
+});
+
+describe('hermiteG2() — capture-time API', () => {
+  it('registers a curve3d record with degree 5 and 6 control points', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const curve = kcad.hermiteG2(
+      { point: [0, 0, 0], tangent: [10, 0, 0] },
+      { point: [10, 0, 0], tangent: [10, 0, 0] },
+    );
+    const rec = session.getRecords().find((r) => r.kind === 'curve3d');
+    expect(rec).toBeDefined();
+    expect(curve.id).toBe(rec!.id);
+    const m = rec!.metadata?.curve3d;
+    expect(m?.degree).toBe(5);
+    expect(m?.controlPoints).toHaveLength(6);
+    expect(m?.closed).toBe(false);
+  });
+});
+
+describe('hermiteG2() — OCCT evaluation', () => {
+  beforeAll(async () => {
+    await initOcct();
+  }, 60000);
+
+  it('linear case: equal collinear tangents produce a curve lying on the X axis', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const curve = kcad.hermiteG2(
+      { point: [0, 0, 0], tangent: [10, 0, 0] },
+      { point: [10, 0, 0], tangent: [10, 0, 0] },
+    );
+    const samples = curve.sample(10);
+    expect(samples.length).toBeGreaterThan(0);
+    for (const [, y, z] of samples) {
+      expect(approxEq(y, 0)).toBe(true);
+      expect(approxEq(z, 0)).toBe(true);
+    }
+  });
+
+  it('curved case: heading +Y at start and -Y at end bulges the curve toward +Y', () => {
+    // a.tangent +Y, b.tangent -Y means the curve leaves a heading up and
+    // arrives at b heading down — i.e. a single +Y hump. Symmetric +Y at
+    // both ends would cancel by symmetry, so this asymmetric pair is the
+    // canonical "hump" probe.
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const curve = kcad.hermiteG2(
+      { point: [0, 0, 0], tangent: [0, 10, 0] },
+      { point: [10, 0, 0], tangent: [0, -10, 0] },
+    );
+    const mid = curve.pointAt(0.5);
+    expect(mid[1]).toBeGreaterThan(0);
+  });
+
+  it('G2 case: non-zero curvatures change the visible bulge vs the G1-only case', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const g1 = kcad.hermiteG2(
+      { point: [0, 0, 0], tangent: [0, 10, 0] },
+      { point: [10, 0, 0], tangent: [0, -10, 0] },
+    );
+    const session2 = new CaptureSession();
+    const kcad2 = createApi({ session: session2 });
+    const g2 = kcad2.hermiteG2(
+      { point: [0, 0, 0], tangent: [0, 10, 0], curvature: [0, 100, 0] },
+      { point: [10, 0, 0], tangent: [0, -10, 0], curvature: [0, 100, 0] },
+    );
+    const midG1 = g1.pointAt(0.5);
+    const midG2 = g2.pointAt(0.5);
+    // Different curvatures => different midpoint Y (more than the OCCT
+    // tessellation noise floor).
+    expect(Math.abs(midG1[1] - midG2[1])).toBeGreaterThan(1e-3);
+  });
+
+  it('endpoint interpolation: pointAt(0) ≈ a.point and pointAt(1) ≈ b.point', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const a = { point: [0, 0, 0] as [number, number, number], tangent: [5, 5, 0] as [number, number, number] };
+    const b = { point: [10, 3, 2] as [number, number, number], tangent: [5, -2, 0] as [number, number, number] };
+    const curve = kcad.hermiteG2(a, b);
+    const p0 = curve.pointAt(0);
+    const p1 = curve.pointAt(1);
+    expect(approxEq(p0[0], a.point[0], EPS_LOOSE)).toBe(true);
+    expect(approxEq(p0[1], a.point[1], EPS_LOOSE)).toBe(true);
+    expect(approxEq(p0[2], a.point[2], EPS_LOOSE)).toBe(true);
+    expect(approxEq(p1[0], b.point[0], EPS_LOOSE)).toBe(true);
+    expect(approxEq(p1[1], b.point[1], EPS_LOOSE)).toBe(true);
+    expect(approxEq(p1[2], b.point[2], EPS_LOOSE)).toBe(true);
+  });
+
+  it('tangent matching: tangentAt(0) is parallel to a.tangent (normalized)', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const aTan: [number, number, number] = [3, 4, 0]; // magnitude 5
+    const bTan: [number, number, number] = [0, 0, 7]; // magnitude 7
+    const curve = kcad.hermiteG2(
+      { point: [0, 0, 0], tangent: aTan },
+      { point: [10, 0, 0], tangent: bTan },
+    );
+    // Expected unit a.tangent = (0.6, 0.8, 0).
+    const t0 = curve.tangentAt(0);
+    expect(approxEq(t0[0], 0.6, EPS_LOOSE)).toBe(true);
+    expect(approxEq(t0[1], 0.8, EPS_LOOSE)).toBe(true);
+    expect(approxEq(t0[2], 0, EPS_LOOSE)).toBe(true);
+    // Expected unit b.tangent = (0, 0, 1).
+    const t1 = curve.tangentAt(1);
+    expect(approxEq(t1[0], 0, EPS_LOOSE)).toBe(true);
+    expect(approxEq(t1[1], 0, EPS_LOOSE)).toBe(true);
+    expect(approxEq(t1[2], 1, EPS_LOOSE)).toBe(true);
+  });
+});

--- a/tests/unit/diagnostics/codes.test.ts
+++ b/tests/unit/diagnostics/codes.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from 'vitest';
 import { DIAGNOSTIC_CODES, HINT_TEMPLATES } from '../../../src/shared/diagnostics/codes';
 
 describe('diagnostic catalogue invariants', () => {
-  it('emits exactly 46 codes', () => {
-    expect(DIAGNOSTIC_CODES).toHaveLength(46);
-    expect(new Set(DIAGNOSTIC_CODES).size).toBe(46);
+  it('emits exactly 65 codes', () => {
+    expect(DIAGNOSTIC_CODES).toHaveLength(65);
+    expect(new Set(DIAGNOSTIC_CODES).size).toBe(65);
   });
 
   it('every code has a non-empty hint template', () => {

--- a/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
+++ b/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
@@ -66,19 +66,20 @@ function emittedCodes(): Set<string> {
 describe('every diagnostic code emitted in src/ is in the catalogue', () => {
   const catalogue = new Set<string>(DIAGNOSTIC_CODES);
 
-  it('catalogue has exactly 63 codes', () => {
+  it('catalogue has exactly 65 codes', () => {
     // 46 baseline (milestone-C diagnostic-vocab spec)
     //  + 11 Slice B (Curve3D + variableSweep capture validation)
     //  +  6 Slice C (surfaceFromBoundary + G2 fillet)
-    // = 63.
-    expect(catalogue.size).toBe(63);
+    //  +  2 Slice C Task 5 (hermiteG2 quintic Hermite solver)
+    // = 65.
+    expect(catalogue.size).toBe(65);
   });
 
   it('no emit site uses a code outside the catalogue', () => {
     const stale = [...emittedCodes()].filter((c) => !catalogue.has(c)).sort();
     expect(
       stale,
-      `Stale codes still emitted in src/: ${JSON.stringify(stale)}.\nMigration policy: every code must be one of the 63 in DIAGNOSTIC_CODES.`,
+      `Stale codes still emitted in src/: ${JSON.stringify(stale)}.\nMigration policy: every code must be one of the 65 in DIAGNOSTIC_CODES.`,
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- New top-level API `hermiteG2(a, b): Curve3D` builds a quintic Hermite transition curve between two endpoints with prescribed tangent and (optional) curvature, emitted as a degree-5 6-control-point nurbsCurve via Slice B's `addCurve3D`. Pure-JS solver — no new OCCT bindings.
- Two new diagnostic codes — `feature.hermite-g2.non-finite-input` and `feature.hermite-g2.degenerate-tangent` — carry the validation errors thrown on NaN / Infinity coords or a zero-magnitude tangent. Catalogue counts updated 63 -> 65 in the drift sentinel tests.

## Math

The quintic Hermite-to-Bezier conversion on [0, 1]:

    B0 = P0
    B1 = P0 + T0 / 5
    B2 = P0 + 2*T0 / 5 + C0 / 20
    B3 = P1 - 2*T1 / 5 + C1 / 20
    B4 = P1 - T1 / 5
    B5 = P1

Curvature defaults to [0,0,0], which collapses the result to a quintic-degree cubic Hermite — G1 only.

## Test plan

- [x] `npx vitest run tests/unit/capture/hermiteG2.test.ts` — 12 passed (solver math, NaN/Inf rejection, zero-tangent rejection, linear / curved / G2 OCCT eval, endpoint interpolation, tangent matching).
- [x] `npx vitest run tests/unit/diagnostics/` — 8 passed (catalogue counts + drift sentinels).
- [x] `npx vitest run tests/unit/capture/` — 258 passed (no regressions in sibling capture tests).
- [x] `npx tsc --noEmit` — clean.