### PR TITLE
feat(studio): automate cloud MCP setup

### DIFF
--- a/src/agent/cli/commands/mcp.ts
+++ b/src/agent/cli/commands/mcp.ts
@@ -5,11 +5,20 @@ import { runStdioServer } from '../../mcp/server';
 export function mcpCommand(): Command {
   return new Command('mcp')
     .description('Run the kernelCAD MCP server (stdio transport).')
-    .action(async () => {
+    .option('--cloud', 'proxy MCP tools through the hosted kernelCAD cloud kernel')
+    .option('--api-base-url <url>', 'kernelCAD API base URL', process.env.KERNELCAD_API_BASE_URL)
+    .option('--token <token>', 'kernelCAD MCP token', process.env.KERNELCAD_API_TOKEN)
+    .action(async (opts: { cloud?: boolean; apiBaseUrl?: string; token?: string }) => {
       // The MCP protocol uses stdout for JSON-RPC. Errors and any non-protocol
       // logs go to stderr.
       try {
-        await runStdioServer();
+        await runStdioServer({
+          cloud: Boolean(opts.cloud),
+          cloudOptions: {
+            ...(opts.apiBaseUrl ? { apiBaseUrl: opts.apiBaseUrl } : {}),
+            ...(opts.token ? { token: opts.token } : {}),
+          },
+        });
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         process.stderr.write(`MCP server failed: ${msg}\n`);

--- a/src/agent/mcp/cloudClient.test.ts
+++ b/src/agent/mcp/cloudClient.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { callCloudTool, listCloudTools, resolveCloudMcpOptions } from './cloudClient';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.KERNELCAD_API_TOKEN;
+  delete process.env.KERNELCAD_API_BASE_URL;
+});
+
+describe('cloud MCP client', () => {
+  it('requires a token for cloud mode', () => {
+    expect(() => resolveCloudMcpOptions()).toThrow(/KERNELCAD_API_TOKEN/);
+  });
+
+  it('lists tools from the hosted MCP gateway', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        tools: [{ name: 'evaluate_script', description: 'eval', inputSchema: { type: 'object' } }],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const tools = await listCloudTools({ apiBaseUrl: 'https://api.test/', token: 'kc_test' });
+
+    expect(fetchMock).toHaveBeenCalledWith('https://api.test/api/v1/mcp/tools', {
+      headers: { Authorization: 'Bearer kc_test' },
+    });
+    expect(tools[0]?.name).toBe('evaluate_script');
+  });
+
+  it('calls a hosted MCP tool', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: { ok: true } }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(callCloudTool('evaluate_script', { code: 'return box(1,1,1);' }, {
+      apiBaseUrl: 'https://api.test',
+      token: 'kc_test',
+    })).resolves.toEqual({ ok: true });
+
+    expect(fetchMock).toHaveBeenCalledWith('https://api.test/api/v1/mcp/call', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer kc_test',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: 'evaluate_script',
+        arguments: { code: 'return box(1,1,1);' },
+      }),
+    });
+  });
+});

