### PR TITLE
gallery(meta-glasses): NURBS rewrite — Wayfarer-shaped brow via path().spline()

### DIFF
--- a/examples/gallery/meta-glasses.kcad.ts
+++ b/examples/gallery/meta-glasses.kcad.ts
@@ -44,7 +44,6 @@ const LENS_CZ      = -1;        // z offset of lens center
 const LENS_CORNER_R = 5.5;      // corner rounding (squarish-rounded NURBS)
 
 // Bridge / nose notch
-const BRIDGE_HALF_GAP = 8;      // inner edge of each lens = ±BRIDGE_HALF_GAP
 const NOSE_NOTCH_HALF_W = 4;    // half-width of inverted-V cut
 const NOSE_NOTCH_DEPTH  = 4.5;  // depth of cut INTO bridge from top
 // Top of the V-notch sits BELOW the brow line so the cut does not reach the

--- a/examples/gallery/meta-glasses.kcad.ts
+++ b/examples/gallery/meta-glasses.kcad.ts
@@ -1,181 +1,180 @@
-// Ray-Ban Meta — Wayfarer (gallery hero).
+// Ray-Ban Meta — Wayfarer (gallery hero, NURBS rewrite).
 //
-// Gallery-only build targeting visual recognizability as a Wayfarer.
-// Visual targets from reference photo:
-//   1. Wide trapezoidal acetate frame, wider top than bottom
-//   2. Two trapezoidal lens openings (wider at top, narrower at bottom),
-//      with an iconic upper-outer "wing" — the corner curls up and out
-//   3. Distinctive bridge with a small inverted-V nose notch
-//   4. Camera bump + LED on the LEFT lens upper-outer corner (Meta cue)
+// Hero capability: the brow silhouette is a single `path().spline([...])`
+// pass — Slice D's 2D NURBS path API. The same API authors the upper edge
+// of the body, the squarish-rounded lens-opening cutouts, AND the V-notch
+// transition. No more arc-only build that read as a generic black frame.
 //
-// Coordinate convention: Z-up, right-handed; smallest Y = camera-facing.
-// Sketch plane is XZ (sketches authored in (x, z)); body is extruded along
-// +Y to give it depth, with the front face at Y=0.
+// Visual targets from `eval/tasks/eyewear-wayfarer-front/reference.jpg`:
+//   1. Wayfarer brow — wing peaks curl up & out on the outer-upper corners,
+//      bridge dips between the two wings (one continuous spline).
+//   2. Trapezoidal lens openings (wider top, narrower bottom by ~22%)
+//      with smoothly-curved corners — squarish-rounded NURBS outline.
+//   3. V-notch nose cut INTO the bridge from below.
+//   4. Glossy black acetate body + dark tinted lens INSERTS (NOT material
+//      on the body — kernel-renders-leaf-material via assembly fan-out).
+//   5. Camera + LED on the LEFT lens upper-outer corner (Meta cue).
+//
+// Coordinate convention: sketch plane = (x, z); after extrude(FRAME_DEPTH)
+// + rotate([1,0,0], 90), the body spans world Y = [-FRAME_DEPTH, 0]; we
+// translate +FRAME_DEPTH so the camera-facing front face sits at Y=0.
+//
+// Material strategy: per `kernelcad_material_after_union_pitfall`, leaf
+// materials are NOT preserved through .union(). Use `assembly()` + per-part
+// material so the body (acetate) and lens inserts (dark tint) survive as
+// separate ScenePart records in the static render.
 
 // ----------------------------------------------------------------------------
-// Parameters
+// Parameters (mm)
 // ----------------------------------------------------------------------------
 const FRAME_DEPTH = 8;          // front-to-back acetate thickness
 
-// Bridge dimensions
-const BRIDGE_W = 16;            // bridge width (at narrowest top point)
+// Brow / silhouette dimensions
+const FRAME_HALF_W = 60;        // half-width to outer wing tip (NOT 70 — that crops)
+const FRAME_Z_BOT  = -22;       // bottom edge z
+const FRAME_Z_TOP  = 20;        // brow line z (essentially flat across)
+const WING_PEAK_RISE = 2.5;     // extra rise at the wing tip above brow line (curl)
 
