### PR TITLE
fix(nurbs): buildSkinnedSurface accepts NURBS-bearing sketches

### DIFF
--- a/src/kernel/backends/occt/nurbsSurfaceLowerer.ts
+++ b/src/kernel/backends/occt/nurbsSurfaceLowerer.ts
@@ -1,6 +1,8 @@
 import * as replicad from 'replicad';
 import { getOC } from 'replicad';
 import { OcctBackend } from './occtBackend';
+import { buildNurbsSketchOnPlane } from './pathNurbsLowerer';
+import type { SketchCommand } from '../../../shared/capture/sketchCommand';
 import type { Vec3 } from '../../../shared/intent/types';
 
 /**
@@ -210,19 +212,37 @@ export function buildSkinnedSurface(
   }
   // Lift each sketch onto its target plane. Mirrors OcctBackend.loftFromSketches'
   // section-prep pass but inlined here so we can request the shell variant.
+  //
+  // Two paths:
+  //   - Pen-only sketches (`_drawing` populated): lift via
+  //     `Drawing.sketchOnPlane(plane, origin)` exactly as before.
+  //   - NURBS-bearing sketches (`_hasNurbs` set + `_commands` populated,
+  //     `_drawing` null — Slice D Task 3 leaves the pen empty because it
+  //     can't construct `spline` / `nurbsSegment` / `hermiteG2_2d` edges):
+  //     build the section wire directly on the target plane via
+  //     `buildNurbsSketchOnPlane`, which returns a `replicad.Sketch` whose
+  //     `.loftWith(...)` works the same way as the pen-derived Sketch.
+  //     The `origin` offset isn't applied here (matches
+  //     `OcctBackend.loftFromSketches`'s NURBS branch — path coordinates
+  //     must already encode their final position).
   const lifted: unknown[] = [];
   for (let i = 0; i < sectionShapes.length; i++) {
     const s = sectionShapes[i] as unknown as {
       kind?: string;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       _drawing?: any;
+      _hasNurbs?: boolean;
+      _commands?: SketchCommand[];
     };
-    const drawing = s._drawing;
-    if (s.kind !== 'sketch' || !drawing) {
+    if (s.kind !== 'sketch' || (!s._drawing && !s._hasNurbs)) {
       throw new Error(`buildSkinnedSurface: input ${i} is not a sketch-tagged OcctBackend`);
     }
     const p = planes[i];
-    lifted.push(drawing.sketchOnPlane(p.plane, p.origin));
+    if (s._hasNurbs && s._commands) {
+      lifted.push(buildNurbsSketchOnPlane(s._commands, p.plane));
+    } else {
+      lifted.push(s._drawing!.sketchOnPlane(p.plane, p.origin));
+    }
   }
   const [first, ...rest] = lifted;
   // returnShell=true → BRepOffsetAPI_ThruSections returns a TopoDS_Shell of

--- a/tests/unit/backends/occt/surfaceFromCurves.nurbsSketches.test.ts
+++ b/tests/unit/backends/occt/surfaceFromCurves.nurbsSketches.test.ts
@@ -1,0 +1,172 @@
+// tests/unit/backends/occt/surfaceFromCurves.nurbsSketches.test.ts
+//
+// Regression + new-path coverage for `buildSkinnedSurface` (the OCCT helper
+// behind `surfaceFromCurves`). Slice D Task 3 introduced NURBS-bearing
+// sketches whose `_drawing` is null (the replicad 2D pen can't construct
+// `spline` / `nurbsSegment` / `hermiteG2_2d` edges) — those sketches carry
+// `_hasNurbs = true` plus the raw `_commands`, and the OCCT consumers
+// dispatch to `buildNurbsSketchOnPlane`.
+//
+// Before this fix `buildSkinnedSurface` did a raw `s._drawing` cast and
+// would dereference undefined on the new NURBS path, throwing an unhelpful
+// `TypeError: Cannot read properties of null/undefined`. The fix branches
+// on `_hasNurbs` and lifts the section via `buildNurbsSketchOnPlane`,
+// mirroring the existing `OcctBackend.loftFromSketches` dispatch.
+//
+// Cases:
+//   1. All pen sketches (regression — must keep working unchanged).
+//   2. All NURBS sketches (the previously-broken path).
+//   3. Mixed pen + NURBS — exercises the per-section branch in isolation.
+//
+// Each case calls `buildSkinnedSurface(sections, planes)` then `thickenFace`
+// to assert the resulting skinned surface lifts cleanly to a positive-volume
+// closed solid.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { OcctBackend, initOcct } from '../../../../src/kernel/backends/occt/occtBackend';
+import { buildSkinnedSurface, thickenFace } from '../../../../src/kernel/backends/occt/nurbsSurfaceLowerer';
+import type { SketchCommand } from '../../../../src/shared/capture/sketchCommand';
+import { toParam } from '../../../../src/shared/runtime/editableHelpers';
+
+const mm = (n: number) => toParam(n, 'mm');
+const ul = (n: number) => toParam(n, 'unitless');
+
+// Pen-only square (4×4, centered at origin) — lowered via the replicad pen
+// path, populates `_drawing`.
+const penSquare4x4: SketchCommand[] = [
+  { kind: 'moveTo', x: mm(-2), y: mm(-2) },
+  { kind: 'lineTo', x: mm(2), y: mm(-2) },
+  { kind: 'lineTo', x: mm(2), y: mm(2) },
+  { kind: 'lineTo', x: mm(-2), y: mm(2) },
+  { kind: 'close' },
+];
+
+const penSquare6x6: SketchCommand[] = [
+  { kind: 'moveTo', x: mm(-3), y: mm(-3) },
+  { kind: 'lineTo', x: mm(3), y: mm(-3) },
+  { kind: 'lineTo', x: mm(3), y: mm(3) },
+  { kind: 'lineTo', x: mm(-3), y: mm(3) },
+  { kind: 'close' },
+];
+
+// NURBS-bearing section: a closed loop comprised of two `spline` segments —
+// a top arc (lifting up to +y peak) and a bottom arc (mirrored to -y peak),
+// closing back to the start. The commands array includes a NURBS segment, so
+// `fromSketchCommands` flips `_hasNurbs = true` and leaves `_drawing` null.
+//
+// Both section A and section B share identical wire topology (two spline
+// edges) so `BRepOffsetAPI_ThruSections` can correspond their edges
+// cleanly across the loft. They differ only in radius `r`.
+function nurbsEllipseCommands(r: number): SketchCommand[] {
+  return [
+    { kind: 'moveTo', x: mm(-r), y: mm(0) },
+    {
+      kind: 'spline',
+      points: [
+        { x: mm(-r), y: mm(0) },
+        { x: mm(-r * 0.5), y: mm(r * 0.6) },
+        { x: mm(r * 0.5), y: mm(r * 0.6) },
+        { x: mm(r), y: mm(0) },
+      ],
+    },
+    {
+      kind: 'spline',
+      points: [
+        { x: mm(r), y: mm(0) },
+        { x: mm(r * 0.5), y: mm(-r * 0.6) },
+        { x: mm(-r * 0.5), y: mm(-r * 0.6) },
+        { x: mm(-r), y: mm(0) },
+      ],
+    },
+    { kind: 'close' },
+  ];
+}
+
+// A NURBS variant using `nurbsSegment` instead (same topology — two
+// closed NURBS edges) so we exercise a different Slice D segment kind.
+function nurbsSegmentEllipseCommands(r: number): SketchCommand[] {
+  return [
+    { kind: 'moveTo', x: mm(-r), y: mm(0) },
+    {
+      kind: 'nurbsSegment',
+      controlPoints: [
+        { x: mm(-r), y: mm(0) },
+        { x: mm(-r * 0.5), y: mm(r * 0.8) },
+        { x: mm(r * 0.5), y: mm(r * 0.8) },
+        { x: mm(r), y: mm(0) },
+      ],
+      degree: ul(3),
+    },
+    {
+      kind: 'nurbsSegment',
+      controlPoints: [
+        { x: mm(r), y: mm(0) },
+        { x: mm(r * 0.5), y: mm(-r * 0.8) },
+        { x: mm(-r * 0.5), y: mm(-r * 0.8) },
+        { x: mm(-r), y: mm(0) },
+      ],
+      degree: ul(3),
+    },
+    { kind: 'close' },
+  ];
+}
+
+describe('buildSkinnedSurface — NURBS-bearing sketches', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('regression: all pen sketches still produce a positive-volume thickened solid', () => {
+    const s1 = OcctBackend.fromSketchCommands(penSquare4x4);
+    const s2 = OcctBackend.fromSketchCommands(penSquare6x6);
+    const planes: Array<{ plane: 'XY'; origin: [number, number, number] }> = [
+      { plane: 'XY', origin: [0, 0, 0] },
+      { plane: 'XY', origin: [0, 0, 20] },
+    ];
+    const surface = buildSkinnedSurface([s1, s2], planes);
+    expect(surface.kind).toBe('skinned');
+    const thickened = thickenFace(surface, 2);
+    const v = thickened.volume();
+    expect(Number.isFinite(v)).toBe(true);
+    expect(v).toBeGreaterThan(0);
+  });
+
+  it('NURBS sketches lift via buildNurbsSketchOnPlane and produce a positive-volume thickened solid', () => {
+    const s1 = OcctBackend.fromSketchCommands(nurbsEllipseCommands(5));
+    const s2 = OcctBackend.fromSketchCommands(nurbsSegmentEllipseCommands(8));
+    // Sanity: these are NURBS-bearing — `_drawing` is null on both.
+    expect((s1 as unknown as { _drawing: unknown })._drawing).toBeNull();
+    expect((s2 as unknown as { _drawing: unknown })._drawing).toBeNull();
+    expect((s1 as unknown as { _hasNurbs: boolean })._hasNurbs).toBe(true);
+    expect((s2 as unknown as { _hasNurbs: boolean })._hasNurbs).toBe(true);
+
+    const planes: Array<{ plane: 'XY'; origin: [number, number, number] }> = [
+      { plane: 'XY', origin: [0, 0, 0] },
+      { plane: 'XY', origin: [0, 0, 15] },
+    ];
+    const surface = buildSkinnedSurface([s1, s2], planes);
+    expect(surface.kind).toBe('skinned');
+    const thickened = thickenFace(surface, 0.5);
+    const v = thickened.volume();
+    expect(Number.isFinite(v)).toBe(true);
+    expect(v).toBeGreaterThan(0);
+  });
+
+  it('mixed pen + NURBS sections lift cleanly and thicken to a positive-volume solid', () => {
+    // Section 0 is a pen-only square; section 1 is a NURBS ellipse.
+    // Both are closed loops, suitable for `BRepOffsetAPI_ThruSections`.
+    const s1 = OcctBackend.fromSketchCommands(penSquare4x4);
+    const s2 = OcctBackend.fromSketchCommands(nurbsEllipseCommands(5));
+    expect((s1 as unknown as { _hasNurbs: boolean })._hasNurbs).toBe(false);
+    expect((s2 as unknown as { _hasNurbs: boolean })._hasNurbs).toBe(true);
+
+    const planes: Array<{ plane: 'XY'; origin: [number, number, number] }> = [
+      { plane: 'XY', origin: [0, 0, 0] },
+      { plane: 'XY', origin: [0, 0, 15] },
+    ];
+    const surface = buildSkinnedSurface([s1, s2], planes);
+    expect(surface.kind).toBe('skinned');
+    const thickened = thickenFace(surface, 0.5);
+    const v = thickened.volume();
+    expect(Number.isFinite(v)).toBe(true);
+    expect(v).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Slice D Task 3 (PR #244) introduced NURBS-bearing sketches whose `_drawing` is null (replicad's 2D pen can't construct `spline` / `nurbsSegment` / `hermiteG2_2d` edges). `buildSkinnedSurface` still did a raw `s._drawing` cast and would throw an unhelpful TypeError on the new path, breaking `surfaceFromCurves([nurbsSketch, ...])`.
- Branch on `_hasNurbs` exactly like `OcctBackend.loftFromSketches`: NURBS-bearing sections lift via `buildNurbsSketchOnPlane(s._commands, p.plane)` (returns a `replicad.Sketch` whose `.loftWith(...)` works identically to the pen-derived Sketch); pen-only sections keep the original `Drawing.sketchOnPlane(plane, origin)` path.
- Adds `tests/unit/backends/occt/surfaceFromCurves.nurbsSketches.test.ts` covering all-pen regression, all-NURBS, and mixed pen+NURBS sections — each asserts the skinned surface lifts to a positive-volume solid via `thickenFace`.

## Test plan

- [x] `npx vitest run tests/unit/backends/occt/surfaceFromCurves.nurbsSketches.test.ts` — 3/3 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run tests/unit/backends/occt/loftFromSketches.test.ts tests/unit/backends/occt/fromSketchCommands.nurbsSegments.test.ts tests/unit/modules/nurbsSurfaceApi.test.ts` — 19/19 pass (no regressions in adjacent NURBS / loft paths)