### PR TITLE
fix(occt): strict typecheck clean for pathNurbsLowerer + loftFromSketches

### DIFF
--- a/src/kernel/backends/occt/occtBackend.ts
+++ b/src/kernel/backends/occt/occtBackend.ts
@@ -625,7 +625,8 @@ export class OcctBackend implements ShapeBackend {
         // explicitly via the SketchCommand coordinates.
         lifted.push(buildNurbsSketchOnPlane(s._commands, p.plane));
       } else {
-        lifted.push(s._drawing!.sketchOnPlane(p.plane, p.origin as unknown as Parameters<typeof s._drawing.sketchOnPlane>[1]));
+        const drawing = s._drawing!;
+        lifted.push(drawing.sketchOnPlane(p.plane, p.origin as unknown as Parameters<typeof drawing.sketchOnPlane>[1]));
       }
     }
     // Replicad's Sketch.loftWith expects the receiver as the first section

--- a/src/kernel/backends/occt/pathNurbsLowerer.ts
+++ b/src/kernel/backends/occt/pathNurbsLowerer.ts
@@ -264,12 +264,12 @@ export function buildNurbsSketchOnPlane(
     const c = commands[i];
     if (c.kind === 'lineTo') {
       const p = ensurePen();
-      pen = p.lineTo([c.x.evaluated, c.y.evaluated]) as typeof pen;
+      pen = p.lineTo([c.x.evaluated, c.y.evaluated]) as replicad.DrawingPen;
       currentX = c.x.evaluated;
       currentY = c.y.evaluated;
     } else if (c.kind === 'tangentArc') {
       const p = ensurePen();
-      pen = p.tangentArcTo([c.x.evaluated, c.y.evaluated]) as typeof pen;
+      pen = p.tangentArcTo([c.x.evaluated, c.y.evaluated]) as replicad.DrawingPen;
       currentX = c.x.evaluated;
       currentY = c.y.evaluated;
     } else if (c.kind === 'threePointsArc') {
@@ -277,17 +277,17 @@ export function buildNurbsSketchOnPlane(
       pen = p.threePointsArcTo(
         [c.x.evaluated, c.y.evaluated],
         [c.midX.evaluated, c.midY.evaluated],
-      ) as typeof pen;
+      ) as replicad.DrawingPen;
       currentX = c.x.evaluated;
       currentY = c.y.evaluated;
     } else if (c.kind === 'sagittaArc') {
       const p = ensurePen();
-      pen = p.sagittaArcTo([c.x.evaluated, c.y.evaluated], c.sagitta.evaluated) as typeof pen;
+      pen = p.sagittaArcTo([c.x.evaluated, c.y.evaluated], c.sagitta.evaluated) as replicad.DrawingPen;
       currentX = c.x.evaluated;
       currentY = c.y.evaluated;
     } else if (c.kind === 'bulgeArc') {
       const p = ensurePen();
-      pen = p.bulgeArcTo([c.x.evaluated, c.y.evaluated], c.bulge.evaluated) as typeof pen;
+      pen = p.bulgeArcTo([c.x.evaluated, c.y.evaluated], c.bulge.evaluated) as replicad.DrawingPen;
       currentX = c.x.evaluated;
       currentY = c.y.evaluated;
     } else if (c.kind === 'radiusArc') {
@@ -306,12 +306,12 @@ export function buildNurbsSketchOnPlane(
       const sagittaMagnitude = Math.abs(cr) - Math.sqrt(cr * cr - halfChord * halfChord);
       const signedSagitta = Math.sign(cr) * sagittaMagnitude;
       const p = ensurePen();
-      pen = p.sagittaArcTo([cx, cy], signedSagitta) as typeof pen;
+      pen = p.sagittaArcTo([cx, cy], signedSagitta) as replicad.DrawingPen;
       currentX = cx;
       currentY = cy;
     } else if (c.kind === 'smoothSpline') {
       const p = ensurePen();
-      pen = p.smoothSplineTo([c.x.evaluated, c.y.evaluated]) as typeof pen;
+      pen = p.smoothSplineTo([c.x.evaluated, c.y.evaluated]) as replicad.DrawingPen;
       currentX = c.x.evaluated;
       currentY = c.y.evaluated;
     } else if (c.kind === 'spline' || c.kind === 'nurbsSegment' || c.kind === 'hermiteG2_2d') {
@@ -342,7 +342,7 @@ export function buildNurbsSketchOnPlane(
   const isAtStart = Math.hypot(currentX - startX, currentY - startY) < 1e-9;
   if (pen !== null) {
     if (!isAtStart) {
-      pen = pen.lineTo([startX, startY]) as typeof pen;
+      pen = pen.lineTo([startX, startY]) as replicad.DrawingPen;
     }
     commitPenRun();
   } else if (!isAtStart) {


### PR DESCRIPTION
Stacked on the NURBS feature branch. Closes the strict-typecheck regression flagged in #247.

## Why

Slice D Task 3 (#244) introduced a `let pen: DrawingPen | null` variable in `pathNurbsLowerer.ts` and \`pen = pen.<op>(...) as typeof pen\` assignments. TypeScript's flow analysis narrowed \`pen\` to \`null\` after \`commitPenRun()\` (which resets it), and \`typeof pen\` then resolved to the literal \`null\` type — so the cast target became "DrawingPen → null", which strict tsc rejects (\`TS2352: Conversion of type 'DrawingPen' to type 'null' may be a mistake\`). 8 sites in \`pathNurbsLowerer.ts\` had this. \`occtBackend.ts:628\` had a parallel issue with \`typeof s._drawing.sketchOnPlane[1]\` (the type query doesn't see the \`!\` non-null assertion).

\`npx tsc --noEmit\` (loose) was happy, but \`npm run typecheck\` (\`tsc -b\`) was broken on the base branch as of #247. This re-greens CI's strict-typecheck gate.

## What

- \`pathNurbsLowerer.ts\` — replace 8 \`as typeof pen\` casts with the concrete \`as replicad.DrawingPen\`.
- \`occtBackend.ts:628\` — pull \`s._drawing!\` into a \`const drawing\` so the \`typeof drawing.sketchOnPlane[1]\` type query sees the narrowed type.

Same runtime behavior, no public-API change.

## Test plan

- [x] \`npm run typecheck\` — clean (was failing on the base before this fix)
- [x] \`npx vitest run tests/unit/backends/occt/fromSketchCommands.nurbsSegments.test.ts tests/unit/backends/occt/surfaceFromCurves.nurbsSketches.test.ts\` — green