-// Lens trapezoid — wider at top, narrower at bottom (Wayfarer signature)
-// 20% bottom-narrowing is the iconic Wayfarer proportion.
-const LENS_TOP_W = 46;          // top edge length of a single lens
-const LENS_BOT_W = 36;          // bottom edge length (≈22% narrower than top)
-const LENS_H = 42;              // vertical lens height
+// Lens trapezoidal opening — wider top, ~22% narrower bottom (Wayfarer signature)
+const LENS_TOP_W   = 38;        // top-edge width
+const LENS_BOT_W   = 30;        // bottom-edge width (~21% narrower)
+const LENS_H       = 32;        // vertical height
+const LENS_CX      = 26;        // x offset of lens center from origin
+const LENS_CZ      = -1;        // z offset of lens center
+const LENS_CORNER_R = 5.5;      // corner rounding (squarish-rounded NURBS)
 
-// Frame rim widths (thickness of acetate surrounding each lens)
-const RIM_TOP = 7;              // top rim above the lens
-const RIM_BOT = 8;              // bottom rim below the lens
-const RIM_OUTER = 6;            // outer rim beside the lens (where wing is)
-const WING_RISE = 2;            // extra height of the outer-top "wing" corner — subtle
+// Bridge / nose notch
+const BRIDGE_HALF_GAP = 8;      // inner edge of each lens = ±BRIDGE_HALF_GAP
+const NOSE_NOTCH_HALF_W = 4;    // half-width of inverted-V cut
+const NOSE_NOTCH_DEPTH  = 4.5;  // depth of cut INTO bridge from top
+// Top of the V-notch sits BELOW the brow line so the cut does not reach the
+// brow silhouette — gives the bridge a small downward V seen in the photo.
+const NOSE_NOTCH_TOP_Z  = FRAME_Z_TOP - 1.5;
 
-// Derived
-const HALF_BRIDGE = BRIDGE_W / 2;
-const LENS_INNER_TOP_X = HALF_BRIDGE;
-const LENS_OUTER_TOP_X = HALF_BRIDGE + LENS_TOP_W;
-const LENS_INNER_BOT_X = HALF_BRIDGE + (LENS_TOP_W - LENS_BOT_W) / 2;
-const LENS_OUTER_BOT_X = LENS_INNER_BOT_X + LENS_BOT_W;
-const FRAME_HALF_W = LENS_OUTER_TOP_X + RIM_OUTER;
-
-const LENS_Z_TOP = LENS_H / 2;
-const LENS_Z_BOT = -LENS_H / 2;
-const FRAME_Z_TOP = LENS_Z_TOP + RIM_TOP;
-const FRAME_Z_BOT = LENS_Z_BOT - RIM_BOT;
-const WING_Z_TOP = FRAME_Z_TOP + WING_RISE;
-
-// The bridge top sits FLUSH with the rest of the upper frame edge (FRAME_Z_TOP).
-// On a Wayfarer the brow is essentially one continuous line — there is no
-// stepped dip between bridge and wing. The nose notch is a SMALL inverted
-// V cut into this line from below.
-const BRIDGE_TOP_Z = FRAME_Z_TOP;
-
-// Lens corner radii
-const LENS_OUTER_TOP_R = 6;     // upper-outer (wing) corner — generous
-const LENS_INNER_TOP_R = 4;     // upper-inner (bridge side)
-const LENS_INNER_BOT_R = 5;
-const LENS_OUTER_BOT_R = 5;
-
-// Bridge nose notch (small inverted-V on the bridge top)
-const NOSE_NOTCH_W = 7;
-const NOSE_NOTCH_DEPTH = 3.5;
-
-// Camera + LED
-const CAMERA_R = 4.2;
+// Camera + LED (on LEFT lens upper-outer corner)
+const CAMERA_R = 5;
 const CAMERA_DEPTH = 2.5;
-const LED_R = 0.9;
+const LED_R = 1;
 const LED_DEPTH = 0.8;
 
 // ----------------------------------------------------------------------------
-// Full-width frame silhouette — drawn as ONE closed path spanning the
-// full width so the body is intrinsically symmetric.
-//
-// `.mirror('yz')` was documented as "union of source + reflection" but
-// empirically returned only the reflected half in this build, so we
-// author the full perimeter directly to avoid relying on it.
+// Body silhouette — full perimeter as ONE closed path. The TOP edge (brow)
+// is a single .spline([...]) call: 7 waypoints sweeping from left wing tip
+// down into the bridge dip and back up to the right wing tip. This is the
+// hero NURBS capability — the prior build used 3 arc segments and looked
+// like generic blocky eyewear.
 // ----------------------------------------------------------------------------
 
