### PR TITLE
fix: bust gallery lightbox stylesheet cache

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -13,7 +13,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,wght@0,500;1,500&family=Inter:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/style.css?v=2026-05-23-gallery-lightbox-model" />
   <title>kernelCAD — CAD for agents</title>
   <!--
     Cloudflare Web Analytics — anonymous beacon (no cookies, no IP storage).


### PR DESCRIPTION
## Summary
- add a stylesheet cache-bust to the marketing page so the live lightbox loads the new model-viewer sizing CSS immediately

## Why
Cloudflare was serving stale /style.css with the old .lightbox-video rule while the HTML had already switched the lightbox to model-viewer.

## Verification
- npx vitest run scripts/staticGalleryLanding.test.ts
- git diff --check