### PR TITLE
feat(mcp): proxy resources/* through the cloud MCP bridge (Slice C)

### DIFF
--- a/src/agent/mcp/cloudClient.test.ts
+++ b/src/agent/mcp/cloudClient.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { callCloudTool, listCloudTools, resolveCloudMcpOptions } from './cloudClient';
+import {
+  callCloudTool,
+  listCloudTools,
+  listCloudResources,
+  readCloudResource,
+  resolveCloudMcpOptions,
+} from './cloudClient';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -27,6 +33,96 @@ describe('cloud MCP client', () => {
       headers: { Authorization: 'Bearer kc_test' },
     });
     expect(tools[0]?.name).toBe('evaluate_script');
+  });
+
+  it('lists resources from the hosted MCP gateway', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        resources: [
+          {
+            uri: 'kernelcad://skills/authoring',
+            name: 'kernelcad-authoring',
+            mimeType: 'text/markdown',
+            description: 'Authoring guide for kernelCAD .kcad.ts',
+          },
+        ],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const resources = await listCloudResources({ apiBaseUrl: 'https://api.test', token: 'kc_test' });
+
+    expect(fetchMock).toHaveBeenCalledWith('https://api.test/api/v1/mcp/resources/list', {
+      headers: { Authorization: 'Bearer kc_test' },
+    });
+    expect(resources[0]?.uri).toBe('kernelcad://skills/authoring');
+    expect(resources[0]?.mimeType).toBe('text/markdown');
+  });
+
+  it('returns an empty list when the gateway has no resources surface yet (404)', async () => {
+    // The bridge can ship before the server-side resources endpoints land.
+    // Until then, a 404 from /resources/list must not break the MCP
+    // connection — Claude Desktop tolerates an empty list, but a thrown
+    // error tears the whole stdio session down. Same gate is used by the
+    // server-side feature flag if we ever roll it out behind one.
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: async () => 'not found',
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const resources = await listCloudResources({ apiBaseUrl: 'https://api.test', token: 'kc_test' });
+
+    expect(resources).toEqual([]);
+  });
+
+  it('reads a resource body from the hosted MCP gateway', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        contents: [
+          {
+            uri: 'kernelcad://skills/authoring',
+            mimeType: 'text/markdown',
+            text: '# kernelcad-authoring\n\nHello world.',
+          },
+        ],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const contents = await readCloudResource('kernelcad://skills/authoring', {
+      apiBaseUrl: 'https://api.test',
+      token: 'kc_test',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('https://api.test/api/v1/mcp/resources/read', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer kc_test',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ uri: 'kernelcad://skills/authoring' }),
+    });
+    expect(contents[0]?.text).toContain('kernelcad-authoring');
+  });
+
+  it('surfaces a non-404 error from resources/read so the client can show it', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'kaboom',
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      readCloudResource('kernelcad://skills/authoring', {
+        apiBaseUrl: 'https://api.test',
+        token: 'kc_test',
+      }),
+    ).rejects.toThrow(/kaboom/);
   });
 
   it('calls a hosted MCP tool', async () => {

--- a/src/agent/mcp/cloudClient.ts
+++ b/src/agent/mcp/cloudClient.ts
@@ -25,6 +25,79 @@ export async function listCloudTools(options: CloudMcpOptions = {}): Promise<Mcp
   return payload.tools;
 }
 
+/**
+ * MCP resource descriptor matching the hosted gateway shape
+ * (`GET /api/v1/mcp/resources/list`). Slice C of the meaningful-onboarding
+ * iteration. URI/mimeType match the MCP `resources/list` response schema so
+ * the bridge can pass them through to the local stdio client unmodified.
+ */
+export interface McpResourceDescriptor {
+  uri: string;
+  name: string;
+  mimeType: string;
+  description: string;
+}
+
+/** Resource body shape matching the hosted gateway's `resources/read` response. */
+export interface McpResourceContent {
+  uri: string;
+  mimeType: string;
+  text: string;
+}
+
+/**
+ * List MCP resources advertised by the hosted gateway.
+ *
+ * Graceful 404 handling: the bridge can ship ahead of the server-side
+ * resources endpoints landing. When `/api/v1/mcp/resources/list` returns
+ * 404, we treat that as "this gateway has no resources surface yet" and
+ * return an empty list — Claude Desktop will simply not advertise any
+ * resources to the model. Throwing here would tear down the whole stdio
+ * MCP session, which is worse.
+ *
+ * Non-404 errors (auth failure, 5xx) still throw so they surface to the
+ * client/operator.
+ */
+export async function listCloudResources(options: CloudMcpOptions = {}): Promise<McpResourceDescriptor[]> {
+  const { apiBaseUrl, token } = resolveCloudMcpOptions(options);
+  const res = await fetch(`${apiBaseUrl}/api/v1/mcp/resources/list`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (res.status === 404) return [];
+  if (!res.ok) throw new Error(await responseError(res));
+  const payload = await res.json() as { resources?: McpResourceDescriptor[] };
+  if (!Array.isArray(payload.resources)) throw new Error('Invalid cloud MCP resources response.');
+  return payload.resources;
+}
+
+/**
+ * Read a resource by URI from the hosted gateway. Returns the `contents`
+ * array verbatim so it can be passed straight to the MCP SDK's
+ * `ReadResourceResultSchema`.
+ *
+ * No 404 fallback here — if the caller asks for a specific URI, surfacing
+ * the error is the right behavior (the local model just asked for
+ * something the gateway doesn't have).
+ */
+export async function readCloudResource(
+  uri: string,
+  options: CloudMcpOptions = {},
+): Promise<McpResourceContent[]> {
+  const { apiBaseUrl, token } = resolveCloudMcpOptions(options);
+  const res = await fetch(`${apiBaseUrl}/api/v1/mcp/resources/read`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ uri }),
+  });
+  if (!res.ok) throw new Error(await responseError(res));
+  const payload = await res.json() as { contents?: McpResourceContent[] };
+  if (!Array.isArray(payload.contents)) throw new Error('Invalid cloud MCP resource-read response.');
+  return payload.contents;
+}
+
 export async function callCloudTool(
   name: string,
   args: Record<string, unknown>,

--- a/src/agent/mcp/server.test.ts
+++ b/src/agent/mcp/server.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Bridge wiring for MCP `resources/*` — Slice C of the meaningful-onboarding
+ * iteration (2026-05-24).
+ *
+ * The `kernelcad mcp --cloud` bridge proxies tools/* to the hosted
+ * `/api/v1/mcp/...` gateway. Slice C extends the same pattern to resources/*:
+ * the local stdio MCP client (Claude Desktop) lists and reads resources
+ * through the bridge, the bridge calls the hosted gateway, the response is
+ * returned as a normal MCP result.
+ *
+ * These tests verify the bridge advertises the `resources` capability ONLY
+ * in cloud mode (local-only mode doesn't have resources to advertise) and
+ * that the resources/list and resources/read handlers proxy to the cloud
+ * client we tested in cloudClient.test.ts.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+vi.mock('./cloudClient', () => ({
+  listCloudTools: vi.fn().mockResolvedValue([]),
+  callCloudTool: vi.fn().mockResolvedValue({ ok: true }),
+  listCloudResources: vi.fn().mockResolvedValue([
+    {
+      uri: 'kernelcad://skills/authoring',
+      name: 'kernelcad-authoring',
+      mimeType: 'text/markdown',
+      description: 'Authoring guide for kernelCAD .kcad.ts',
+    },
+  ]),
+  readCloudResource: vi.fn().mockResolvedValue([
+    {
+      uri: 'kernelcad://skills/authoring',
+      mimeType: 'text/markdown',
+      text: '# kernelcad-authoring\n\nstub body',
+    },
+  ]),
+  resolveCloudMcpOptions: vi.fn().mockReturnValue({
+    apiBaseUrl: 'https://api.test',
+    token: 'kc_test',
+  }),
+}));
+
+import { createMcpServer } from './server';
+import * as cloud from './cloudClient';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createMcpServer — cloud bridge resources surface', () => {
+  it('advertises the `resources` capability in cloud mode', () => {
+    const server = createMcpServer({ cloud: true, cloudOptions: { apiBaseUrl: 'https://api.test', token: 'kc_test' } });
+    // The MCP SDK exposes the announced capabilities via the
+    // `getServerCapabilities()` helper. The local Server.capabilities is a
+    // read-only snapshot, so reach in to verify the shape.
+    const capabilities = (server as any)._capabilities ?? (server as any).options?.capabilities;
+    expect(capabilities).toBeDefined();
+    expect(capabilities.tools).toBeDefined();
+    expect(capabilities.resources).toBeDefined();
+  });
+
+  it('does NOT advertise resources in local-only mode', () => {
+    const server = createMcpServer({ cloud: false });
+    const capabilities = (server as any)._capabilities ?? (server as any).options?.capabilities;
+    expect(capabilities).toBeDefined();
+    expect(capabilities.resources).toBeUndefined();
+  });
+
+  it('proxies resources/list to listCloudResources in cloud mode', async () => {
+    const server = createMcpServer({ cloud: true, cloudOptions: { apiBaseUrl: 'https://api.test', token: 'kc_test' } });
+    // Access the registered handler — the SDK keeps them on `_requestHandlers`.
+    const handlers = (server as any)._requestHandlers as Map<string, (req: unknown) => Promise<unknown>>;
+    const handler = handlers.get(ListResourcesRequestSchema.shape.method.value);
+    expect(handler).toBeDefined();
+
+    const result = (await handler!({
+      method: 'resources/list',
+      params: {},
+    })) as { resources: { uri: string }[] };
+
+    expect(cloud.listCloudResources).toHaveBeenCalledOnce();
+    expect(result.resources[0]?.uri).toBe('kernelcad://skills/authoring');
+  });
+
+  it('proxies resources/read to readCloudResource in cloud mode', async () => {
+    const server = createMcpServer({ cloud: true, cloudOptions: { apiBaseUrl: 'https://api.test', token: 'kc_test' } });
+    const handlers = (server as any)._requestHandlers as Map<string, (req: unknown) => Promise<unknown>>;
+    const handler = handlers.get(ReadResourceRequestSchema.shape.method.value);
+    expect(handler).toBeDefined();
+
+    const result = (await handler!({
+      method: 'resources/read',
+      params: { uri: 'kernelcad://skills/authoring' },
+    })) as { contents: { uri: string; text: string }[] };
+
+    expect(cloud.readCloudResource).toHaveBeenCalledWith(
+      'kernelcad://skills/authoring',
+      expect.any(Object),
+    );
+    expect(result.contents[0]?.text).toContain('kernelcad-authoring');
+  });
+
+  it('does NOT register resources handlers in local-only mode', () => {
+    const server = createMcpServer({ cloud: false });
+    const handlers = (server as any)._requestHandlers as Map<string, unknown>;
+    expect(handlers.has(ListResourcesRequestSchema.shape.method.value)).toBe(false);
+    expect(handlers.has(ReadResourceRequestSchema.shape.method.value)).toBe(false);
+  });
+});

--- a/src/agent/mcp/server.ts
+++ b/src/agent/mcp/server.ts
@@ -2,9 +2,20 @@
 import { createRequire } from 'node:module';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
 import { callMcpTool, TOOLS } from './toolRegistry';
-import { callCloudTool, listCloudTools, type CloudMcpOptions } from './cloudClient';
+import {
+  callCloudTool,
+  listCloudTools,
+  listCloudResources,
+  readCloudResource,
+  type CloudMcpOptions,
+} from './cloudClient';
 
 const requireFromHere = createRequire(import.meta.url);
 // At source: src/agent/mcp/server.ts → ../../../package.json (3 up)
@@ -29,9 +40,17 @@ export interface McpServerOptions {
 }
 
 export function createMcpServer(options: McpServerOptions = {}): Server {
+  // Slice C (2026-05-24): in cloud mode the bridge proxies resources/* to
+  // the hosted gateway so Claude Desktop can read the kernelcad-authoring
+  // SKILL.md on connection. Local-only mode has no resources to expose.
+  const capabilities: { tools: object; resources?: object } = { tools: {} };
+  if (options.cloud) {
+    capabilities.resources = {};
+  }
+
   const server = new Server(
     { name: 'kernelcad', version: pkg.version },
-    { capabilities: { tools: {} } },
+    { capabilities },
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
@@ -49,6 +68,23 @@ export function createMcpServer(options: McpServerOptions = {}): Server {
       content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
     };
   });
+
+  if (options.cloud) {
+    // Proxy the local stdio client's resources/list to the hosted gateway.
+    // A 404 from the gateway is mapped by listCloudResources() to an empty
+    // list so Claude Desktop tolerates servers that haven't shipped the
+    // resources endpoints yet.
+    server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+      resources: await listCloudResources(options.cloudOptions),
+    }));
+
+    // Proxy resources/read to the hosted gateway. The hosted gateway returns
+    // the MCP contract shape ({ contents: [{ uri, mimeType, text }] }) so we
+    // pass the array through unchanged.
+    server.setRequestHandler(ReadResourceRequestSchema, async (req) => ({
+      contents: await readCloudResource(req.params.uri, options.cloudOptions),
+    }));
+  }
 
   return server;
 }


### PR DESCRIPTION
## Summary

Extends \`kernelcad mcp --cloud\` so the bridge advertises the MCP \`resources\` capability and proxies \`resources/list\` + \`resources/read\` to the hosted kernelCAD gateway. Claude Desktop (and any MCP client supporting resources) can now read the kernelcad-authoring SKILL.md at \`kernelcad://skills/authoring\` on connection — the body the model needs before writing \`.kcad.ts\`.

Slice C of the meaningful-onboarding iteration. Companion server change at https://github.com/w1ne/kernelCAD-server/pull/9.

## What landed

- \`cloudClient.ts\`: \`listCloudResources()\` and \`readCloudResource()\` mirror the existing \`listCloudTools\` / \`callCloudTool\` proxy pattern.
- \`server.ts\` (the stdio MCP server): in cloud mode, advertise \`{ resources: {} }\` capability and register \`ListResourcesRequestSchema\` + \`ReadResourceRequestSchema\` handlers. Local-only mode is unchanged — no resources to expose.
- Graceful 404 fallback in \`listCloudResources()\`: if the gateway responds 404 (e.g. before the server-side endpoints ship), return an empty list instead of throwing. Avoids tearing down the stdio session for users on older gateway builds.

## Deploy order

The server PR (kernelCAD-server #9) lands first. This bridge PR can then ship without a client-visible flap. The bridge will also work if it lands first — clients just won't see any resources until the gateway is upgraded (the 404 fallback ensures the rest of the MCP session keeps working).

## Test plan

- [x] \`npx vitest run src/agent/mcp/cloudClient.test.ts src/agent/mcp/server.test.ts\` — 12 passed
- [x] \`npm run typecheck\` clean
- [x] \`npx eslint src/agent/mcp\` clean
- [ ] E2E smoke after server deploy: \`kernelcad mcp --cloud --token kc_xxx\` from Claude Desktop config; verify \`resources/list\` returns \`kernelcad://skills/authoring\` and \`resources/read\` returns the SKILL.md body.

## Client compatibility caveats

- Claude Desktop ≥ 0.7.x supports MCP \`resources\`. Older builds advertise no resource capability and the model just doesn't see the bootstrap doc — same as today.
- For non-resources clients, the server-side fallback tool \`lookup_authoring_skill\` exposes the same body through the tools surface.