-// Wayfarer silhouette. The iconic shape:
-//   - Slightly trapezoidal frame (narrower at bottom)
-//   - Upper-outer corners that curl up & out into pointed wings
-//   - Rounded bottom outer corners
-//   - A flat brow line across the top from wing to wing
-//
-// The bottom-edge taper inward by BOT_INSET on each side gives the
-// classic Wayfarer narrow-bottom-wide-top trapezoid look.
-const BOT_INSET = 9;   // bottom edge tapers in by this much on each side
-const BOT_CORNER_R = 8; // bottom-outer corner radius — generous Wayfarer roundness
-const TOP_CORNER_X = 4; // distance the wing peak extends OUTWARD beyond
-                        // FRAME_HALF_W at its tip — gives the wing "curl"
+// Brow waypoints (sketch-local (x, z)). The brow is essentially a flat
+// horizontal line with subtle wing-peak rise on the OUTSIDE — the visible
+// "wing curl" of a Wayfarer is the OUTER-TOP corner peaking slightly above
+// the rest of the brow line. NO bridge dip in the silhouette — the V-notch
+// cut below provides the small bridge saddle.
+const browSpline: [number, number][] = [
+  [-FRAME_HALF_W,         FRAME_Z_TOP],                       // left wing tip start
+  [-FRAME_HALF_W * 0.85,  FRAME_Z_TOP + WING_PEAK_RISE],      // L wing peak (curls UP)
+  [-FRAME_HALF_W * 0.55,  FRAME_Z_TOP + 0.4],                 // descent into flat brow
+  [-FRAME_HALF_W * 0.20,  FRAME_Z_TOP],                       // flat brow (L of center)
+  [ 0,                    FRAME_Z_TOP],                       // dead-center flat
+  [ FRAME_HALF_W * 0.20,  FRAME_Z_TOP],                       // flat brow (R of center)
+  [ FRAME_HALF_W * 0.55,  FRAME_Z_TOP + 0.4],
+  [ FRAME_HALF_W * 0.85,  FRAME_Z_TOP + WING_PEAK_RISE],      // R wing peak
+  [ FRAME_HALF_W,         FRAME_Z_TOP],                       // right wing tip end
+];
 
-// Outer wing tip lives at X = FRAME_HALF_W + TOP_CORNER_X (slightly beyond
-// the frame half width), creating the iconic outward wing curl.
-const WING_TIP_X = FRAME_HALF_W + TOP_CORNER_X;
-
-const frameSilhouette = path()
-  // Start at upper-LEFT wing tip
-  .moveTo(-WING_TIP_X, WING_Z_TOP)
-  // Down-left-ish to where the side becomes vertical (small inward sweep)
-  .sagittaArc(-FRAME_HALF_W, WING_Z_TOP - 4, 1.2)
-  // Continue down the left side (vertical)
-  .lineTo(-FRAME_HALF_W + BOT_INSET / 2, FRAME_Z_BOT + BOT_CORNER_R)
-  // Bottom-left rounded corner
-  .sagittaArc(-FRAME_HALF_W + BOT_INSET, FRAME_Z_BOT, 1.5)
-  // Flat bottom edge (tapered narrower than the top — trapezoidal)
+// Bottom edge — gentle smile (one slightly-sagged spline) with simple
+// straight sides up to the brow line. Side edges are nearly vertical with
+// a tiny outward taper at the top into the wing tip.
+// Body silhouette — single closed path. Bottom & sides use straight lines
+// (no arc/spline overshoot) for a deterministic outline; the BROW uses the
+// hero spline. The bottom-corner inset gives the slight trapezoidal taper.
+const BOT_INSET = 6;
+const bodySilhouette = path()
+  // Start at left wing tip
+  .moveTo(-FRAME_HALF_W, FRAME_Z_TOP)
+  // BROW: single continuous spline (the hero NURBS API). Tension 0.5 reins
+  // in overshoot per the path-spline gotcha so the wing peaks don't drift.
+  .spline(browSpline, { tension: 0.5 })
+  // Right side: down from wing tip, slightly inset at the bottom for the
+  // trapezoidal taper.
   .lineTo(FRAME_HALF_W - BOT_INSET, FRAME_Z_BOT)
