### PR TITLE
fix(deploy): force fresh app css asset

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -29,6 +29,7 @@
 
 :root {
     /* Fallback/Raw usage if needed, but Tailwind handles the above mapping */
+    --app-asset-revision: "2026-05-22-css-redeploy";
     --highlight-orange: #FF9F1C;
     --selection-blue: #2EC4B6;
     --snap-green: #00FF9D;


### PR DESCRIPTION
## Summary\n- force a fresh Vite CSS asset hash so Cloudflare stops serving the poisoned index-DSj6Ig6C.css asset\n- no visible UI change; adds an unused asset revision custom property\n\n## Verification\n- npm run build\n- build emitted dist/assets/index-DV8Wm6Dd.css instead of the poisoned index-DSj6Ig6C.css\n\nContext: PR #270 deployed successfully with --skip-caching, but the live app still referenced the same CSS hash and Cloudflare continued returning HTTP 500 / zero bytes for that path.\n