### PR TITLE
ci: make kernelcad.com deploy single-owned

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -1,13 +1,11 @@
 name: Deploy to Cloudflare Pages
 
-# Auto-deploys two Cloudflare Pages projects on every push.
+# Auto-deploys app.kernelcad.com on every push.
 #
-# Both projects serve the Studio Vite app (dist/) so the prompt-funnel
-# landing route (/) renders at kernelcad.com AND app.kernelcad.com. The
-# marketing project bundles site/functions/ (CF Pages Functions for the
-# /api/subscribe D1 endpoint) and site/public/ overlays (brand assets,
-# rendered hero demo.mp4) on top of dist/. kernelcad.com is bound to
-# kernelcad-marketing; app.kernelcad.com is bound to kernelcad-app.
+# kernelcad.com is deployed to the kernelcad-marketing Cloudflare Pages
+# project by the private kernelCAD-server workflow. Keep that deploy path
+# single-owned so public pushes cannot race or overwrite the production
+# marketing site and its Pages Functions bindings.
 
 on:
   push:
@@ -24,60 +22,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  marketing:
-    name: Deploy marketing site
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install ffmpeg
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq ffmpeg
-          ffmpeg -version | head -1
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install Playwright Chromium (for brand asset rendering)
-        run: npx playwright install --with-deps chromium
-
-      - name: Build Vite app (Studio funnel — kernelcad.com landing)
-        env:
-          VITE_BASE_PATH: /
-          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
-          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
-          VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
-        run: npm run build
-
-      - name: Build demo + curated gallery + brand assets
-        run: |
-          npx tsx site/scripts/build-demo.ts
-          npx tsx site/scripts/build-gallery.ts
-          node site/scripts/render-brand.mjs
-
-      - name: Overlay site/ assets + functions on dist/
-        run: |
-          # CF Pages Functions for /api/subscribe (D1-backed).
-          cp -r site/functions dist/functions
-          # site/public/ has favicon.svg, og-image.png, demo.mp4, brand/,
-          # gallery JSON — overlay onto dist/ so kernelcad.com serves them.
-          cp -r site/public/. dist/
-
-      - name: Deploy to Cloudflare Pages (kernelcad-marketing)
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=kernelcad-marketing --branch=main --commit-dirty=true
-
   app:
     name: Deploy visual debugger app
     runs-on: ubuntu-latest

