### PR TITLE
test(production): probe app and gallery assets

### DIFF
--- a/scripts/lib/productionSiteProbe.test.ts
+++ b/scripts/lib/productionSiteProbe.test.ts
@@ -9,14 +9,61 @@ function response(opts: {
   status: number;
   headers?: Record<string, string>;
   json?: unknown;
+  body?: string;
   bodyBytes?: number;
 }): ProbeResponse {
   return {
     status: opts.status,
     headers: new Headers(opts.headers ?? {}),
     json: async () => opts.json,
-    arrayBuffer: async () => new ArrayBuffer(opts.bodyBytes ?? 0),
+    arrayBuffer: async () => {
+      if (opts.body !== undefined) return new TextEncoder().encode(opts.body).buffer;
+      return new ArrayBuffer(opts.bodyBytes ?? 0);
+    },
   };
+}
+
+function galleryEntry(slug: string) {
+  return {
+    slug,
+    title: slug,
+    videoUrl: `/gallery/${slug}/video.mp4`,
+    posterUrl: `/gallery/${slug}/poster.jpg`,
+    modelUrl: `/gallery/${slug}/model.glb`,
+    promptUrl: `/gallery/${slug}/prompt.md`,
+  };
+}
+
+function galleryAssetResponse(path: string): ProbeResponse {
+  if (path.endsWith('/model.glb')) {
+    return response({
+      status: 200,
+      headers: { 'content-type': 'model/gltf-binary' },
+      bodyBytes: 2048,
+    });
+  }
+  if (path.endsWith('/video.mp4')) {
+    return response({
+      status: 206,
+      headers: { 'content-type': 'video/mp4' },
+      bodyBytes: 1024,
+    });
+  }
+  if (path.endsWith('/poster.jpg')) {
+    return response({
+      status: 200,
+      headers: { 'content-type': 'image/jpeg' },
+      bodyBytes: 1024,
+    });
+  }
+  if (path.endsWith('/prompt.md')) {
+    return response({
+      status: 200,
+      headers: { 'content-type': 'text/markdown' },
+      bodyBytes: 256,
+    });
+  }
+  throw new Error(`unexpected gallery asset ${path}`);
 }
 
 describe('normalizeSiteBaseUrl', () => {
@@ -30,6 +77,83 @@ describe('normalizeSiteBaseUrl', () => {
 });
 
 describe('buildProductionSiteChecks', () => {
+  it('checks linked app css and js assets in app mode', async () => {
+    const fetched: string[] = [];
+    const checks = buildProductionSiteChecks({
+      baseUrl: 'https://app.kernelcad.com/',
+      expectedVersion: 'v0.2.1',
+      mode: 'app',
+      fetch: async (url) => {
+        fetched.push(url);
+        const path = new URL(url).pathname;
+        if (path === '/') {
+          return response({
+            status: 200,
+            headers: { 'content-type': 'text/html; charset=utf-8' },
+            body: [
+              '<!doctype html>',
+              '<link rel="stylesheet" href="/assets/index-abc123.css">',
+              '<script type="module" src="/assets/index-def456.js"></script>',
+            ].join(''),
+          });
+        }
+        if (path === '/assets/index-abc123.css') {
+          return response({
+            status: 200,
+            headers: { 'content-type': 'text/css' },
+            bodyBytes: 128,
+          });
+        }
+        if (path === '/assets/index-def456.js') {
+          return response({
+            status: 200,
+            headers: { 'content-type': 'application/javascript' },
+            bodyBytes: 256,
+          });
+        }
+        throw new Error(`unexpected URL ${url}`);
+      },
+    });
+
+    await expect(Promise.all(checks.map((check) => check.run()))).resolves.toEqual([
+      { ok: true, name: 'app built assets', detail: '1 css, 1 js assets ok' },
+    ]);
+    expect(fetched).toEqual([
+      'https://app.kernelcad.com/',
+      'https://app.kernelcad.com/assets/index-abc123.css',
+      'https://app.kernelcad.com/assets/index-def456.js',
+    ]);
+  });
+
+  it('fails app mode when a linked css asset is empty', async () => {
+    const checks = buildProductionSiteChecks({
+      baseUrl: 'https://app.kernelcad.com/',
+      expectedVersion: 'v0.2.1',
+      mode: 'app',
+      fetch: async (url) => {
+        const path = new URL(url).pathname;
+        if (path === '/') {
+          return response({
+            status: 200,
+            headers: { 'content-type': 'text/html' },
+            body: '<link rel="stylesheet" href="/assets/index-empty.css">',
+          });
+        }
+        return response({
+          status: 200,
+          headers: { 'content-type': 'text/css' },
+          bodyBytes: 0,
+        });
+      },
+    });
+
+    await expect(checks[0].run()).resolves.toEqual({
+      ok: false,
+      name: 'app built assets',
+      detail: '/assets/index-empty.css expected non-empty body, got 0 bytes',
+    });
+  });
+
   it('accepts the current patch release pointing at its minor demo iteration', async () => {
     const checks = buildProductionSiteChecks({
       baseUrl: 'https://kernelcad.com/',
@@ -59,6 +183,15 @@ describe('buildProductionSiteChecks', () => {
             bodyBytes: 1024,
           });
         }
+        if (path === '/gallery.json') {
+          return response({
+            status: 200,
+            json: { entries: [galleryEntry('one'), galleryEntry('two'), galleryEntry('three')] },
+          });
+        }
+        if (path.startsWith('/gallery/')) {
+          return galleryAssetResponse(path);
+        }
         if (path === '/api/subscribe') {
           expect(init?.method).toBe('POST');
           return response({
@@ -73,8 +206,71 @@ describe('buildProductionSiteChecks', () => {
     await expect(Promise.all(checks.map((check) => check.run()))).resolves.toEqual([
       { ok: true, name: 'demo metadata', detail: 'v0.2.1 -> v0.2/subtract-then-fillet-rim' },
       { ok: true, name: 'demo mp4', detail: 'video/mp4 bytes 0-1023/276295' },
+      { ok: true, name: 'gallery assets', detail: '2 entries, 8 assets ok' },
       { ok: true, name: 'subscribe invalid-email path', detail: '/?error=invalid_email#signup' },
     ]);
+  });
+
+  it('probes every gallery asset when allGalleryAssets is enabled', async () => {
+    const fetchedAssetPaths: string[] = [];
+    const checks = buildProductionSiteChecks({
+      baseUrl: 'https://kernelcad.com',
+      expectedVersion: 'v0.2.1',
+      allGalleryAssets: true,
+      fetch: async (url) => {
+        const path = new URL(url).pathname;
+        if (path === '/gallery.json') {
+          return response({
+            status: 200,
+            json: {
+              entries: [
+                galleryEntry('one'),
+                galleryEntry('two'),
+                galleryEntry('three'),
+              ],
+            },
+          });
+        }
+        fetchedAssetPaths.push(path);
+        return galleryAssetResponse(path);
+      },
+    });
+
+    await expect(checks.find((check) => check.name === 'gallery assets')?.run()).resolves.toEqual({
+      ok: true,
+      name: 'gallery assets',
+      detail: '3 entries, 12 assets ok',
+    });
+    expect(fetchedAssetPaths).toHaveLength(12);
+    expect(fetchedAssetPaths).toContain('/gallery/three/prompt.md');
+  });
+
+  it('fails marketing checks when gallery asset content type is wrong', async () => {
+    const checks = buildProductionSiteChecks({
+      baseUrl: 'https://kernelcad.com',
+      expectedVersion: 'v0.2.1',
+      fetch: async (url) => {
+        const path = new URL(url).pathname;
+        if (path === '/gallery.json') {
+          return response({
+            status: 200,
+            json: { entries: [galleryEntry('fixture')] },
+          });
+        }
+        return response({
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+          bodyBytes: 1024,
+        });
+      },
+    });
+
+    await expect(checks.find((check) => check.name === 'gallery assets')?.run()).resolves.toEqual({
+      ok: false,
+      name: 'gallery assets',
+      detail:
+        '/gallery/fixture/model.glb expected model/gltf-binary or application/octet-stream, got 200 text/html',
+    });
   });
 
   it('fails when live demo metadata reports the wrong version', async () => {

--- a/scripts/lib/productionSiteProbe.ts
+++ b/scripts/lib/productionSiteProbe.ts
@@ -33,6 +33,13 @@ interface DemoJson {
   source?: unknown;
 }
 
+interface GalleryAsset {
+  key: 'modelUrl' | 'videoUrl' | 'posterUrl' | 'promptUrl';
+  path: string;
+  contentTypes: string[];
+  range?: boolean;
+}
+
 function result(ok: boolean, name: string, detail: string): ProbeResult {
   return { ok, name, detail };
 }
@@ -45,6 +52,62 @@ function expectedIterationForVersion(version: string): string {
   const match = /^v?(\d+)\.(\d+)\.\d+/.exec(version);
   if (!match) return version;
   return `v${match[1]}.${match[2]}`;
+}
+
+async function responseBytes(res: ProbeResponse): Promise<number> {
+  return (await res.arrayBuffer()).byteLength;
+}
+
+function contentType(res: ProbeResponse): string {
+  return res.headers.get('content-type') ?? 'missing content-type';
+}
+
+function hasExpectedContentType(actual: string, expected: string[]): boolean {
+  return expected.some((type) => actual.toLowerCase().includes(type));
+}
+
+function resolveSiteUrl(baseUrl: string, pathOrUrl: string): string {
+  return new URL(pathOrUrl, `${baseUrl}/`).toString();
+}
+
+function extractBuiltAssetPaths(html: string): string[] {
+  const paths = new Set<string>();
+  const attrRegex = /\b(?:href|src)=["']([^"']+)["']/g;
+  for (const match of html.matchAll(attrRegex)) {
+    const path = match[1];
+    if (/^\/assets\/[^?#]+\.(?:css|js)(?:[?#].*)?$/.test(path)) {
+      paths.add(path.replace(/[?#].*$/, ''));
+    }
+  }
+  return [...paths].sort();
+}
+
+function galleryAssetsFor(entry: Record<string, unknown>): GalleryAsset[] | undefined {
+  const assets: GalleryAsset[] = [
+    {
+      key: 'modelUrl',
+      path: String(entry.modelUrl ?? ''),
+      contentTypes: ['model/gltf-binary', 'application/octet-stream'],
+    },
+    {
+      key: 'videoUrl',
+      path: String(entry.videoUrl ?? ''),
+      contentTypes: ['video/mp4'],
+      range: true,
+    },
+    {
+      key: 'posterUrl',
+      path: String(entry.posterUrl ?? ''),
+      contentTypes: ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'],
+    },
+    {
+      key: 'promptUrl',
+      path: String(entry.promptUrl ?? ''),
+      contentTypes: ['text/markdown', 'text/plain'],
+    },
+  ];
+
+  return assets.every((asset) => asset.path.length > 0) ? assets : undefined;
 }
 
 export function normalizeSiteBaseUrl(input: string): string {
@@ -62,11 +125,61 @@ export function buildProductionSiteChecks(opts: {
   baseUrl: string;
   expectedVersion: string;
   expectedDemoIteration?: string;
+  mode?: 'marketing' | 'app';
+  allGalleryAssets?: boolean;
   fetch: ProbeFetch;
 }): ProductionSiteCheck[] {
   const baseUrl = normalizeSiteBaseUrl(opts.baseUrl);
   const expectedDemoIteration =
     opts.expectedDemoIteration ?? expectedIterationForVersion(opts.expectedVersion);
+
+  if (opts.mode === 'app') {
+    return [
+      {
+        name: 'app built assets',
+        async run() {
+          const htmlRes = await opts.fetch(`${baseUrl}/`);
+          const htmlType = contentType(htmlRes);
+          if (htmlRes.status !== 200 || !htmlType.includes('text/html')) {
+            return result(
+              false,
+              this.name,
+              `expected 200 text/html from /, got ${htmlRes.status} ${htmlType}`,
+            );
+          }
+          const html = new TextDecoder().decode(await htmlRes.arrayBuffer());
+          const assets = extractBuiltAssetPaths(html);
+          if (assets.length === 0) {
+            return result(false, this.name, 'expected linked /assets/*.css or /assets/*.js');
+          }
+
+          let cssCount = 0;
+          let jsCount = 0;
+          for (const asset of assets) {
+            const res = await opts.fetch(resolveSiteUrl(baseUrl, asset));
+            const type = contentType(res);
+            const expectedTypes = asset.endsWith('.css')
+              ? ['text/css']
+              : ['application/javascript', 'text/javascript'];
+            if (res.status !== 200 || !hasExpectedContentType(type, expectedTypes)) {
+              return result(
+                false,
+                this.name,
+                `${asset} expected ${expectedTypes.join(' or ')}, got ${res.status} ${type}`,
+              );
+            }
+            const bytes = await responseBytes(res);
+            if (bytes <= 0) {
+              return result(false, this.name, `${asset} expected non-empty body, got ${bytes} bytes`);
+            }
+            if (asset.endsWith('.css')) cssCount += 1;
+            if (asset.endsWith('.js')) jsCount += 1;
+          }
+          return result(true, this.name, `${cssCount} css, ${jsCount} js assets ok`);
+        },
+      },
+    ];
+  }
 
   return [
     {
@@ -131,6 +244,59 @@ export function buildProductionSiteChecks(opts: {
           this.name,
           `${type} ${res.headers.get('content-range') ?? `${bytes.byteLength} bytes`}`,
         );
+      },
+    },
+    {
+      name: 'gallery assets',
+      async run() {
+        const res = await opts.fetch(`${baseUrl}/gallery.json`);
+        if (res.status !== 200) {
+          return result(false, this.name, `expected 200 from /gallery.json, got ${res.status}`);
+        }
+        const payload = await res.json();
+        if (!isObject(payload) || !Array.isArray(payload.entries)) {
+          return result(false, this.name, 'expected /gallery.json entries array');
+        }
+        if (payload.entries.length === 0) {
+          return result(false, this.name, 'expected /gallery.json to contain entries');
+        }
+
+        const entries = opts.allGalleryAssets ? payload.entries : payload.entries.slice(0, 2);
+        let assetCount = 0;
+        for (const entry of entries) {
+          if (!isObject(entry)) {
+            return result(false, this.name, 'expected gallery entry object');
+          }
+          const assets = galleryAssetsFor(entry);
+          if (!assets) {
+            return result(false, this.name, 'expected gallery entry asset URLs');
+          }
+          for (const asset of assets) {
+            const assetInit = asset.range ? { headers: { Range: 'bytes=0-1023' } } : undefined;
+            const assetRes = await opts.fetch(resolveSiteUrl(baseUrl, asset.path), assetInit);
+            const type = contentType(assetRes);
+            const okStatus = asset.range
+              ? assetRes.status === 200 || assetRes.status === 206
+              : assetRes.status === 200;
+            if (!okStatus || !hasExpectedContentType(type, asset.contentTypes)) {
+              return result(
+                false,
+                this.name,
+                `${asset.path} expected ${asset.contentTypes.join(' or ')}, got ${assetRes.status} ${type}`,
+              );
+            }
+            const bytes = await responseBytes(assetRes);
+            if (bytes <= 0) {
+              return result(
+                false,
+                this.name,
+                `${asset.path} expected non-empty body, got ${bytes} bytes`,
+              );
+            }
+            assetCount += 1;
+          }
+        }
+        return result(true, this.name, `${entries.length} entries, ${assetCount} assets ok`);
       },
     },
     {

--- a/scripts/verifyProductionSite.ts
+++ b/scripts/verifyProductionSite.ts
@@ -24,14 +24,23 @@ function argValue(name: string): string | undefined {
   return index >= 0 ? process.argv[index + 1] : undefined;
 }
 
+function hasFlag(name: string): boolean {
+  return process.argv.includes(name);
+}
+
 async function main() {
   const baseUrl = argValue('--url') ?? 'https://kernelcad.com';
   const expectedVersion = argValue('--expected-version') ?? readPackageVersion();
   const expectedDemoIteration = argValue('--expected-demo-iteration');
+  const mode = argValue('--mode') === 'app' || new URL(baseUrl).hostname === 'app.kernelcad.com'
+    ? 'app'
+    : 'marketing';
   const checks = buildProductionSiteChecks({
     baseUrl,
     expectedVersion,
     expectedDemoIteration,
+    mode,
+    allGalleryAssets: hasFlag('--all-gallery-assets'),
     fetch,
   });
 


### PR DESCRIPTION
## Summary
- add app-mode production probe for built CSS/JS assets
- probe marketing gallery JSON plus first two entry assets by default
- add --all-gallery-assets for release verification

## Verification
- npm test -- scripts/lib/productionSiteProbe.test.ts
- npm run typecheck
- npx tsx scripts/verifyProductionSite.ts --url=https://app.kernelcad.com

Note: marketing live probe now passes demo/gallery asset checks but currently reports POST /api/subscribe as 405 instead of the existing expected 303 invalid-email redirect.