--- a/src/agent/mcp/cloudClient.ts
+++ b/src/agent/mcp/cloudClient.ts
@@ -1,0 +1,50 @@
+import type { McpToolDefinition } from './toolRegistry';
+
+export interface CloudMcpOptions {
+  apiBaseUrl?: string;
+  token?: string;
+}
+
+const DEFAULT_API_BASE_URL = 'https://api.kernelcad.com';
+
+export function resolveCloudMcpOptions(options: CloudMcpOptions = {}): Required<CloudMcpOptions> {
+  const apiBaseUrl = (options.apiBaseUrl ?? process.env.KERNELCAD_API_BASE_URL ?? DEFAULT_API_BASE_URL).replace(/\/+$/, '');
+  const token = options.token ?? process.env.KERNELCAD_API_TOKEN ?? '';
+  if (!token) throw new Error('Missing MCP token. Set KERNELCAD_API_TOKEN or pass --token.');
+  return { apiBaseUrl, token };
+}
+
+export async function listCloudTools(options: CloudMcpOptions = {}): Promise<McpToolDefinition[]> {
+  const { apiBaseUrl, token } = resolveCloudMcpOptions(options);
+  const res = await fetch(`${apiBaseUrl}/api/v1/mcp/tools`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(await responseError(res));
+  const payload = await res.json() as { tools?: McpToolDefinition[] };
+  if (!Array.isArray(payload.tools)) throw new Error('Invalid cloud MCP tools response.');
+  return payload.tools;
+}
+
+export async function callCloudTool(
+  name: string,
+  args: Record<string, unknown>,
+  options: CloudMcpOptions = {},
+): Promise<unknown> {
+  const { apiBaseUrl, token } = resolveCloudMcpOptions(options);
+  const res = await fetch(`${apiBaseUrl}/api/v1/mcp/call`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ name, arguments: args }),
+  });
+  if (!res.ok) throw new Error(await responseError(res));
+  const payload = await res.json() as { result?: unknown };
+  return payload.result;
+}
+
+async function responseError(res: Response): Promise<string> {
+  const text = await res.text().catch(() => '');
+  return text || `HTTP ${res.status}`;
+}

--- a/src/agent/mcp/server.ts
+++ b/src/agent/mcp/server.ts
@@ -4,6 +4,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { callMcpTool, TOOLS } from './toolRegistry';
+import { callCloudTool, listCloudTools, type CloudMcpOptions } from './cloudClient';
 
 const requireFromHere = createRequire(import.meta.url);
 // At source: src/agent/mcp/server.ts → ../../../package.json (3 up)
@@ -22,18 +23,27 @@ const pkg = loadPkg();
 
 export { TOOLS };
 
