### PR TITLE
chore(scripts): perf + diagnostic harnesses for the planetary stage

### DIFF
--- a/scripts/diagPlanetary.mjs
+++ b/scripts/diagPlanetary.mjs
@@ -1,0 +1,10 @@
+import { evaluateAndBuildScript } from '../src/agent/cli/commands/evaluate.ts';
+const r = await evaluateAndBuildScript({ file: 'examples/gallery/gearfinity-planetary-stage.kcad.ts' });
+console.log('exitCode:', r.evaluation.exitCode);
+for (const d of r.evaluation.diagnostics) {
+  console.log('-', d.severity, d.code, '||', d.message);
+  if (d.hint) console.log('   hint:', d.hint);
+}
+console.log('records:', (r.model?.records ?? []).length);
+const parts = (r.model?.records ?? []).filter((x) => x.kind === 'assemblyPart');
+console.log('assemblyParts:', parts.length);

--- a/scripts/perfMeshCache.mjs
+++ b/scripts/perfMeshCache.mjs
@@ -1,0 +1,65 @@
+import { performance } from 'node:perf_hooks';
+import { readFileSync } from 'node:fs';
+import { buildModel, updateModelParams } from '../src/modeling/buildModel.ts';
+import { meshFeaturesPerFeature } from '../src/modeling/capture/featureMeshing.ts';
+
+const file = 'examples/gallery/gearfinity-planetary-stage.kcad.ts';
+const code = readFileSync(file, 'utf8');
+const dir = file.replace(/\/[^/]+$/, '');
+
+console.log('--- cold build ---');
+let t = performance.now();
+const model = await buildModel({ code, fileName: file, scriptDir: dir });
+console.log(`buildModel: ${(performance.now() - t).toFixed(0)} ms  records=${model.records.length}`);
+
+const session = model.session;
+
+console.log('\n--- cold mesh #1 (no seedShapes) ---');
+t = performance.now();
+const mesh1 = await meshFeaturesPerFeature(model.records, session.paramTable, session);
+console.log(`meshFeaturesPerFeature: ${(performance.now() - t).toFixed(0)} ms  features=${mesh1.features.length}`);
+console.log(`  cachedFeatureMeshes: ${session.cachedFeatureMeshes.size}`);
+console.log(`  cachedAssemblyPartMeshes: ${[...session.cachedAssemblyPartMeshes.values()].reduce((s, m) => s + m.size, 0)}`);
+
+console.log('\n--- params.update driveAngleDeg=150 ---');
+t = performance.now();
+await updateModelParams(model, [{ name: 'driveAngleDeg', value: 150 }]);
+console.log(`updateModelParams: ${(performance.now() - t).toFixed(0)} ms`);
+console.log(`  cachedFeatureMeshes after invalidation: ${session.cachedFeatureMeshes.size}`);
+
+console.log('\n--- warm mesh #2 (with seedShapes from cache) ---');
+// Build seedShapes from records whose shape AND mesh are still cached
+const seedShapes = new Map();
+for (const r of model.records) {
+  if (session.cachedShapes.has(r.id) && session.cachedFeatureMeshes.has(r.id)) {
+    seedShapes.set(r.id, session.cachedShapes.get(r.id));
+  }
+}
+console.log(`  seedShapes size: ${seedShapes.size}`);
+
+t = performance.now();
+const mesh2 = await meshFeaturesPerFeature(model.records, session.paramTable, session, seedShapes);
+console.log(`meshFeaturesPerFeature (warm): ${(performance.now() - t).toFixed(0)} ms  features=${mesh2.features.length}`);
+
+console.log('\n--- warm mesh #3 (same pose, fully cached) ---');
+t = performance.now();
+const seedShapes3 = new Map();
+for (const r of model.records) {
+  if (session.cachedShapes.has(r.id) && session.cachedFeatureMeshes.has(r.id)) {
+    seedShapes3.set(r.id, session.cachedShapes.get(r.id));
+  }
+}
+const mesh3 = await meshFeaturesPerFeature(model.records, session.paramTable, session, seedShapes3);
+console.log(`meshFeaturesPerFeature (warm again): ${(performance.now() - t).toFixed(0)} ms  features=${mesh3.features.length}`);
+
+console.log('\n--- another params.update + warm mesh ---');
+await updateModelParams(model, [{ name: 'driveAngleDeg', value: 200 }]);
+const seedShapes4 = new Map();
+for (const r of model.records) {
+  if (session.cachedShapes.has(r.id) && session.cachedFeatureMeshes.has(r.id)) {
+    seedShapes4.set(r.id, session.cachedShapes.get(r.id));
+  }
+}
+t = performance.now();
+const mesh4 = await meshFeaturesPerFeature(model.records, session.paramTable, session, seedShapes4);
+console.log(`meshFeaturesPerFeature (post-edit warm): ${(performance.now() - t).toFixed(0)} ms  features=${mesh4.features.length}`);

