### PR TITLE
feat: open gallery objects in Studio

### DIFF
--- a/scripts/lib/galleryEntries.test.ts
+++ b/scripts/lib/galleryEntries.test.ts
@@ -26,6 +26,47 @@ describe('parseGalleryEntries', () => {
     expect(result.entries[0].slug).toBe('desktop-3axis-mates');
   });
 
+  it('accepts curated entries because studioUrl can be derived from codeLocal', () => {
+    const result = parseGalleryEntries({ entries: [validEntry] });
+    expect(result.entries[0].codeLocal).toBe(validEntry.codeLocal);
+    expect(result.entries[0].appUrl).toBeNull();
+  });
+
+  it('accepts studio entries with appUrl and without codeLocal', () => {
+    const entry = {
+      ...validEntry,
+      slug: 'saved-public-project',
+      source: 'studio' as const,
+      codeLocal: null,
+      appUrl: 'https://app.kernelcad.com/p/public-project',
+    };
+    const result = parseGalleryEntries({ entries: [entry] });
+    expect(result.entries[0].source).toBe('studio');
+    expect(result.entries[0].appUrl).toBe(entry.appUrl);
+  });
+
+  it('rejects studio entries without appUrl', () => {
+    const entry = {
+      ...validEntry,
+      slug: 'broken-studio-entry',
+      source: 'studio' as const,
+      codeLocal: null,
+      appUrl: null,
+    };
+    expect(() => parseGalleryEntries({ entries: [entry] })).toThrow(/studio.*appUrl/i);
+  });
+
+  it('rejects studio entries when appUrl is omitted', () => {
+    const entry = {
+      ...validEntry,
+      slug: 'omitted-studio-app-url',
+      source: 'studio' as const,
+      codeLocal: null,
+    };
+    delete (entry as Partial<typeof entry>).appUrl;
+    expect(() => parseGalleryEntries({ entries: [entry] })).toThrow(/studio.*appUrl/i);
+  });
+
   it('rejects entries missing required slug', () => {
     const bad = { ...validEntry } as Partial<typeof validEntry>;
     delete bad.slug;
@@ -53,12 +94,6 @@ describe('parseGalleryEntries', () => {
 
     const result = parseGalleryEntries({ entries: [first, second] });
     expect(result.entries).toHaveLength(2);
-  });
-
-  it('accepts source = studio for forward-compat', () => {
-    const studioEntry = { ...validEntry, slug: 'other', source: 'studio' as const };
-    const result = parseGalleryEntries({ entries: [studioEntry] });
-    expect(result.entries[0].source).toBe('studio');
   });
 
   it('rejects unknown source values', () => {

--- a/scripts/lib/galleryEntries.ts
+++ b/scripts/lib/galleryEntries.ts
@@ -6,7 +6,7 @@ export const galleryMechanismReviewSchema = z.object({
   evidence: z.string().min(1),
 });
 
-export const galleryEntrySchema = z.object({
+const galleryEntryBaseSchema = z.object({
   slug: z.string().min(1).regex(/^[a-z0-9-]+$/, 'slug must be lowercase kebab-case'),
   title: z.string().min(1).max(80),
   author: z.object({
@@ -15,16 +15,30 @@ export const galleryEntrySchema = z.object({
   }),
   version: z.string().regex(/^v\d+\.\d+(\.\d+)?$/),
   prompt: z.string().min(1),
-  source: z.enum(['curated', 'studio']),
   video: z.string().min(1),
-  codeLocal: z.string().min(1),
   code: z.string().url(),
   tags: z.array(z.string()).default([]),
   featured: z.boolean().default(false),
   createdAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
-  appUrl: z.string().url().nullable().default(null),
   mechanismReview: galleryMechanismReviewSchema.optional(),
 });
+
+const curatedGalleryEntrySchema = galleryEntryBaseSchema.extend({
+  source: z.literal('curated'),
+  codeLocal: z.string().min(1),
+  appUrl: z.string().url().nullable().default(null),
+});
+
+const studioGalleryEntrySchema = galleryEntryBaseSchema.extend({
+  source: z.literal('studio'),
+  codeLocal: z.string().min(1).nullable().default(null),
+  appUrl: z.string({ error: 'studio entries require appUrl' }).url(),
+});
+
+export const galleryEntrySchema = z.discriminatedUnion('source', [
+  curatedGalleryEntrySchema,
+  studioGalleryEntrySchema,
+]);
 
 export const galleryEntriesFileSchema = z.object({
   entries: z.array(galleryEntrySchema),

--- a/scripts/staticGalleryLanding.test.ts
+++ b/scripts/staticGalleryLanding.test.ts
@@ -81,7 +81,7 @@ describe('static gallery landing page', () => {
     expect(source).toContain('onFocus');
   });
 
-  it('keeps the royal watch gallery tile face-forward with its poster', () => {
+  it('keeps the royal watch gallery tile face-forward while allowing model-viewer upgrade', () => {
     const html = readFileSync(path.resolve(__dirname, '../site/index.html'), 'utf8');
 
     expect(html).toContain("entry.slug === 'royal-pop-pocket-watch'");
@@ -89,5 +89,7 @@ describe('static gallery landing page', () => {
     expect(html).toContain("viewer.setAttribute('min-camera-orbit', orbit.min)");
     expect(html).toContain("viewer.setAttribute('max-camera-orbit', orbit.max)");
     expect(html).toContain("viewer.setAttribute('camera-orbit', orbit.initial)");
+    expect(html).not.toContain("if (entry.slug === 'royal-pop-pocket-watch') return;");
+    expect(html).not.toContain("tile.__entry?.slug !== 'royal-pop-pocket-watch'");
   });
 });

--- a/scripts/staticGalleryLanding.test.ts
+++ b/scripts/staticGalleryLanding.test.ts
@@ -45,6 +45,9 @@ describe('static gallery landing page', () => {
     expect(html).toContain("tile.addEventListener('focus'");
     const renderLoop = html.slice(html.indexOf('for (const entry of g.entries)'), html.indexOf('grid.appendChild(tile);'));
     expect(renderLoop).toContain('class="tile-poster"');
+    expect(renderLoop).toContain('class="tile-studio-link"');
+    expect(renderLoop).toContain('href="${entry.studioUrl}"');
+    expect(renderLoop).toContain('Open in Studio');
     expect(renderLoop).not.toContain('<model-viewer');
     expect(renderLoop).not.toContain('cacheKeyedUrl(entry.modelUrl, galleryCacheKey)');
     expect(html).toContain("fetch('/gallery.json')");
@@ -55,6 +58,8 @@ describe('static gallery landing page', () => {
     expect(html).toContain('entry.promptUrl');
     expect(html).toContain('Build brief');
     expect(html).toContain('<video class="lightbox-video" autoplay muted loop playsinline controls>');
+    expect(html).toContain('class="lightbox-studio-link"');
+    expect(html).toContain('Free projects are public by link');
     expect(redirects).toContain('/demo-poster.png /public/demo-poster.png 200');
     expect(redirects).toContain('/gallery.json  /public/gallery.json   200');
     expect(redirects).toContain('/gallery/*     /public/gallery/:splat 200');

--- a/site/index.html
+++ b/site/index.html
@@ -257,7 +257,6 @@
 
     function upgradeGalleryTile(tile, entry, galleryCacheKey) {
       if (tile.dataset.modelViewerUpgraded === 'true') return;
-      if (entry.slug === 'royal-pop-pocket-watch') return;
 
       tile.dataset.modelViewerUpgraded = 'true';
       loadModelViewer();
@@ -285,7 +284,6 @@
     }
 
     function armGalleryTileUpgrade(tile, entry, galleryCacheKey) {
-      if (entry.slug === 'royal-pop-pocket-watch') return;
       const upgrade = () => upgradeGalleryTile(tile, entry, galleryCacheKey);
       tile.addEventListener('pointerenter', upgrade, { once: true });
       tile.addEventListener('focus', upgrade, { once: true });
@@ -305,7 +303,7 @@
       }, { rootMargin: '500px 0px' });
 
       for (const tile of tiles) {
-        if (tile.__entry?.slug !== 'royal-pop-pocket-watch') observer.observe(tile);
+        observer.observe(tile);
       }
     }
 

--- a/site/index.html
+++ b/site/index.html
@@ -184,11 +184,13 @@
             <button type="submit" class="btn btn-primary">Subscribe</button>
           </form>
           <div class="lightbox-secondary">
+            <a class="lightbox-studio-link" href="#" target="_blank" rel="noopener">Open in Studio</a>
             <a class="lightbox-star" href="https://github.com/w1ne/kernelCAD-web" target="_blank" rel="noopener">★ Star on GitHub</a>
             <a class="lightbox-source" href="#" target="_blank" rel="noopener">View source ↗</a>
             <a class="lightbox-app" href="#" target="_blank" rel="noopener" hidden>Open in app ↗</a>
           </div>
         </div>
+        <p class="gallery-privacy-note">Free projects are public by link. Upgrade for private projects.</p>
         <p class="lightbox-footer">
           <a class="gallery-submit"
              href="https://github.com/w1ne/kernelCAD-web/issues/new?template=gallery-submission.md">
@@ -329,9 +331,15 @@
             <span class="tile-chip tile-chip-bl title">${entry.title}</span>
             <span class="tile-chip tile-chip-br"><span class="version">${entry.version}</span></span>
             ${entry.featured ? '<span class="tile-featured">Featured</span>' : ''}
+            <a class="tile-studio-link" href="${entry.studioUrl}" target="_blank" rel="noopener">
+              Open in Studio
+            </a>
           `;
           tile.__entry = entry;
           armGalleryTileUpgrade(tile, entry, galleryCacheKey);
+          tile.querySelector('.tile-studio-link')?.addEventListener('click', (event) => {
+            event.stopPropagation();
+          });
           tile.addEventListener('click', () => {
             upgradeGalleryTile(tile, entry, galleryCacheKey);
             openLightbox(entry);
@@ -350,6 +358,7 @@
         const sourceInput = dialog.querySelector('input[name="source"]');
         const sourceLink = dialog.querySelector('.lightbox-source');
         const appLink = dialog.querySelector('.lightbox-app');
+        const studioLink = dialog.querySelector('.lightbox-studio-link');
         const closeBtn = dialog.querySelector('.lightbox-close');
 
         function openLightbox(entry) {
@@ -367,6 +376,7 @@
           }
           sourceInput.value = `gallery-lightbox:${entry.slug}`;
           sourceLink.href = entry.code;
+          studioLink.href = entry.studioUrl;
           if (entry.appUrl) { appLink.href = entry.appUrl; appLink.hidden = false; }
           else { appLink.hidden = true; }
           dialog.showModal();

--- a/site/scripts/build-gallery.test.ts
+++ b/site/scripts/build-gallery.test.ts
@@ -76,6 +76,34 @@ describe('buildGallery', () => {
     })).rejects.toThrow(/missing-video|video.*not.*found/i);
   });
 
+  it('rejects studio entries without codeLocal after validating the video exists', async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), 'gallery-build-'));
+    const entriesDir = path.join(tmp, 'gallery');
+    mkdirSync(entriesDir, { recursive: true });
+
+    const fixturesRoot = path.resolve(__dirname, '../../tests/fixtures/gallery');
+    copyFileSync(path.join(fixturesRoot, 'short-clip.mp4'), path.join(entriesDir, 'short-clip.mp4'));
+    writeFileSync(
+      path.join(entriesDir, 'entries.json'),
+      JSON.stringify({
+        entries: [{
+          slug: 'studio-no-code-local', title: 'Studio no code local',
+          author: { handle: 'k', url: 'https://x.com/k' },
+          version: 'v0.11.0', prompt: 'p', source: 'studio',
+          video: 'short-clip.mp4', codeLocal: null,
+          code: 'https://github.com/w1ne/kernelCAD-web',
+          tags: [], featured: false, createdAt: '2026-05-15',
+          appUrl: 'https://app.kernelcad.com/studio/projects/studio-no-code-local',
+        }],
+      }),
+    );
+
+    await expect(buildGallery({
+      entriesPath: path.join(entriesDir, 'entries.json'),
+      publicDir: path.join(tmp, 'public'),
+    })).rejects.toThrow(/studio gallery entries without codeLocal are not buildable yet/i);
+  });
+
   it('rejects a mechanism entry before asset work when cached review evidence is missing', async () => {
     tmp = mkdtempSync(path.join(tmpdir(), 'gallery-build-'));
     const entriesDir = path.join(tmp, 'gallery');

--- a/site/scripts/build-gallery.test.ts
+++ b/site/scripts/build-gallery.test.ts
@@ -34,7 +34,7 @@ describe('buildGallery', () => {
     expect(out.entries[0].posterUrl).toBe('/gallery/fixture-build/poster.jpg');
     expect(out.entries[0].modelUrl).toBe('/gallery/fixture-build/model.glb');
     expect(out.entries[0].promptUrl).toBe('/gallery/fixture-build/prompt.md');
-    expect(out.entries[0].studioUrl).toBe('/studio?gallery=fixture-build');
+    expect(out.entries[0].studioUrl).toBe('https://app.kernelcad.com/studio?gallery=fixture-build');
     expect(out.entries[0].sourceUrl).toBe('/gallery/fixture-build/source.kcad.ts');
 
     expect(existsSync(path.join(publicDir, 'gallery/fixture-build/video.mp4'))).toBe(true);

--- a/site/scripts/build-gallery.test.ts
+++ b/site/scripts/build-gallery.test.ts
@@ -34,11 +34,16 @@ describe('buildGallery', () => {
     expect(out.entries[0].posterUrl).toBe('/gallery/fixture-build/poster.jpg');
     expect(out.entries[0].modelUrl).toBe('/gallery/fixture-build/model.glb');
     expect(out.entries[0].promptUrl).toBe('/gallery/fixture-build/prompt.md');
+    expect(out.entries[0].studioUrl).toBe('/studio?gallery=fixture-build');
+    expect(out.entries[0].sourceUrl).toBe('/gallery/fixture-build/source.kcad.ts');
 
     expect(existsSync(path.join(publicDir, 'gallery/fixture-build/video.mp4'))).toBe(true);
     expect(existsSync(path.join(publicDir, 'gallery/fixture-build/poster.jpg'))).toBe(true);
     expect(existsSync(path.join(publicDir, 'gallery/fixture-build/model.glb'))).toBe(true);
     expect(existsSync(path.join(publicDir, 'gallery/fixture-build/prompt.md'))).toBe(true);
+    expect(existsSync(path.join(publicDir, 'gallery/fixture-build/source.kcad.ts'))).toBe(true);
+    expect(readFileSync(path.join(publicDir, 'gallery/fixture-build/source.kcad.ts'), 'utf8'))
+      .toContain('box');
 
     // GLB has glTF magic bytes
     const glb = readFileSync(path.join(publicDir, 'gallery/fixture-build/model.glb'));

--- a/site/scripts/build-gallery.ts
+++ b/site/scripts/build-gallery.ts
@@ -22,11 +22,13 @@ export interface BuildGalleryOptions {
   publicDir: string;
 }
 
-interface PublishedEntry extends Omit<GalleryEntry, 'video' | 'codeLocal' | 'mechanismReview'> {
+interface PublishedEntry extends Omit<GalleryEntry, 'video' | 'codeLocal'> {
   videoUrl: string;
   posterUrl: string;
   modelUrl: string;
   promptUrl: string;
+  sourceUrl: string | null;
+  studioUrl: string;
 }
 
 const GLB_SIZE_HARD_CAP = 500_000;
@@ -54,6 +56,10 @@ export async function buildGallery(opts: BuildGalleryOptions): Promise<void> {
       throw new Error(`entry ${entry.slug}: video not found at ${srcVideo}`);
     }
 
+    if (entry.source === 'studio' && !entry.codeLocal) {
+      throw new Error(`entry ${entry.slug}: studio gallery entries without codeLocal are not buildable yet`);
+    }
+
     const srcScript = path.resolve(entriesDir, entry.codeLocal);
     if (!existsSync(srcScript)) {
       throw new Error(`entry ${entry.slug}: codeLocal not found at ${srcScript}`);
@@ -63,8 +69,17 @@ export async function buildGallery(opts: BuildGalleryOptions): Promise<void> {
     const dstPoster = path.join(slugDir, 'poster.jpg');
     const dstModel = path.join(slugDir, 'model.glb');
     const dstPrompt = path.join(slugDir, 'prompt.md');
+    const dstSource = path.join(slugDir, 'source.kcad.ts');
+    const sourceUrl = entry.source === 'curated' ? `/gallery/${entry.slug}/source.kcad.ts` : null;
+    const studioUrl = entry.source === 'curated'
+      ? `/studio?gallery=${encodeURIComponent(entry.slug)}`
+      : new URL(entry.appUrl).pathname;
 
     copyFileSync(srcVideo, dstVideo);
+    if (entry.source === 'curated') {
+      copyFileSync(srcScript, dstSource);
+    }
+
     await extractPoster({ videoPath: dstVideo, outPath: dstPoster, timestampSeconds: 2 });
 
     const isBlack = await isVideoMostlyBlack(dstVideo, {
@@ -93,6 +108,8 @@ export async function buildGallery(opts: BuildGalleryOptions): Promise<void> {
       posterUrl: `/gallery/${entry.slug}/poster.jpg`,
       modelUrl: `/gallery/${entry.slug}/model.glb`,
       promptUrl: `/gallery/${entry.slug}/prompt.md`,
+      sourceUrl,
+      studioUrl,
     });
   }
 

--- a/site/scripts/build-gallery.ts
+++ b/site/scripts/build-gallery.ts
@@ -32,6 +32,7 @@ interface PublishedEntry extends Omit<GalleryEntry, 'video' | 'codeLocal'> {
 }
 
 const GLB_SIZE_HARD_CAP = 500_000;
+const STUDIO_ORIGIN = 'https://app.kernelcad.com';
 
 export async function buildGallery(opts: BuildGalleryOptions): Promise<void> {
   const raw = JSON.parse(readFileSync(opts.entriesPath, 'utf8'));
@@ -72,8 +73,8 @@ export async function buildGallery(opts: BuildGalleryOptions): Promise<void> {
     const dstSource = path.join(slugDir, 'source.kcad.ts');
     const sourceUrl = entry.source === 'curated' ? `/gallery/${entry.slug}/source.kcad.ts` : null;
     const studioUrl = entry.source === 'curated'
-      ? `/studio?gallery=${encodeURIComponent(entry.slug)}`
-      : new URL(entry.appUrl).pathname;
+      ? `${STUDIO_ORIGIN}/studio?gallery=${encodeURIComponent(entry.slug)}`
+      : entry.appUrl;
 
     copyFileSync(srcVideo, dstVideo);
     if (entry.source === 'curated') {

--- a/site/style.css
+++ b/site/style.css
@@ -422,6 +422,14 @@ body {
   font-size: 0.65rem; font-weight: 600;
   padding: 3px 7px; border-radius: 3px;
 }
+.tile-studio-link {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 1;
+  max-width: calc(100% - 16px);
+  white-space: nowrap;
+}
 
 /* ---------- Lightbox ---------- */
 #gallery-lightbox {
@@ -495,4 +503,26 @@ body {
 .lightbox-secondary { display: flex; flex-direction: column; gap: 0.4rem; }
 .lightbox-secondary a { font-size: 0.85rem; color: #fff; opacity: 0.8; }
 .lightbox-secondary a:hover { opacity: 1; }
+.tile-studio-link,
+.lightbox-studio-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  padding: 0.45rem 0.7rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: #fff;
+  background: rgba(255, 255, 255, 0.08);
+  text-decoration: none;
+  font-size: 0.85rem;
+}
+.tile-studio-link:hover,
+.lightbox-studio-link:hover {
+  background: rgba(255, 255, 255, 0.16);
+}
+.gallery-privacy-note {
+  margin: 0.5rem 0 0;
+  font-size: 0.8rem;
+  opacity: 0.72;
+}
 .lightbox-footer { margin-top: 1rem; opacity: 0.6; font-size: 0.85rem; }

--- a/src/funnel/lib/apiClient.ts
+++ b/src/funnel/lib/apiClient.ts
@@ -64,12 +64,15 @@ export async function authedFetch<T>(
 // Projects
 // ---------------------------------------------------------------------------
 
+export type ProjectPrivacy = 'public_unlisted' | 'public_featured' | 'private';
+
 export interface SaveProjectInput {
   generationId: string;
   anonId?: string;
   title: string;
   code: string;
   parameters: Artifact['parameters'];
+  privacy?: Extract<ProjectPrivacy, 'public_unlisted' | 'private'>;
 }
 
 export interface SaveProjectResult {
@@ -85,7 +88,8 @@ export interface ProjectRow {
   id: string;
   slug: string;
   title: string;
-  privacy: 'public' | 'private';
+  privacy: ProjectPrivacy | 'public';
+  featured_at?: string | null;
   current_code: string;
   parameters: Artifact['parameters'];
   version: number;
@@ -97,7 +101,7 @@ export async function fetchProjectBySlug(slug: string): Promise<ProjectRow | nul
   const supabase = getSupabase();
   const { data, error } = await supabase
     .from('projects')
-    .select('id, slug, title, privacy, current_code, parameters, version, updated_at, owner_id')
+    .select('id, slug, title, privacy, featured_at, current_code, parameters, version, updated_at, owner_id')
     .eq('slug', slug)
     .maybeSingle();
   if (error) throw new Error(error.message);
@@ -108,7 +112,7 @@ export async function listMyProjects(): Promise<ProjectRow[]> {
   const supabase = getSupabase();
   const { data, error } = await supabase
     .from('projects')
-    .select('id, slug, title, privacy, current_code, parameters, version, updated_at, owner_id')
+    .select('id, slug, title, privacy, featured_at, current_code, parameters, version, updated_at, owner_id')
     .order('updated_at', { ascending: false });
   if (error) throw new Error(error.message);
   return (data as ProjectRow[] | null) ?? [];

--- a/src/studio/App.gallerySource.test.tsx
+++ b/src/studio/App.gallerySource.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment happy-dom
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+const mocks = vi.hoisted(() => ({
+  currentCode: '// DEFAULT_WORKBENCH_CODE',
+  localProjectCode: '// LOCAL_PROJECT_CODE',
+  saveActiveProject: vi.fn(),
+  setCode: vi.fn((nextCode: string) => {
+    mocks.currentCode = nextCode;
+  }),
+  setViewMode: vi.fn(),
+  setViewMode3D: vi.fn(),
+}));
+
+vi.mock('./context/WorkbenchContext', async () => {
+  const React = await import('react');
+
+  return {
+    WorkbenchProvider: ({ children, initialCode }: { children: ReactNode; initialCode?: string }) => {
+      const [code, setCode] = React.useState(initialCode ?? '// DEFAULT_WORKBENCH_CODE');
+      mocks.currentCode = code;
+
+      return (
+        <div data-testid="workbench-provider">
+          {children}
+        </div>
+      );
+    },
+    useWorkbench: () => ({
+      code: mocks.currentCode,
+      setCode: mocks.setCode,
+      viewMode: 'code',
+      setViewMode: mocks.setViewMode,
+      viewMode3D: 'shadedWithEdges',
+      setViewMode3D: mocks.setViewMode3D,
+      sidePanelVisible: true,
+      showSketches: true,
+    }),
+  };
+});
+
+vi.mock('./context/ProjectContext', () => ({
+  useProject: () => ({
+    activeProject: {
+      code: mocks.localProjectCode,
+      viewState: {
+        viewMode: 'code',
+        viewMode3D: 'shadedWithEdges',
+        agentRailOpen: false,
+      },
+    },
+    saveActiveProject: mocks.saveActiveProject,
+  }),
+}));
+
+vi.mock('./store/useShellStore', () => ({
+  useShellStore: () => ({ agentRailOpen: false }),
+}));
+
+vi.mock('./store/shellStore', () => ({
+  shellStore: {
+    setAgentRailOpen: vi.fn(),
+  },
+}));
+
+vi.mock('./StudioShell', () => ({
+  StudioShell: () => (
+    <main data-testid="studio-shell">
+      <span data-testid="workbench-code">{mocks.currentCode}</span>
+    </main>
+  ),
+}));
+
+import App from './App';
+
+const gallerySource = 'export default box(1, 1, 1);';
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+async function flushSourceLoad() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  mocks.currentCode = '// DEFAULT_WORKBENCH_CODE';
+  mocks.localProjectCode = '// LOCAL_PROJECT_CODE';
+  mocks.saveActiveProject.mockClear();
+  mocks.setCode.mockClear();
+  mocks.setViewMode.mockClear();
+  mocks.setViewMode3D.mockClear();
+  consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  window.history.pushState(null, '', '/studio');
+});
+
+afterEach(() => {
+  cleanup();
+  consoleErrorSpy.mockRestore();
+  vi.unstubAllGlobals();
+});
+
+describe('App gallery source route', () => {
+  it('loads gallery source into the workbench without syncing or autosaving it into the local project', async () => {
+    window.history.pushState(null, '', '/studio?gallery=fixture-build');
+
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === '/gallery.json') {
+        return {
+          ok: true,
+          json: async () => ({
+            entries: [
+              { slug: 'other-build', sourceUrl: '/gallery/other-build/source.kcad.ts' },
+              { slug: 'fixture-build', sourceUrl: '/gallery/fixture-build/source.kcad.ts' },
+            ],
+          }),
+        };
+      }
+
+      return {
+        ok: true,
+        text: async () => gallerySource,
+      };
+    }) as unknown as typeof fetch);
+
+    render(<App />);
+
+    await flushSourceLoad();
+
+    expect(screen.getByTestId('workbench-code').textContent).toBe(gallerySource);
+    expect(screen.getByTestId('workbench-code').textContent).not.toBe(mocks.localProjectCode);
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 1700));
+    });
+
+    expect(mocks.saveActiveProject).not.toHaveBeenCalled();
+  });
+
+  it('shows a visible error instead of the Studio shell when gallery source loading fails', async () => {
+    window.history.pushState(null, '', '/studio?gallery=bad-slug');
+
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        entries: [
+          { slug: 'fixture-build', sourceUrl: '/gallery/fixture-build/source.kcad.ts' },
+        ],
+      }),
+    })) as unknown as typeof fetch);
+
+    render(<App />);
+
+    await flushSourceLoad();
+
+    expect(screen.getByText(/failed to load studio source/i)).toBeTruthy();
+    expect(screen.queryByTestId('studio-shell')).toBeNull();
+    expect(screen.queryByText(mocks.localProjectCode)).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to load Studio source:', expect.any(Error));
+  });
+});

--- a/src/studio/App.tsx
+++ b/src/studio/App.tsx
@@ -23,11 +23,16 @@ function isCodeParsable(code: string): boolean {
 }
 
 import { useProject } from './context/ProjectContext';
-import { loadStudioScriptSource } from './scriptSource';
+import { loadGalleryScriptSource, loadStudioScriptSource } from './scriptSource';
 
 function readScriptParam(): string | null {
   if (typeof window === 'undefined') return null;
   return new URLSearchParams(window.location.search).get('script');
+}
+
+function readGalleryParam(): string | null {
+  if (typeof window === 'undefined') return null;
+  return new URLSearchParams(window.location.search).get('gallery');
 }
 
 function AppContent({ isDevLab }: { isDevLab: boolean }) {
@@ -40,12 +45,17 @@ function AppContent({ isDevLab }: { isDevLab: boolean }) {
   const { agentRailOpen } = useShellStore();
   const [isInitialized, setIsInitialized] = useState(false);
   const scriptParam = readScriptParam();
+  const galleryParam = readGalleryParam();
 
   useEffect(() => {
-    if (isDevLab || !scriptParam) return;
+    if (isDevLab || (!scriptParam && !galleryParam)) return;
 
     let cancelled = false;
-    loadStudioScriptSource(scriptParam)
+    const sourcePromise = galleryParam
+      ? loadGalleryScriptSource(galleryParam)
+      : loadStudioScriptSource(scriptParam as string);
+
+    sourcePromise
       .then((source) => {
         if (cancelled) return;
         setCode(source);
@@ -59,11 +69,11 @@ function AppContent({ isDevLab }: { isDevLab: boolean }) {
     return () => {
       cancelled = true;
     };
-  }, [isDevLab, scriptParam, setCode, setViewMode]);
+  }, [galleryParam, isDevLab, scriptParam, setCode, setViewMode]);
 
   // Sync active project -> workbench state
   useEffect(() => {
-    if (scriptParam) return;
+    if (scriptParam || galleryParam) return;
     if (isDevLab || !activeProject) return;
 
     // Only sync on initial load or project switch
@@ -77,11 +87,11 @@ function AppContent({ isDevLab }: { isDevLab: boolean }) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsInitialized(true);
     }
-  }, [activeProject, isDevLab, setCode, setViewMode, setViewMode3D, isInitialized, code, viewMode3D, scriptParam]);
+  }, [activeProject, isDevLab, setCode, setViewMode, setViewMode3D, isInitialized, code, viewMode3D, scriptParam, galleryParam]);
 
   // Auto-save: workbench state -> active project
   useEffect(() => {
-    if (scriptParam) return;
+    if (scriptParam || galleryParam) return;
     if (isDevLab || !isInitialized || !activeProject) return;
     if (!isCodeParsable(code)) return;
 
@@ -99,7 +109,7 @@ function AppContent({ isDevLab }: { isDevLab: boolean }) {
     }, 1500); // 1.5s debounce for project save
 
     return () => clearTimeout(timeoutId);
-  }, [code, viewMode, viewMode3D, sidePanelVisible, showSketches, agentRailOpen, isDevLab, isInitialized, activeProject, saveActiveProject, scriptParam]);
+  }, [code, viewMode, viewMode3D, sidePanelVisible, showSketches, agentRailOpen, isDevLab, isInitialized, activeProject, saveActiveProject, scriptParam, galleryParam]);
 
   return isDevLab ? (
     <Suspense fallback={null}>

--- a/src/studio/App.tsx
+++ b/src/studio/App.tsx
@@ -44,13 +44,17 @@ function AppContent({ isDevLab }: { isDevLab: boolean }) {
   const { activeProject, saveActiveProject } = useProject();
   const { agentRailOpen } = useShellStore();
   const [isInitialized, setIsInitialized] = useState(false);
+  const [sourceLoadError, setSourceLoadError] = useState<string | null>(null);
   const scriptParam = readScriptParam();
   const galleryParam = readGalleryParam();
+  const isSourceRoute = !isDevLab && Boolean(scriptParam || galleryParam);
 
   useEffect(() => {
     if (isDevLab || (!scriptParam && !galleryParam)) return;
 
     let cancelled = false;
+    setSourceLoadError(null);
+    setIsInitialized(false);
     const sourcePromise = galleryParam
       ? loadGalleryScriptSource(galleryParam)
       : loadStudioScriptSource(scriptParam as string);
@@ -63,7 +67,9 @@ function AppContent({ isDevLab }: { isDevLab: boolean }) {
         setIsInitialized(true);
       })
       .catch((error) => {
-        console.error('Failed to load script source:', error);
+        if (cancelled) return;
+        console.error('Failed to load Studio source:', error);
+        setSourceLoadError('Failed to load Studio source.');
       });
 
     return () => {
@@ -110,6 +116,22 @@ function AppContent({ isDevLab }: { isDevLab: boolean }) {
 
     return () => clearTimeout(timeoutId);
   }, [code, viewMode, viewMode3D, sidePanelVisible, showSketches, agentRailOpen, isDevLab, isInitialized, activeProject, saveActiveProject, scriptParam, galleryParam]);
+
+  if (isSourceRoute && sourceLoadError) {
+    return (
+      <main role="alert" aria-live="polite">
+        <p>{sourceLoadError}</p>
+      </main>
+    );
+  }
+
+  if (isSourceRoute && !isInitialized) {
+    return (
+      <main aria-live="polite">
+        <p>Loading Studio source...</p>
+      </main>
+    );
+  }
 
   return isDevLab ? (
     <Suspense fallback={null}>

--- a/src/studio/App.tsx
+++ b/src/studio/App.tsx
@@ -44,17 +44,19 @@ function AppContent({ isDevLab }: { isDevLab: boolean }) {
   const { activeProject, saveActiveProject } = useProject();
   const { agentRailOpen } = useShellStore();
   const [isInitialized, setIsInitialized] = useState(false);
-  const [sourceLoadError, setSourceLoadError] = useState<string | null>(null);
+  const [loadedSourceRouteKey, setLoadedSourceRouteKey] = useState<string | null>(null);
+  const [sourceLoadError, setSourceLoadError] = useState<{ routeKey: string; message: string } | null>(null);
   const scriptParam = readScriptParam();
   const galleryParam = readGalleryParam();
   const isSourceRoute = !isDevLab && Boolean(scriptParam || galleryParam);
+  const sourceRouteKey = isSourceRoute
+    ? (galleryParam ? `gallery:${galleryParam}` : `script:${scriptParam}`)
+    : null;
 
   useEffect(() => {
-    if (isDevLab || (!scriptParam && !galleryParam)) return;
+    if (!sourceRouteKey) return;
 
     let cancelled = false;
-    setSourceLoadError(null);
-    setIsInitialized(false);
     const sourcePromise = galleryParam
       ? loadGalleryScriptSource(galleryParam)
       : loadStudioScriptSource(scriptParam as string);
@@ -64,18 +66,21 @@ function AppContent({ isDevLab }: { isDevLab: boolean }) {
         if (cancelled) return;
         setCode(source);
         setViewMode('code');
+        setSourceLoadError(null);
+        setLoadedSourceRouteKey(sourceRouteKey);
         setIsInitialized(true);
       })
       .catch((error) => {
         if (cancelled) return;
         console.error('Failed to load Studio source:', error);
-        setSourceLoadError('Failed to load Studio source.');
+        setSourceLoadError({ routeKey: sourceRouteKey, message: 'Failed to load Studio source.' });
+        setLoadedSourceRouteKey(null);
       });
 
     return () => {
       cancelled = true;
     };
-  }, [galleryParam, isDevLab, scriptParam, setCode, setViewMode]);
+  }, [galleryParam, scriptParam, setCode, setViewMode, sourceRouteKey]);
 
   // Sync active project -> workbench state
   useEffect(() => {
@@ -117,15 +122,19 @@ function AppContent({ isDevLab }: { isDevLab: boolean }) {
     return () => clearTimeout(timeoutId);
   }, [code, viewMode, viewMode3D, sidePanelVisible, showSketches, agentRailOpen, isDevLab, isInitialized, activeProject, saveActiveProject, scriptParam, galleryParam]);
 
-  if (isSourceRoute && sourceLoadError) {
+  const activeSourceLoadError = sourceRouteKey && sourceLoadError?.routeKey === sourceRouteKey
+    ? sourceLoadError.message
+    : null;
+
+  if (activeSourceLoadError) {
     return (
       <main role="alert" aria-live="polite">
-        <p>{sourceLoadError}</p>
+        <p>{activeSourceLoadError}</p>
       </main>
     );
   }
 
-  if (isSourceRoute && !isInitialized) {
+  if (sourceRouteKey && loadedSourceRouteKey !== sourceRouteKey) {
     return (
       <main aria-live="polite">
         <p>Loading Studio source...</p>

--- a/src/studio/gallerySource.ts
+++ b/src/studio/gallerySource.ts
@@ -1,0 +1,19 @@
+export interface GalleryManifestEntry {
+  slug: string;
+  sourceUrl: string | null;
+}
+
+export async function findGallerySourceUrl(slug: string): Promise<string> {
+  const response = await fetch('/gallery.json');
+  if (!response.ok) throw new Error(`Failed to load gallery manifest: ${response.status}`);
+
+  const payload = await response.json();
+  const entries = Array.isArray(payload?.entries)
+    ? payload.entries as GalleryManifestEntry[]
+    : [];
+  const entry = entries.find(candidate => candidate.slug === slug);
+  if (!entry) throw new Error(`Gallery entry not found: ${slug}`);
+  if (!entry.sourceUrl) throw new Error(`Gallery entry has no source: ${slug}`);
+
+  return entry.sourceUrl;
+}

--- a/src/studio/gallerySource.ts
+++ b/src/studio/gallerySource.ts
@@ -3,8 +3,24 @@ export interface GalleryManifestEntry {
   sourceUrl: string | null;
 }
 
+const MARKETING_GALLERY_ORIGIN = 'https://kernelcad.com';
+
+function galleryManifestUrl(): string {
+  if (typeof window !== 'undefined' && window.location.hostname === 'app.kernelcad.com') {
+    return `${MARKETING_GALLERY_ORIGIN}/gallery.json`;
+  }
+  return '/gallery.json';
+}
+
+function resolveGalleryAssetUrl(sourceUrl: string, manifestUrl: string): string {
+  if (/^https?:\/\//i.test(sourceUrl)) return sourceUrl;
+  if (/^https?:\/\//i.test(manifestUrl)) return new URL(sourceUrl, manifestUrl).toString();
+  return sourceUrl;
+}
+
 export async function findGallerySourceUrl(slug: string): Promise<string> {
-  const response = await fetch('/gallery.json');
+  const manifestUrl = galleryManifestUrl();
+  const response = await fetch(manifestUrl);
   if (!response.ok) throw new Error(`Failed to load gallery manifest: ${response.status}`);
 
   const payload = await response.json();
@@ -15,5 +31,5 @@ export async function findGallerySourceUrl(slug: string): Promise<string> {
   if (!entry) throw new Error(`Gallery entry not found: ${slug}`);
   if (!entry.sourceUrl) throw new Error(`Gallery entry has no source: ${slug}`);
 
-  return entry.sourceUrl;
+  return resolveGalleryAssetUrl(entry.sourceUrl, manifestUrl);
 }

--- a/src/studio/routes/g.$genId.tsx
+++ b/src/studio/routes/g.$genId.tsx
@@ -93,7 +93,7 @@ function AnonGenPage() {
 
   const headerRight = (
     <div className="flex items-center gap-2 min-w-0">
-      <span className="text-[10px] text-gray-500 font-mono whitespace-nowrap">
+      <span className="hidden md:inline text-[10px] text-gray-500 font-mono truncate max-w-[190px]">
         Free saves are public by link.
       </span>
       {session ? (

--- a/src/studio/routes/g.$genId.tsx
+++ b/src/studio/routes/g.$genId.tsx
@@ -60,6 +60,7 @@ function AnonGenPage() {
         title: gen!.prompt.slice(0, 60),
         code: gen!.code,
         parameters: [],
+        privacy: 'public_unlisted',
       });
       void navigate({ to: '/p/$slug', params: { slug: result.slug } });
     } catch (err) {
@@ -90,22 +91,29 @@ function AnonGenPage() {
     </div>
   );
 
-  const headerRight = session ? (
-    <button
-      type="button"
-      onClick={() => void handleSave()}
-      disabled={savingState === 'saving'}
-      className="px-3 py-1 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 transition-colors"
-    >
-      {savingState === 'saving' ? 'Saving…' : savingState === 'error' ? 'Retry save' : 'Save'}
-    </button>
-  ) : (
-    <SignInButton
-      redirectTo={typeof window !== 'undefined' ? window.location.href : undefined}
-      className="inline-flex items-center gap-1.5 px-3 py-1 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 transition-colors"
-    >
-      Sign in to save
-    </SignInButton>
+  const headerRight = (
+    <div className="flex items-center gap-2 min-w-0">
+      <span className="text-[10px] text-gray-500 font-mono whitespace-nowrap">
+        Free saves are public by link.
+      </span>
+      {session ? (
+        <button
+          type="button"
+          onClick={() => void handleSave()}
+          disabled={savingState === 'saving'}
+          className="px-3 py-1 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 transition-colors"
+        >
+          {savingState === 'saving' ? 'Saving…' : savingState === 'error' ? 'Retry save' : 'Save'}
+        </button>
+      ) : (
+        <SignInButton
+          redirectTo={typeof window !== 'undefined' ? window.location.href : undefined}
+          className="inline-flex items-center gap-1.5 px-3 py-1 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 transition-colors"
+        >
+          Sign in to save
+        </SignInButton>
+      )}
+    </div>
   );
 
   return <App initialCode={gen.code} headerLeft={headerLeft} headerRight={headerRight} />;

--- a/src/studio/routes/p.$slug.tsx
+++ b/src/studio/routes/p.$slug.tsx
@@ -9,6 +9,12 @@ export const Route = createFileRoute('/p/$slug')({
   component: ProjectPage,
 });
 
+function formatPrivacyLabel(privacy: ProjectRow['privacy']): string {
+  if (privacy === 'private') return 'private';
+  if (privacy === 'public_featured') return 'featured';
+  return 'public by link';
+}
+
 function ProjectPage() {
   const { slug } = Route.useParams();
   const { session } = useSession();
@@ -40,7 +46,7 @@ function ProjectPage() {
         {project.title}
       </span>
       <span className="text-[10px] uppercase tracking-widest text-gray-500 font-mono px-1.5 py-0.5 rounded border border-[#333]">
-        {project.privacy}
+        {formatPrivacyLabel(project.privacy)}
       </span>
     </div>
   );

--- a/src/studio/scriptSource.test.ts
+++ b/src/studio/scriptSource.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { loadStudioScriptSource } from './scriptSource';
+import { loadGalleryScriptSource, loadStudioScriptSource } from './scriptSource';
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe('loadStudioScriptSource', () => {
@@ -21,5 +22,52 @@ describe('loadStudioScriptSource', () => {
     expect(fetchMock).not.toHaveBeenCalledWith(
       expect.stringContaining('/__kernelcad/mesh'),
     );
+  });
+});
+
+describe('loadGalleryScriptSource', () => {
+  it('loads static gallery source by slug', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === '/gallery.json') {
+        return {
+          ok: true,
+          json: async () => ({
+            entries: [
+              {
+                slug: 'fixture-build',
+                sourceUrl: '/gallery/fixture-build/source.kcad.ts',
+              },
+            ],
+          }),
+        };
+      }
+
+      return {
+        ok: true,
+        text: async () => 'export default box(1, 1, 1);',
+      };
+    }) as unknown as typeof fetch;
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(loadGalleryScriptSource('fixture-build')).resolves.toContain('box');
+    expect(fetchMock).toHaveBeenCalledWith('/gallery.json');
+    expect(fetchMock).toHaveBeenCalledWith('/gallery/fixture-build/source.kcad.ts');
+  });
+
+  it('rejects gallery entries without sourceUrl', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        entries: [
+          {
+            slug: 'studio-project',
+            sourceUrl: null,
+          },
+        ],
+      }),
+    })) as unknown as typeof fetch);
+
+    await expect(loadGalleryScriptSource('studio-project')).rejects.toThrow(/source/i);
   });
 });

--- a/src/studio/scriptSource.test.ts
+++ b/src/studio/scriptSource.test.ts
@@ -34,6 +34,10 @@ describe('loadGalleryScriptSource', () => {
           json: async () => ({
             entries: [
               {
+                slug: 'first-build',
+                sourceUrl: '/gallery/first-build/source.kcad.ts',
+              },
+              {
                 slug: 'fixture-build',
                 sourceUrl: '/gallery/fixture-build/source.kcad.ts',
               },
@@ -53,6 +57,7 @@ describe('loadGalleryScriptSource', () => {
     await expect(loadGalleryScriptSource('fixture-build')).resolves.toContain('box');
     expect(fetchMock).toHaveBeenCalledWith('/gallery.json');
     expect(fetchMock).toHaveBeenCalledWith('/gallery/fixture-build/source.kcad.ts');
+    expect(fetchMock).not.toHaveBeenCalledWith('/gallery/first-build/source.kcad.ts');
   });
 
   it('rejects gallery entries without sourceUrl', async () => {

--- a/src/studio/scriptSource.test.ts
+++ b/src/studio/scriptSource.test.ts
@@ -60,6 +60,36 @@ describe('loadGalleryScriptSource', () => {
     expect(fetchMock).not.toHaveBeenCalledWith('/gallery/first-build/source.kcad.ts');
   });
 
+  it('loads app-hosted Studio gallery source from the marketing gallery origin', async () => {
+    vi.stubGlobal('window', { location: { hostname: 'app.kernelcad.com' } });
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === 'https://kernelcad.com/gallery.json') {
+        return {
+          ok: true,
+          json: async () => ({
+            entries: [
+              {
+                slug: 'fixture-build',
+                sourceUrl: '/gallery/fixture-build/source.kcad.ts',
+              },
+            ],
+          }),
+        };
+      }
+
+      return {
+        ok: true,
+        text: async () => 'export default box(2, 2, 2);',
+      };
+    }) as unknown as typeof fetch;
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(loadGalleryScriptSource('fixture-build')).resolves.toContain('box(2');
+    expect(fetchMock).toHaveBeenCalledWith('https://kernelcad.com/gallery.json');
+    expect(fetchMock).toHaveBeenCalledWith('https://kernelcad.com/gallery/fixture-build/source.kcad.ts');
+  });
+
   it('rejects gallery entries without sourceUrl', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({
       ok: true,

--- a/src/studio/scriptSource.ts
+++ b/src/studio/scriptSource.ts
@@ -1,3 +1,5 @@
+import { findGallerySourceUrl } from './gallerySource';
+
 export async function loadStudioScriptSource(script: string): Promise<string> {
   const response = await fetch(`/__kernelcad/source?script=${encodeURIComponent(script)}`);
   const payload = await response.json();
@@ -9,4 +11,11 @@ export async function loadStudioScriptSource(script: string): Promise<string> {
     throw new Error('Source endpoint did not return source code.');
   }
   return payload.source;
+}
+
+export async function loadGalleryScriptSource(slug: string): Promise<string> {
+  const sourceUrl = await findGallerySourceUrl(slug);
+  const response = await fetch(sourceUrl);
+  if (!response.ok) throw new Error(`Failed to load gallery source: ${response.status}`);
+  return response.text();
 }

--- a/tests/funnel/apiClient.test.ts
+++ b/tests/funnel/apiClient.test.ts
@@ -15,6 +15,7 @@ import {
   createMcpToken,
   fetchMyPlan,
   openBillingPortal,
+  saveProject,
 } from '../../src/funnel/lib/apiClient';
 
 const ORIGINAL_FETCH = globalThis.fetch;
@@ -124,6 +125,25 @@ describe('createMcpToken', () => {
     expect(init.method).toBe('POST');
     expect((init.headers as Record<string, string>).Authorization).toBe('Bearer jwt-token-123');
     expect(result).toEqual({ token: 'kc_secret', tokenPrefix: 'kc_secret' });
+  });
+});
+
+describe('saveProject', () => {
+  it('sends public_unlisted as the default save privacy', async () => {
+    const fetchMock = mockFetchOnce({ slug: 'saved-object', projectId: 'project-1' });
+
+    await saveProject({
+      generationId: 'gen-1',
+      title: 'Saved object',
+      code: 'return box(1, 1, 1);',
+      parameters: [],
+      privacy: 'public_unlisted',
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      privacy: 'public_unlisted',
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- add gallery studioUrl/sourceUrl metadata and static source publishing
- load gallery source in app Studio from the marketing gallery origin
- add Open in Studio links on gallery tiles and lightbox
- fix Royal Pop watch tile so it upgrades to rotating model-viewer
- expose public-unlisted save semantics in the web client

## Verification
- npx vitest run scripts/lib/galleryEntries.test.ts site/scripts/build-gallery.test.ts scripts/staticGalleryLanding.test.ts src/studio/scriptSource.test.ts src/studio/App.gallerySource.test.tsx src/studio/context/ProjectContext.funnel.test.tsx tests/funnel/apiClient.test.ts src/studio/routes/index.test.ts
- npm run site:build
- npm run typecheck
- git diff --check