### PR TITLE
fix: simplify Royal Pop gallery rotation

### DIFF
--- a/scripts/staticGalleryLanding.test.ts
+++ b/scripts/staticGalleryLanding.test.ts
@@ -92,9 +92,11 @@ describe('static gallery landing page', () => {
     expect(html).toContain("entry.slug === 'royal-pop-pocket-watch'");
     expect(html).toContain('class="tile-poster"');
     expect(html).toContain("initial: '0deg 158deg auto'");
-    expect(html).toContain("min: '-14deg 145deg auto'");
-    expect(html).toContain("max: '14deg 168deg auto'");
+    expect(html).toContain("min: '-16deg 158deg auto'");
+    expect(html).toContain("max: '16deg 158deg auto'");
     expect(html).toContain('function animateRoyalWatchFace(viewer)');
+    expect(html).toContain('Math.sin(now / 1200) * 14');
+    expect(html).toContain('`${theta.toFixed(2)}deg 158deg auto`');
     expect(html).toContain("if (!orbit.faceForward)");
     expect(html).toContain('if (orbit.faceForward) animateRoyalWatchFace(viewer)');
     expect(html).toContain("viewer.setAttribute('min-camera-orbit', orbit.min)");

--- a/site/index.html
+++ b/site/index.html
@@ -253,7 +253,7 @@
 
     function galleryTileOrbit(entry) {
       return entry.slug === 'royal-pop-pocket-watch'
-        ? { initial: '0deg 158deg auto', min: '-14deg 145deg auto', max: '14deg 168deg auto', faceForward: true }
+        ? { initial: '0deg 158deg auto', min: '-16deg 158deg auto', max: '16deg 158deg auto', faceForward: true }
         : { initial: '45deg 75deg auto', min: 'auto auto auto', max: 'auto auto auto' };
     }
 
@@ -261,9 +261,8 @@
       let frame = 0;
       const tick = (now) => {
         if (!viewer.isConnected) return;
-        const theta = Math.sin(now / 950) * 12;
-        const phi = 158 + Math.sin(now / 1350) * 4;
-        viewer.setAttribute('camera-orbit', `${theta.toFixed(2)}deg ${phi.toFixed(2)}deg auto`);
+        const theta = Math.sin(now / 1200) * 14;
+        viewer.setAttribute('camera-orbit', `${theta.toFixed(2)}deg 158deg auto`);
         frame = requestAnimationFrame(tick);
       };
       frame = requestAnimationFrame(tick);


### PR DESCRIPTION
## Summary
- keep Royal Pop's dial at a fixed face-visible camera angle
- replace two-axis wobble with a single horizontal left-right rotation

## Verification
- npx vitest run scripts/staticGalleryLanding.test.ts
- local Playwright smoke: Royal Pop model-viewer moves while keeping phi fixed at 158deg