### PR TITLE
fix: sync gallery full view with live model viewer

### DIFF
--- a/scripts/staticGalleryLanding.test.ts
+++ b/scripts/staticGalleryLanding.test.ts
@@ -54,10 +54,13 @@ describe('static gallery landing page', () => {
     expect(html).toContain('function loadModelViewerNearGallery(section)');
     expect(html).toContain("import('https://cdn.jsdelivr.net/npm/@google/model-viewer/dist/model-viewer.min.js')");
     expect(html).toContain('cacheKeyedUrl(entry.modelUrl, galleryCacheKey)');
-    expect(html).toContain('cacheKeyedUrl(entry.videoUrl, galleryCacheKey)');
+    expect(html).not.toContain('cacheKeyedUrl(entry.videoUrl, galleryCacheKey)');
+    expect(html).not.toContain('class="lightbox-video"');
     expect(html).toContain('entry.promptUrl');
     expect(html).toContain('Build brief');
-    expect(html).toContain('<video class="lightbox-video" autoplay muted loop playsinline controls>');
+    expect(html).toContain('<div class="lightbox-stage"></div>');
+    expect(html).toContain('function mountLightboxModel(entry, galleryCacheKey)');
+    expect(html).toContain("viewer.setAttribute('src', cacheKeyedUrl(entry.modelUrl, galleryCacheKey))");
     expect(html).toContain('class="lightbox-studio-link"');
     expect(html).toContain('Free projects are public by link');
     expect(redirects).toContain('/demo-poster.png /public/demo-poster.png 200');
@@ -99,6 +102,7 @@ describe('static gallery landing page', () => {
     expect(html).toContain('`${theta.toFixed(2)}deg 158deg auto`');
     expect(html).toContain("if (!orbit.faceForward)");
     expect(html).toContain('if (orbit.faceForward) animateRoyalWatchFace(viewer)');
+    expect(html).toContain('mountLightboxModel(entry, galleryCacheKey)');
     expect(html).toContain("viewer.setAttribute('min-camera-orbit', orbit.min)");
     expect(html).toContain("viewer.setAttribute('max-camera-orbit', orbit.max)");
     expect(html).toContain("viewer.setAttribute('camera-orbit', orbit.initial)");

--- a/site/index.html
+++ b/site/index.html
@@ -171,7 +171,7 @@
   <dialog id="gallery-lightbox">
     <div class="lightbox-inner">
       <button class="lightbox-close" aria-label="Close" type="button">×</button>
-      <video class="lightbox-video" autoplay muted loop playsinline controls></video>
+      <div class="lightbox-stage"></div>
       <div class="lightbox-body">
         <h3 class="lightbox-title"></h3>
         <p class="lightbox-meta"></p>
@@ -268,15 +268,10 @@
       frame = requestAnimationFrame(tick);
     }
 
-    function upgradeGalleryTile(tile, entry, galleryCacheKey) {
-      if (tile.dataset.modelViewerUpgraded === 'true') return;
-
-      tile.dataset.modelViewerUpgraded = 'true';
-      loadModelViewer();
-
+    function createGalleryViewer(entry, galleryCacheKey, className) {
       const orbit = galleryTileOrbit(entry);
       const viewer = document.createElement('model-viewer');
-      viewer.className = 'tile-viewer';
+      viewer.className = className;
       viewer.setAttribute('src', cacheKeyedUrl(entry.modelUrl, galleryCacheKey));
       viewer.setAttribute('poster', cacheKeyedUrl(entry.posterUrl, galleryCacheKey));
       viewer.setAttribute('alt', entry.title);
@@ -292,11 +287,28 @@
       viewer.setAttribute('reveal', 'auto');
       viewer.setAttribute('disable-zoom', '');
       viewer.setAttribute('loading', 'lazy');
+      if (orbit.faceForward) animateRoyalWatchFace(viewer);
+      return viewer;
+    }
+
+    function upgradeGalleryTile(tile, entry, galleryCacheKey) {
+      if (tile.dataset.modelViewerUpgraded === 'true') return;
+
+      tile.dataset.modelViewerUpgraded = 'true';
+      loadModelViewer();
+
+      const viewer = createGalleryViewer(entry, galleryCacheKey, 'tile-viewer');
 
       const poster = tile.querySelector('.tile-poster');
       if (poster) poster.replaceWith(viewer);
       else tile.prepend(viewer);
-      if (orbit.faceForward) animateRoyalWatchFace(viewer);
+    }
+
+    function mountLightboxModel(entry, galleryCacheKey) {
+      loadModelViewer();
+      const stage = document.querySelector('#gallery-lightbox .lightbox-stage');
+      stage.textContent = '';
+      stage.appendChild(createGalleryViewer(entry, galleryCacheKey, 'lightbox-viewer'));
     }
 
     function armGalleryTileUpgrade(tile, entry, galleryCacheKey) {
@@ -365,7 +377,6 @@
         upgradeGalleryTilesNearViewport(grid, galleryCacheKey);
 
         const dialog = document.getElementById('gallery-lightbox');
-        const video = dialog.querySelector('.lightbox-video');
         const title = dialog.querySelector('.lightbox-title');
         const meta = dialog.querySelector('.lightbox-meta');
         const promptEl = dialog.querySelector('.lightbox-prompt');
@@ -376,7 +387,7 @@
         const closeBtn = dialog.querySelector('.lightbox-close');
 
         function openLightbox(entry) {
-          video.src = cacheKeyedUrl(entry.videoUrl, galleryCacheKey);
+          mountLightboxModel(entry, galleryCacheKey);
           title.textContent = entry.title;
           meta.textContent = `by @${entry.author.handle} · ${entry.version} · ${entry.createdAt}`;
           promptEl.textContent = entry.prompt;
@@ -396,9 +407,7 @@
           dialog.showModal();
         }
         function closeLightbox() {
-          video.pause();
-          video.removeAttribute('src');
-          video.load();
+          dialog.querySelector('.lightbox-stage').textContent = '';
           dialog.close();
         }
         closeBtn.addEventListener('click', closeLightbox);
@@ -406,9 +415,7 @@
           if (e.target === dialog) closeLightbox();
         });
         dialog.addEventListener('close', () => {
-          video.pause();
-          video.removeAttribute('src');
-          video.load();
+          dialog.querySelector('.lightbox-stage').textContent = '';
         });
 
         // Expose for tile click handlers (closure captured above).

--- a/site/style.css
+++ b/site/style.css
@@ -460,7 +460,18 @@ body {
   cursor: pointer;
   z-index: 1;
 }
-.lightbox-video { width: 100%; max-height: 48vh; display: block; background: #000; }
+.lightbox-stage {
+  width: 100%;
+  height: min(58vh, 560px);
+  min-height: 320px;
+  background: #111;
+}
+.lightbox-viewer {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background: #111;
+}
 .lightbox-body {
   padding: 1.5rem;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- replace gallery lightbox videos with the same live model-viewer path used by gallery tiles
- share viewer creation/orbit code so Royal Pop rotation stays synced between tile and full view
- remove lightbox dependence on baked gallery video files

## Verification
- npx vitest run scripts/staticGalleryLanding.test.ts
- git diff --check
- local Playwright smoke: Royal Pop tile and lightbox both mount model-viewer, no lightbox video, both move with fixed 158deg face angle