### PR TITLE
fix(studio): require explicit Generate click before AgentActivityLog mints an MCP token

### DIFF
--- a/src/studio/AgentActivityLog.tsx
+++ b/src/studio/AgentActivityLog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { createMcpToken } from '../funnel/lib/apiClient';
 
 /**
@@ -9,24 +9,21 @@ export const AgentActivityLog: React.FC = () => {
     const [copied, setCopied] = useState<string | null>(null);
     const [token, setToken] = useState<string | null>(null);
     const [tokenError, setTokenError] = useState<string | null>(null);
+    const [isMinting, setIsMinting] = useState(false);
 
-    useEffect(() => {
-        let active = true;
-        createMcpToken()
-            .then((result) => {
-                if (!active) return;
-                setToken(result.token);
-                setTokenError(null);
-            })
-            .catch((err: unknown) => {
-                if (!active) return;
-                setToken(null);
-                setTokenError(err instanceof Error ? err.message : String(err));
-            });
-        return () => {
-            active = false;
-        };
-    }, []);
+    const handleGenerateToken = async () => {
+        setIsMinting(true);
+        setTokenError(null);
+        try {
+            const result = await createMcpToken();
+            setToken(result.token);
+        } catch (err: unknown) {
+            setToken(null);
+            setTokenError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setIsMinting(false);
+        }
+    };
 
     const copyCommand = async (id: string, command: string) => {
         await navigator.clipboard.writeText(command);
@@ -34,7 +31,7 @@ export const AgentActivityLog: React.FC = () => {
         window.setTimeout(() => setCopied((current) => (current === id ? null : current)), 1200);
     };
 
-    const tokenArg = token ?? '<sign-in-required>';
+    const tokenArg = token ?? '<click Generate to mint a token>';
     const commands = useMemo(() => [
         {
             id: 'claude',
@@ -63,10 +60,23 @@ export const AgentActivityLog: React.FC = () => {
                 </div>
                 <div className="mt-2 text-[10px] leading-snug text-gray-500">
                     {token
-                        ? 'Token ready. Copy a command below.'
+                        ? 'Token ready. Copy a command below. Generating again issues a fresh token; previous tokens stay valid.'
                         : tokenError
-                            ? 'Sign in to create a cloud MCP token automatically.'
-                            : 'Preparing cloud MCP token...'}
+                            ? 'Sign in to mint a cloud MCP token, then click Generate.'
+                            : isMinting
+                                ? 'Minting cloud MCP token...'
+                                : 'Click Generate to mint a token, then copy a command below.'}
+                </div>
+                <div className="mt-3">
+                    <button
+                        type="button"
+                        onClick={() => void handleGenerateToken()}
+                        disabled={isMinting}
+                        aria-label={token ? 'Generate a new cloud MCP token' : 'Generate a cloud MCP token'}
+                        className="rounded border border-[#3a3a3a] px-2 py-1 text-[11px] text-gray-200 hover:bg-[#222] hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                        {isMinting ? 'Minting…' : token ? 'Generate new token' : 'Generate token'}
+                    </button>
                 </div>
                 <div className="mt-3 flex flex-col gap-2">
                     {commands.map(({ id, label, command }) => (
@@ -77,7 +87,9 @@ export const AgentActivityLog: React.FC = () => {
                                     type="button"
                                     aria-label={`Copy ${label} MCP command`}
                                     onClick={() => void copyCommand(id, command)}
-                                    className="rounded border border-[#3a3a3a] px-2 py-0.5 text-[10px] text-gray-300 hover:bg-[#222] hover:text-white"
+                                    disabled={!token}
+                                    title={token ? undefined : 'Generate a token first'}
+                                    className="rounded border border-[#3a3a3a] px-2 py-0.5 text-[10px] text-gray-300 hover:bg-[#222] hover:text-white disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent disabled:hover:text-gray-300"
                                 >
                                     {copied === id ? 'copied' : 'copy'}
                                 </button>

--- a/src/studio/__tests__/AgentActivityLog.test.tsx
+++ b/src/studio/__tests__/AgentActivityLog.test.tsx
@@ -16,17 +16,37 @@ afterEach(() => {
 });
 
 describe('AgentActivityLog', () => {
-    it('renders cloud MCP connector commands for common clients', async () => {
+    it('does NOT mint a token on mount (waits for explicit Generate click)', () => {
         createMcpToken.mockResolvedValue({ token: 'kc_ready_token', tokenPrefix: 'kc_ready_' });
-        const { getByText } = render(<AgentActivityLog />);
-        expect(getByText(/Cloud MCP connector/i)).toBeDefined();
-        expect(getByText(/One-line MCP install with token auth, local tooling, and hosted kernel/i)).toBeDefined();
+        const { getByRole } = render(<AgentActivityLog />);
+        expect(createMcpToken).not.toHaveBeenCalled();
+        // Connector card prompts for explicit Generate click rather than running on mount.
+        expect(getByRole('button', { name: /generate a cloud mcp token/i })).toBeDefined();
+    });
+
+    it('mints a token on Generate click and reveals the commands with the token inline', async () => {
+        createMcpToken.mockResolvedValue({ token: 'kc_ready_token', tokenPrefix: 'kc_ready_' });
+        const { getByText, getByRole } = render(<AgentActivityLog />);
+
+        fireEvent.click(getByRole('button', { name: /generate a cloud mcp token/i }));
+
         await waitFor(() => {
-            expect(getByText(/claude mcp add kernelcad -- npx -y kernelcad mcp --cloud --token kc_ready_token/i)).toBeDefined();
+            expect(getByText(/Token ready/i)).toBeDefined();
         });
+        expect(createMcpToken).toHaveBeenCalledTimes(1);
+        expect(getByText(/claude mcp add kernelcad -- npx -y kernelcad mcp --cloud --token kc_ready_token/i)).toBeDefined();
         expect(getByText(/codex mcp add kernelcad -- npx -y kernelcad mcp --cloud --token kc_ready_token/i)).toBeDefined();
         expect(getByText(/Studio Agent Mode/i)).toBeDefined();
         expect(getByText(/^cloud$/i)).toBeDefined();
+    });
+
+    it('keeps copy buttons disabled until a token exists', () => {
+        createMcpToken.mockResolvedValue({ token: 'kc_ready_token', tokenPrefix: 'kc_ready_' });
+        const { getByRole } = render(<AgentActivityLog />);
+        const copyClaude = getByRole('button', { name: /copy claude/i }) as HTMLButtonElement;
+        const copyCodex = getByRole('button', { name: /copy codex/i }) as HTMLButtonElement;
+        expect(copyClaude.disabled).toBe(true);
+        expect(copyCodex.disabled).toBe(true);
     });
 
     it('copies the selected connect command with the minted token', async () => {
@@ -37,6 +57,8 @@ describe('AgentActivityLog', () => {
             value: { writeText },
         });
         const { getByRole, getByText } = render(<AgentActivityLog />);
+
+        fireEvent.click(getByRole('button', { name: /generate a cloud mcp token/i }));
         await waitFor(() => {
             expect(getByText(/Token ready/i)).toBeDefined();
         });
@@ -48,9 +70,29 @@ describe('AgentActivityLog', () => {
 
     it('shows sign-in guidance when token creation is unauthorized', async () => {
         createMcpToken.mockRejectedValue(new Error('{"error":"missing_token"}'));
-        const { getByText } = render(<AgentActivityLog />);
+        const { getByText, getByRole } = render(<AgentActivityLog />);
+        fireEvent.click(getByRole('button', { name: /generate a cloud mcp token/i }));
         await waitFor(() => {
-            expect(getByText(/Sign in to create a cloud MCP token automatically/i)).toBeDefined();
+            expect(getByText(/Sign in to mint a cloud MCP token/i)).toBeDefined();
         });
+    });
+
+    it('issues a fresh token on Generate re-click; aria-label flips to "new"', async () => {
+        createMcpToken
+            .mockResolvedValueOnce({ token: 'kc_first', tokenPrefix: 'kc_first' })
+            .mockResolvedValueOnce({ token: 'kc_second', tokenPrefix: 'kc_second' });
+
+        const { getByRole, getByText } = render(<AgentActivityLog />);
+        fireEvent.click(getByRole('button', { name: /generate a cloud mcp token/i }));
+        await waitFor(() => {
+            expect(getByText(/claude mcp add kernelcad .* --token kc_first/i)).toBeDefined();
+        });
+
+        const secondClickButton = getByRole('button', { name: /generate a new cloud mcp token/i });
+        fireEvent.click(secondClickButton);
+        await waitFor(() => {
+            expect(getByText(/claude mcp add kernelcad .* --token kc_second/i)).toBeDefined();
+        });
+        expect(createMcpToken).toHaveBeenCalledTimes(2);
     });
 });


### PR DESCRIPTION
## Summary

Opening the Studio agent rail mounted \`AgentActivityLog\`, which fired a \`useEffect\` that immediately POSTed \`/api/v1/mcp/tokens\` — minting a long-lived token **without any user action**. Every rail-open created a new \`mcp_tokens\` row in Supabase and accumulated unused credentials.

Flagged by the Slice 1A subagent during PR #292 review:

> The pre-existing AgentActivityLog (commit eca639a3) auto-fetches a token on mount for its CLI-command flow (\`claude mcp add ...\`). Opening the Agent rail silently mints a token, which is worth click-gating in a follow-up.

## Fix

- Replaced the auto-mount \`useEffect\` with an explicit **Generate token** button + \`handleGenerateToken()\` handler.
- Initial render: no fetch, no token, copy buttons disabled (with \`title="Generate a token first"\`).
- After click: minted token populates state in memory only — never \`localStorage\`, never logged.
- Re-clicks issue fresh tokens; aria-label flips between *Generate a cloud MCP token* and *Generate a new cloud MCP token*.
- Help-text states cover four cases: idle (\`Click Generate…\`), minting (\`Minting cloud MCP token…\`), ready (\`Token ready. Copy a command below.\`), error (\`Sign in to mint a cloud MCP token, then click Generate.\`).

## Verification

- \`npx vitest run src/studio/__tests__/AgentActivityLog.test.tsx\` → **6/6 passing** (3 new cases: no-mint-on-mount, copy-disabled-pre-mint, fresh-token-on-re-click).
- Token never appears in localStorage (state-only), never in \`console.log\`, never in analytics — grepped.

## Followup

- Apply the same click-gate pattern to any other surface that hits \`/api/v1/mcp/tokens\` on mount (none today, but worth a lint rule).