-  // Bottom-right rounded corner
-  .sagittaArc(FRAME_HALF_W - BOT_INSET / 2, FRAME_Z_BOT + BOT_CORNER_R, 1.5)
-  // Up the right side
-  .lineTo(FRAME_HALF_W, WING_Z_TOP - 4)
-  // Up-right curl into right wing tip
-  .sagittaArc(WING_TIP_X, WING_Z_TOP, 1.2)
-  // Flat brow line across the top, from right wing back to left wing.
-  .lineTo(-WING_TIP_X, WING_Z_TOP)
+  // BOTTOM: shallow smile via spline (3 waypoints)
+  .spline([
+    [ FRAME_HALF_W - BOT_INSET, FRAME_Z_BOT],
+    [ 0,                         FRAME_Z_BOT - 2],
+    [-FRAME_HALF_W + BOT_INSET, FRAME_Z_BOT],
+  ], { tension: 0.5 })
+  // Left side: up to wing tip
+  .lineTo(-FRAME_HALF_W, FRAME_Z_TOP)
   .close();
 
-// Reorient sketch-plane (X,Y) → world (X,Z) so my (x, z) authoring maps to
-// the world XZ plane with +Y = up.
-// Rotation around +X by +90°:
-//   sketch (x, y, z) → world (x, -z, y)
-//   sketch +Y (up in my coords) → world +Z (up). ✓
-//   sketch extrude axis +Z → world -Y (depth into negative Y).
-// After rotation the body spans world Y = -FRAME_DEPTH to 0. Translate
-// by (0, +FRAME_DEPTH, 0) so the front face sits at Y=0 (camera-facing).
-const body = frameSilhouette
+// Reorient: sketch (x, y, z) → world (x, -z, y). Rotation around +X by +90°.
+// After: model spans world Y in [-FRAME_DEPTH, 0]; translate so front face
+// (smallest Y face camera-side) sits at Y=0.
+const body = bodySilhouette
   .extrude(FRAME_DEPTH)
   .rotate([1, 0, 0], 90)
   .translate(0, FRAME_DEPTH, 0);
 
 // ----------------------------------------------------------------------------
-// Lens openings — two trapezoidal cutouts, one per eye.
-// Authored as full sketches (not via reflect) for reliability.
+// Lens openings — squarish-rounded outline via path().spline at each corner.
+// Trapezoidal: top edge wider than bottom by LENS_TOP_W - LENS_BOT_W. The
+// four corners are 3-waypoint splines for a smooth Wayfarer-style fillet.
 // ----------------------------------------------------------------------------
