### PR TITLE
perf(studio): lazy load route-only surfaces

### DIFF
--- a/src/studio/App.tsx
+++ b/src/studio/App.tsx
@@ -3,12 +3,15 @@ import { StudioShell } from './StudioShell';
 import { shellStore } from './store/shellStore';
 import { useShellStore } from './store/useShellStore';
 import { ErrorBoundary } from './components/ErrorBoundary';
-import { DevLab } from './devlab/DevLab';
-import { devLabScenarios } from './devlab/scenarios';
-import { useEffect, useState, type ReactNode } from 'react';
+import { lazy, Suspense, useEffect, useState, type ReactNode } from 'react';
 import { parseCode } from '../shared/codeGeneration/ast';
-import { DemoPlayerPage } from './components/demoPlayer/DemoPlayerPage';
 import { StudioChromeProvider } from './context/StudioChromeContext';
+
+const LazyDevLab = lazy(() =>
+  import('./devlab/DevLab').then(({ DevLab }) => ({
+    default: DevLab,
+  })),
+);
 
 function isCodeParsable(code: string): boolean {
   try {
@@ -98,12 +101,13 @@ function AppContent({ isDevLab }: { isDevLab: boolean }) {
     return () => clearTimeout(timeoutId);
   }, [code, viewMode, viewMode3D, sidePanelVisible, showSketches, agentRailOpen, isDevLab, isInitialized, activeProject, saveActiveProject, scriptParam]);
 
-  return isDevLab ? <DevLab /> : <StudioShell />;
-}
-
-function isDemoPlayerRoute(): boolean {
-  if (typeof window === 'undefined') return false;
-  return window.location.pathname === '/demo-player';
+  return isDevLab ? (
+    <Suspense fallback={null}>
+      <LazyDevLab />
+    </Suspense>
+  ) : (
+    <StudioShell />
+  );
 }
 
 interface AppProps {
@@ -119,15 +123,12 @@ interface AppProps {
   headerRight?: ReactNode;
 }
 
-export default function App({ initialCode: initialCodeProp, headerLeft, headerRight }: AppProps = {}) {
-  if (isDemoPlayerRoute()) {
-    return <DemoPlayerPage />;
-  }
-
-  const isDevLab = typeof window !== 'undefined' && window.location.pathname.startsWith('/dev-lab');
-  const initialCode =
-    initialCodeProp ?? (isDevLab ? (devLabScenarios[0]?.code ?? undefined) : undefined);
-
+function AppProviders({
+  initialCode,
+  isDevLab,
+  headerLeft,
+  headerRight,
+}: AppProps & { isDevLab: boolean }) {
   return (
     <WorkbenchProvider initialCode={initialCode}>
       <StudioChromeProvider value={{ headerLeft, headerRight }}>
@@ -136,5 +137,55 @@ export default function App({ initialCode: initialCodeProp, headerLeft, headerRi
         </ErrorBoundary>
       </StudioChromeProvider>
     </WorkbenchProvider>
+  );
+}
+
+function DevLabApp({ headerLeft, headerRight }: Pick<AppProps, 'headerLeft' | 'headerRight'>) {
+  const [initialCode, setInitialCode] = useState<string | undefined>();
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    import('./devlab/scenarios')
+      .then(({ devLabScenarios }) => {
+        if (cancelled) return;
+        setInitialCode(devLabScenarios[0]?.code);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoaded(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!isLoaded) return null;
+
+  return (
+    <AppProviders
+      initialCode={initialCode}
+      isDevLab={true}
+      headerLeft={headerLeft}
+      headerRight={headerRight}
+    />
+  );
+}
+
+export default function App({ initialCode: initialCodeProp, headerLeft, headerRight }: AppProps = {}) {
+  const isDevLab = typeof window !== 'undefined' && window.location.pathname.startsWith('/dev-lab');
+
+  if (isDevLab && initialCodeProp === undefined) {
+    return <DevLabApp headerLeft={headerLeft} headerRight={headerRight} />;
+  }
+
+  return (
+    <AppProviders
+      initialCode={initialCodeProp}
+      isDevLab={isDevLab}
+      headerLeft={headerLeft}
+      headerRight={headerRight}
+    />
   );
 }

--- a/src/studio/main.tsx
+++ b/src/studio/main.tsx
@@ -3,15 +3,9 @@ import { createRoot } from 'react-dom/client';
 import { RouterProvider, createRouter } from '@tanstack/react-router';
 import '../index.css';
 import { initFeatures } from '../modeling/features/init';
-import { GeometryEngine } from '../shared/worker/geometryEngine';
 import { routeTree } from './routeTree.gen';
 
 initFeatures();
-
-// Eagerly spawn the OCCT worker so its 11 MB WASM fetch + compile overlap with React's
-// first render. The singleton dedupes; later mounts are no-ops. Failures surface through
-// GeometryProvider's existing retry path.
-GeometryEngine.getInstance().initialize().catch(() => { /* see provider */ });
 
 const router = createRouter({ routeTree });
 

--- a/src/studio/routes/demo-player.tsx
+++ b/src/studio/routes/demo-player.tsx
@@ -1,10 +1,20 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { DemoPlayerPage } from '../components/demoPlayer/DemoPlayerPage';
+import { Suspense, lazy } from 'react';
+
+const LazyDemoPlayerPage = lazy(() =>
+  import('../components/demoPlayer/DemoPlayerPage').then(({ DemoPlayerPage }) => ({
+    default: DemoPlayerPage,
+  })),
+);
 
 export const Route = createFileRoute('/demo-player')({
   component: DemoPlayerRoute,
 });
 
 function DemoPlayerRoute() {
-  return <DemoPlayerPage />;
+  return (
+    <Suspense fallback={null}>
+      <LazyDemoPlayerPage />
+    </Suspense>
+  );
 }

--- a/src/studio/routes/index.test.ts
+++ b/src/studio/routes/index.test.ts
@@ -11,6 +11,38 @@ describe('App root route (src/studio/routes/index.tsx)', () => {
   });
 });
 
+describe('Initial Studio bundle import sentinels', () => {
+  const appSource = readFileSync('src/studio/App.tsx', 'utf8');
+  const mainSource = readFileSync('src/studio/main.tsx', 'utf8');
+  const demoPlayerRouteSource = readFileSync('src/studio/routes/demo-player.tsx', 'utf8');
+  const codeContextSource = readFileSync('src/studio/context/CodeContext.tsx', 'utf8');
+
+  it('does not warm the GeometryEngine before route content mounts', () => {
+    expect(mainSource).not.toMatch(/GeometryEngine/);
+    expect(mainSource).not.toMatch(/getInstance\(\)\.initialize\(\)/);
+  });
+
+  it('keeps route-only Studio surfaces out of App module imports', () => {
+    expect(appSource).not.toMatch(/import\s+\{\s*DevLab\s*\}\s+from\s+['"]\.\/devlab\/DevLab['"]/);
+    expect(appSource).not.toMatch(/import\s+\{\s*devLabScenarios\s*\}\s+from\s+['"]\.\/devlab\/scenarios['"]/);
+    expect(appSource).not.toMatch(/import\s+\{\s*DemoPlayerPage\s*\}\s+from\s+['"]\.\/components\/demoPlayer\/DemoPlayerPage['"]/);
+    expect(appSource).toContain("import('./devlab/DevLab')");
+    expect(appSource).toContain("import('./devlab/scenarios')");
+  });
+
+  it('lazy-loads the demo-player page from its route', () => {
+    expect(demoPlayerRouteSource).not.toMatch(/import\s+\{\s*DemoPlayerPage\s*\}\s+from\s+['"]\.\.\/components\/demoPlayer\/DemoPlayerPage['"]/);
+    expect(demoPlayerRouteSource).toContain("import('../components/demoPlayer/DemoPlayerPage')");
+  });
+
+  it('keeps AI and refactoring services behind dynamic imports', () => {
+    expect(codeContextSource).not.toMatch(/import\s+.*LLMService/);
+    expect(codeContextSource).not.toMatch(/import\s+.*RefactoringManager/);
+    expect(codeContextSource).toContain("import('../features-ui/ai/LLMService')");
+    expect(codeContextSource).toContain("import('../../modeling/features/modeling/RefactoringManager')");
+  });
+});
+
 /**
  * Generate-page contract: the Words-to-CAD prompt stays visible to anonymous
  * users, but generation is gated by auth. On submit, the route stores the


### PR DESCRIPTION
## Summary
- remove unconditional GeometryEngine warmup from app boot
- lazy-load DemoPlayerPage, DevLab, and devLabScenarios
- add route import sentinels for eager heavy imports

## Verification
- npm test -- src/studio/routes/index.test.ts
- npm run build
- dist asset size listing checked