### PR TITLE
refactor(funnel): extract authedFetch<T> helper

### DIFF
--- a/src/funnel/lib/apiClient.ts
+++ b/src/funnel/lib/apiClient.ts
@@ -24,6 +24,46 @@ export async function fetchGeneration(genId: string): Promise<GenerationRow | nu
   return (data as GenerationRow | null) ?? null;
 }
 
+// ---------------------------------------------------------------------------
+// authedFetch — single source of truth for kernelCAD-server HTTP calls.
+//
+// Pattern collapsed:
+//   1. resolve Supabase session (Authorization header is optional when no
+//      session — Studio routes are reachable anon for some endpoints).
+//   2. fetch VITE_API_BASE_URL + path with JSON content-type.
+//   3. on non-2xx, throw an Error whose message is the response body (or
+//      `HTTP <status>` fallback). Tests assert on the body text.
+//   4. on success, parse + return JSON as T.
+// ---------------------------------------------------------------------------
+
+export async function authedFetch<T>(
+  method: 'GET' | 'POST',
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const supabase = getSupabase();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  const base = import.meta.env.VITE_API_BASE_URL;
+  const res = await fetch(`${base}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(session ? { Authorization: `Bearer ${session.access_token}` } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+  if (!res.ok) {
+    throw new Error(await res.text().catch(() => `HTTP ${res.status}`));
+  }
+  return res.json() as Promise<T>;
+}
+
+// ---------------------------------------------------------------------------
+// Projects
+// ---------------------------------------------------------------------------
+
 export interface SaveProjectInput {
   generationId: string;
   anonId?: string;
@@ -38,23 +78,7 @@ export interface SaveProjectResult {
 }
 
 export async function saveProject(input: SaveProjectInput): Promise<SaveProjectResult> {
-  const supabase = getSupabase();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const base = import.meta.env.VITE_API_BASE_URL;
-  const res = await fetch(`${base}/api/v1/save`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(session ? { Authorization: `Bearer ${session.access_token}` } : {}),
-    },
-    body: JSON.stringify(input),
-  });
-  if (!res.ok) {
-    throw new Error(await res.text().catch(() => `HTTP ${res.status}`));
-  }
-  return res.json();
+  return authedFetch<SaveProjectResult>('POST', '/api/v1/save', input);
 }
 
 export interface ProjectRow {
@@ -110,65 +134,19 @@ export interface BillingPortalSession {
   url: string;
 }
 
-/** Authed GET against the kernelCAD-server billing/plan endpoint.
- * Mirrors saveProject's auth + non-2xx handling exactly. */
+/** Authed GET against the kernelCAD-server billing/plan endpoint. */
 export async function fetchMyPlan(): Promise<MyPlan> {
-  const supabase = getSupabase();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const base = import.meta.env.VITE_API_BASE_URL;
-  const res = await fetch(`${base}/api/v1/me/plan`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(session ? { Authorization: `Bearer ${session.access_token}` } : {}),
-    },
-  });
-  if (!res.ok) {
-    throw new Error(await res.text().catch(() => `HTTP ${res.status}`));
-  }
-  return res.json();
+  return authedFetch<MyPlan>('GET', '/api/v1/me/plan');
 }
 
 /** POST /api/v1/billing/create-checkout — returns a Stripe Checkout URL
  * the caller should redirect to (window.location.href = url). */
 export async function createCheckoutSession(): Promise<CheckoutSession> {
-  const supabase = getSupabase();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const base = import.meta.env.VITE_API_BASE_URL;
-  const res = await fetch(`${base}/api/v1/billing/create-checkout`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(session ? { Authorization: `Bearer ${session.access_token}` } : {}),
-    },
-  });
-  if (!res.ok) {
-    throw new Error(await res.text().catch(() => `HTTP ${res.status}`));
-  }
-  return res.json();
+  return authedFetch<CheckoutSession>('POST', '/api/v1/billing/create-checkout');
 }
 
 /** POST /api/v1/billing/portal — returns a Stripe Customer Portal URL
  * for the signed-in pro user to manage / cancel their subscription. */
 export async function openBillingPortal(): Promise<BillingPortalSession> {
-  const supabase = getSupabase();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const base = import.meta.env.VITE_API_BASE_URL;
-  const res = await fetch(`${base}/api/v1/billing/portal`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(session ? { Authorization: `Bearer ${session.access_token}` } : {}),
-    },
-  });
-  if (!res.ok) {
-    throw new Error(await res.text().catch(() => `HTTP ${res.status}`));
-  }
-  return res.json();
+  return authedFetch<BillingPortalSession>('POST', '/api/v1/billing/portal');
 }

--- a/tests/funnel/apiClient.test.ts
+++ b/tests/funnel/apiClient.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../src/funnel/lib/supabaseClient', () => ({
 }));
 
 import {
+  authedFetch,
   createCheckoutSession,
   fetchMyPlan,
   openBillingPortal,
@@ -108,5 +109,41 @@ describe('openBillingPortal', () => {
   it('throws on non-2xx', async () => {
     mockFetchOnce('no portal session', { status: 400 });
     await expect(openBillingPortal()).rejects.toThrow(/no portal session/);
+  });
+});
+
+describe('authedFetch', () => {
+  it('serializes the body and forwards Authorization on POST', async () => {
+    const fetchMock = mockFetchOnce({ ok: true });
+    const result = await authedFetch<{ ok: boolean }>(
+      'POST',
+      '/api/v1/save',
+      { hello: 'world' },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.example.com/api/v1/save');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(JSON.stringify({ hello: 'world' }));
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer jwt-token-123');
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('omits Authorization and body when no session and no body provided', async () => {
+    getSession.mockResolvedValueOnce({ data: { session: null } });
+    const fetchMock = mockFetchOnce({ plan: 'free' });
+    await authedFetch<unknown>('GET', '/api/v1/me/plan');
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.method).toBe('GET');
+    expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
+    expect(init.body).toBeUndefined();
+  });
+
+  it('throws an Error containing the response body on non-2xx', async () => {
+    mockFetchOnce('upstream exploded', { status: 500 });
+    await expect(authedFetch('POST', '/api/v1/save', {})).rejects.toThrow(/upstream exploded/);
   });
 });


### PR DESCRIPTION
## Summary

Collapse the repeated session + fetch + non-2xx + JSON-parse pattern in `src/funnel/lib/apiClient.ts` into a single generic helper:

```ts
async function authedFetch<T>(
  method: 'GET' | 'POST',
  path: string,
  body?: unknown,
): Promise<T>
```

Each migrated function is now a one-liner that names the route + payload.

## Functions migrated (HTTP, not Supabase-direct)

- `saveProject`            -> `authedFetch('POST', '/api/v1/save', input)`
- `fetchMyPlan`            -> `authedFetch('GET',  '/api/v1/me/plan')`
- `createCheckoutSession`  -> `authedFetch('POST', '/api/v1/billing/create-checkout')`
- `openBillingPortal`      -> `authedFetch('POST', '/api/v1/billing/portal')`

The three Supabase-direct functions (`fetchGeneration`, `fetchProjectBySlug`, `listMyProjects`) do not hit the kernelCAD-server HTTP surface and are left untouched.

## Behavior preserved (no contract change)

- **Error contract**: `throw new Error(<response.text() body>)` with `HTTP <status>` fallback. Three existing caller tests assert on the body substring (`/plan endpoint unavailable/`, `/billing unavailable/`, `/no portal session/`) and continue to pass.
- **No-session behavior**: Authorization header is *omitted* when no session, NOT a thrown error. The existing `omits Authorization header when no session` test continues to assert this, and the helper preserves it. (The task description floated an eager throw; that would have broken the existing contract, so I did not add one.)
- Public function signatures unchanged — all studio/funnel consumers (`g.$genId.tsx`, `me.tsx`, `index.tsx`, `PlanCard.tsx`) compile without edits.

## LoC delta

- `src/funnel/lib/apiClient.ts`: 175 -> 149 (-26 net; -67/+45)
- `tests/funnel/apiClient.test.ts`: +37 (3 new helper-level tests)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` -> 0 errors (3 pre-existing warnings unrelated)
- [x] `npx vitest run tests/funnel/` -> 35/35 pass (10 in apiClient.test.ts)
- [x] `npx vitest run tests/integration/studio/` -> 11/11 pass
- [x] Full `npm test` -> 2393/2393 pass; the only failure is `tests/integration/cli-bundle/startup.test.ts` which requires `dist/cli/index.js` (built by `npm run qc`); verified pre-existing on clean develop.