### PR TITLE
fix(studio): coalesce mesh recomputes

### DIFF
--- a/src/studio/context/GeometryContext.test.tsx
+++ b/src/studio/context/GeometryContext.test.tsx
@@ -19,6 +19,16 @@ function deferred<T>(): Deferred<T> {
   return { promise, resolve, reject };
 }
 
+function fetchUrl(fetchMock: ReturnType<typeof vi.spyOn>, callIndex: number): string {
+  return String(fetchMock.mock.calls[callIndex - 1]?.[0] ?? '');
+}
+
+function expectFetchSignal(fetchMock: ReturnType<typeof vi.spyOn>, callIndex: number) {
+  expect(fetchMock.mock.calls[callIndex - 1]?.[1]).toEqual(
+    expect.objectContaining({ signal: expect.any(Object) }),
+  );
+}
+
 const mockEngine = {
   initialize: vi.fn().mockResolvedValue(undefined),
   executeCode: vi.fn(),
@@ -44,6 +54,7 @@ function Probe() {
     executionHistory,
     scriptParams,
     scriptReview,
+    error,
     setPreviewCode,
   } = useGeometry();
   const faceCount = geometries[0]?.faces.length ?? 0;
@@ -66,6 +77,7 @@ function Probe() {
       <span data-testid="script-param-name">{scriptParams[0]?.name ?? ''}</span>
       <span data-testid="script-review-ok">{String(scriptReview?.ok ?? '')}</span>
       <span data-testid="script-review-repair">{scriptReview?.suggestedRepairPrompt ?? ''}</span>
+      <span data-testid="error">{error ?? ''}</span>
       <button data-testid="trigger-preview" onClick={() => setPreviewCode('return makeBox(1,1,1);')}>Trigger</button>
       <button data-testid="trigger-preview-2" onClick={() => setPreviewCode('return makeBox(2,2,2);')}>Trigger2</button>
       <button data-testid="clear-preview" onClick={() => setPreviewCode(null)}>Clear</button>
@@ -329,12 +341,10 @@ describe('GeometryContext latest-intent-wins', () => {
     expect(fetchMock).toHaveBeenNthCalledWith(1,
       '/__kernelcad/session?script=examples%2Frobot-arm%2Fdesktop-3axis-mates.kcad.ts',
     );
-    expect(fetchMock).toHaveBeenNthCalledWith(2,
-      '/__kernelcad/mesh?session=tok-abc',
-    );
-    expect(fetchMock).toHaveBeenNthCalledWith(3,
-      '/__kernelcad/review?session=tok-abc&script=examples%2Frobot-arm%2Fdesktop-3axis-mates.kcad.ts',
-    );
+    expect(fetchUrl(fetchMock, 2)).toBe('/__kernelcad/mesh?session=tok-abc');
+    expectFetchSignal(fetchMock, 2);
+    expect(fetchUrl(fetchMock, 3)).toBe('/__kernelcad/review?session=tok-abc&script=examples%2Frobot-arm%2Fdesktop-3axis-mates.kcad.ts');
+    expectFetchSignal(fetchMock, 3);
     expect(mockEngine.executeCode).not.toHaveBeenCalled();
     expect(screen.getByTestId('face-count').textContent).toBe('1');
     expect(screen.getByTestId('first-color').textContent).toBe('beam');
@@ -425,8 +435,212 @@ describe('GeometryContext latest-intent-wins', () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(4);
-    expect(fetchMock).toHaveBeenNthCalledWith(4, '/__kernelcad/mesh?session=tok-abc');
+    expect(fetchUrl(fetchMock, 4)).toBe('/__kernelcad/mesh?session=tok-abc');
+    expectFetchSignal(fetchMock, 4);
     expect(screen.getByTestId('script-param-name').textContent).toBe('heightAdjustMm');
     expect(screen.getByTestId('script-review-repair').textContent).toBe('initial review');
+  });
+
+  it('coalesces relower bursts into one active mesh fetch plus one trailing fetch', async () => {
+    window.history.pushState(
+      {},
+      '',
+      '/?script=examples/robot-arm/desktop-3axis-mates.kcad.ts',
+    );
+
+    let relowerHandler: (() => void) | null = null;
+    (globalThis as { EventSource?: unknown }).EventSource = class FakeES {
+      addEventListener(type: string, cb: () => void) {
+        if (type === 'relower') relowerHandler = cb;
+      }
+      removeEventListener() {}
+      close() {}
+      onerror: (() => void) | null = null;
+    };
+
+    const firstRelower = deferred<Response>();
+    const secondRelower = deferred<Response>();
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ sessionToken: 'tok-abc' }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          features: [],
+          bounds: { min: [0, 0, 0], max: [0, 0, 0] },
+          params: {},
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          diagnostics: [],
+          suggestedRepairPrompt: 'initial review',
+        }),
+      } as Response)
+      .mockImplementationOnce(() => firstRelower.promise)
+      .mockImplementationOnce(() => secondRelower.promise);
+
+    render(
+      <GeometryProvider code={'const ignored = 1;'}>
+        <Probe />
+      </GeometryProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(relowerHandler).not.toBeNull();
+
+    await act(async () => {
+      relowerHandler?.();
+      relowerHandler?.();
+      relowerHandler?.();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+
+    await act(async () => {
+      firstRelower.resolve({
+        ok: true,
+        json: async () => ({
+          features: [],
+          bounds: { min: [0, 0, 0], max: [0, 0, 0] },
+          params: {
+            width: {
+              name: 'width',
+              type: 'number',
+              value: 12,
+              defaultValue: 10,
+            },
+          },
+        }),
+      } as Response);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+
+    await act(async () => {
+      secondRelower.resolve({
+        ok: true,
+        json: async () => ({
+          features: [],
+          bounds: { min: [0, 0, 0], max: [0, 0, 0] },
+          params: {
+            width: {
+              name: 'width',
+              type: 'number',
+              value: 13,
+              defaultValue: 10,
+            },
+          },
+        }),
+      } as Response);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(screen.getByTestId('script-param-name').textContent).toBe('width');
+    expect(screen.getByTestId('execution-count').textContent).toBe('3');
+  });
+
+  it('treats aborted relower mesh fetches as stale and keeps existing geometry visible', async () => {
+    window.history.pushState(
+      {},
+      '',
+      '/?script=examples/robot-arm/desktop-3axis-mates.kcad.ts',
+    );
+
+    let relowerHandler: (() => void) | null = null;
+    (globalThis as { EventSource?: unknown }).EventSource = class FakeES {
+      addEventListener(type: string, cb: () => void) {
+        if (type === 'relower') relowerHandler = cb;
+      }
+      removeEventListener() {}
+      close() {}
+      onerror: (() => void) | null = null;
+    };
+
+    const abortError = Object.assign(new Error('stale relower'), { name: 'AbortError' });
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ sessionToken: 'tok-abc' }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          features: [
+            {
+              featureId: 'stable',
+              featureKind: 'box',
+              predecessors: [],
+              color: 'stable-color',
+              faces: [
+                {
+                  vertices: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+                  indices: [0, 1, 2],
+                  normals: [0, 0, 1, 0, 0, 1, 0, 0, 1],
+                  faceId: 0,
+                },
+              ],
+            },
+          ],
+          bounds: { min: [0, 0, 0], max: [1, 1, 0] },
+          params: {},
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          diagnostics: [],
+          suggestedRepairPrompt: 'initial review',
+        }),
+      } as Response)
+      .mockRejectedValueOnce(abortError);
+
+    render(
+      <GeometryProvider code={'const ignored = 1;'}>
+        <Probe />
+      </GeometryProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('face-count').textContent).toBe('1');
+    expect(screen.getByTestId('first-color').textContent).toBe('stable-color');
+    expect(screen.getByTestId('error').textContent).toBe('');
+
+    await act(async () => {
+      relowerHandler?.();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(screen.getByTestId('face-count').textContent).toBe('1');
+    expect(screen.getByTestId('first-color').textContent).toBe('stable-color');
+    expect(screen.getByTestId('error').textContent).toBe('');
+    expect(screen.getByTestId('is-computing').textContent).toBe('false');
   });
 });

