### PR TITLE
fix: keep Royal Pop gallery face visible

### DIFF
--- a/scripts/staticGalleryLanding.test.ts
+++ b/scripts/staticGalleryLanding.test.ts
@@ -91,6 +91,12 @@ describe('static gallery landing page', () => {
 
     expect(html).toContain("entry.slug === 'royal-pop-pocket-watch'");
     expect(html).toContain('class="tile-poster"');
+    expect(html).toContain("initial: '0deg 158deg auto'");
+    expect(html).toContain("min: '-14deg 145deg auto'");
+    expect(html).toContain("max: '14deg 168deg auto'");
+    expect(html).toContain('function animateRoyalWatchFace(viewer)');
+    expect(html).toContain("if (!orbit.faceForward)");
+    expect(html).toContain('if (orbit.faceForward) animateRoyalWatchFace(viewer)');
     expect(html).toContain("viewer.setAttribute('min-camera-orbit', orbit.min)");
     expect(html).toContain("viewer.setAttribute('max-camera-orbit', orbit.max)");
     expect(html).toContain("viewer.setAttribute('camera-orbit', orbit.initial)");

--- a/site/index.html
+++ b/site/index.html
@@ -253,8 +253,20 @@
 
     function galleryTileOrbit(entry) {
       return entry.slug === 'royal-pop-pocket-watch'
-        ? { initial: '0deg 75deg auto', min: '-35deg 60deg auto', max: '35deg 85deg auto' }
+        ? { initial: '0deg 158deg auto', min: '-14deg 145deg auto', max: '14deg 168deg auto', faceForward: true }
         : { initial: '45deg 75deg auto', min: 'auto auto auto', max: 'auto auto auto' };
+    }
+
+    function animateRoyalWatchFace(viewer) {
+      let frame = 0;
+      const tick = (now) => {
+        if (!viewer.isConnected) return;
+        const theta = Math.sin(now / 950) * 12;
+        const phi = 158 + Math.sin(now / 1350) * 4;
+        viewer.setAttribute('camera-orbit', `${theta.toFixed(2)}deg ${phi.toFixed(2)}deg auto`);
+        frame = requestAnimationFrame(tick);
+      };
+      frame = requestAnimationFrame(tick);
     }
 
     function upgradeGalleryTile(tile, entry, galleryCacheKey) {
@@ -269,9 +281,11 @@
       viewer.setAttribute('src', cacheKeyedUrl(entry.modelUrl, galleryCacheKey));
       viewer.setAttribute('poster', cacheKeyedUrl(entry.posterUrl, galleryCacheKey));
       viewer.setAttribute('alt', entry.title);
-      viewer.setAttribute('auto-rotate', '');
-      viewer.setAttribute('auto-rotate-delay', '0');
-      viewer.setAttribute('rotation-per-second', '20deg');
+      if (!orbit.faceForward) {
+        viewer.setAttribute('auto-rotate', '');
+        viewer.setAttribute('auto-rotate-delay', '0');
+        viewer.setAttribute('rotation-per-second', '20deg');
+      }
       viewer.setAttribute('camera-orbit', orbit.initial);
       viewer.setAttribute('min-camera-orbit', orbit.min);
       viewer.setAttribute('max-camera-orbit', orbit.max);
@@ -283,6 +297,7 @@
       const poster = tile.querySelector('.tile-poster');
       if (poster) poster.replaceWith(viewer);
       else tile.prepend(viewer);
+      if (orbit.faceForward) animateRoyalWatchFace(viewer);
     }
 
     function armGalleryTileUpgrade(tile, entry, galleryCacheKey) {


### PR DESCRIPTION
## Summary
- keep Royal Pop's gallery model-viewer orbit face-forward
- replace full auto-rotate with a narrow animated camera sweep so the dial remains visible

## Verification
- npx vitest run scripts/staticGalleryLanding.test.ts
- local Playwright smoke: Royal Pop tile renders model-viewer, Studio link is present, camera orbit changes over time, and screenshot shows the dial face