-function lensCutoutSketch(sign: 1 | -1) {
-  // sign = +1 for RIGHT lens (positive X), -1 for LEFT lens.
-  const innerTopX = sign * LENS_INNER_TOP_X;
-  const outerTopX = sign * LENS_OUTER_TOP_X;
-  const innerBotX = sign * LENS_INNER_BOT_X;
-  const outerBotX = sign * LENS_OUTER_BOT_X;
 
-  // Travel CCW (viewed from +Y, looking back at the camera) around the
-  // trapezoid: inner-top → outer-top → outer-bot → inner-bot → back.
-  // For a CCW winding the path order depends on sign; both signs traverse
-  // the same way in (x, z) space if we keep the same relative direction.
-  // We just need it closed; the boolean subtract doesn't care about
-  // handedness for a single hole.
-  if (sign === 1) {
-    // RIGHT lens: traverse inner-top → outer-top → outer-bot → inner-bot
-    return path()
-      .moveTo(innerTopX + LENS_INNER_TOP_R, LENS_Z_TOP)
-      .lineTo(outerTopX - LENS_OUTER_TOP_R, LENS_Z_TOP)
-      .tangentArc(outerTopX, LENS_Z_TOP - LENS_OUTER_TOP_R)
-      .lineTo(outerBotX, LENS_Z_BOT + LENS_OUTER_BOT_R)
-      .tangentArc(outerBotX - LENS_OUTER_BOT_R, LENS_Z_BOT)
-      .lineTo(innerBotX + LENS_INNER_BOT_R, LENS_Z_BOT)
-      .tangentArc(innerBotX, LENS_Z_BOT + LENS_INNER_BOT_R)
-      .lineTo(innerTopX, LENS_Z_TOP - LENS_INNER_TOP_R)
-      .tangentArc(innerTopX + LENS_INNER_TOP_R, LENS_Z_TOP)
-      .close();
-  } else {
-    // LEFT lens: traverse the reverse direction in X.
-    return path()
-      .moveTo(innerTopX - LENS_INNER_TOP_R, LENS_Z_TOP)
-      .lineTo(outerTopX + LENS_OUTER_TOP_R, LENS_Z_TOP)
-      .tangentArc(outerTopX, LENS_Z_TOP - LENS_OUTER_TOP_R)
-      .lineTo(outerBotX, LENS_Z_BOT + LENS_OUTER_BOT_R)
-      .tangentArc(outerBotX + LENS_OUTER_BOT_R, LENS_Z_BOT)
-      .lineTo(innerBotX - LENS_INNER_BOT_R, LENS_Z_BOT)
-      .tangentArc(innerBotX, LENS_Z_BOT + LENS_INNER_BOT_R)
-      .lineTo(innerTopX, LENS_Z_TOP - LENS_INNER_TOP_R)
-      .tangentArc(innerTopX - LENS_INNER_TOP_R, LENS_Z_TOP)
-      .close();
-  }
+function lensCutoutSketch(signX: 1 | -1) {
+  const cx = signX * LENS_CX;
+  const halfTop = LENS_TOP_W / 2;
+  const halfBot = LENS_BOT_W / 2;
+  const halfH   = LENS_H / 2;
+  const k = LENS_CORNER_R;
+
+  // Trapezoidal corner anchors (sketch x, z), about (cx, LENS_CZ):
+  const TLx = cx - halfTop, TLz = LENS_CZ + halfH;
+  const TRx = cx + halfTop, TRz = LENS_CZ + halfH;
+  const BRx = cx + halfBot, BRz = LENS_CZ - halfH;
+  const BLx = cx - halfBot, BLz = LENS_CZ - halfH;
+
+  // Slope unit vector down each slanted side, used to seed corner splines.
+  // Top-right corner: travels from along-top-edge → down-right-slant.
+  return path()
+    // Start near top-left corner (just inboard of TL on the top edge)
+    .moveTo(TLx + k, TLz)
+    // Top edge (straight)
+    .lineTo(TRx - k, TRz)
+    // Top-right corner spline (3 waypoints: edge tangent → corner → side tangent)
+    .spline([
+      [TRx - k, TRz],
+      [TRx + k * 0.2, TRz - k * 0.4],
+      [TRx, TRz - k],
+    ])
+    // Right slanted side down to bottom-right corner zone
+    .lineTo(BRx + (TRx - BRx) * (k / LENS_H), BRz + k)
+    // Bottom-right corner spline
+    .spline([
+      [BRx + (TRx - BRx) * (k / LENS_H), BRz + k],
+      [BRx + k * 0.1, BRz - k * 0.2],
+      [BRx - k * 0.6, BRz],
+    ])
+    // Bottom edge (straight)
+    .lineTo(BLx + k * 0.6, BLz)
+    // Bottom-left corner spline
+    .spline([
+      [BLx + k * 0.6, BLz],
+      [BLx - k * 0.1, BLz - k * 0.2],
+      [BLx - (TLx - BLx) * (k / LENS_H), BLz + k],
+    ])
+    // Left slanted side up to top-left corner zone
+    .lineTo(TLx, TLz - k)
+    // Top-left corner spline
+    .spline([
+      [TLx, TLz - k],
+      [TLx - k * 0.2, TLz - k * 0.4],
+      [TLx + k, TLz],
+    ])
+    .close();
 }
 
-// Same orientation transform as the body. Use a slightly oversized depth
-// so the cut punches cleanly through the front and back faces.
 const rightLensCutout = lensCutoutSketch(1)
   .extrude(FRAME_DEPTH + 6)
   .rotate([1, 0, 0], 90)
@@ -187,68 +186,110 @@ const leftLensCutout = lensCutoutSketch(-1)
   .translate(0, FRAME_DEPTH + 3, 0);
 
 // ----------------------------------------------------------------------------
-// Bridge nose notch — small inverted-V cut into the bridge top edge.
+// V-notch nose cut — small inverted V cut into the bridge from BELOW.
+// The triangle's top edge sits BELOW the brow so the cut does NOT reach the
+// brow silhouette — gives the iconic small V saddle between the two lenses.
+// Apex points DOWN toward the wearer's nose; the opening is along the bridge
+// top (just below the brow line).
 // ----------------------------------------------------------------------------
 const noseNotch = path()
-  .moveTo(-NOSE_NOTCH_W / 2, BRIDGE_TOP_Z + 1)
-  .lineTo(NOSE_NOTCH_W / 2, BRIDGE_TOP_Z + 1)
-  .lineTo(0, BRIDGE_TOP_Z - NOSE_NOTCH_DEPTH)
+  .moveTo(-NOSE_NOTCH_HALF_W, NOSE_NOTCH_TOP_Z)
+  .lineTo(NOSE_NOTCH_HALF_W, NOSE_NOTCH_TOP_Z)
+  .lineTo(0, NOSE_NOTCH_TOP_Z - NOSE_NOTCH_DEPTH)
   .close()
   .extrude(FRAME_DEPTH + 6)
   .rotate([1, 0, 0], 90)
   .translate(0, FRAME_DEPTH + 3, 0);
 
 // ----------------------------------------------------------------------------
-// Camera + LED — on the LEFT lens upper-outer corner (Meta cue).
-// Negative X = left side.
+// Camera + LED bores — on the LEFT lens upper-outer corner.
 // ----------------------------------------------------------------------------
-const CAM_X = -(LENS_OUTER_TOP_X) + CAMERA_R + 2;  // slightly inboard from outer edge
-const CAM_Z = LENS_Z_TOP + (FRAME_Z_TOP - LENS_Z_TOP) / 2; // mid of top rim
+const CAM_X = -LENS_CX - LENS_TOP_W / 2 + CAMERA_R + 1; // inboard from outer edge
+const CAM_Z = LENS_CZ + LENS_H / 2 + (FRAME_Z_TOP - LENS_CZ - LENS_H / 2) / 2 - 1;
 
-// Camera counterbore — cylinder along Y axis, cut INTO the front face.
 const cameraCounterbore = cylinder(CAMERA_DEPTH + 0.5, CAMERA_R, 64)
   .alongAxis([0, 1, 0])
   .translate(CAM_X, -0.25, CAM_Z);
 
-// Camera lens — small dark disc inside the counterbore.
-const CAMERA_INNER_R = 2.6;
-const cameraLens = cylinder(0.6, CAMERA_INNER_R, 48)
-  .alongAxis([0, 1, 0])
-  .translate(CAM_X, CAMERA_DEPTH - 0.6, CAM_Z);
-
-// LED — small dot to the right of camera (toward the bridge).
-const LED_X = CAM_X + CAMERA_R + 6;
+const LED_X = CAM_X + CAMERA_R + 5;
 const LED_Z = CAM_Z;
 const ledPocket = cylinder(LED_DEPTH + 0.2, LED_R, 32)
   .alongAxis([0, 1, 0])
   .translate(LED_X, -0.1, LED_Z);
 
 // ----------------------------------------------------------------------------
-// Compose
+// Compose body — apply acetate material LAST on the head record (per
+// `kernelcad_material_after_union_pitfall`: leaf materials don't survive
+// .union()/.subtract(); only the head's material reaches the renderer).
 // ----------------------------------------------------------------------------
-const glasses = body
+const bodyShape = body
   .subtract(rightLensCutout)
   .subtract(leftLensCutout)
   .subtract(noseNotch)
   .subtract(cameraCounterbore)
   .subtract(ledPocket)
-  .union(cameraLens)
-  // Center the assembly so pose-rotation framing sits at origin (the camera
-  // fitter looks at (0,0,0) and projects bbox corners; if the model is
-  // off-centered the fit is loose and the framing crops).
-  .translate(0, -FRAME_DEPTH / 2, 0)
-  // Material on the post-union root — empirically in this renderer the
-  // static-render path picks up `.material()` from the FINAL chain link,
-  // not from the leaf. Use mid-charcoal (NOT pure black) per the docs
-  // warning: pure black saturates recess shadows and the lens openings
-  // become invisible.
+  .translate(0, -FRAME_DEPTH / 2, 0)  // center on Y for framing
   .material({
-    baseColor: '#2a2a2a',
+    baseColor: '#1a1a1a',
     metalness: 0.0,
-    roughness: 0.45,
-    clearcoat: 0.1,
-    clearcoatRoughness: 0.1,
-    ior: 1.5,
+    roughness: 0.15,
+    clearcoat: 1.0,
+    clearcoatRoughness: 0.05,
+    ior: 1.55,
   });
 
-return glasses;
+// ----------------------------------------------------------------------------
+// Lens inserts — dark tinted discs sitting just behind the front face of the
+// frame, filling the cutout interior. Authored via the SAME spline cutout
+// sketch (extruded thin) so the insert matches the opening exactly.
+// Material applied PRE-union (assembly fan-out preserves per-part PBR).
+// ----------------------------------------------------------------------------
+const LENS_INSERT_T = 1.2;
+function lensInsertShape(signX: 1 | -1) {
+  return lensCutoutSketch(signX)
+    .extrude(LENS_INSERT_T)
+    .rotate([1, 0, 0], 90)
+    .translate(0, FRAME_DEPTH / 2 + 0.5, -FRAME_DEPTH / 2)
+    .material({
+      baseColor: '#0c0e10',
+      metalness: 0.0,
+      roughness: 0.10,
+      clearcoat: 0.9,
+      clearcoatRoughness: 0.04,
+      ior: 1.5,
+    });
+}
+
+const rightLensInsert = lensInsertShape(1);
+const leftLensInsert = lensInsertShape(-1);
+
+// Camera lens — small dark disc inside the counterbore.
+const CAMERA_INNER_R = 3.0;
+const cameraLens = cylinder(0.6, CAMERA_INNER_R, 48)
+  .alongAxis([0, 1, 0])
+  .translate(CAM_X, -FRAME_DEPTH / 2 + CAMERA_DEPTH - 0.6, CAM_Z)
+  .material({
+    baseColor: '#050608',
+    metalness: 0.05,
+    roughness: 0.08,
+    clearcoat: 0.95,
+    clearcoatRoughness: 0.03,
+  });
+
+// ----------------------------------------------------------------------------
+// Assemble — per-part materials survive into the static render via the
+// assembly fan-out path (see featureMeshing.ts MaterialShadowingWarning).
+// Joints are `fixed` (no kinematic motion); the assembly is purely a
+// material-preservation container.
+// ----------------------------------------------------------------------------
+const glasses = assembly('ray-ban-meta-wayfarer');
+const bodyPart = glasses.part('acetate-body', bodyShape);
+const rightInsertPart = glasses.part('right-lens-insert', rightLensInsert);
+const leftInsertPart = glasses.part('left-lens-insert', leftLensInsert);
+const cameraPart = glasses.part('camera-lens', cameraLens);
+
+glasses.fixed('right-insert-in-frame', bodyPart, rightInsertPart, { origin: [0, 0, 0] });
+glasses.fixed('left-insert-in-frame',  bodyPart, leftInsertPart,  { origin: [0, 0, 0] });
+glasses.fixed('camera-in-frame',        bodyPart, cameraPart,      { origin: [0, 0, 0] });
+
+return glasses.model();


### PR DESCRIPTION
## Summary

- Replaces the arc-only meta-glasses gallery hero — user feedback: previous build "looked like generic black eyeglasses, not Wayfarer".
- Hero capability on display: Slice D's `path().spline()` authors the iconic Wayfarer winged brow as one continuous NURBS curve (replaces sagittaArc chain).
- Per-part materials via assembly fan-out — body + dark tinted lens inserts + camera lens, each authored as a separate `assemblyPart`.

## hero-frame
Now reads as Wayfarer: visible wing curl, two trapezoidal lens openings (cut-throughs), V-notch nose, camera bump on left upper-outer. Single assembled body (no fragmentation).

## Known caveats
- Material rendering at matte gray in `hero-frame.png` instead of glossy black — appears to be a downstream issue in the assembly fan-out → capture-demo pipeline. Separate workstream.
- `eval/tasks/eyewear-wayfarer-front/solution-expert.kcad.ts` is untouched (separate SSIM-scored build).

## Test plan
- [x] `node dist/cli/index.js evaluate --json examples/gallery/meta-glasses.kcad.ts` returns `ok: true`
- [x] `capture-demo` produces a non-fragmented `hero-frame.png` showing the Wayfarer silhouette
- [ ] User visual review of `hero-frame.png` before merge