--- a/scripts/perfPlanetary.mjs
+++ b/scripts/perfPlanetary.mjs
@@ -1,0 +1,42 @@
+import { performance } from 'node:perf_hooks';
+import { writeFileSync } from 'node:fs';
+import { evaluateAndBuildScript } from '../src/agent/cli/commands/evaluate.ts';
+import { loadScriptFeatures } from '../src/modeling/runtime/scriptLoader.ts';
+import { meshFeaturesPerFeature } from '../src/modeling/capture/featureMeshing.ts';
+
+const file = 'examples/gallery/gearfinity-planetary-stage.kcad.ts';
+const lines = [];
+const log = (s) => { lines.push(s); console.log(s); };
+
+const t0 = performance.now();
+const evalRes = await evaluateAndBuildScript({ file });
+log(`evaluateAndBuildScript: ${(performance.now() - t0).toFixed(0)} ms  records=${(evalRes.model?.records ?? []).length}`);
+
+const t2 = performance.now();
+const loaded = await loadScriptFeatures(file);
+log(`loadScriptFeatures: ${(performance.now() - t2).toFixed(0)} ms features=${loaded.features.length}`);
+
+const t4 = performance.now();
+const meshing = await meshFeaturesPerFeature(
+  loaded.features.map((f) => f.record),
+  loaded.paramTable,
+  loaded.session,
+);
+log(`meshFeaturesPerFeature: ${(performance.now() - t4).toFixed(0)} ms features=${meshing.features.length} failed=${meshing.failedFeatureIds.length}`);
+
+const sample = meshing.features[0] || {};
+log(`feature keys: ${Object.keys(sample).join(', ')}`);
+if (sample.mesh) log(`  mesh keys: ${Object.keys(sample.mesh).join(', ')}`);
+
+const perFeat = meshing.features.map((f) => {
+  const tri = f.mesh?.triangleCount ?? f.mesh?.indices?.length / 3 ?? 0;
+  const verts = f.mesh?.vertexCount ?? (f.mesh?.positions?.length ? f.mesh.positions.length / 3 : 0);
+  return { id: f.id, kind: f.kind, triangles: tri, verts };
+}).sort((a, b) => b.triangles - a.triangles).slice(0, 20);
+
+log('\nTop 20 features by triangle count:');
+for (const f of perFeat) {
+  log(`  tri=${String(f.triangles).padStart(6)}  v=${String(f.verts).padStart(6)}  ${(f.kind || '').padEnd(18)}  ${f.id}`);
+}
+
+writeFileSync('/tmp/perfPlanetary.log', lines.join('\n'));

--- a/scripts/perfScrub.mjs
+++ b/scripts/perfScrub.mjs
@@ -1,0 +1,29 @@
+import { performance } from 'node:perf_hooks';
+import { buildModel, updateModelParams } from '../src/modeling/buildModel.ts';
+import { readFileSync } from 'node:fs';
+
+const file = 'examples/gallery/gearfinity-planetary-stage.kcad.ts';
+const code = readFileSync(file, 'utf8');
+
+console.log('--- cold build ---');
+const t0 = performance.now();
+const model = await buildModel({ code, fileName: file, scriptDir: file.replace(/\/[^/]+$/, '') });
+console.log(`buildModel: ${(performance.now() - t0).toFixed(0)} ms  records=${model.records.length}`);
+
+const editedNames = ['driveAngleDeg'];
+const recordsAffected = model.records.filter(r => {
+  const refs = (r.metadata)?.paramRefs ?? [];
+  return refs.some(n => editedNames.includes(n));
+});
+console.log(`records with driveAngleDeg refs: ${recordsAffected.length}`);
+for (const r of recordsAffected.slice(0, 8)) {
+  console.log(`  ${r.kind.padEnd(20)} ${r.id}`);
+}
+
+console.log('\n--- pose-only edit driveAngleDeg = 120 ---');
+for (let i = 0; i < 3; i++) {
+  const t = performance.now();
+  const upd = await updateModelParams(model, [{ name: 'driveAngleDeg', value: 90 + (i + 1) * 30 }]);
+  const ms = performance.now() - t;
+  console.log(`  edit ${i + 1}: ${ms.toFixed(0)} ms  relowered=${upd.result.relowered.length} skipped=${upd.result.skipped.length}`);
+}


### PR DESCRIPTION
## Summary

Four runnable dev harnesses captured during the engine-perf workstream that produced #296 (mesh cache) and #302 (animationView). Useful as regression checks against the planetary-stage gallery example after any kernel/runtime touch:

- `scripts/diagPlanetary.mjs` (10 LOC) — quick `evaluateAndBuildScript` smoke; exitCode + diagnostics + record/part counts.
- `scripts/perfScrub.mjs` (29 LOC) — `buildModel` + 3 pose-only `updateModelParams` iterations. Verifies engine-side pose-cache stays in 1-10 ms. Regression signal: pose edits >100 ms means `buildSeedShapes` lost its first-affected fast path.
- `scripts/perfMeshCache.mjs` (65 LOC) — cold mesh + `params.update` + warm-mesh sequence. Verifies the per-session mesh cache drops warm meshing from ~5 s cold to ~5 ms warm. Regression signal: warm-mesh within an order of magnitude of cold means `cachedAssemblyPartMeshes` isn't being reused.
- `scripts/perfPlanetary.mjs` (42 LOC) — full profile: evaluate + `loadScriptFeatures` + `meshFeaturesPerFeature` with per-feature triangle/vertex breakdown.

All four are `npx tsx scripts/<name>.mjs` runnable; default to the planetary gear example.

## Not included

`scripts/captureKinematic.mjs` and `scripts/renderPlanetary.mjs` from the workstream are intentionally not committed — superseded by `scripts/captureAnimationView.mjs` (in #302). Left locally if useful, but redundant once `animationView()` ships.

## Test plan

- [x] Each script runs cleanly against the current planetary example
- [x] No effect on any test or build target — pure additions under `scripts/`, no imports anywhere else in the tree