### PR TITLE
chore(connect): align Claude Desktop install copy with hosted-MCP behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ kernelCAD runs as an MCP server, so Claude Desktop can drive it locally. After
 Restart Claude Desktop. The kernelCAD MCP tools (`review_cad`, model
 introspection, export helpers, etc.) appear in the tools list.
 
+For prompt-driven authoring against the hosted gateway, sign in at
+[app.kernelcad.com/connect](https://app.kernelcad.com/connect) and use the
+generated `kernelcad mcp --cloud --token <…>` snippet. The hosted surface adds
+`generate_kcad_from_prompt` (turn a natural-language brief into a `.kcad.ts`
+source) on top of the introspection and review tools, and serves the
+`kernelcad-authoring` skill as an MCP resource so Claude Desktop loads it
+automatically on connect. Free tier: 3 LLM-generated parts per month;
+introspection and review tools are unlimited.
+
 > A one-shot `kernelcad install --claude-desktop` command that edits this
 > config for you is on the next slice — until then the snippet above is the
 > interim path.

--- a/scripts/staticGalleryLanding.test.ts
+++ b/scripts/staticGalleryLanding.test.ts
@@ -42,6 +42,13 @@ describe('static gallery landing page', () => {
     expect(stackBlock).toContain('id="claude-desktop-link"');
     expect(stackBlock).toContain('href="/app/connect"');
     expect(stackBlock).toContain('Use with Claude Desktop');
+
+    // Free-tier caption sits near the install stack so the Claude Desktop CTA
+    // links to a page whose marketing matches what the hosted gateway delivers:
+    // 3 LLM-generated parts/month, unlimited introspection + review.
+    expect(html).toContain('id="claude-desktop-note"');
+    expect(html).toContain('3 LLM-generated parts per month');
+    expect(html).toContain('Introspection and review tools are unlimited');
   });
 
   it('documents the same full marketing build command used by deploy', () => {

--- a/site/index.html
+++ b/site/index.html
@@ -75,6 +75,7 @@
             <span class="copy">copy</span>
           </button>
         </div>
+        <p class="install-note" id="claude-desktop-note">Free tier: 3 LLM-generated parts per month. Introspection and review tools are unlimited.</p>
       </div>
       <div class="hero-proof" aria-label="kernelCAD generated artifact preview">
         <div class="demo-meta">

--- a/site/style.css
+++ b/site/style.css
@@ -121,6 +121,7 @@ body {
 .install-command { overflow-wrap: anywhere; line-height: 1.45; }
 .install .prompt { color: var(--copper); }
 .install .copy { color: var(--ink-faint); font-size: 11px; padding-left: 8px; border-left: 1px solid #1F2A3D; }
+.install-note { max-width: 620px; margin: 8px 0 0; color: var(--ink-faint); font-size: 12px; line-height: 1.5; }
 
 /* DEMO */
 .hero-proof { min-width: 0; }

--- a/src/studio/routes/connect.tsx
+++ b/src/studio/routes/connect.tsx
@@ -52,8 +52,8 @@ function ConnectPage() {
               Connect kernelCAD to Claude Desktop
             </h1>
             <p className="text-ink-soft text-sm mt-2">
-              Sign in to generate a hosted MCP token. Free tier includes 3 parts
-              on signup.
+              Sign in to generate a hosted MCP token. Free tier: 3 LLM-generated
+              parts per month. Introspection and review tools are unlimited.
             </p>
             <div className="mt-6 flex justify-center">
               <SignInButton redirectTo={`${window.location.origin}/connect`} />


### PR DESCRIPTION
## Summary

Slice A of the meaningful-Claude-Desktop-onboarding iteration: copy-only edits so the marketing on `/connect`, the homepage install stack, and the README match what Slices B and C deliver on the hosted MCP gateway.

- `/connect` pre-auth: now reads "Free tier: 3 LLM-generated parts per month. Introspection and review tools are unlimited." (was the misleading "Free tier includes 3 parts on signup" — `BILLABLE_TOOL_NAMES` is scoped to the prompt-driven generator, not all tool calls).
- Homepage hero install stack: adds one-line caption with the same statement so the "Use with Claude Desktop →" CTA's promise is visible inline.
- README "Use with Claude Desktop" section: points at `app.kernelcad.com/connect` for the hosted-gateway flow, names `generate_kcad_from_prompt` (Slice B) and the `kernelcad-authoring` MCP resource (Slice C) that the bridge auto-loads on connect. Interim-path hedge kept until B+C ship.

## Blocked on

**Slices B + C landing in production** (hosted MCP `generate_kcad_from_prompt` tool + MCP `kernelcad-authoring` resource via the bridge). Until those are live, this copy promises features that don't exist; the PR must stay in draft. Convert to ready-for-review once B and C merge.

## Notes

- File location nit: the misleading pre-auth copy actually lives in `src/studio/routes/connect.tsx` (the route's anonymous fallback), not in `src/studio/components/Connect/ConnectClaudeDesktop.tsx`. Edit applied to the correct file. The `ConnectClaudeDesktop.test.tsx` suite had no pre-auth-text assertion to update.
- README still hedges the one-shot installer ("interim path") because that workstream is separate from Slices B/C.
- Tool name `generate_kcad_from_prompt` and resource name `kernelcad-authoring` taken from the spec; verify the Slice B/C subagents shipped under the same identifiers before flipping to ready-for-review.

## Test plan

- [x] `npx vitest run src/studio/components/Connect/` — 6 passed (existing assertions unaffected).
- [x] `npx vitest run scripts/staticGalleryLanding.test.ts` — 7 passed (extended with new caption assertion).
- [ ] Once B+C are live, manually verify `/connect` (signed-out and signed-in), homepage hero, and README render the new copy correctly.