### PR TITLE
fix(cli): lazy-import playwright so non-render commands don't crash on fresh install (v0.11.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,33 @@ That's it. For agents: `kernelcad mcp` runs an MCP server with dynamic model
 introspection tools. See `SKILL.md` (bundled with the install) for the full API
 surface and authoring guide.
 
+## Use with Claude Desktop
+
+kernelCAD runs as an MCP server, so Claude Desktop can drive it locally. After
+`npm install -g kernelcad`, add an entry to your Claude Desktop config file:
+
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+- **Linux:** `~/.config/Claude/claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "kernelcad": {
+      "command": "npx",
+      "args": ["-y", "kernelcad", "mcp"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The kernelCAD MCP tools (`review_cad`, model
+introspection, export helpers, etc.) appear in the tools list.
+
+> A one-shot `kernelcad install --claude-desktop` command that edits this
+> config for you is on the next slice — until then the snippet above is the
+> interim path.
+
 ## Contributing
 
 Web app + dev workflow (clone the repo, `npm install`, `npm run dev`) for contributors who want to hack on the kernel or the visual debugger:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kernelcad",
   "private": false,
-  "version": "0.11.0",
+  "version": "0.11.1",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",
@@ -128,5 +128,8 @@
     "typescript-eslint": "^8.46.4",
     "vite": "^7.2.4",
     "vitest": "^4.0.18"
+  },
+  "optionalDependencies": {
+    "playwright": "^1.58.0"
   }
 }

--- a/src/agent/render/headlessRender.ts
+++ b/src/agent/render/headlessRender.ts
@@ -7,7 +7,7 @@
 // Cold start dominates wall-clock time (puppeteer launch + vite bundle +
 // kernel WASM init); the screenshot itself is sub-second per view.
 
-import { chromium, type Browser, type Page } from 'playwright';
+import type { Browser, Page } from 'playwright';
 import sharp from 'sharp';
 import { loadScriptFeatures } from '../../modeling/runtime/scriptLoader';
 import { meshFeaturesPerFeature } from '../../modeling/capture/featureMeshing';
@@ -163,10 +163,20 @@ export async function headlessRender(opts: HeadlessRenderOpts): Promise<Headless
   }
   const serialized = meshing.features.map(serializeForBridge);
 
-  // 2. Launch headless chromium.
+  // 2. Launch headless chromium. Lazy-import playwright so the CLI's
+  //    evaluate/export/mcp/skill paths don't fail at module load when
+  //    playwright isn't installed (it's an optional dependency).
   let browser: Browser | undefined;
   let page: Page | undefined;
   try {
+    let chromium;
+    try {
+      ({ chromium } = await import('playwright'));
+    } catch {
+      throw new Error(
+        "kernelcad render requires 'playwright'. Install with: npm install playwright && npx playwright install chromium",
+      );
+    }
     browser = await chromium.launch({ args: ['--disable-dev-shm-usage'] });
     const context = await browser.newContext({
       // DemoPlayer's headless ViewerPane is currently fixed at 1920×1080.


### PR DESCRIPTION
## Summary

v0.11.0 was published to npm and **immediately broke fresh installs**: every CLI command (`evaluate`, `export`, `mcp`, `skill`, `validate`) crashed on module load with \`ERR_MODULE_NOT_FOUND: Cannot find package 'playwright'\`. Root cause: \`src/agent/render/headlessRender.ts\` had a top-level \`import { chromium } from 'playwright'\`, the bundle treated playwright as external, but it was only in \`devDependencies\` — so a vanilla \`npm install kernelcad\` resolved a bundle that imports a package not on disk.

## Fix

- Convert the playwright import to type-only + a dynamic \`await import('playwright')\` inside the render code path.
- Add \`playwright\` to \`optionalDependencies\` so users who actually want \`kernelcad render\` get it auto-installed.
- Surface a clear error message if the render path can't find playwright at runtime.
- Bump to 0.11.1.

## Validation

Local tarball install from a fresh sandbox:
- \`npx kernelcad --version\` → \`0.11.1\` ✅
- \`npx kernelcad evaluate b.kcad.ts\` → \`Features: 1, OK\` ✅
- \`npx kernelcad export stl b.kcad.ts\` → 684-byte valid STL ✅
- \`npx kernelcad mcp --help\` → command listing ✅
- \`npx kernelcad skill --help\` → command listing ✅

## Test plan

- [ ] Confirm CI green
- [ ] After merge: \`npm publish\` 0.11.1 (manual)
- [ ] Deprecate 0.11.0 on npm: \`npm deprecate kernelcad@0.11.0 "Broken — playwright missing from runtime; use 0.11.1+"\`