-export function createMcpServer(): Server {
+export interface McpServerOptions {
+  cloud?: boolean;
+  cloudOptions?: CloudMcpOptions;
+}
+
+export function createMcpServer(options: McpServerOptions = {}): Server {
   const server = new Server(
     { name: 'kernelcad', version: pkg.version },
     { capabilities: { tools: {} } },
   );
 
-  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: options.cloud ? await listCloudTools(options.cloudOptions) : TOOLS,
+  }));
 
   server.setRequestHandler(CallToolRequestSchema, async (req) => {
     const { name, arguments: args } = req.params;
     const input = (args ?? {}) as Record<string, unknown>;
-    const result = await callMcpTool(name, input);
+    const result = options.cloud
+      ? await callCloudTool(name, input, options.cloudOptions)
+      : await callMcpTool(name, input);
 
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
@@ -43,8 +53,8 @@ export function createMcpServer(): Server {
   return server;
 }
 
-export async function runStdioServer(): Promise<void> {
-  const server = createMcpServer();
+export async function runStdioServer(options: McpServerOptions = {}): Promise<void> {
+  const server = createMcpServer(options);
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/src/funnel/lib/apiClient.ts
+++ b/src/funnel/lib/apiClient.ts
@@ -150,3 +150,17 @@ export async function createCheckoutSession(): Promise<CheckoutSession> {
 export async function openBillingPortal(): Promise<BillingPortalSession> {
   return authedFetch<BillingPortalSession>('POST', '/api/v1/billing/portal');
 }
+
+// ---------------------------------------------------------------------------
+// MCP tokens
+// ---------------------------------------------------------------------------
+
+export interface McpTokenResult {
+  token: string;
+  tokenPrefix: string;
+}
+
+/** POST /api/v1/mcp/tokens — creates a one-time-visible token for cloud MCP. */
+export async function createMcpToken(): Promise<McpTokenResult> {
+  return authedFetch<McpTokenResult>('POST', '/api/v1/mcp/tokens');
+}

--- a/src/studio/AgentActivityLog.tsx
+++ b/src/studio/AgentActivityLog.tsx
@@ -1,22 +1,107 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { createMcpToken } from '../funnel/lib/apiClient';
 
 /**
- * Subscribes to the agent event stream when one exists. The current
- * `AgentAPI` is a synchronous command dispatcher with no event emitter,
- * so v1 renders the offline/empty state. Slice 1.5 lights this up when
- * the MCP event channel ships.
+ * Agent connection surface. The npm package is the portable MCP/token/tooling
+ * shim; hosted cloud kernels and Studio-aware sessions sit behind it.
  */
 export const AgentActivityLog: React.FC = () => {
+    const [copied, setCopied] = useState<string | null>(null);
+    const [token, setToken] = useState<string | null>(null);
+    const [tokenError, setTokenError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let active = true;
+        createMcpToken()
+            .then((result) => {
+                if (!active) return;
+                setToken(result.token);
+                setTokenError(null);
+            })
+            .catch((err: unknown) => {
+                if (!active) return;
+                setToken(null);
+                setTokenError(err instanceof Error ? err.message : String(err));
+            });
+        return () => {
+            active = false;
+        };
+    }, []);
+
+    const copyCommand = async (id: string, command: string) => {
+        await navigator.clipboard.writeText(command);
+        setCopied(id);
+        window.setTimeout(() => setCopied((current) => (current === id ? null : current)), 1200);
+    };
+
+    const tokenArg = token ?? '<sign-in-required>';
+    const commands = useMemo(() => [
+        {
+            id: 'claude',
+            label: 'Claude',
+            command: `claude mcp add kernelcad -- npx -y kernelcad mcp --cloud --token ${tokenArg}`,
+        },
+        {
+            id: 'codex',
+            label: 'Codex',
+            command: `codex mcp add kernelcad -- npx -y kernelcad mcp --cloud --token ${tokenArg}`,
+        },
+    ], [tokenArg]);
+
     return (
-        <div className="h-full p-3 flex flex-col gap-2 overflow-y-auto">
+        <div className="h-full p-3 flex flex-col gap-3 overflow-y-auto">
             <div className="uppercase tracking-wide text-[10px] text-gray-500">
-                Agent activity
+                Agents
             </div>
-            <div className="text-xs text-gray-500 italic">
-                Agent offline · MCP not connected
+
+            <div className="rounded border border-[#2a2e38] bg-[#111] p-3">
+                <div className="text-xs font-semibold text-gray-100">
+                    Cloud MCP connector
+                </div>
+                <div className="mt-1 text-[11px] leading-snug text-gray-500">
+                    One-line MCP install with token auth, local tooling, and hosted kernel execution.
+                </div>
+                <div className="mt-2 text-[10px] leading-snug text-gray-500">
+                    {token
+                        ? 'Token ready. Copy a command below.'
+                        : tokenError
+                            ? 'Sign in to create a cloud MCP token automatically.'
+                            : 'Preparing cloud MCP token...'}
+                </div>
+                <div className="mt-3 flex flex-col gap-2">
+                    {commands.map(({ id, label, command }) => (
+                        <div key={id} className="rounded border border-[#2d2d2d] bg-black/40 p-2">
+                            <div className="mb-1 flex items-center justify-between gap-2">
+                                <span className="text-[11px] font-medium text-gray-300">{label}</span>
+                                <button
+                                    type="button"
+                                    aria-label={`Copy ${label} MCP command`}
+                                    onClick={() => void copyCommand(id, command)}
+                                    className="rounded border border-[#3a3a3a] px-2 py-0.5 text-[10px] text-gray-300 hover:bg-[#222] hover:text-white"
+                                >
+                                    {copied === id ? 'copied' : 'copy'}
+                                </button>
+                            </div>
+                            <div className="break-all font-mono text-[10px] leading-snug text-gray-500">
+                                {command}
+                            </div>
+                        </div>
+                    ))}
+                </div>
             </div>
-            <div className="text-[11px] text-gray-600 leading-snug">
-                Agent activity will appear here when MCP connects.
+
+            <div className="rounded border border-[#2a2e38] bg-[#0d0d0d] p-3">
+                <div className="flex items-center justify-between gap-2">
+                    <div className="text-xs font-semibold text-gray-100">
+                        Studio Agent Mode
+                    </div>
+                    <span className="rounded border border-amber-800/60 bg-amber-950/30 px-1.5 py-0.5 text-[10px] text-amber-300">
+                        cloud
+                    </span>
+                </div>
+                <div className="mt-1 text-[11px] leading-snug text-gray-500">
+                    Coming later: paid API-driven Studio sessions with OAuth, live edits, and review/apply flow.
+                </div>
             </div>
         </div>
     );

--- a/src/studio/AgentRail.tsx
+++ b/src/studio/AgentRail.tsx
@@ -4,7 +4,7 @@ import { StagedEditSlot } from './StagedEditSlot';
 import { AgentActivityLog } from './AgentActivityLog';
 
 /**
- * Right-side rail. Width animates between 0 and 240px based on
+ * Left-side rail. Width animates between 0 and 240px based on
  * `agentRailOpen` in the shell store. Two stacked panes: staged-edit slot
  * on top, agent activity log below.
  */
@@ -17,7 +17,7 @@ export const AgentRail: React.FC = () => {
             aria-hidden={!agentRailOpen}
             data-open={agentRailOpen}
             style={{ width: agentRailOpen ? 240 : 0 }}
-            className="h-full flex-shrink-0 overflow-hidden bg-[#1a1a1a] border-l border-[#2d2d2d] text-gray-200 text-xs flex flex-col"
+            className="h-full flex-shrink-0 overflow-hidden bg-[#1a1a1a] border-r border-[#2d2d2d] text-gray-200 text-xs flex flex-col"
         >
             <div className="flex-shrink-0 border-b border-[#2d2d2d]">
                 <StagedEditSlot />

--- a/src/studio/StudioShell.tsx
+++ b/src/studio/StudioShell.tsx
@@ -14,8 +14,6 @@ import { ValidityTab } from './tabs/ValidityTab';
 import { ExportTab } from './tabs/ExportTab';
 import { StatusBar } from './components/Layout/StatusBar';
 import ProjectManagerDialog from './components/Dialogs/ProjectManagerDialog';
-import { FloatingAgent } from './features-ui/ai/FloatingAgent';
-import { SmartWidget } from './features-ui/ai/SmartWidget';
 import { useWorkbench } from './context/WorkbenchContext';
 import { useShellStore, shellStore } from './store/useShellStore';
 import type { StagedEdit } from './store/shellStore';
@@ -160,8 +158,6 @@ export function StudioShell() {
         >
             <Header />
             <Toolbar
-                project={activeProject ? { name: activeProject.name } : null}
-                filename={activeProject?.name ? `${activeProject.name}.kcad.ts` : 'untitled.kcad.ts'}
                 isModified={isModified}
                 onValidate={handleValidate}
                 onRun={handleRun}
@@ -177,9 +173,9 @@ export function StudioShell() {
             />
 
             <div className="flex-1 flex overflow-hidden relative">
+                {agentRailOpen && <AgentRail />}
                 <Viewport />
                 <Inspector tabSlots={tabSlots} />
-                {agentRailOpen && <AgentRail />}
 
                 {!workbench.isReady && (
                     <div
@@ -191,8 +187,6 @@ export function StudioShell() {
                     </div>
                 )}
 
-                <FloatingAgent />
-                <SmartWidget />
             </div>
 
             <BottomDrawer />

--- a/src/studio/Toolbar.tsx
+++ b/src/studio/Toolbar.tsx
@@ -1,8 +1,6 @@
 import { CheckCircle2, Play, MessageSquare, Image as ImageIcon } from 'lucide-react';
 
 interface ToolbarProps {
-    project: { name: string } | null;
-    filename: string;
     isModified: boolean;
     onValidate: () => void;
     onRun: () => void;
@@ -25,8 +23,6 @@ interface ToolbarProps {
 }
 
 export function Toolbar({
-    project,
-    filename,
     isModified,
     onValidate,
     onRun,
@@ -45,20 +41,21 @@ export function Toolbar({
             data-testid="studio-toolbar"
             className="h-8 shrink-0 border-b border-[#2b313c] bg-[#111] flex items-center justify-between px-3 text-xs text-gray-300 select-none"
         >
-            <div className="flex items-center gap-3 min-w-0">
-                <span
-                    data-testid="toolbar-project-chip"
-                    className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded bg-[#222] text-gray-200 truncate max-w-[180px]"
+            <div className="flex items-center gap-2 min-w-0">
+                <button
+                    type="button"
+                    onClick={onToggleAgentRail}
+                    aria-label={agentRailOpen ? 'Close agent rail' : 'Open agent rail'}
+                    aria-pressed={agentRailOpen}
+                    className={`inline-flex items-center gap-1 px-2 py-1 rounded transition-colors ${
+                        agentRailOpen
+                            ? 'bg-[#333] text-white'
+                            : 'text-gray-300 hover:text-white hover:bg-[#222]'
+                    }`}
                 >
-                    <span className="w-1.5 h-1.5 rounded-full bg-blue-500" />
-                    <span className="truncate">{project?.name ?? 'Untitled Project'}</span>
-                </span>
-                <span
-                    data-testid="toolbar-filename"
-                    className="truncate max-w-[240px] text-gray-400"
-                >
-                    {filename}
-                </span>
+                    <MessageSquare size={12} />
+                    Agent
+                </button>
                 {isModified && (
                     <span
                         data-testid="toolbar-modified-dot"
@@ -119,20 +116,6 @@ export function Toolbar({
                         Env: {renderEnvironmentPresetLabel}
                     </button>
                 )}
-                <button
-                    type="button"
-                    onClick={onToggleAgentRail}
-                    aria-label={agentRailOpen ? 'Close agent rail' : 'Open agent rail'}
-                    aria-pressed={agentRailOpen}
-                    className={`inline-flex items-center gap-1 px-2 py-1 rounded transition-colors ${
-                        agentRailOpen
-                            ? 'bg-[#333] text-white'
-                            : 'text-gray-300 hover:text-white hover:bg-[#222]'
-                    }`}
-                >
-                    <MessageSquare size={12} />
-                    Agent
-                </button>
             </div>
         </div>
     );

--- a/src/studio/__tests__/AgentActivityLog.test.tsx
+++ b/src/studio/__tests__/AgentActivityLog.test.tsx
@@ -1,20 +1,56 @@
 // @vitest-environment happy-dom
-import { afterEach, describe, expect, it } from 'vitest';
-import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import { AgentActivityLog } from '../AgentActivityLog';
+
+const { createMcpToken } = vi.hoisted(() => ({
+    createMcpToken: vi.fn(),
+}));
+vi.mock('../../funnel/lib/apiClient', () => ({
+    createMcpToken,
+}));
 
 afterEach(() => {
     cleanup();
+    vi.clearAllMocks();
 });
 
 describe('AgentActivityLog', () => {
-    it('renders the v1 offline state', () => {
+    it('renders cloud MCP connector commands for common clients', async () => {
+        createMcpToken.mockResolvedValue({ token: 'kc_ready_token', tokenPrefix: 'kc_ready_' });
         const { getByText } = render(<AgentActivityLog />);
-        expect(getByText(/Agent offline · MCP not connected/i)).toBeDefined();
+        expect(getByText(/Cloud MCP connector/i)).toBeDefined();
+        expect(getByText(/One-line MCP install with token auth, local tooling, and hosted kernel/i)).toBeDefined();
+        await waitFor(() => {
+            expect(getByText(/claude mcp add kernelcad -- npx -y kernelcad mcp --cloud --token kc_ready_token/i)).toBeDefined();
+        });
+        expect(getByText(/codex mcp add kernelcad -- npx -y kernelcad mcp --cloud --token kc_ready_token/i)).toBeDefined();
+        expect(getByText(/Studio Agent Mode/i)).toBeDefined();
+        expect(getByText(/^cloud$/i)).toBeDefined();
     });
 
-    it('shows the empty-state hint that activity will appear when MCP connects', () => {
+    it('copies the selected connect command with the minted token', async () => {
+        createMcpToken.mockResolvedValue({ token: 'kc_ready_token', tokenPrefix: 'kc_ready_' });
+        const writeText = vi.fn();
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: { writeText },
+        });
+        const { getByRole, getByText } = render(<AgentActivityLog />);
+        await waitFor(() => {
+            expect(getByText(/Token ready/i)).toBeDefined();
+        });
+
+        fireEvent.click(getByRole('button', { name: /copy claude/i }));
+
+        expect(writeText).toHaveBeenCalledWith('claude mcp add kernelcad -- npx -y kernelcad mcp --cloud --token kc_ready_token');
+    });
+
+    it('shows sign-in guidance when token creation is unauthorized', async () => {
+        createMcpToken.mockRejectedValue(new Error('{"error":"missing_token"}'));
         const { getByText } = render(<AgentActivityLog />);
-        expect(getByText(/Agent activity will appear here when MCP connects/i)).toBeDefined();
+        await waitFor(() => {
+            expect(getByText(/Sign in to create a cloud MCP token automatically/i)).toBeDefined();
+        });
     });
 });

--- a/src/studio/__tests__/AgentRail.test.tsx
+++ b/src/studio/__tests__/AgentRail.test.tsx
@@ -30,7 +30,7 @@ describe('AgentRail', () => {
         expect(rail.getAttribute('data-open')).toBe('true');
         expect((rail as HTMLElement).style.width).toBe('240px');
         expect(getByText(/Staged edits/i)).toBeDefined();
-        expect(getByText(/Agent offline · MCP not connected/i)).toBeDefined();
+        expect(getByText(/Cloud MCP connector/i)).toBeDefined();
     });
 
     it('reacts to store toggles after mount', () => {

--- a/src/studio/__tests__/StudioShell.status.test.tsx
+++ b/src/studio/__tests__/StudioShell.status.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 let workbenchComputing = false;
+let agentRailOpen = false;
 
 vi.mock('../context/WorkbenchContext', () => ({
     useWorkbench: () => ({
@@ -24,7 +25,7 @@ vi.mock('../context/WorkbenchContext', () => ({
 }));
 
 vi.mock('../store/useShellStore', () => ({
-    useShellStore: () => ({ agentRailOpen: false, selectedFeatureId: null }),
+    useShellStore: () => ({ agentRailOpen, selectedFeatureId: null }),
     shellStore: {
         setAgentRailOpen: vi.fn(),
         proposeStagedEdit: vi.fn(),
@@ -54,8 +55,6 @@ vi.mock('../Inspector', () => ({ Inspector: () => <div data-testid="inspector" /
 vi.mock('../AgentRail', () => ({ AgentRail: () => <div data-testid="agent-rail" /> }));
 vi.mock('../BottomDrawer', () => ({ BottomDrawer: () => <div data-testid="bottom-drawer" /> }));
 vi.mock('../components/Dialogs/ProjectManagerDialog', () => ({ default: () => null }));
-vi.mock('../features-ui/ai/FloatingAgent', () => ({ FloatingAgent: () => null }));
-vi.mock('../features-ui/ai/SmartWidget', () => ({ SmartWidget: () => null }));
 vi.mock('../components/Layout/StatusBar', () => ({
     StatusBar: ({ isComputing }: { isComputing: boolean }) => (
         <div data-testid="status-is-computing">{String(isComputing)}</div>
@@ -68,6 +67,7 @@ afterEach(() => cleanup());
 
 beforeEach(() => {
     workbenchComputing = false;
+    agentRailOpen = false;
 });
 
 describe('StudioShell status plumbing', () => {
@@ -77,5 +77,15 @@ describe('StudioShell status plumbing', () => {
         render(<StudioShell />);
 
         expect(screen.getByTestId('status-is-computing').textContent).toBe('true');
+    });
+
+    it('places the open agent rail before the viewport', () => {
+        agentRailOpen = true;
+
+        render(<StudioShell />);
+
+        const rail = screen.getByTestId('agent-rail');
+        const viewport = screen.getByTestId('viewport');
+        expect(rail.compareDocumentPosition(viewport) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     });
 });

--- a/src/studio/__tests__/Toolbar.test.tsx
+++ b/src/studio/__tests__/Toolbar.test.tsx
@@ -7,8 +7,6 @@ afterEach(() => cleanup());
 
 function renderToolbar(overrides: Partial<Parameters<typeof Toolbar>[0]> = {}) {
     const props = {
-        project: { name: 'so100-arm' },
-        filename: 'so100.kcad.ts',
         isModified: false,
         onValidate: vi.fn(),
         onRun: vi.fn(),
@@ -24,11 +22,11 @@ function renderToolbar(overrides: Partial<Parameters<typeof Toolbar>[0]> = {}) {
 }
 
 describe('Toolbar', () => {
-    it('renders project name, filename, validate and run buttons', () => {
+    it('renders validate and run buttons without duplicating project identity', () => {
         renderToolbar();
 
-        expect(screen.getByText('so100-arm')).toBeDefined();
-        expect(screen.getByText('so100.kcad.ts')).toBeDefined();
+        expect(screen.queryByText('so100-arm')).toBeNull();
+        expect(screen.queryByText('so100.kcad.ts')).toBeNull();
         expect(screen.getByRole('button', { name: 'Validate' })).toBeDefined();
         expect(screen.getByRole('button', { name: 'Run' })).toBeDefined();
     });
@@ -57,6 +55,17 @@ describe('Toolbar', () => {
         expect(btn.getAttribute('aria-pressed')).toBe('true');
     });
 
+    it('places the agent toggle before validate and run controls', () => {
+        renderToolbar();
+
+        const agent = screen.getByRole('button', { name: 'Open agent rail' });
+        const validate = screen.getByRole('button', { name: 'Validate' });
+        const run = screen.getByRole('button', { name: 'Run' });
+
+        expect(agent.compareDocumentPosition(validate) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+        expect(agent.compareDocumentPosition(run) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
     it('shows modified dot when isModified=true', () => {
         renderToolbar({ isModified: true });
         expect(screen.getByTestId('toolbar-modified-dot')).toBeDefined();
@@ -67,9 +76,10 @@ describe('Toolbar', () => {
         expect(screen.queryByTestId('toolbar-modified-dot')).toBeNull();
     });
 
-    it('falls back to placeholder name when project is null', () => {
-        renderToolbar({ project: null });
-        expect(screen.getByText('Untitled Project')).toBeDefined();
+    it('does not render placeholder project text when no project is loaded', () => {
+        renderToolbar();
+        expect(screen.queryByText('Untitled Project')).toBeNull();
+        expect(screen.queryByText('untitled.kcad.ts')).toBeNull();
     });
 
     it('omits the reference-images toggle when no reference image is present', () => {

--- a/tests/funnel/apiClient.test.ts
+++ b/tests/funnel/apiClient.test.ts
@@ -12,6 +12,7 @@ vi.mock('../../src/funnel/lib/supabaseClient', () => ({
 import {
   authedFetch,
   createCheckoutSession,
+  createMcpToken,
   fetchMyPlan,
   openBillingPortal,
 } from '../../src/funnel/lib/apiClient';
@@ -109,6 +110,20 @@ describe('openBillingPortal', () => {
   it('throws on non-2xx', async () => {
     mockFetchOnce('no portal session', { status: 400 });
     await expect(openBillingPortal()).rejects.toThrow(/no portal session/);
+  });
+});
+
+describe('createMcpToken', () => {
+  it('POSTs to the MCP token endpoint with auth and returns the token once', async () => {
+    const fetchMock = mockFetchOnce({ token: 'kc_secret', tokenPrefix: 'kc_secret' });
+    const result = await createMcpToken();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.example.com/api/v1/mcp/tokens');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer jwt-token-123');
+    expect(result).toEqual({ token: 'kc_secret', tokenPrefix: 'kc_secret' });
   });
 });
 


### PR DESCRIPTION
## Summary
- move Studio agent controls into the left rail and remove duplicate object identity from the toolbar
- add cloud MCP proxy support to the kernelcad CLI
- create cloud MCP tokens from the Studio rail so the install command is ready after sign-in

## Verification
- npm test -- src/studio/__tests__/AgentActivityLog.test.tsx tests/funnel/apiClient.test.ts src/agent/mcp/cloudClient.test.ts
- npm run typecheck
- npm run build:cli