--- a/scripts/lib/cloudflareDeployWorkflow.test.ts
+++ b/scripts/lib/cloudflareDeployWorkflow.test.ts
@@ -3,29 +3,33 @@ import { describe, expect, it } from 'vitest';
 import YAML from 'yaml';
 
 describe('Cloudflare Pages deploy workflow', () => {
-  it('deploys the Studio dist/ bundle to kernelcad-marketing (so kernelcad.com serves the prompt funnel)', () => {
+  it('does not deploy kernelcad.com from the public kernelCAD-web workflow', () => {
     const workflow = YAML.parse(readFileSync('.github/workflows/deploy-cloudflare.yml', 'utf8'));
-    const marketingSteps = workflow.jobs.marketing.steps as Array<{
+    expect(Object.keys(workflow.jobs)).not.toContain('marketing');
+    expect(readFileSync('.github/workflows/deploy-cloudflare.yml', 'utf8')).not.toContain(
+      '--project-name=kernelcad-marketing',
+    );
+  });
+
+  it('keeps app.kernelcad.com deployed from the public workflow', () => {
+    const workflow = YAML.parse(readFileSync('.github/workflows/deploy-cloudflare.yml', 'utf8'));
+    const appSteps = workflow.jobs.app.steps as Array<{
       name?: string;
       with?: { command?: string; workingDirectory?: string };
     }>;
 
-    const deployStep = marketingSteps.find((step) =>
+    const deployStep = appSteps.find((step) =>
       step.name?.includes('Deploy to Cloudflare Pages'),
     );
 
-    // After hotfix: deploy runs from repo root and uploads dist/ (which gets
-    // site/functions and site/public overlaid by the preceding step). The old
-    // site-as-workingDirectory shape served a static landing without the
-    // prompt funnel.
     expect(deployStep?.with?.command).toBe(
-      'pages deploy dist --project-name=kernelcad-marketing --branch=main --commit-dirty=true',
+      'pages deploy dist --project-name=kernelcad-app --branch=main --commit-dirty=true',
     );
   });
 
-  it('passes VITE_SUPABASE_* secrets to both Vite build jobs (otherwise supabaseClient throws on bundle load)', () => {
+  it('passes VITE_SUPABASE_* secrets to the Vite build job (otherwise supabaseClient throws on bundle load)', () => {
     const workflow = YAML.parse(readFileSync('.github/workflows/deploy-cloudflare.yml', 'utf8'));
-    for (const jobName of ['marketing', 'app'] as const) {
+    for (const jobName of ['app'] as const) {
       const steps = workflow.jobs[jobName].steps as Array<{
         name?: string;
         env?: Record<string, string>;

--- a/scripts/packageReleaseAudit.test.ts
+++ b/scripts/packageReleaseAudit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { auditPackageJsonText, formatPackageAuditReport } from './packageReleaseAudit';
+import { auditPackageJsonText, auditPackageReleaseState, formatPackageAuditReport } from './packageReleaseAudit';
 
 describe('packageReleaseAudit', () => {
   it('requires prepack to build the CLI bundle before npm pack or publish', () => {
@@ -24,5 +24,22 @@ describe('packageReleaseAudit', () => {
     }));
 
     expect(result.blockers).toEqual([]);
+  });
+
+  it('blocks package versions that outrun the checked-out stable release tags', () => {
+    const result = auditPackageReleaseState({
+      packageJsonText: JSON.stringify({
+        version: '0.11.0',
+        bin: { kernelcad: 'dist/cli/index.js' },
+        files: ['dist/cli', 'README.md', 'LICENSE'],
+        scripts: { prepack: 'npm run build:cli' },
+      }),
+      tagNames: ['v0.6.1', 'v0.8.0', 'v0.9.0-rc.1'],
+    });
+
+    expect(result.blockers).toContainEqual({
+      kind: 'package-version-ahead-of-local-tag',
+      message: 'package.json version 0.11.0 is ahead of highest local stable tag v0.8.0',
+    });
   });
 });

--- a/scripts/packageReleaseAudit.ts
+++ b/scripts/packageReleaseAudit.ts
@@ -1,7 +1,11 @@
 import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
-export type PackageAuditKind = 'missing-prepack-build' | 'missing-bin-file-entry';
+export type PackageAuditKind =
+  | 'missing-prepack-build'
+  | 'missing-bin-file-entry'
+  | 'package-version-ahead-of-local-tag';
 
 export interface PackageAuditFinding {
   kind: PackageAuditKind;
@@ -16,6 +20,12 @@ interface PackageJsonShape {
   bin?: Record<string, string> | string;
   files?: string[];
   scripts?: Record<string, string>;
+  version?: string;
+}
+
+interface PackageAuditInput {
+  packageJsonText: string;
+  tagNames?: string[];
 }
 
 function binPaths(pkg: PackageJsonShape): string[] {
@@ -33,7 +43,36 @@ function fileEntryIncludesPath(files: string[], path: string): boolean {
 }
 
 export function auditPackageJsonText(text: string): PackageAuditResult {
-  const pkg = JSON.parse(text) as PackageJsonShape;
+  return auditPackageReleaseState({ packageJsonText: text });
+}
+
+function parseStableSemverTag(tagName: string): [number, number, number] | null {
+  const match = /^v(\d+)\.(\d+)\.(\d+)$/.exec(tagName.trim());
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareSemver(a: [number, number, number], b: [number, number, number]): number {
+  for (let i = 0; i < 3; i += 1) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+function highestStableTag(tagNames: string[]): [number, number, number] | null {
+  return tagNames
+    .map(parseStableSemverTag)
+    .filter((version): version is [number, number, number] => version !== null)
+    .sort(compareSemver)
+    .at(-1) ?? null;
+}
+
+function formatSemver(version: [number, number, number]): string {
+  return version.join('.');
+}
+
+export function auditPackageReleaseState(input: PackageAuditInput): PackageAuditResult {
+  const pkg = JSON.parse(input.packageJsonText) as PackageJsonShape;
   const blockers: PackageAuditFinding[] = [];
 
   if (pkg.scripts?.prepack !== 'npm run build:cli') {
@@ -53,6 +92,17 @@ export function auditPackageJsonText(text: string): PackageAuditResult {
     }
   }
 
+  if (input.tagNames) {
+    const packageVersion = pkg.version ? parseStableSemverTag(`v${pkg.version}`) : null;
+    const highestTag = highestStableTag(input.tagNames);
+    if (packageVersion && highestTag && compareSemver(packageVersion, highestTag) > 0) {
+      blockers.push({
+        kind: 'package-version-ahead-of-local-tag',
+        message: `package.json version ${pkg.version} is ahead of highest local stable tag v${formatSemver(highestTag)}`,
+      });
+    }
+  }
+
   return { blockers };
 }
 
@@ -61,7 +111,16 @@ export function formatPackageAuditReport(result: PackageAuditResult): string {
 }
 
 function main(): void {
-  const result = auditPackageJsonText(readFileSync('package.json', 'utf8'));
+  const strictTags = process.env.KERNELCAD_RELEASE_AUDIT_TAGS === '1';
+  const tagNames = strictTags
+    ? execFileSync('git', ['tag', '--list'], { encoding: 'utf8' })
+      .split('\n')
+      .filter(Boolean)
+    : undefined;
+  const result = auditPackageReleaseState({
+    packageJsonText: readFileSync('package.json', 'utf8'),
+    tagNames,
+  });
   const report = formatPackageAuditReport(result);
   if (report) console.error(report);
   if (result.blockers.length > 0) {


### PR DESCRIPTION
## Summary
- remove public kernelcad.com / kernelcad-marketing deploy from kernelCAD-web
- keep app.kernelcad.com deploy in the public workflow
- add workflow/release audit coverage for deploy ownership and package/tag drift

## Test Plan
- npm run typecheck
- npm test -- scripts/lib/cloudflareDeployWorkflow.test.ts scripts/packageReleaseAudit.test.ts tests/funnel/generateClient.test.ts tests/funnel/apiClient.test.ts
- npm run test:package
- KERNELCAD_RELEASE_AUDIT_TAGS=1 npm run test:package (expected release blocker until v0.11.0 tag exists)