### PR TITLE
feat(studio): add /connect surface for hosted MCP onboarding (Slice 1A)

### DIFF
--- a/src/studio/Toolbar.tsx
+++ b/src/studio/Toolbar.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, Play, MessageSquare, Image as ImageIcon } from 'lucide-react';
+import { CheckCircle2, Play, MessageSquare, Image as ImageIcon, Plug } from 'lucide-react';
 
 interface ToolbarProps {
     isModified: boolean;
@@ -56,6 +56,15 @@ export function Toolbar({
                     <MessageSquare size={12} />
                     Agent
                 </button>
+                <a
+                    href="/connect"
+                    data-testid="toolbar-connect-link"
+                    aria-label="Connect to Claude Desktop"
+                    className="inline-flex items-center gap-1 px-2 py-1 rounded text-gray-300 hover:text-white hover:bg-[#222] transition-colors"
+                >
+                    <Plug size={12} />
+                    Connect
+                </a>
                 {isModified && (
                     <span
                         data-testid="toolbar-modified-dot"

--- a/src/studio/__tests__/Toolbar.test.tsx
+++ b/src/studio/__tests__/Toolbar.test.tsx
@@ -104,4 +104,11 @@ describe('Toolbar', () => {
         fireEvent.click(screen.getByRole('button', { name: /reference images?/i }));
         expect(props.onToggleReferenceImages).toHaveBeenCalledTimes(1);
     });
+
+    it('renders the Connect link pointing at /connect', () => {
+        renderToolbar();
+        const link = screen.getByTestId('toolbar-connect-link');
+        expect(link.getAttribute('href')).toBe('/connect');
+        expect(link.textContent).toContain('Connect');
+    });
 });

--- a/src/studio/components/Connect/ConnectClaudeDesktop.test.tsx
+++ b/src/studio/components/Connect/ConnectClaudeDesktop.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { ConnectClaudeDesktop } from './ConnectClaudeDesktop';
+
+const { createMcpToken } = vi.hoisted(() => ({
+    createMcpToken: vi.fn(),
+}));
+vi.mock('../../../funnel/lib/apiClient', () => ({
+    createMcpToken,
+}));
+
+afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+});
+
+describe('ConnectClaudeDesktop', () => {
+    it('renders snippet with <TOKEN> placeholder before token is generated', () => {
+        const { getByTestId } = render(<ConnectClaudeDesktop userEmail="user@example.com" />);
+        const snippet = getByTestId('connect-snippet').textContent ?? '';
+        expect(snippet).toContain('"kernelcad"');
+        expect(snippet).toContain('<TOKEN>');
+        // Copy button is disabled until a token is minted.
+        expect(getByTestId('connect-copy-button').hasAttribute('disabled')).toBe(true);
+    });
+
+    it('mints a token only when the generate button is clicked', async () => {
+        createMcpToken.mockResolvedValue({ token: 'kc_live_secret_value', tokenPrefix: 'kc_live' });
+        const { getByTestId } = render(<ConnectClaudeDesktop userEmail="user@example.com" />);
+
+        // The token API has NOT been called on mount — this is the difference
+        // from AgentActivityLog (which auto-fetches). We only mint on user
+        // intent.
+        expect(createMcpToken).not.toHaveBeenCalled();
+
+        fireEvent.click(getByTestId('connect-generate-button'));
+
+        await waitFor(() => {
+            expect(createMcpToken).toHaveBeenCalledTimes(1);
+        });
+        await waitFor(() => {
+            const snippet = getByTestId('connect-snippet').textContent ?? '';
+            expect(snippet).toContain('kc_live_secret_value');
+        });
+        // Prefix is rendered as confirmation.
+        expect(getByTestId('connect-token-prefix').textContent).toContain('kc_live');
+    });
+
+    it('copies the snippet (with token) to the clipboard', async () => {
+        createMcpToken.mockResolvedValue({ token: 'kc_clip_token', tokenPrefix: 'kc_clip' });
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: { writeText },
+        });
+
+        const { getByTestId } = render(<ConnectClaudeDesktop userEmail="user@example.com" />);
+        fireEvent.click(getByTestId('connect-generate-button'));
+        await waitFor(() => {
+            expect((getByTestId('connect-snippet').textContent ?? '')).toContain('kc_clip_token');
+        });
+        fireEvent.click(getByTestId('connect-copy-button'));
+        await waitFor(() => {
+            expect(writeText).toHaveBeenCalledTimes(1);
+        });
+        const written = String(writeText.mock.calls[0][0]);
+        expect(written).toContain('kc_clip_token');
+        expect(written).toContain('"mcpServers"');
+        expect(written).toContain('"kernelcad"');
+    });
+
+    it('switches the platform-specific config path via tabs', () => {
+        const { getByTestId } = render(<ConnectClaudeDesktop userEmail="user@example.com" />);
+        // Default: macOS
+        expect(getByTestId('connect-config-path').textContent).toContain('Library/Application Support/Claude');
+
+        fireEvent.click(getByTestId('connect-platform-windows'));
+        expect(getByTestId('connect-config-path').textContent).toContain('%APPDATA%');
+
+        fireEvent.click(getByTestId('connect-platform-linux'));
+        expect(getByTestId('connect-config-path').textContent).toContain('.config/Claude');
+    });
+
+    it('shows an error if token minting fails', async () => {
+        createMcpToken.mockRejectedValue(new Error('unauthorized'));
+        const { getByTestId } = render(<ConnectClaudeDesktop userEmail="user@example.com" />);
+        fireEvent.click(getByTestId('connect-generate-button'));
+        await waitFor(() => {
+            expect(getByTestId('connect-error').textContent).toContain('unauthorized');
+        });
+        // No token rendered.
+        const snippet = getByTestId('connect-snippet').textContent ?? '';
+        expect(snippet).toContain('<TOKEN>');
+    });
+
+    it('renders three numbered steps', () => {
+        const { container } = render(<ConnectClaudeDesktop userEmail="user@example.com" />);
+        const steps = container.querySelectorAll('ol > li');
+        expect(steps.length).toBe(3);
+    });
+});

