### PR TITLE
fix(studio): dispose retained Three resources

### DIFF
--- a/src/studio/components/demoPlayer/DemoPlayerPage.tsx
+++ b/src/studio/components/demoPlayer/DemoPlayerPage.tsx
@@ -17,7 +17,7 @@ import type { ReferenceImageMetadata } from '../../../shared/intent/referenceIma
 import type { RenderEnvironmentSpec } from '../../../shared/intent/renderEnvironmentRecord';
 import type { CameraTargetMetadata } from '../../../shared/intent/cameraTargetRecord';
 import { applyEnvironment } from '../../../shared/render/environment';
-import { buildMaterialFromPBR, DEFAULT_MESH_COLOR } from './buildMaterialFromPBR';
+import { buildMaterialFromPBR, DEFAULT_MESH_COLOR, disposeMaterialDeep } from './buildMaterialFromPBR';
 import { buildReferenceImagePlane } from './buildReferenceImagePlane';
 import type { RenderView } from '../../../shared/render/views';
 export type { RenderView };
@@ -222,6 +222,11 @@ function buildMeshFromFace(
   const mesh = new THREE.Mesh(geom, material);
   mesh.name = name;
   return mesh;
+}
+
+function disposeMeshResources(mesh: THREE.Mesh): void {
+  mesh.geometry.dispose();
+  disposeMaterialDeep(mesh.material);
 }
 
 function wildcardMatches(pattern: string, text: string): boolean {
@@ -752,7 +757,7 @@ export function DemoPlayerPage(): React.JSX.Element {
             hidden.mesh.visible = hidden.visible;
           }
           for (const material of temporaryMaterials) {
-            material.dispose();
+            disposeMaterialDeep(material);
           }
           ctx.scene.background = originalBackground;
           ctx.renderer.render(ctx.scene, ctx.camera);
@@ -866,7 +871,7 @@ export function DemoPlayerPage(): React.JSX.Element {
             hidden.mesh.visible = hidden.visible;
           }
           for (const material of temporaryMaterials) {
-            material.dispose();
+            disposeMaterialDeep(material);
           }
           target.dispose();
           ctx.scene.background = originalBackground;
@@ -888,8 +893,7 @@ export function DemoPlayerPage(): React.JSX.Element {
             scene.remove(child);
             child.traverse((o) => {
               if (o instanceof THREE.Mesh) {
-                o.geometry.dispose();
-                (o.material as THREE.Material).dispose();
+                disposeMeshResources(o);
               }
             });
           }
@@ -1042,6 +1046,10 @@ export function DemoPlayerPage(): React.JSX.Element {
             const textureUrl = `/__kernelcad/image?path=${encodeURIComponent(ri.path)}`;
             const loader = new THREE.TextureLoader();
             loader.loadAsync(textureUrl).then((tex) => {
+              if (riGroup.parent !== scene) {
+                tex.dispose();
+                return;
+              }
               const mesh = buildReferenceImagePlane(ri, tex, sceneBbox);
               riGroup.add(mesh);
               if (sceneRef.current) {
@@ -1057,6 +1065,10 @@ export function DemoPlayerPage(): React.JSX.Element {
               const canvas = document.createElement('canvas');
               canvas.width = 1; canvas.height = 1;
               const fallbackTex = new THREE.CanvasTexture(canvas);
+              if (riGroup.parent !== scene) {
+                fallbackTex.dispose();
+                return;
+              }
               const mesh = buildReferenceImagePlane(ri, fallbackTex, sceneBbox);
               riGroup.add(mesh);
               if (sceneRef.current) {

--- a/src/studio/components/demoPlayer/buildMaterialFromPBR.test.ts
+++ b/src/studio/components/demoPlayer/buildMaterialFromPBR.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+import { disposeMaterialDeep } from './buildMaterialFromPBR';
+
+describe('disposeMaterialDeep', () => {
+  it('disposes material arrays and every texture map attached to each material', () => {
+    const textureA = new THREE.Texture();
+    const textureB = new THREE.Texture();
+    const textureC = new THREE.Texture();
+    const materialA = new THREE.MeshPhysicalMaterial({
+      map: textureA,
+      normalMap: textureB,
+    });
+    materialA.userData.extra = 'kept';
+    const materialB = new THREE.MeshStandardMaterial({
+      roughnessMap: textureC,
+    });
+
+    const textureADispose = vi.spyOn(textureA, 'dispose');
+    const textureBDispose = vi.spyOn(textureB, 'dispose');
+    const textureCDispose = vi.spyOn(textureC, 'dispose');
+    const materialADispose = vi.spyOn(materialA, 'dispose');
+    const materialBDispose = vi.spyOn(materialB, 'dispose');
+
+    disposeMaterialDeep([materialA, materialB]);
+
+    expect(textureADispose).toHaveBeenCalledTimes(1);
+    expect(textureBDispose).toHaveBeenCalledTimes(1);
+    expect(textureCDispose).toHaveBeenCalledTimes(1);
+    expect(materialADispose).toHaveBeenCalledTimes(1);
+    expect(materialBDispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/studio/components/demoPlayer/buildMaterialFromPBR.ts
+++ b/src/studio/components/demoPlayer/buildMaterialFromPBR.ts
@@ -31,6 +31,53 @@ const TEXTURE_SLOTS: ReadonlyArray<{
   { key: 'emissive', prop: 'emissiveMap', colorSpace: THREE.SRGBColorSpace },
 ];
 
+const MATERIAL_TEXTURE_PROPS = [
+  'alphaMap',
+  'aoMap',
+  'anisotropyMap',
+  'bumpMap',
+  'clearcoatMap',
+  'clearcoatNormalMap',
+  'clearcoatRoughnessMap',
+  'displacementMap',
+  'emissiveMap',
+  'envMap',
+  'gradientMap',
+  'lightMap',
+  'map',
+  'metalnessMap',
+  'normalMap',
+  'roughnessMap',
+  'sheenColorMap',
+  'sheenRoughnessMap',
+  'specularColorMap',
+  'specularIntensityMap',
+  'thicknessMap',
+  'transmissionMap',
+] as const;
+
+export function disposeMaterialDeep(
+  materialOrMaterials: THREE.Material | THREE.Material[] | null | undefined,
+): void {
+  if (materialOrMaterials === null || materialOrMaterials === undefined) return;
+  const materials = Array.isArray(materialOrMaterials)
+    ? materialOrMaterials
+    : [materialOrMaterials];
+  const disposedTextures = new Set<THREE.Texture>();
+
+  for (const material of materials) {
+    const materialRecord = material as unknown as Record<string, unknown>;
+    for (const prop of MATERIAL_TEXTURE_PROPS) {
+      const value = materialRecord[prop];
+      if (value instanceof THREE.Texture && !disposedTextures.has(value)) {
+        disposedTextures.add(value);
+        value.dispose();
+      }
+    }
+    material.dispose();
+  }
+}
+
 /** Browser-side URL prefix for the dev-server texture route. */
 function browserTextureUrl(path: string): string {
   if (/^https?:\/\//i.test(path)) return path;

--- a/src/studio/components/viewer/entities/ShapeGeometry.test.tsx
+++ b/src/studio/components/viewer/entities/ShapeGeometry.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import * as THREE from 'three';
+import type { FaceGeometry, GeometryResult } from '../../../../shared/worker/geometryEngine';
+
+let FaceSelectionOverlay: typeof import('./ShapeGeometry').FaceSelectionOverlay;
+let GhostShape: typeof import('./ShapeGeometry').GhostShape;
+
+const faceA: FaceGeometry = {
+    vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+    normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+    indices: new Uint32Array([0, 1, 2]),
+    faceId: 1,
+};
+
+const faceB: FaceGeometry = {
+    vertices: new Float32Array([0, 0, 0, 2, 0, 0, 0, 2, 0]),
+    normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+    indices: new Uint32Array([0, 1, 2]),
+    faceId: 2,
+};
+
+describe('ShapeGeometry disposable overlays', () => {
+    beforeAll(async () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        ({ FaceSelectionOverlay, GhostShape } = await import('./ShapeGeometry'));
+    });
+
+    beforeEach(() => {
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.restoreAllMocks();
+    });
+
+    it('disposes ghost geometries on unmount', () => {
+        const disposeSpy = vi.spyOn(THREE.BufferGeometry.prototype, 'dispose');
+        const geometry: GeometryResult = { faces: [faceA, faceB] };
+
+        const { unmount } = render(<GhostShape geometry={geometry} />);
+
+        expect(disposeSpy).not.toHaveBeenCalled();
+        unmount();
+        expect(disposeSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('disposes replaced and unmounted face selection overlay geometries', () => {
+        const disposeSpy = vi.spyOn(THREE.BufferGeometry.prototype, 'dispose');
+
+        const { rerender, unmount } = render(
+            <FaceSelectionOverlay face={faceA} isSelected={true} />,
+        );
+        expect(disposeSpy).not.toHaveBeenCalled();
+
+        rerender(<FaceSelectionOverlay face={faceB} isSelected={true} />);
+        expect(disposeSpy).toHaveBeenCalledTimes(1);
+
+        unmount();
+        expect(disposeSpy).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/studio/components/viewer/entities/ShapeGeometry.tsx
+++ b/src/studio/components/viewer/entities/ShapeGeometry.tsx
@@ -19,6 +19,30 @@ interface ShapeProps {
     name: string | undefined;
 }
 
+function bufferGeometryFromFace(face: FaceGeometry): THREE.BufferGeometry {
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(face.vertices, 3));
+    geometry.setAttribute('normal', new THREE.BufferAttribute(face.normals, 3));
+    geometry.setIndex(new THREE.BufferAttribute(face.indices, 1));
+    return geometry;
+}
+
+function GhostFaceMesh({ face }: { face: FaceGeometry }) {
+    const geometry = useMemo(() => bufferGeometryFromFace(face), [face]);
+
+    useEffect(() => {
+        return () => {
+            geometry.dispose();
+        };
+    }, [geometry]);
+
+    return (
+        <mesh geometry={geometry}>
+            <meshBasicMaterial color={CAD_COLORS_HEX.selection} transparent opacity={0.4} />
+        </mesh>
+    );
+}
+
 export function GhostShape({
     geometry,
 }: {
@@ -27,18 +51,9 @@ export function GhostShape({
     const transformMatrix = useMemo(() => matrixFromGeometryTransform(geometry), [geometry]);
     return (
         <group matrix={transformMatrix} matrixAutoUpdate={transformMatrix ? false : undefined}>
-            {geometry.faces.map((face) => {
-                const threeGeometry = new THREE.BufferGeometry();
-                threeGeometry.setAttribute('position', new THREE.BufferAttribute(face.vertices, 3));
-                threeGeometry.setAttribute('normal', new THREE.BufferAttribute(face.normals, 3));
-                threeGeometry.setIndex(new THREE.BufferAttribute(face.indices, 1));
-
-                return (
-                    <mesh key={face.faceId} geometry={threeGeometry}>
-                        <meshBasicMaterial color={CAD_COLORS_HEX.selection} transparent opacity={0.4} />
-                    </mesh>
-                );
-            })}
+            {geometry.faces.map((face) => (
+                <GhostFaceMesh key={face.faceId} face={face} />
+            ))}
         </group>
     );
 }
@@ -46,12 +61,14 @@ export function GhostShape({
 export function FaceSelectionOverlay({ face, isSelected }: { face?: FaceGeometry, isSelected: boolean }) {
     const geometry = useMemo(() => {
         if (!face) return null;
-        const geo = new THREE.BufferGeometry();
-        geo.setAttribute('position', new THREE.BufferAttribute(face.vertices, 3));
-        geo.setAttribute('normal', new THREE.BufferAttribute(face.normals, 3));
-        geo.setIndex(new THREE.BufferAttribute(face.indices, 1));
-        return geo;
+        return bufferGeometryFromFace(face);
     }, [face]);
+
+    useEffect(() => {
+        return () => {
+            geometry?.dispose();
+        };
+    }, [geometry]);
 
     if (!face || !geometry) return null;
 

--- a/src/studio/hooks/viewer/useConsolidatedGeometry.test.tsx
+++ b/src/studio/hooks/viewer/useConsolidatedGeometry.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import * as THREE from 'three';
+import { useEffect } from 'react';
+import type { FaceGeometry } from '../../../shared/worker/geometryEngine';
+import { useConsolidatedGeometry } from './useConsolidatedGeometry';
+
+const faceA: FaceGeometry = {
+  vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+  normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+  indices: new Uint32Array([0, 1, 2]),
+  faceId: 1,
+};
+
+const faceB: FaceGeometry = {
+  vertices: new Float32Array([0, 0, 0, 2, 0, 0, 0, 2, 0]),
+  normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+  indices: new Uint32Array([0, 1, 2]),
+  faceId: 2,
+};
+
+function Harness({
+  faces,
+  onGeometry,
+}: {
+  faces: FaceGeometry[];
+  onGeometry: (geometry: THREE.BufferGeometry | null) => void;
+}) {
+  const { geometry } = useConsolidatedGeometry(faces);
+  useEffect(() => {
+    onGeometry(geometry);
+  }, [geometry, onGeometry]);
+  return null;
+}
+
+describe('useConsolidatedGeometry', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('disposes replaced and unmounted merged geometries', () => {
+    const disposeSpy = vi.spyOn(THREE.BufferGeometry.prototype, 'dispose');
+    const onGeometry = vi.fn();
+
+    const { rerender, unmount } = render(
+      <Harness faces={[faceA]} onGeometry={onGeometry} />,
+    );
+    expect(disposeSpy).not.toHaveBeenCalled();
+
+    rerender(<Harness faces={[faceB]} onGeometry={onGeometry} />);
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(disposeSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/studio/hooks/viewer/useConsolidatedGeometry.ts
+++ b/src/studio/hooks/viewer/useConsolidatedGeometry.ts
@@ -1,9 +1,9 @@
 import * as THREE from "three";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import type { FaceGeometry } from "../../../shared/worker/geometryEngine";
 
 export function useConsolidatedGeometry(faces: FaceGeometry[]) {
-    return useMemo(() => {
+    const result = useMemo(() => {
         if (faces.length === 0) return { geometry: null, faceMap: null };
         let totalVertices = 0;
         let totalIndices = 0;
@@ -46,4 +46,12 @@ export function useConsolidatedGeometry(faces: FaceGeometry[]) {
 
         return { geometry, faceMap };
     }, [faces]);
+
+    useEffect(() => {
+        return () => {
+            result.geometry?.dispose();
+        };
+    }, [result.geometry]);
+
+    return result;
 }


### PR DESCRIPTION
## Summary
- dispose consolidated geometries on replacement/unmount
- clean up ghost and face-selection overlay geometries
- add reusable deep material/texture disposal and use it in demo player cleanup

## Verification
- npm test -- src/studio/components/demoPlayer/DemoPlayerPage.test.tsx src/studio/components/demoPlayer/CameraController.test.ts src/studio/components/viewer/entities/geometryTransform.test.ts
- npm test -- src/studio/components/demoPlayer/buildMaterialFromPBR.test.ts src/studio/hooks/viewer/useConsolidatedGeometry.test.tsx src/studio/components/viewer/entities/ShapeGeometry.test.tsx
- npm run typecheck
- git diff --check