### PR TITLE
feat(cli): kernelcad install for four MCP-client targets (Slice 3)

### DIFF
--- a/src/agent/cli/commands/install.ts
+++ b/src/agent/cli/commands/install.ts
@@ -1,0 +1,427 @@
+// src/agent/cli/commands/install.ts
+//
+// `kernelcad install <target> [--token X] [--dry-run]` — auto-configures
+// one of four MCP-client targets to talk to kernelCAD.
+//
+// Targets:
+//   --claude-desktop : writes <ConfigDir>/claude_desktop_config.json directly
+//                      (file is dedicated to MCP entries; safe to merge).
+//   --cursor         : writes ~/.cursor/mcp.json directly (dedicated MCP file).
+//   --claude-code    : delegates to `claude mcp add ... --scope user`.
+//                      `~/.claude.json` mixes MCP entries with OAuth and
+//                      project state; editing it directly is unsafe.
+//   --codex          : delegates to `codex mcp add ...`.
+//                      `~/.codex/config.toml` is TOML and shared with other
+//                      Codex config; the CLI is the supported edit path.
+//
+// `--token <X>` (optional): if provided, the generated server entry runs
+// `kernelcad mcp --cloud --token <X>`; otherwise local stdio (`kernelcad mcp`).
+//
+// `--dry-run`: print the resulting config (or the CLI command we would
+// invoke) without touching the filesystem.
+//
+// Idempotency: re-running with identical args is a no-op. Re-running with a
+// new token replaces the kernelcad entry's token but preserves other
+// `mcpServers` entries. For delegated targets we run the CLI's `remove`-then-
+// `add` so the entry ends up matching the requested token.
+
+import { Command } from 'commander';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir, platform } from 'node:os';
+import { dirname, join } from 'node:path';
+
+export type InstallTarget = 'claude-desktop' | 'claude-code' | 'codex' | 'cursor';
+
+export interface InstallOptions {
+  token?: string;
+  dryRun?: boolean;
+  /** Override the OS-detected config directory. Used by tests. */
+  configDir?: string;
+  /** Override `process.platform`. Used by tests. */
+  platformOverride?: NodeJS.Platform;
+  /** Override `process.env.HOME` / `os.homedir()`. Used by tests. */
+  homeOverride?: string;
+  /** Override APPDATA on Windows. Used by tests. */
+  appDataOverride?: string;
+  /**
+   * For delegated targets, an injectable shell-runner used by tests. Default
+   * runs the real command via `spawnSync`.
+   */
+  runCommand?: (cmd: string, args: string[]) => { status: number; stdout: string; stderr: string };
+  /**
+   * Stream sink for status messages. Defaults to `console.log` / `process.stderr`.
+   * Pulled out for testability.
+   */
+  log?: (msg: string) => void;
+  errorLog?: (msg: string) => void;
+}
+
+interface MergeResult {
+  /** Absolute path of the file we updated (or would update under --dry-run). */
+  path: string;
+  /** Whether anything actually changed on disk. */
+  changed: boolean;
+  /** The final JSON we wrote (or would write). */
+  config: Record<string, unknown>;
+  /** Human-readable summary line printed on success. */
+  summary: string;
+}
+
+interface DelegateResult {
+  /** The command line we ran (or would run). */
+  command: string;
+  /** Whether the delegated CLI was invoked successfully. */
+  changed: boolean;
+  /** Human-readable summary line printed on success. */
+  summary: string;
+}
+
+const KERNELCAD_SERVER_KEY = 'kernelcad';
+
+// ---------------------------------------------------------------------------
+// OS / path helpers
+// ---------------------------------------------------------------------------
+
+export function detectHome(opts: Pick<InstallOptions, 'homeOverride'> = {}): string {
+  return opts.homeOverride ?? homedir() ?? process.env.HOME ?? '.';
+}
+
+export function detectPlatform(opts: Pick<InstallOptions, 'platformOverride'> = {}): NodeJS.Platform {
+  return opts.platformOverride ?? platform();
+}
+
+/**
+ * Default config directory for a given target on the current OS.
+ * Returned path is the directory; the caller appends the filename.
+ */
+export function defaultConfigDir(target: InstallTarget, opts: InstallOptions = {}): string {
+  const home = detectHome(opts);
+  const plat = detectPlatform(opts);
+  const appData = opts.appDataOverride ?? process.env.APPDATA ?? join(home, 'AppData', 'Roaming');
+
+  switch (target) {
+    case 'claude-desktop':
+      if (plat === 'darwin') return join(home, 'Library', 'Application Support', 'Claude');
+      if (plat === 'win32') return join(appData, 'Claude');
+      return join(home, '.config', 'Claude');
+    case 'cursor':
+      return join(home, '.cursor');
+    case 'claude-code':
+      // ~/.claude.json is the actual file; the directory is the home dir.
+      // We only need the home dir to check the parent exists.
+      return home;
+    case 'codex':
+      return join(home, '.codex');
+  }
+}
+
+export function configFilePath(target: InstallTarget, opts: InstallOptions = {}): string {
+  const dir = opts.configDir ?? defaultConfigDir(target, opts);
+  switch (target) {
+    case 'claude-desktop':
+      return join(dir, 'claude_desktop_config.json');
+    case 'cursor':
+      return join(dir, 'mcp.json');
+    case 'claude-code':
+      return join(dir, '.claude.json');
+    case 'codex':
+      return join(dir, 'config.toml');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Server-entry shape (Claude Desktop, Claude Code, Cursor all use this
+// roughly-compatible JSON shape).
+// ---------------------------------------------------------------------------
+
+export interface McpServerEntry {
+  command: string;
+  args: string[];
+  /** Optional env block (Claude Desktop / Cursor honour this). */
+  env?: Record<string, string>;
+}
+
+export function buildServerEntry(token?: string): McpServerEntry {
+  const args = ['-y', 'kernelcad', 'mcp'];
+  if (token) {
+    args.push('--cloud', '--token', token);
+  }
+  return { command: 'npx', args };
+}
+
+function entriesEqual(a: McpServerEntry, b: McpServerEntry): boolean {
+  if (a.command !== b.command) return false;
+  if (a.args.length !== b.args.length) return false;
+  for (let i = 0; i < a.args.length; i++) {
+    if (a.args[i] !== b.args[i]) return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// JSON merge (Claude Desktop, Cursor)
+// ---------------------------------------------------------------------------
+
+interface JsonConfig {
+  mcpServers?: Record<string, McpServerEntry>;
+  [k: string]: unknown;
+}
+
+function readJsonConfig(filePath: string): JsonConfig {
+  if (!existsSync(filePath)) return {};
+  const raw = readFileSync(filePath, 'utf8');
+  if (raw.trim() === '') return {};
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('not a JSON object');
+    }
+    return parsed as JsonConfig;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Config file at ${filePath} is malformed (${msg}). Refusing to overwrite — please fix or remove it and re-run.`,
+    );
+  }
+}
+
+function mergeJsonConfig(existing: JsonConfig, entry: McpServerEntry): { config: JsonConfig; changed: boolean } {
+  const next: JsonConfig = { ...existing };
+  const servers: Record<string, McpServerEntry> = { ...(existing.mcpServers ?? {}) };
+  const prior = servers[KERNELCAD_SERVER_KEY];
+  const changed = !prior || !entriesEqual(prior, entry);
+  servers[KERNELCAD_SERVER_KEY] = entry;
+  next.mcpServers = servers;
+  return { config: next, changed };
+}
+
+function writeJsonTarget(target: InstallTarget, opts: InstallOptions): MergeResult {
+  const filePath = configFilePath(target, opts);
+  const dir = dirname(filePath);
+
+  // Refuse to silently create the parent directory for desktop targets —
+  // if Claude Desktop / Cursor isn't installed, the parent won't exist and
+  // we should error so the user sees a clear "install <X> first" message.
+  if (!existsSync(dir)) {
+    const link = target === 'claude-desktop'
+      ? 'https://claude.ai/download'
+      : 'https://cursor.com/';
+    throw new Error(
+      `Target directory ${dir} does not exist. ${target} is not installed. ` +
+      `Install it first from ${link}, or pass --config-dir to override.`,
+    );
+  }
+
+  const existing = readJsonConfig(filePath);
+  const entry = buildServerEntry(opts.token);
+  const { config, changed } = mergeJsonConfig(existing, entry);
+
+  const formatted = JSON.stringify(config, null, 2) + '\n';
+
+  if (changed && !opts.dryRun) {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(filePath, formatted, 'utf8');
+  }
+
+  const restartHint = target === 'claude-desktop'
+    ? 'Restart Claude Desktop to load kernelCAD tools.'
+    : 'Restart Cursor to load kernelCAD tools.';
+
+  let summary: string;
+  if (!changed) {
+    summary = `kernelCAD MCP entry already up to date at ${filePath}. (no-op)`;
+  } else if (opts.dryRun) {
+    summary = `Would write kernelCAD MCP entry to ${filePath} (dry-run; no changes made).`;
+  } else {
+    summary = `Wrote kernelCAD MCP entry to ${filePath}. ${restartHint}`;
+  }
+
+  return {
+    path: filePath,
+    changed,
+    config: config as Record<string, unknown>,
+    summary,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Delegated targets (Claude Code, Codex)
+// ---------------------------------------------------------------------------
+
+function defaultRunCommand(cmd: string, args: string[]): { status: number; stdout: string; stderr: string } {
+  const res = spawnSync(cmd, args, { encoding: 'utf8' });
+  return {
+    status: res.status ?? (res.error ? 127 : 1),
+    stdout: res.stdout ?? '',
+    stderr: res.stderr ?? (res.error ? res.error.message : ''),
+  };
+}
+
+function whichBinary(
+  cmd: string,
+  runner: (cmd: string, args: string[]) => { status: number },
+  plat: NodeJS.Platform,
+): boolean {
+  const which = plat === 'win32' ? 'where' : 'which';
+  const res = runner(which, [cmd]);
+  return res.status === 0;
+}
+
+function delegateCli(
+  target: InstallTarget,
+  binary: 'claude' | 'codex',
+  opts: InstallOptions,
+): DelegateResult {
+  const runner = opts.runCommand ?? defaultRunCommand;
+  const plat = detectPlatform(opts);
+
+  if (!whichBinary(binary, runner, plat)) {
+    const installHint = binary === 'claude'
+      ? 'Install Claude Code from https://claude.ai/code, then re-run.'
+      : 'Install OpenAI Codex CLI from https://developers.openai.com/codex/, then re-run.';
+    throw new Error(
+      `${binary} CLI not found on PATH. kernelcad install --${target} delegates to the ${binary} CLI. ${installHint}`,
+    );
+  }
+
+  // Build the `<bin> mcp add` argv.
+  //
+  // Claude Code: `claude mcp add kernelcad --scope user -- npx -y kernelcad mcp [...]`
+  // Codex:       `codex mcp add kernelcad -- npx -y kernelcad mcp [...]`
+  //
+  // We `remove`-then-`add` to keep idempotency in the face of a previously
+  // configured (possibly token-stale) entry. `remove` is allowed to fail
+  // (entry may not exist yet); `add` is the authoritative step.
+  const serverArgs = ['-y', 'kernelcad', 'mcp'];
+  if (opts.token) serverArgs.push('--cloud', '--token', opts.token);
+
+  const removeArgs = binary === 'claude'
+    ? ['mcp', 'remove', KERNELCAD_SERVER_KEY, '--scope', 'user']
+    : ['mcp', 'remove', KERNELCAD_SERVER_KEY];
+
+  const addArgs = binary === 'claude'
+    ? ['mcp', 'add', KERNELCAD_SERVER_KEY, '--scope', 'user', '--', 'npx', ...serverArgs]
+    : ['mcp', 'add', KERNELCAD_SERVER_KEY, '--', 'npx', ...serverArgs];
+
+  // Build a printable command line for dry-run / logging. We deliberately
+  // redact the token in the printed form (the real argv keeps it).
+  const printableServerArgs = ['-y', 'kernelcad', 'mcp'];
+  if (opts.token) printableServerArgs.push('--cloud', '--token', '<redacted>');
+  const printableAddArgs = binary === 'claude'
+    ? ['mcp', 'add', KERNELCAD_SERVER_KEY, '--scope', 'user', '--', 'npx', ...printableServerArgs]
+    : ['mcp', 'add', KERNELCAD_SERVER_KEY, '--', 'npx', ...printableServerArgs];
+  const commandLine = `${binary} ${printableAddArgs.join(' ')}`;
+
+  if (opts.dryRun) {
+    return {
+      command: commandLine,
+      changed: false,
+      summary: `Would run: ${commandLine}`,
+    };
+  }
+
+  // `remove` is best-effort.
+  runner(binary, removeArgs);
+
+  const res = runner(binary, addArgs);
+  if (res.status !== 0) {
+    throw new Error(
+      `${binary} mcp add failed (exit ${res.status}). stderr: ${res.stderr.trim() || '<empty>'}`,
+    );
+  }
+
+  const restartHint = binary === 'claude'
+    ? 'Restart Claude Code (or open a fresh session) to load kernelCAD tools.'
+    : 'Restart Codex (or open a fresh session) to load kernelCAD tools.';
+  return {
+    command: commandLine,
+    changed: true,
+    summary: `Configured kernelCAD MCP entry via ${binary} CLI. ${restartHint}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public entry points (also exported for tests)
+// ---------------------------------------------------------------------------
+
+export function runInstall(target: InstallTarget, opts: InstallOptions = {}): MergeResult | DelegateResult {
+  switch (target) {
+    case 'claude-desktop':
+    case 'cursor':
+      return writeJsonTarget(target, opts);
+    case 'claude-code':
+      return delegateCli(target, 'claude', opts);
+    case 'codex':
+      return delegateCli(target, 'codex', opts);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Commander wiring
+// ---------------------------------------------------------------------------
+
+export function installCommand(): Command {
+  const cmd = new Command('install')
+    .description(
+      'Auto-configure an MCP client to talk to kernelCAD. Pass exactly one ' +
+      'target flag.',
+    )
+    .option('--claude-desktop', 'install into Claude Desktop config')
+    .option('--claude-code', 'install into Claude Code (via `claude mcp add`)')
+    .option('--codex', 'install into OpenAI Codex CLI (via `codex mcp add`)')
+    .option('--cursor', 'install into Cursor config (~/.cursor/mcp.json)')
+    .option('--token <token>', 'kernelCAD cloud token; if omitted, local stdio mode is used')
+    .option('--dry-run', 'print the resulting config without writing it')
+    .option('--config-dir <dir>', 'override the target config directory (advanced; mainly for tests)')
+    .action((opts: {
+      claudeDesktop?: boolean;
+      claudeCode?: boolean;
+      codex?: boolean;
+      cursor?: boolean;
+      token?: string;
+      dryRun?: boolean;
+      configDir?: string;
+    }) => {
+      const picks: InstallTarget[] = [];
+      if (opts.claudeDesktop) picks.push('claude-desktop');
+      if (opts.claudeCode) picks.push('claude-code');
+      if (opts.codex) picks.push('codex');
+      if (opts.cursor) picks.push('cursor');
+
+      if (picks.length === 0) {
+        process.stderr.write(
+          'Error: pass exactly one target — --claude-desktop, --claude-code, --codex, or --cursor.\n',
+        );
+        process.exitCode = 1;
+        return;
+      }
+      if (picks.length > 1) {
+        process.stderr.write(
+          `Error: pass exactly one target; got ${picks.length} (${picks.join(', ')}).\n`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      const target = picks[0];
+      try {
+        const result = runInstall(target, {
+          ...(opts.token ? { token: opts.token } : {}),
+          ...(opts.dryRun ? { dryRun: true } : {}),
+          ...(opts.configDir ? { configDir: opts.configDir } : {}),
+        });
+
+        if (opts.dryRun && 'config' in result) {
+          process.stdout.write(JSON.stringify(result.config, null, 2) + '\n');
+        }
+        process.stdout.write(result.summary + '\n');
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`kernelcad install --${target}: ${msg}\n`);
+        process.exitCode = 1;
+      }
+    });
+
+  return cmd;
+}

--- a/src/agent/cli/index.ts
+++ b/src/agent/cli/index.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import { createRequire } from 'node:module';
 import { evaluateCommand } from './commands/evaluate';
 import { exportCommand } from './commands/export';
+import { installCommand } from './commands/install';
 import { interferenceCommand } from './commands/interference';
 import { mcpCommand } from './commands/mcp';
 import { renderCommand } from './commands/render';
@@ -32,6 +33,7 @@ program
 
 program.addCommand(evaluateCommand());
 program.addCommand(exportCommand());
+program.addCommand(installCommand());
 program.addCommand(interferenceCommand());
 program.addCommand(mcpCommand());
 program.addCommand(renderCommand());

--- a/tests/integration/cli/install.test.ts
+++ b/tests/integration/cli/install.test.ts
@@ -1,0 +1,408 @@
+// tests/integration/cli/install.test.ts
+//
+// Integration tests for `kernelcad install <target>`. For each target we
+// simulate the on-disk config layout in a tmpdir (via `--config-dir`) and
+// assert the resulting JSON / delegated invocation. For the two delegated
+// targets (claude-code, codex) we inject a fake `runCommand` runner so the
+// test doesn't depend on the host having the upstream CLI installed.
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  buildServerEntry,
+  configFilePath,
+  defaultConfigDir,
+  runInstall,
+  type InstallOptions,
+  type InstallTarget,
+} from '../../../src/agent/cli/commands/install';
+
+function freshTmp(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+// ---------------------------------------------------------------------------
+// OS-aware path detection
+// ---------------------------------------------------------------------------
+
+describe('install: default config dir resolution', () => {
+  it('claude-desktop: uses ~/Library/Application Support/Claude on macOS', () => {
+    const home = '/Users/alice';
+    expect(defaultConfigDir('claude-desktop', { homeOverride: home, platformOverride: 'darwin' }))
+      .toBe('/Users/alice/Library/Application Support/Claude');
+  });
+
+  it('claude-desktop: uses %APPDATA%/Claude on Windows', () => {
+    expect(defaultConfigDir('claude-desktop', {
+      homeOverride: 'C:\\Users\\alice',
+      platformOverride: 'win32',
+      appDataOverride: 'C:\\Users\\alice\\AppData\\Roaming',
+    })).toBe('C:\\Users\\alice\\AppData\\Roaming/Claude');
+  });
+
+  it('claude-desktop: uses ~/.config/Claude on Linux', () => {
+    expect(defaultConfigDir('claude-desktop', { homeOverride: '/home/alice', platformOverride: 'linux' }))
+      .toBe('/home/alice/.config/Claude');
+  });
+
+  it('cursor: uses ~/.cursor on all platforms', () => {
+    expect(defaultConfigDir('cursor', { homeOverride: '/home/alice', platformOverride: 'linux' }))
+      .toBe('/home/alice/.cursor');
+    expect(defaultConfigDir('cursor', { homeOverride: '/Users/alice', platformOverride: 'darwin' }))
+      .toBe('/Users/alice/.cursor');
+  });
+
+  it('codex: uses ~/.codex on all platforms', () => {
+    expect(defaultConfigDir('codex', { homeOverride: '/home/alice', platformOverride: 'linux' }))
+      .toBe('/home/alice/.codex');
+  });
+});
+
+describe('install: configFilePath joins target file correctly', () => {
+  it.each<[InstallTarget, string]>([
+    ['claude-desktop', 'claude_desktop_config.json'],
+    ['cursor', 'mcp.json'],
+    ['claude-code', '.claude.json'],
+    ['codex', 'config.toml'],
+  ])('%s -> ends with %s', (target, expected) => {
+    const dir = '/tmp/xyz';
+    const filePath = configFilePath(target, { configDir: dir });
+    expect(filePath.endsWith(expected)).toBe(true);
+    expect(filePath.startsWith(dir)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JSON-write targets: claude-desktop and cursor
+// ---------------------------------------------------------------------------
+
+describe.each<InstallTarget>(['claude-desktop', 'cursor'])('install: %s (JSON write)', (target) => {
+  const fileName = target === 'claude-desktop' ? 'claude_desktop_config.json' : 'mcp.json';
+
+  it('writes a fresh config with mcpServers.kernelcad when the directory is empty', () => {
+    const dir = freshTmp(`kc-install-${target}-`);
+    const result = runInstall(target, { configDir: dir });
+
+    expect('path' in result).toBe(true);
+    if (!('path' in result)) return;
+
+    expect(result.path).toBe(join(dir, fileName));
+    expect(result.changed).toBe(true);
+    expect(existsSync(result.path)).toBe(true);
+
+    const written = JSON.parse(readFileSync(result.path, 'utf8')) as {
+      mcpServers: { kernelcad: { command: string; args: string[] } };
+    };
+    expect(written.mcpServers).toBeDefined();
+    expect(written.mcpServers.kernelcad).toBeDefined();
+    expect(written.mcpServers.kernelcad.command).toBe('npx');
+    // No token: local stdio mode — no --cloud / --token in args.
+    expect(written.mcpServers.kernelcad.args).toEqual(['-y', 'kernelcad', 'mcp']);
+  });
+
+  it('uses --cloud --token when --token is provided', () => {
+    const dir = freshTmp(`kc-install-${target}-token-`);
+    const result = runInstall(target, { configDir: dir, token: 'kcl_TESTTOKEN' });
+    if (!('path' in result)) throw new Error('expected MergeResult');
+    const written = JSON.parse(readFileSync(result.path, 'utf8')) as {
+      mcpServers: { kernelcad: { args: string[] } };
+    };
+    expect(written.mcpServers.kernelcad.args)
+      .toEqual(['-y', 'kernelcad', 'mcp', '--cloud', '--token', 'kcl_TESTTOKEN']);
+  });
+
+  it('preserves other mcpServers entries when merging', () => {
+    const dir = freshTmp(`kc-install-${target}-preserve-`);
+    const filePath = join(dir, fileName);
+    writeFileSync(filePath, JSON.stringify({
+      mcpServers: {
+        otherServer: { command: 'node', args: ['/path/to/other.js'] },
+      },
+    }, null, 2), 'utf8');
+
+    runInstall(target, { configDir: dir, token: 'TOK' });
+
+    const written = JSON.parse(readFileSync(filePath, 'utf8')) as {
+      mcpServers: Record<string, unknown>;
+    };
+    expect(Object.keys(written.mcpServers).sort()).toEqual(['kernelcad', 'otherServer']);
+    expect(written.mcpServers.otherServer)
+      .toEqual({ command: 'node', args: ['/path/to/other.js'] });
+  });
+
+  it('preserves unrelated top-level keys', () => {
+    const dir = freshTmp(`kc-install-${target}-toplevel-`);
+    const filePath = join(dir, fileName);
+    writeFileSync(filePath, JSON.stringify({
+      someOtherSetting: { foo: 'bar' },
+      mcpServers: {},
+    }, null, 2), 'utf8');
+
+    runInstall(target, { configDir: dir });
+
+    const written = JSON.parse(readFileSync(filePath, 'utf8')) as { someOtherSetting: unknown };
+    expect(written.someOtherSetting).toEqual({ foo: 'bar' });
+  });
+
+  it('is idempotent: second run with identical args reports no change', () => {
+    const dir = freshTmp(`kc-install-${target}-idem-`);
+    const r1 = runInstall(target, { configDir: dir, token: 'SAME' });
+    const r2 = runInstall(target, { configDir: dir, token: 'SAME' });
+    if (!('changed' in r1) || !('changed' in r2)) throw new Error('expected MergeResult');
+    expect(r1.changed).toBe(true);
+    expect(r2.changed).toBe(false);
+    expect(r2.summary).toMatch(/already up to date|no-op/);
+  });
+
+  it('replaces the token but preserves siblings when re-run with a different token', () => {
+    const dir = freshTmp(`kc-install-${target}-rotate-`);
+    const filePath = join(dir, fileName);
+    writeFileSync(filePath, JSON.stringify({
+      mcpServers: {
+        sibling: { command: 'node', args: ['x.js'] },
+      },
+    }, null, 2), 'utf8');
+
+    runInstall(target, { configDir: dir, token: 'OLD' });
+    runInstall(target, { configDir: dir, token: 'NEW' });
+
+    const written = JSON.parse(readFileSync(filePath, 'utf8')) as {
+      mcpServers: { kernelcad: { args: string[] }; sibling: unknown };
+    };
+    expect(written.mcpServers.kernelcad.args).toContain('NEW');
+    expect(written.mcpServers.kernelcad.args).not.toContain('OLD');
+    expect(written.mcpServers.sibling).toEqual({ command: 'node', args: ['x.js'] });
+  });
+
+  it('--dry-run does not touch the filesystem and summary says "Would write"', () => {
+    const dir = freshTmp(`kc-install-${target}-dry-`);
+    const filePath = join(dir, fileName);
+    const result = runInstall(target, { configDir: dir, dryRun: true });
+    if (!('path' in result)) throw new Error('expected MergeResult');
+    expect(result.changed).toBe(true);   // would change
+    expect(existsSync(filePath)).toBe(false);
+    expect(result.summary).toMatch(/dry-run/i);
+    expect(result.summary).not.toMatch(/^Wrote /);
+  });
+
+  it('errors clearly when the parent config directory does not exist', () => {
+    const missing = join(tmpdir(), `kc-install-missing-${Date.now()}-${Math.random()}`);
+    expect(() => runInstall(target, { configDir: missing }))
+      .toThrow(/does not exist|not installed/i);
+  });
+
+  it('refuses to overwrite a malformed config file', () => {
+    const dir = freshTmp(`kc-install-${target}-malformed-`);
+    const filePath = join(dir, fileName);
+    writeFileSync(filePath, '{this is not valid json', 'utf8');
+    expect(() => runInstall(target, { configDir: dir }))
+      .toThrow(/malformed|Refusing/i);
+  });
+
+  it('rejects a non-object JSON root (e.g. array)', () => {
+    const dir = freshTmp(`kc-install-${target}-array-`);
+    const filePath = join(dir, fileName);
+    writeFileSync(filePath, '[]', 'utf8');
+    expect(() => runInstall(target, { configDir: dir }))
+      .toThrow(/malformed|Refusing/i);
+  });
+
+  it('summary includes a restart hint on success', () => {
+    const dir = freshTmp(`kc-install-${target}-hint-`);
+    const r = runInstall(target, { configDir: dir });
+    if (!('summary' in r)) throw new Error('expected MergeResult');
+    expect(r.summary).toMatch(/Restart/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Delegated targets: claude-code, codex
+// ---------------------------------------------------------------------------
+
+interface CapturedCall { cmd: string; args: string[]; }
+
+function makeRunner(opts: {
+  hasBinary?: boolean;
+  addStatus?: number;
+  addStderr?: string;
+}): { runner: InstallOptions['runCommand']; calls: CapturedCall[] } {
+  const hasBinary = opts.hasBinary ?? true;
+  const calls: CapturedCall[] = [];
+  const runner: InstallOptions['runCommand'] = (cmd, args) => {
+    calls.push({ cmd, args });
+    if (cmd === 'which' || cmd === 'where') {
+      return { status: hasBinary ? 0 : 1, stdout: '', stderr: '' };
+    }
+    if (args[0] === 'mcp' && args[1] === 'remove') {
+      // mimic CLI returning non-zero when entry doesn't exist; install should
+      // tolerate this.
+      return { status: 1, stdout: '', stderr: 'no such server' };
+    }
+    if (args[0] === 'mcp' && args[1] === 'add') {
+      return { status: opts.addStatus ?? 0, stdout: '', stderr: opts.addStderr ?? '' };
+    }
+    return { status: 0, stdout: '', stderr: '' };
+  };
+  return { runner, calls };
+}
+
+describe.each<{ target: InstallTarget; bin: string }>([
+  { target: 'claude-code', bin: 'claude' },
+  { target: 'codex', bin: 'codex' },
+])('install: $target (delegates to $bin CLI)', ({ target, bin }) => {
+  it('errors with install hint when the upstream CLI is not on PATH', () => {
+    const { runner } = makeRunner({ hasBinary: false });
+    expect(() => runInstall(target, { runCommand: runner }))
+      .toThrow(new RegExp(`${bin} CLI not found`, 'i'));
+  });
+
+  it('invokes `${bin} mcp add kernelcad` with the right argv (no token)', () => {
+    const { runner, calls } = makeRunner({});
+    const r = runInstall(target, { runCommand: runner });
+    if (!('command' in r)) throw new Error('expected DelegateResult');
+    expect(r.changed).toBe(true);
+
+    const addCall = calls.find(c => c.cmd === bin && c.args[0] === 'mcp' && c.args[1] === 'add');
+    expect(addCall).toBeDefined();
+    expect(addCall!.args).toContain('kernelcad');
+    expect(addCall!.args).toContain('--');
+    expect(addCall!.args).toContain('npx');
+    expect(addCall!.args).toContain('-y');
+    expect(addCall!.args).not.toContain('--token');
+  });
+
+  it('passes --cloud --token <X> through to `npx kernelcad mcp` when token is set', () => {
+    const { runner, calls } = makeRunner({});
+    runInstall(target, { runCommand: runner, token: 'kcl_DELEGATED_TOKEN' });
+
+    const addCall = calls.find(c => c.cmd === bin && c.args[0] === 'mcp' && c.args[1] === 'add');
+    expect(addCall).toBeDefined();
+    expect(addCall!.args).toContain('--cloud');
+    const tokIdx = addCall!.args.indexOf('--token');
+    expect(tokIdx).toBeGreaterThan(-1);
+    expect(addCall!.args[tokIdx + 1]).toBe('kcl_DELEGATED_TOKEN');
+  });
+
+  it('uses --scope user only for the claude binary', () => {
+    const { runner, calls } = makeRunner({});
+    runInstall(target, { runCommand: runner });
+    const addCall = calls.find(c => c.cmd === bin && c.args[0] === 'mcp' && c.args[1] === 'add')!;
+    const usesScope = addCall.args.includes('--scope');
+    if (bin === 'claude') {
+      expect(usesScope).toBe(true);
+      const scopeIdx = addCall.args.indexOf('--scope');
+      expect(addCall.args[scopeIdx + 1]).toBe('user');
+    } else {
+      expect(usesScope).toBe(false);
+    }
+  });
+
+  it('--dry-run prints the planned command without running mcp add', () => {
+    const { runner, calls } = makeRunner({});
+    const r = runInstall(target, { runCommand: runner, dryRun: true, token: 'SECRET' });
+    if (!('command' in r)) throw new Error('expected DelegateResult');
+    expect(r.changed).toBe(false);
+    expect(r.command).toContain(`${bin} mcp add kernelcad`);
+    // Redacts the token in the printed command line.
+    expect(r.command).not.toContain('SECRET');
+    expect(r.command).toContain('<redacted>');
+
+    // Only the `which` probe ran — no mcp add.
+    const addCall = calls.find(c => c.args[0] === 'mcp' && c.args[1] === 'add');
+    expect(addCall).toBeUndefined();
+  });
+
+  it('surfaces a clear error if the delegated CLI exits non-zero', () => {
+    const { runner } = makeRunner({ addStatus: 2, addStderr: 'oh no' });
+    expect(() => runInstall(target, { runCommand: runner }))
+      .toThrow(/mcp add failed.*oh no/);
+  });
+
+  it('tolerates `mcp remove` returning non-zero (entry may not exist yet)', () => {
+    const { runner } = makeRunner({}); // remove returns 1, add returns 0
+    expect(() => runInstall(target, { runCommand: runner })).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Server-entry builder
+// ---------------------------------------------------------------------------
+
+describe('install: buildServerEntry', () => {
+  it('local mode (no token)', () => {
+    expect(buildServerEntry()).toEqual({ command: 'npx', args: ['-y', 'kernelcad', 'mcp'] });
+  });
+  it('cloud mode (with token)', () => {
+    expect(buildServerEntry('X'))
+      .toEqual({ command: 'npx', args: ['-y', 'kernelcad', 'mcp', '--cloud', '--token', 'X'] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Token-leak guard
+// ---------------------------------------------------------------------------
+
+describe('install: token is not leaked to logs / summaries', () => {
+  it('JSON-write target: summary text does not echo the token', () => {
+    const dir = freshTmp('kc-install-leak-');
+    const r = runInstall('claude-desktop', { configDir: dir, token: 'kcl_DO_NOT_LEAK' });
+    if (!('summary' in r)) throw new Error('expected MergeResult');
+    expect(r.summary).not.toContain('kcl_DO_NOT_LEAK');
+  });
+
+  it('Delegated target: dry-run printable command redacts the token', () => {
+    const { runner } = makeRunner({});
+    const r = runInstall('claude-code', {
+      runCommand: runner, dryRun: true, token: 'kcl_DO_NOT_LEAK',
+    });
+    if (!('command' in r)) throw new Error('expected DelegateResult');
+    expect(r.command).not.toContain('kcl_DO_NOT_LEAK');
+    expect(r.summary).not.toContain('kcl_DO_NOT_LEAK');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Smoke: the installCommand() Command object exists and accepts the four flags.
+// ---------------------------------------------------------------------------
+
+describe('install: commander wiring', () => {
+  it('registers all four target flags + --token + --dry-run', async () => {
+    const { installCommand } = await import('../../../src/agent/cli/commands/install');
+    const cmd = installCommand();
+    const longs = cmd.options.map(o => o.long);
+    expect(longs).toEqual(expect.arrayContaining([
+      '--claude-desktop', '--claude-code', '--codex', '--cursor',
+      '--token', '--dry-run', '--config-dir',
+    ]));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-target: directory layout simulation
+// ---------------------------------------------------------------------------
+
+describe('install: simulates real OS layouts via --config-dir', () => {
+  it('claude-desktop into a tmpdir layout mimicking ~/Library/Application Support/Claude', () => {
+    const fakeHome = freshTmp('kc-fakehome-');
+    const claudeDir = join(fakeHome, 'Library', 'Application Support', 'Claude');
+    mkdirSync(claudeDir, { recursive: true });
+
+    const r = runInstall('claude-desktop', { configDir: claudeDir, token: 'TOK' });
+    if (!('path' in r)) throw new Error('expected MergeResult');
+    expect(r.path).toBe(join(claudeDir, 'claude_desktop_config.json'));
+    expect(existsSync(r.path)).toBe(true);
+  });
+
+  it('cursor into a tmpdir layout mimicking ~/.cursor', () => {
+    const fakeHome = freshTmp('kc-fakehome-');
+    const cursorDir = join(fakeHome, '.cursor');
+    mkdirSync(cursorDir, { recursive: true });
+
+    const r = runInstall('cursor', { configDir: cursorDir });
+    if (!('path' in r)) throw new Error('expected MergeResult');
+    expect(r.path).toBe(join(cursorDir, 'mcp.json'));
+    expect(existsSync(r.path)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Ships **Slice 3** of the hosted-MCP onboarding spec — `kernelcad install [target]` lets an agent (or human) auto-configure any of four MCP-client targets to talk to kernelCAD, with **no JSON pasting required**.

```bash
kernelcad install --claude-desktop                  # local stdio
kernelcad install --claude-desktop --token kcl_XYZ  # cloud mode
kernelcad install --cursor --token kcl_XYZ
kernelcad install --claude-code --token kcl_XYZ
kernelcad install --codex --token kcl_XYZ
kernelcad install --claude-desktop --dry-run        # preview, no write
```

## Per-target strategy

The four targets split into two implementation paths, picked on a per-target basis based on the **safety** of editing the config file directly:

| Target | Path | Why |
|---|---|---|
| `--claude-desktop` | **Direct JSON write** to `<ConfigDir>/claude_desktop_config.json` | File is dedicated to MCP entries (no OAuth tokens, no app state). Safe to deep-merge. |
| `--cursor` | **Direct JSON write** to `~/.cursor/mcp.json` | Same — dedicated MCP file. |
| `--claude-code` | **Delegate** to `claude mcp add kernelcad --scope user -- npx -y kernelcad mcp [...]` | The user-scope MCP config lives in `~/.claude.json`, which **mixes MCP entries with OAuth session, project state, and caches**. Editing it directly risks corrupting the unified Claude Code state. The `claude mcp add` CLI is the supported edit path. |
| `--codex` | **Delegate** to `codex mcp add kernelcad -- npx -y kernelcad mcp [...]` | Config is `~/.codex/config.toml` (TOML, not JSON). Rather than ship a TOML parser/emitter, delegate to the `codex mcp add` CLI which already understands the file layout. |

For delegated targets, if the upstream binary isn't on `PATH` the command errors with a clear install hint (e.g. `claude CLI not found on PATH. Install Claude Code from https://claude.ai/code, then re-run.`).

## OS detection

`defaultConfigDir()` resolves the right directory per `process.platform`:

- `claude-desktop`: macOS `~/Library/Application Support/Claude/`, Windows `%APPDATA%/Claude/`, Linux `~/.config/Claude/`
- `cursor`: `~/.cursor/` on all platforms
- `codex`: `~/.codex/` on all platforms
- `claude-code`: `$HOME/` (file is `~/.claude.json`, but we never touch it — delegated)

OS-specific overrides are exposed via `InstallOptions` for tests (`platformOverride`, `homeOverride`, `appDataOverride`, `configDir`).

## Idempotency / token rotation

- Re-running with **identical args** is a no-op (`"... already up to date. (no-op)"`).
- Re-running with a **new token** replaces the `mcpServers.kernelcad` token but preserves every other entry (`otherServer`, `mySupabaseMcp`, ...) and every unrelated top-level key.
- For delegated targets, the controller runs `mcp remove kernelcad` (best-effort, allowed to fail) then `mcp add ...` so the entry ends up matching the requested token.

## Token-leak hygiene

- `--dry-run` prints the planned JSON for direct-write targets and the **redacted** command line for delegated targets (`--token <redacted>` rather than the literal token).
- The on-success summary line never echoes the token.
- Tests assert this explicitly: `install: token is not leaked to logs / summaries`.

## Edge cases handled

- Missing target directory: clear error (`Target X is not installed. Install it first from <link>, or pass --config-dir to override.`).
- Malformed existing JSON: refuses to overwrite, errors with `... is malformed (<reason>). Refusing to overwrite — please fix or remove it and re-run.`
- Non-object JSON root (e.g. an array): same refusal.
- Zero / multiple target flags: clear usage error.
- Delegated CLI exits non-zero: surfaces `<bin> mcp add failed (exit N). stderr: <captured>`.

## Tests

`tests/integration/cli/install.test.ts` — **52 integration tests** covering:

- Default config-dir resolution on darwin / win32 / linux for every target.
- JSON-write targets: empty -> merged, token argv shape, sibling preservation, top-level key preservation, idempotency, token rotation, `--dry-run` no-write + "would write" summary, missing-dir error, malformed-JSON refusal, non-object-root refusal, restart-hint copy.
- Delegated targets: missing-binary error with install hint, correct `mcp add` argv, `--cloud --token X` propagation, `--scope user` only for `claude` (not `codex`), `--dry-run` doesn't invoke `mcp add` and redacts the token, non-zero exit surfaces the stderr, `mcp remove` returning non-zero is tolerated.
- Commander wiring: all four target flags + `--token` + `--dry-run` + `--config-dir` exist on the command object.
- Token-leak guards on both JSON-write and delegated paths.

**Run it:**

```bash
npx vitest run tests/integration/cli/install.test.ts
# Test Files  1 passed (1)
# Tests       52 passed (52)
```

Related suites still pass:

```bash
npx vitest run src/agent/cli/commands/skill.test.ts \
              tests/integration/cli-bundle/startup.test.ts \
              tests/integration/cli/
# Test Files  4 passed (4)
# Tests       60 passed (60)
```

Typecheck (`npx tsc -b --noEmit` after `npm run pretypecheck`): clean. ESLint on the new files: clean.

## E2E smoke (built dist/cli)

```
node dist/cli/index.js install --claude-desktop --dry-run --config-dir /tmp/x
  -> prints config to stdout, writes nothing
node dist/cli/index.js install --claude-desktop --config-dir /tmp/x --token TKN
  -> writes /tmp/x/claude_desktop_config.json
     summary: "Wrote ... Restart Claude Desktop to load kernelCAD tools."
re-run same
  -> "kernelCAD MCP entry already up to date at ... (no-op)"
install --claude-desktop --config-dir /nonexistent/path
  -> error: "Target directory ... does not exist. claude-desktop is not installed."
install (no target)
  -> error: "pass exactly one target — ..."
install --claude-desktop --cursor
  -> error: "pass exactly one target; got 2 ..."
```

Also verified `--claude-code --dry-run` prints `claude mcp add kernelcad --scope user -- npx -y kernelcad mcp` and `--codex --dry-run` prints `codex mcp add kernelcad -- npx -y kernelcad mcp` when the binaries are on PATH.

## Targets confirmed working in tests

| Target | Static config write? | Runtime CLI check? | Tests passing |
|---|---|---|---|
| claude-desktop | yes (JSON merge) | no | yes |
| cursor | yes (JSON merge) | no | yes |
| claude-code | no | yes (`claude mcp add` via injectable runner) | yes |
| codex | no | yes (`codex mcp add` via injectable runner) | yes |

## Non-changes

- No version bump in `package.json` (per controller direction — release-bump is the user's call; goes into `v0.11.2` or `v0.12.0`).
- No changes outside `src/agent/cli/` and `tests/integration/cli/`.

## Test plan

- [ ] CI passes (lint + typecheck + test).
- [ ] Maintainer: `node dist/cli/index.js install --claude-desktop --dry-run` against your real `~/Library/Application Support/Claude/` (or platform equivalent) and confirm the printed config is the expected shape.
- [ ] Maintainer with `claude` CLI: `node dist/cli/index.js install --claude-code --dry-run` prints the expected `claude mcp add kernelcad --scope user -- npx -y kernelcad mcp` line.