--- a/src/studio/context/GeometryContext.tsx
+++ b/src/studio/context/GeometryContext.tsx
@@ -93,6 +93,13 @@ function readStoredShowSketches(): boolean {
     return true;
 }
 
+function isAbortError(err: unknown): boolean {
+    return typeof err === 'object'
+        && err !== null
+        && 'name' in err
+        && err.name === 'AbortError';
+}
+
 export function GeometryProvider({ children, code }: { children: ReactNode; code: string }) {
     const [geometries, setGeometries] = useState<GeometryResult[]>([]);
     const [geometryTransformOverrides, setGeometryTransformOverrides] = useState<Record<string, number[]>>({});
@@ -121,6 +128,13 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
     const [sessionStatus, setSessionStatus] = useState<'idle' | 'pending' | 'resolved' | 'failed'>('idle');
     const mainRevisionRef = useRef(0);
     const previewRevisionRef = useRef(0);
+    const activeMeshFetchAbortRef = useRef<AbortController | null>(null);
+    const meshFetchBusyRef = useRef(false);
+    const meshFetchTrailingRef = useRef<{
+        script: string;
+        token: string | null;
+        opts?: { keepExistingOnError?: boolean; skipReview?: boolean };
+    } | null>(null);
     const studioScript = readStudioScriptParam();
     const displayGeometries = useMemo(
         () => geometries.map((geometry) => {
@@ -171,6 +185,14 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
         setCurrentCodeRevision(revision);
         setIsComputing(true);
         const fetchStart = performance.now();
+        const abortController = typeof AbortController === 'function'
+            ? new AbortController()
+            : null;
+        activeMeshFetchAbortRef.current?.abort();
+        activeMeshFetchAbortRef.current = abortController;
+        const fetchInit: RequestInit | undefined = abortController
+            ? { signal: abortController.signal }
+            : undefined;
         const meshUrl = token
             ? `/__kernelcad/mesh?session=${encodeURIComponent(token)}`
             : `/__kernelcad/mesh?script=${encodeURIComponent(script)}`;
@@ -178,7 +200,8 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
             ? `/__kernelcad/review?session=${encodeURIComponent(token)}&script=${encodeURIComponent(script)}`
             : `/__kernelcad/review?script=${encodeURIComponent(script)}`;
 
-        const promise = fetch(meshUrl)
+        let aborted = false;
+        const promise = fetch(meshUrl, fetchInit)
             .then(async (response) => {
                 const payload = await response.json();
                 if (!response.ok) {
@@ -213,7 +236,7 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
                     executionCountAtRecord: revision,
                 });
                 if (opts?.skipReview) return;
-                fetch(reviewUrl)
+                return fetch(reviewUrl, fetchInit)
                     .then(async (response) => {
                         const reviewPayload = await response.json();
                         if (!response.ok) {
@@ -226,12 +249,20 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
                         if (revision !== mainRevisionRef.current) return;
                         setScriptReview(reviewPayload);
                     })
-                    .catch(() => {
+                    .catch((err: unknown) => {
+                        if (isAbortError(err)) return;
                         if (revision !== mainRevisionRef.current) return;
                         setScriptReview(null);
                     });
             })
             .catch((err: unknown) => {
+                if (isAbortError(err)) {
+                    aborted = true;
+                    if (revision !== mainRevisionRef.current) {
+                        setStaleMainResponsesDropped((prev) => prev + 1);
+                    }
+                    return;
+                }
                 if (revision !== mainRevisionRef.current) {
                     setStaleMainResponsesDropped((prev) => prev + 1);
                     return;
@@ -250,13 +281,47 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
                 });
             })
             .finally(() => {
-                if (revision === mainRevisionRef.current) {
+                if (activeMeshFetchAbortRef.current === abortController) {
+                    activeMeshFetchAbortRef.current = null;
+                }
+                if (revision === mainRevisionRef.current && !aborted) {
                     setIsComputing(false);
                     setExecutionCount(prev => prev + 1);
+                } else if (revision === mainRevisionRef.current) {
+                    setIsComputing(false);
                 }
             });
         return { revision, promise };
     }, [pushExecutionRecord]);
+
+    const requestMeshAndReview = useCallback((
+        script: string,
+        token: string | null,
+        opts?: { keepExistingOnError?: boolean; skipReview?: boolean },
+    ) => {
+        if (meshFetchBusyRef.current) {
+            meshFetchTrailingRef.current = { script, token, opts };
+            return;
+        }
+
+        meshFetchBusyRef.current = true;
+        const { promise } = fetchMeshAndReview(script, token, opts);
+        void promise.finally(() => {
+            meshFetchBusyRef.current = false;
+            const trailing = meshFetchTrailingRef.current;
+            meshFetchTrailingRef.current = null;
+            if (trailing) {
+                requestMeshAndReview(trailing.script, trailing.token, trailing.opts);
+            }
+        });
+    }, [fetchMeshAndReview]);
+
+    useEffect(() => {
+        return () => {
+            meshFetchTrailingRef.current = null;
+            activeMeshFetchAbortRef.current?.abort();
+        };
+    }, []);
 
     // Slice 2E.bridge: acquire the session token for the script. The pool
     // reuses an existing session if one already exists for this script, so
@@ -299,9 +364,8 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
     useEffect(() => {
         if (!studioScript) return;
         if (sessionStatus === 'pending' || sessionStatus === 'idle') return;
-        const { promise } = fetchMeshAndReview(studioScript, sessionToken);
-        void promise;
-    }, [studioScript, sessionStatus, sessionToken, fetchMeshAndReview]);
+        requestMeshAndReview(studioScript, sessionToken);
+    }, [studioScript, sessionStatus, sessionToken, requestMeshAndReview]);
 
     // Slice 2E.bridge: SSE subscription. Opens an EventSource against the
     // pooled CaptureSession's onRelower channel. Each `relower` frame
@@ -312,7 +376,7 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
         const url = `/__kernelcad/events?session=${encodeURIComponent(sessionToken)}`;
         const es = new EventSource(url);
         const onRelower = () => {
-            fetchMeshAndReview(studioScript, sessionToken, { keepExistingOnError: true, skipReview: true });
+            requestMeshAndReview(studioScript, sessionToken, { keepExistingOnError: true, skipReview: true });
         };
         es.addEventListener('relower', onRelower);
         // The browser auto-reconnects on transient drops; we only log here.
@@ -325,7 +389,7 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
             es.removeEventListener('relower', onRelower);
             es.close();
         };
-    }, [studioScript, sessionToken, fetchMeshAndReview]);
+    }, [studioScript, sessionToken, requestMeshAndReview]);
 
     // Slice 2E.bridge: callback exposed to consumers (forwarded by
     // `useRecomputeResult`). Awaits the server ack; the SSE push that


### PR DESCRIPTION
## Summary
- add AbortController-backed mesh/review fetches
- treat AbortError as stale work instead of visible failure
- coalesce relower bursts to one active fetch plus one trailing fetch

## Verification
- npm test -- src/studio/context/GeometryContext.test.tsx src/studio/__tests__/useRecomputeResult.test.tsx tests/integration/studio/paramsTabScrub.test.tsx
- npm run typecheck
- git diff --check