### PR TITLE
fix(deploy): bypass app Pages asset cache

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -49,4 +49,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=kernelcad-app --branch=main --commit-dirty=true
+          wranglerVersion: '4.94.0'
+          command: pages deploy dist --project-name=kernelcad-app --branch=main --commit-dirty=true --skip-caching

--- a/scripts/lib/cloudflareDeployWorkflow.test.ts
+++ b/scripts/lib/cloudflareDeployWorkflow.test.ts
@@ -22,8 +22,9 @@ describe('Cloudflare Pages deploy workflow', () => {
       step.name?.includes('Deploy to Cloudflare Pages'),
     );
 
+    expect(deployStep?.with?.wranglerVersion).toBe('4.94.0');
     expect(deployStep?.with?.command).toBe(
-      'pages deploy dist --project-name=kernelcad-app --branch=main --commit-dirty=true',
+      'pages deploy dist --project-name=kernelcad-app --branch=main --commit-dirty=true --skip-caching',
     );
   });
 


### PR DESCRIPTION
## Summary\n- pin the app Cloudflare Pages deploy to Wrangler 4.94.0\n- pass --skip-caching so app assets are uploaded without the failing Pages asset-cache path\n- update the deploy workflow guard test\n\n## Verification\n- npm test -- scripts/lib/cloudflareDeployWorkflow.test.ts\n- reproduced live failure before fix: https://app.kernelcad.com/assets/index-DSj6Ig6C.css returned HTTP 500\n