### PR TITLE
fix(marketing): keep metadata fetches cacheable

### DIFF
--- a/scripts/lib/marketingDemoCacheBust.test.ts
+++ b/scripts/lib/marketingDemoCacheBust.test.ts
@@ -13,4 +13,16 @@ describe('marketing demo video cache busting', () => {
     expect(html).not.toContain("src = '/demo.mp4'");
     expect(html).not.toContain('polished-brass-tube.step');
   });
+
+  it('keeps landing metadata fetches cacheable', () => {
+    const html = readFileSync('site/index.html', 'utf8');
+
+    expect(html).toContain("fetch('/demo.json')");
+    expect(html).toContain("fetch('/gallery.json')");
+    expect(html).toContain('fetch(entry.promptUrl)');
+    expect(html).not.toContain('Date.now()');
+    expect(html).not.toContain("cache: 'no-store'");
+    expect(html).not.toContain('cache: "no-store"');
+    expect(html).not.toContain('fetch(cacheKeyedUrl(entry.promptUrl');
+  });
 });

--- a/site/index.html
+++ b/site/index.html
@@ -203,6 +203,7 @@
     // load demo video + version from build-time generated demo.json
     function cacheKeyedUrl(url, cacheKey) {
       if (!url) return url;
+      if (!cacheKey) return url;
       const separator = url.includes('?') ? '&' : '?';
       return `${url}${separator}v=${encodeURIComponent(cacheKey)}`;
     }
@@ -255,7 +256,7 @@
         if (!g || !Array.isArray(g.entries) || g.entries.length === 0) return;
         const section = document.getElementById('gallery');
         const grid = document.getElementById('gallery-grid');
-        const galleryCacheKey = g.generatedAt || Date.now();
+        const galleryCacheKey = g.generatedAt;
         grid.textContent = '';
         for (const entry of g.entries) {
           const orbit = entry.slug === 'royal-pop-pocket-watch'
@@ -314,7 +315,7 @@
           meta.textContent = `by @${entry.author.handle} · ${entry.version} · ${entry.createdAt}`;
           promptEl.textContent = entry.prompt;
           if (entry.promptUrl) {
-            fetch(cacheKeyedUrl(entry.promptUrl, galleryCacheKey), { cache: 'no-store' })
+            fetch(entry.promptUrl)
               .then((r) => (r.ok ? r.text() : null))
               .then((promptText) => {
                 if (promptText) promptEl.textContent = promptText.trim();


### PR DESCRIPTION
## Summary
- remove unstable Date.now fallback from gallery asset cache keys
- stop no-store/cache-busted prompt markdown fetches
- keep demo/gallery asset cache busting tied to stable metadata keys

## Verification
- npm test -- scripts/lib/marketingDemoCacheBust.test.ts scripts/staticGalleryLanding.test.ts