--- a/src/studio/components/Connect/ConnectClaudeDesktop.tsx
+++ b/src/studio/components/Connect/ConnectClaudeDesktop.tsx
@@ -1,0 +1,294 @@
+import { useCallback, useMemo, useState } from 'react';
+import { createMcpToken, type McpTokenResult } from '../../../funnel/lib/apiClient';
+
+type Platform = 'macos' | 'windows' | 'linux';
+
+interface PlatformInfo {
+  id: Platform;
+  label: string;
+  configPath: string;
+  revealHint: string;
+}
+
+const PLATFORMS: PlatformInfo[] = [
+  {
+    id: 'macos',
+    label: 'macOS',
+    configPath: '~/Library/Application Support/Claude/claude_desktop_config.json',
+    revealHint: 'Reveal in Finder: Cmd+Shift+G, paste the path above.',
+  },
+  {
+    id: 'windows',
+    label: 'Windows',
+    configPath: '%APPDATA%\\Claude\\claude_desktop_config.json',
+    revealHint: 'Open Explorer, paste the path above into the address bar.',
+  },
+  {
+    id: 'linux',
+    label: 'Linux',
+    configPath: '~/.config/Claude/claude_desktop_config.json',
+    revealHint: 'Open in your file manager or edit with $EDITOR.',
+  },
+];
+
+const TOKEN_PLACEHOLDER = '<TOKEN>';
+
+function buildSnippet(token: string | null): string {
+  // Token is rendered verbatim only AFTER auth succeeds. Until then the
+  // placeholder lets the user preview the snippet shape without leaking
+  // anything sensitive.
+  const value = token ?? TOKEN_PLACEHOLDER;
+  const obj = {
+    mcpServers: {
+      kernelcad: {
+        command: 'npx',
+        args: ['-y', 'kernelcad', 'mcp', '--cloud', '--token', value],
+      },
+    },
+  };
+  return JSON.stringify(obj, null, 2);
+}
+
+interface ConnectClaudeDesktopProps {
+  userEmail: string;
+}
+
+/**
+ * Slice 1A surface: Connect kernelCAD to Claude Desktop. Signed-in users
+ * click "Generate config" to mint a fresh hosted-MCP token (POST
+ * /api/v1/mcp/tokens). The returned token is stored in component state
+ * ONLY — never persisted to localStorage and never logged.
+ */
+export function ConnectClaudeDesktop({ userEmail }: ConnectClaudeDesktopProps) {
+  const [token, setToken] = useState<string | null>(null);
+  const [tokenPrefix, setTokenPrefix] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [platform, setPlatform] = useState<Platform>('macos');
+
+  const snippet = useMemo(() => buildSnippet(token), [token]);
+
+  const handleGenerate = useCallback(async () => {
+    setBusy(true);
+    setErr(null);
+    setCopied(false);
+    try {
+      const result: McpTokenResult = await createMcpToken();
+      // Note: we intentionally do NOT log the token. The prefix is safe to
+      // display in the UI ("issued kc_xxx…") as confirmation, but the full
+      // value lives only in component state until the user copies it.
+      setToken(result.token);
+      setTokenPrefix(result.tokenPrefix);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+      setToken(null);
+      setTokenPrefix(null);
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const handleCopy = useCallback(async () => {
+    if (!navigator.clipboard) {
+      setErr('Clipboard not available in this browser.');
+      return;
+    }
+    await navigator.clipboard.writeText(snippet);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  }, [snippet]);
+
+  const activePlatform = PLATFORMS.find((p) => p.id === platform) ?? PLATFORMS[0];
+
+  return (
+    <main className="min-h-screen bg-vellum text-ink font-sans">
+      <header className="border-b border-rule px-6 py-3 flex items-center justify-between bg-vellum">
+        <a
+          href="/"
+          className="flex items-center gap-2 font-serif text-base font-medium no-underline text-ink"
+        >
+          <svg
+            className="w-4 h-4 text-ink"
+            viewBox="0 0 84 84"
+            fill="none"
+            aria-label="kernelCAD"
+          >
+            <path
+              d="M 14,12 L 26,12 L 26,34 Q 26,36 27.5,34.5 L 46,12 L 60,12 L 36,40 Q 35,42 36,44 L 60,72 L 46,72 L 27.5,49.5 Q 26,48 26,50 L 26,72 L 14,72 Z"
+              fill="currentColor"
+            />
+          </svg>
+          <span>
+            kernel<span className="text-blueprint">CAD</span>
+          </span>
+        </a>
+        <span className="font-mono text-xs text-ink-soft tracking-wide">
+          {userEmail}
+        </span>
+      </header>
+
+      <section className="px-6 py-10 max-w-3xl mx-auto">
+        <h1
+          data-testid="connect-heading"
+          className="font-serif text-3xl font-medium text-ink"
+        >
+          Connect kernelCAD to Claude Desktop
+        </h1>
+        <p className="text-ink-soft text-sm mt-2 max-w-xl">
+          Generates a hosted MCP token tied to your account. Each click issues a
+          new token; previously issued tokens stay valid until you rotate them
+          server-side.
+        </p>
+
+        <div className="mt-8 flex items-center gap-4">
+          <button
+            type="button"
+            data-testid="connect-generate-button"
+            onClick={handleGenerate}
+            disabled={busy}
+            className="rounded-md bg-blueprint px-4 py-2 font-mono text-xs tracking-wide text-white hover:bg-ink transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {busy
+              ? 'Generating…'
+              : token
+                ? 'Generate new token'
+                : 'Generate config'}
+          </button>
+          {tokenPrefix && (
+            <span
+              data-testid="connect-token-prefix"
+              className="font-mono text-[11px] text-ink-faint tracking-wide"
+            >
+              Issued token: {tokenPrefix}…
+            </span>
+          )}
+        </div>
+        {err && (
+          <p
+            data-testid="connect-error"
+            className="text-copper font-mono text-xs mt-3"
+          >
+            {err}
+          </p>
+        )}
+
+        {/* Step 1 — copy the config snippet */}
+        <ol className="mt-10 space-y-8">
+          <li>
+            <div className="flex items-baseline gap-3">
+              <span className="font-mono text-xs text-ink-faint">1.</span>
+              <h2 className="font-serif text-lg font-medium text-ink">
+                Copy the config
+              </h2>
+            </div>
+            <p className="text-ink-soft text-sm mt-1 ml-7">
+              The snippet below is what Claude Desktop expects under{' '}
+              <code className="font-mono text-xs">mcpServers</code>.
+            </p>
+            <div className="ml-7 mt-3 rounded-lg border border-rule bg-white overflow-hidden">
+              <div className="flex items-center justify-between border-b border-rule bg-vellum-soft px-3 py-2">
+                <span className="font-mono text-[10px] uppercase tracking-wider text-ink-faint">
+                  claude_desktop_config.json
+                </span>
+                <button
+                  type="button"
+                  data-testid="connect-copy-button"
+                  onClick={handleCopy}
+                  disabled={!token}
+                  className="rounded border border-rule px-2 py-0.5 font-mono text-[10px] text-ink-soft hover:border-ink hover:text-ink transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                  aria-label="Copy config snippet"
+                >
+                  {copied ? 'copied' : 'copy'}
+                </button>
+              </div>
+              <pre
+                data-testid="connect-snippet"
+                className="px-3 py-3 font-mono text-[11px] leading-snug text-ink whitespace-pre overflow-x-auto"
+              >
+                {snippet}
+              </pre>
+            </div>
+            {!token && !busy && (
+              <p className="ml-7 mt-2 text-ink-faint font-mono text-[11px]">
+                Click "Generate config" to fill in the token.
+              </p>
+            )}
+          </li>
+
+          {/* Step 2 — paste into Claude Desktop config */}
+          <li>
+            <div className="flex items-baseline gap-3">
+              <span className="font-mono text-xs text-ink-faint">2.</span>
+              <h2 className="font-serif text-lg font-medium text-ink">
+                Paste into Claude Desktop's config file
+              </h2>
+            </div>
+            <p className="text-ink-soft text-sm mt-1 ml-7">
+              Open the config file at the path below. If the file already has
+              other <code className="font-mono text-xs">mcpServers</code>{' '}
+              entries, add the <code className="font-mono text-xs">kernelcad</code>{' '}
+              entry alongside them.
+            </p>
+            <div
+              className="ml-7 mt-3 flex gap-1"
+              role="tablist"
+              aria-label="Operating system"
+            >
+              {PLATFORMS.map((p) => (
+                <button
+                  key={p.id}
+                  type="button"
+                  role="tab"
+                  aria-selected={platform === p.id}
+                  data-testid={`connect-platform-${p.id}`}
+                  onClick={() => setPlatform(p.id)}
+                  className={`rounded-t-md px-3 py-1 font-mono text-[11px] tracking-wide border border-rule border-b-0 transition-colors ${
+                    platform === p.id
+                      ? 'bg-white text-ink'
+                      : 'bg-vellum-soft text-ink-soft hover:text-ink'
+                  }`}
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+            <div className="ml-7 rounded-b-md rounded-tr-md border border-rule bg-white px-3 py-3">
+              <code
+                data-testid="connect-config-path"
+                className="font-mono text-xs text-ink break-all"
+              >
+                {activePlatform.configPath}
+              </code>
+              <p className="text-ink-faint font-mono text-[11px] mt-2">
+                {activePlatform.revealHint}
+              </p>
+            </div>
+          </li>
+
+          {/* Step 3 — restart */}
+          <li>
+            <div className="flex items-baseline gap-3">
+              <span className="font-mono text-xs text-ink-faint">3.</span>
+              <h2 className="font-serif text-lg font-medium text-ink">
+                Restart Claude Desktop
+              </h2>
+            </div>
+            <p className="text-ink-soft text-sm mt-1 ml-7">
+              Quit and reopen Claude Desktop. The{' '}
+              <code className="font-mono text-xs">kernelcad</code> server should
+              appear in the Tools section of the chat sidebar. Ask Claude to
+              "list kernelcad tools" to verify the connection.
+            </p>
+          </li>
+        </ol>
+
+        <p className="mt-12 text-ink-faint font-mono text-[11px] max-w-xl">
+          Tokens are sent only to the hosted MCP gateway at api.kernelcad.com.
+          They live in this browser tab while you read this page and are erased
+          when you reload or close it.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/studio/routes/connect.tsx
+++ b/src/studio/routes/connect.tsx
@@ -1,0 +1,68 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { useSession } from '../../funnel/hooks/useSession';
+import { SignInButton } from '../../funnel/components/SignInButton';
+import { ConnectClaudeDesktop } from '../components/Connect/ConnectClaudeDesktop';
+
+export const Route = createFileRoute('/connect')({
+  component: ConnectPage,
+});
+
+/**
+ * Connect surface for hosted MCP onboarding.
+ *
+ * Reached via `app.kernelcad.com/connect` (the homepage "Use with Claude
+ * Desktop →" CTA, Studio toolbar, etc.). Hooks into the existing
+ * useSession() pattern: signed-in users see the connect flow, anonymous
+ * users see the same sign-in CTA pattern as /me does.
+ */
+function ConnectPage() {
+  const { session, loading } = useSession();
+
+  if (loading) {
+    return (
+      <main className="min-h-screen bg-vellum text-ink font-sans p-8">
+        <p className="text-ink-faint font-mono text-sm">Loading…</p>
+      </main>
+    );
+  }
+
+  if (!session) {
+    return (
+      <main className="min-h-screen bg-vellum text-ink font-sans flex items-center justify-center p-8">
+        <div className="max-w-sm w-full">
+          <div className="flex items-center justify-center gap-2.5 mb-8">
+            <svg
+              className="w-5 h-5 text-ink"
+              viewBox="0 0 84 84"
+              fill="none"
+              aria-label="kernelCAD"
+            >
+              <path
+                d="M 14,12 L 26,12 L 26,34 Q 26,36 27.5,34.5 L 46,12 L 60,12 L 36,40 Q 35,42 36,44 L 60,72 L 46,72 L 27.5,49.5 Q 26,48 26,50 L 26,72 L 14,72 Z"
+                fill="currentColor"
+              />
+            </svg>
+            <span className="font-serif text-lg font-medium">
+              kernel<span className="text-blueprint">CAD</span>
+            </span>
+          </div>
+
+          <div className="rounded-xl border border-rule bg-white p-8 text-center">
+            <h1 className="font-serif text-2xl font-medium text-ink">
+              Connect kernelCAD to Claude Desktop
+            </h1>
+            <p className="text-ink-soft text-sm mt-2">
+              Sign in to generate a hosted MCP token. Free tier includes 3 parts
+              on signup.
+            </p>
+            <div className="mt-6 flex justify-center">
+              <SignInButton redirectTo={`${window.location.origin}/connect`} />
+            </div>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  return <ConnectClaudeDesktop userEmail={session.user.email ?? ''} />;
+}

--- a/tests/e2e/connectClaudeDesktop.spec.ts
+++ b/tests/e2e/connectClaudeDesktop.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect, type Route } from '@playwright/test';
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:5173';
+
+// The tagged test user e2e-bot@kernelcad.com is provisioned by Slice 2 in the
+// prod Supabase project. The password lives in KERNELCAD_E2E_TEST_PASSWORD so
+// no secret is hardcoded in this repo. If the env var is missing, skip the
+// signed-in path with a clear TODO.
+const TEST_EMAIL = 'e2e-bot@kernelcad.com';
+const TEST_PASSWORD = process.env.KERNELCAD_E2E_TEST_PASSWORD;
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL ?? '';
+const SUPABASE_ANON = process.env.VITE_SUPABASE_ANON_KEY ?? '';
+const API_BASE = process.env.VITE_API_BASE_URL ?? 'https://api.kernelcad.com';
+
+// The synthetic token we hand back when the test stubs out the token API.
+// Anything matching kc_e2e_* is safe to grep for in CI logs to confirm no
+// real token leaked into the test output.
+const STUB_TOKEN = 'kc_e2e_stub_token_value';
+const STUB_PREFIX = 'kc_e2e';
+
+test.describe('Connect page (/connect)', () => {
+    test('anonymous visitor sees the sign-in CTA', async ({ page }) => {
+        await page.goto(`${BASE}/connect`);
+        await expect(
+            page.getByRole('heading', { name: /Connect kernelCAD to Claude Desktop/i }),
+        ).toBeVisible();
+        await expect(
+            page.getByRole('button', { name: /Continue with Google/i }),
+        ).toBeVisible();
+    });
+
+    test('renders snippet with placeholder before token is minted (stubbed auth)', async ({
+        page,
+    }) => {
+        // Pre-seed a stub session into localStorage so useSession() resolves
+        // to a signed-in state without going through Supabase. We also stub
+        // the token API so the test does not hit the real backend.
+        await page.addInitScript(() => {
+            const storageKey = 'sb-stub-auth-token';
+            // Minimal shape useSession()/getSession() reads. The supabase-js
+            // client stores serialized session under sb-<project-ref>-auth-token
+            // by default; tests that exercise the live auth path should use
+            // signInWithPassword from inside the page context (see signed-in
+            // test below). For this assertion we only need the route to
+            // render the signed-in branch — but useSession reads from the
+            // SDK directly, so we fall back to mocking the apiClient at the
+            // network layer instead.
+            (window as unknown as { __KCAD_E2E_STUB_AUTH__: string }).__KCAD_E2E_STUB_AUTH__ = storageKey;
+        });
+
+        // Intercept the token API.
+        let tokenApiCalls = 0;
+        await page.route(`${API_BASE}/api/v1/mcp/tokens`, async (route: Route) => {
+            tokenApiCalls += 1;
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ token: STUB_TOKEN, tokenPrefix: STUB_PREFIX }),
+            });
+        });
+
+        // Sign in via the supabase SDK from within the page context. Without
+        // a real session we cannot exercise the signed-in branch — see the
+        // skipped block below for the gated path.
+        test.skip(
+            !TEST_PASSWORD || !SUPABASE_URL || !SUPABASE_ANON,
+            'KERNELCAD_E2E_TEST_PASSWORD / VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY not set — Slice 2 must provision the e2e-bot@kernelcad.com fixture before this branch can run. TODO(slice-2): unblock.',
+        );
+
+        await page.goto(`${BASE}/connect`);
+        // Sign in via the SDK loaded by the app. We poll briefly because
+        // the supabase client is lazy-instantiated.
+        await page.evaluate(
+            async ({ email, password }: { email: string; password: string }) => {
+                // The app exposes the supabase client behind getSupabase(); we
+                // re-import the same module the app uses so we share storage.
+                const mod = await import('/src/funnel/lib/supabaseClient.ts');
+                const supabase = mod.getSupabase();
+                const { error } = await supabase.auth.signInWithPassword({ email, password });
+                if (error) throw new Error(error.message);
+            },
+            { email: TEST_EMAIL, password: TEST_PASSWORD ?? '' },
+        );
+
+        await page.reload();
+        // Verify we landed on the signed-in branch.
+        await expect(page.getByTestId('connect-generate-button')).toBeVisible();
+
+        // 1. Snippet shows placeholder before the user clicks.
+        const placeholderSnippet = await page.getByTestId('connect-snippet').textContent();
+        expect(placeholderSnippet ?? '').toContain('<TOKEN>');
+        expect(placeholderSnippet ?? '').not.toContain(STUB_TOKEN);
+
+        // 2. Click generate → token API fires once.
+        await page.getByTestId('connect-generate-button').click();
+        await expect.poll(() => tokenApiCalls).toBe(1);
+
+        // 3. Rendered snippet now contains the stub token.
+        await expect(page.getByTestId('connect-snippet')).toContainText(STUB_TOKEN);
+        await expect(page.getByTestId('connect-token-prefix')).toContainText(STUB_PREFIX);
+
+        // 4. Copy button writes the snippet (incl. token) to the clipboard.
+        await page.evaluate(() => {
+            (window as unknown as { __copied: string }).__copied = '';
+            Object.defineProperty(navigator, 'clipboard', {
+                configurable: true,
+                value: {
+                    writeText: async (txt: string) => {
+                        (window as unknown as { __copied: string }).__copied = txt;
+                    },
+                },
+            });
+        });
+        await page.getByTestId('connect-copy-button').click();
+        const copied = await page.evaluate(
+            () => (window as unknown as { __copied: string }).__copied,
+        );
+        expect(copied).toContain(STUB_TOKEN);
+        expect(copied).toContain('"mcpServers"');
+        expect(copied).toContain('"kernelcad"');
+
+        // 5. Three numbered steps render with platform-specific paths.
+        await expect(page.getByTestId('connect-config-path')).toContainText(
+            'Library/Application Support/Claude',
+        );
+        await page.getByTestId('connect-platform-windows').click();
+        await expect(page.getByTestId('connect-config-path')).toContainText('%APPDATA%');
+        await page.getByTestId('connect-platform-linux').click();
+        await expect(page.getByTestId('connect-config-path')).toContainText('.config/Claude');
+
+        // 6. Calling generate again issues a fresh token (rotation invariant).
+        await page.getByTestId('connect-generate-button').click();
+        await expect.poll(() => tokenApiCalls).toBe(2);
+    });
+});


### PR DESCRIPTION
## Summary

Slice 1A of the hosted-MCP onboarding work. Adds a dedicated **/connect** surface on the Studio app (reached via `app.kernelcad.com/connect` or the new Toolbar "Connect" link) that lets a signed-in user mint a hosted MCP token and copy a pre-filled Claude Desktop config snippet in one click.

## Why route, not modal

Picked a **route** (`src/studio/routes/connect.tsx`) over a Toolbar modal because:

- It mirrors the existing `/me`, `/signin`, `/generate` pattern (auth-gated single-purpose pages).
- Slice 1B's homepage `Use with Claude Desktop →` button needs a shareable target URL; a modal in the Studio shell would force-load WebGL/OCCT just to render JSON.
- Easier to deep-link, easier to E2E test, easier to extend (Cursor / Claude Code variants later).
- The Studio Toolbar still gets a small `Connect` link for in-app discoverability, but the actual surface is its own route.

## What's in the PR

- `src/studio/routes/connect.tsx` — new TanStack route at `/connect`. Anonymous visitors see the existing `SignInButton` CTA (reuses `/signin` pattern). Signed-in users render `<ConnectClaudeDesktop>`.
- `src/studio/components/Connect/ConnectClaudeDesktop.tsx` — the main surface: "Generate config" button, JSON snippet preview with `<TOKEN>` placeholder until clicked, copy-to-clipboard, platform tabs (macOS / Windows / Linux), three numbered steps, rotation hint.
- `src/studio/components/Connect/ConnectClaudeDesktop.test.tsx` — 6 unit tests (lazy mint, copy-with-token, platform switching, error path, step count).
- `src/studio/Toolbar.tsx` + `__tests__/Toolbar.test.tsx` — small "Connect" link in the Studio toolbar pointing at `/connect`.
- `tests/e2e/connectClaudeDesktop.spec.ts` — Playwright spec. Two tests:
  1. Anonymous visitor sees sign-in CTA (passing against local dev server).
  2. Signed-in happy path: intercept token API, click generate, assert snippet contains token, copy fires `navigator.clipboard.writeText`, platform tabs swap the config path, generate re-issues fresh token. Currently `test.skip()` when `KERNELCAD_E2E_TEST_PASSWORD` / `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` are not set — Slice 2 owns the `e2e-bot@kernelcad.com` fixture per the spec.

## Token-leakage safety

- Token lives in React state only. No `localStorage`, no `sessionStorage`, no cookie writes.
- No `console.log` / `console.error` / `console.warn` touches the token (sanity-grepped).
- No analytics call paths cross the token boundary in the new files.
- Token prefix (safe to display, e.g. `kc_live`) is the only sub-string ever shown outside the JSON snippet itself.

## Test plan

Run:

```bash
# Unit
NODE_OPTIONS='--max-old-space-size=8192' npx vitest run \\
  src/studio/components/Connect/ConnectClaudeDesktop.test.tsx \\
  src/studio/__tests__/Toolbar.test.tsx \\
  src/studio/__tests__/AgentActivityLog.test.tsx

# E2E (anonymous branch always runs; signed-in is gated)
KERNELCAD_E2E_TEST_PASSWORD=... \\
  VITE_SUPABASE_URL=... VITE_SUPABASE_ANON_KEY=... \\
  npx playwright test tests/e2e/connectClaudeDesktop.spec.ts
```

Result locally:

- `ConnectClaudeDesktop.test.tsx` — 6/6 pass.
- `Toolbar.test.tsx` — 14/14 pass (1 new test added).
- `AgentActivityLog.test.tsx` — 3/3 pass (no regression).
- Full `src/studio/__tests__/` sweep — 156/156 pass.
- `npm run typecheck` — clean.
- `npx eslint` over new files — clean.
- Playwright `anonymous visitor sees the sign-in CTA` — passes against `npm run dev` at `127.0.0.1:5174`.
- Playwright signed-in test — correctly skipped without env vars (TODO references Slice 2).

## Surface URL

Signed-in users hit **`https://app.kernelcad.com/connect`** (or `/connect` from any Studio screen via the toolbar).

## Deviations / blockers

- The spec proposed either a `/app/connect` route or a Studio-pane modal. I picked the route; the modal alternative is justified above. Spec wording is consistent with this choice (`"or modal opened from a button on the Studio main pane"`).
- The pre-existing `AgentActivityLog` (cloud MCP connector in the Agent rail, shipped in eca639a3) auto-fetches a token on mount. That's a different surface (CLI `claude mcp add` / `codex mcp add` one-liners) and out of scope for Slice 1A. Flagged for follow-up: the auto-fetch behavior should arguably also be click-gated so opening the Agent rail doesn't silently mint a token.
- The E2E test's signed-in branch is `test.skip()` because `e2e-bot@kernelcad.com` is owned by Slice 2 per the spec's open question on test Supabase. The test body is complete; once Slice 2 ships, removing the skip line is the only change needed.