### PR TITLE
fix: borrow-integration bugs caught by Luxo lamp demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 # kernelCAD v0.11.0
 
+## Unreleased — borrow-integration bug fixes
+
+Caught while building the Luxo lamp demo (2026-05-25) — actual use of the new
+V/Q/kinematic borrows together surfaced two real bugs and one no-repro.
+
+### Fixed — primitives now validate `Editable<number>` inputs
+
+`box`, `cylinder`, and `sphere` previously accepted any value for their
+dimension arguments and silently produced degenerate shapes. The most common
+authoring slip — calling `cylinder({ radius, height })` with an object literal
+instead of the positional `cylinder(h, r)` signature — let the object flow
+through `toParam` and stored `{evaluated: <the object>}` in the feature
+params. The cylinder lowered to a degenerate shape that, when wrapped in an
+`assembly().part()`, recursed into "Maximum call stack size exceeded" during
+the assembly-clone path.
+
+All three primitives now reject non-finite / non-numeric inputs at capture
+time with a clear `feature.invalid-args` diagnostic that names the bad
+argument and points at the correct positional signature. The same guard
+catches `NaN`, `Infinity`, and any value that is neither a finite number nor
+a `ParamRef<number>`. The `kernelcad-nurbs` SKILL.md cookbook snippet was
+also updated — its `cylinder({ radius: 1, height: 5 })` example is now the
+correct `cylinder(5, 1)` positional form.
+
+### Fixed — `solvedModel({poses})` now propagates joint angles to the render
+
+`arm.solvedModel({ shoulder: 90 })` correctly attached the FK-derived
+`worldTransform` to each part record, and STEP/STL exports honoured it, but
+the headless render path (`kernelcad render <file>`) dropped it entirely:
+`DemoPlayerPage`'s per-feature loop rehydrated `fm.transform` via
+`rehydrateFromBridge` and then never applied it to the `THREE.Group` it
+built. The result was that every assembly rendered at its rest pose
+regardless of the pose dict passed to `solvedModel()`.
+
+The fix: apply `fm.transform` to the group's matrix at construction (with
+`matrixAutoUpdate = false`) and compose the bbox centroid offset on top via
+`Matrix4.premultiply` instead of `position.set` (which is decoupled from
+`matrix` when `matrixAutoUpdate` is false and would otherwise silently
+no-op). Verified: a single-joint test arm at `shoulder: 90` now renders
+straight up (was: horizontal rest pose).
+
+A Playwright regression test in `tests/demo_player_smoke.spec.ts` loads a
+feature mesh with a translate-by-7 transform and asserts the KCAD group's
+matrix records the non-zero translation through the centroid recenter.
+
+### No-repro — `variableSweep` + `assembly().part()` render hang
+
+Investigated; could not reproduce on `develop` tip. Three consecutive
+`kernelcad render /tmp/repro-b2-clean.kcad.ts` runs each completed cleanly
+in 9.5–11.5 s. The hang originally observed during the Luxo lamp session
+was almost certainly a zombie-process / stale-build artefact from accumulated
+chromium instances across an extended render iteration loop.
+
 ## Unreleased — V slice: NURBS curve analytics layer
 
 ### Added — `Curve3D.analytics.*` namespace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # kernelCAD v0.11.0
 
+## Unreleased — borrow-integration follow-ups (conventions clarified)
+
+Documentation cleanup for the two non-bug "discoveries" that surfaced while
+debugging the Luxo lamp:
+
+- **Joint-angle unit convention is now explicit.** `kernelcad-kinematic/SKILL.md`
+  opens with a "Units (read this first)" section stating that ALL joint
+  angles in the kinematic API — `solvedModel({poses})`, `revolute({limitsDeg})`,
+  `checkReachable({seed})`, `checkReachable` result `.pose` — use **degrees
+  for revolute and millimetres for prismatic**, with no degree-vs-radian
+  split anywhere on the user-facing surface. The cookbook
+  `02-reachable-with-seed.kcad.ts` seed values are updated from a
+  copy-paste-friendly-but-misleading `0.3`/`0.2` (which looked like radians
+  but the system interpreted as 0.3°/0.2° ≈ effectively zero) to honest
+  `17`/`11`/`-11` degree values. JSDoc on `ReachableOpts.seed` and the
+  MCP `check_reachable` tool's seed field now both name the unit. No API
+  change — the convention was always degrees; the docs caught up.
+
+- **Part-local frame convention is now explicit.** `kernelcad-assemblies/SKILL.md`
+  already said joint origins live in the parent's local frame; the companion
+  rule — "author each part's geometry in its own part-local frame, where the
+  origin sits at the joint this part attaches to its parent" — is now
+  spelled out alongside, with a worked correct / wrong example. Authoring a
+  part with `.translate(110, 0, 30)` when the shoulder joint already supplies
+  the `(0, 0, 30)` rest offset doubles the offset under any non-zero pose.
+  No code change — the cookbook examples already followed the convention; the
+  docs caught up.
+
 ## Unreleased — borrow-integration bug fixes
 
 Caught while building the Luxo lamp demo (2026-05-25) — actual use of the new

--- a/src/agent/mcp/tools/checkReachable.ts
+++ b/src/agent/mcp/tools/checkReachable.ts
@@ -31,7 +31,10 @@ export interface CheckReachableInput extends EvaluateInput {
   prefer_solver?: 'analytical' | 'numeric' | 'auto';
   /** Numeric-path iteration cap. */
   max_iterations?: number;
-  /** Seed pose for numeric path. */
+  /** Optional warm-start pose for the numeric IK path. Units: degrees for
+   *  revolute joints, millimetres for prismatic joints — same convention as
+   *  `arm.solvedModel({poses})`. Pass `{}` or omit for no preference. The
+   *  analytical solver ignores this. */
   seed?: NumericPoses;
 }
 

--- a/src/agent/skills/kernelcad-assemblies/SKILL.md
+++ b/src/agent/skills/kernelcad-assemblies/SKILL.md
@@ -162,6 +162,24 @@ const fused = scene.toUnion();               // antipattern; only when one solid
 
 Joint origins are in the **parent part's local frame** (URDF/MuJoCo convention). Multi-joint chains compose correctly; the FK tree-walk handles N joints.
 
+**Companion rule — author each part's shape in its own part-local frame, NOT in world coordinates.** A part's local frame has its origin at the joint where this part attaches to its parent (or at the world origin, for the root part). All `.translate(x, y, z)` calls on the child's shape are interpreted in this *part-local* frame.
+
+Concretely: if the shoulder joint is at world `(0, 0, 30)` and the lower arm has length 220 mm extending along +X from the shoulder, author the lower arm at part-local frame *centered on the joint*:
+
+```ts
+// ✅ Correct — lower arm in its own local frame; rest position comes from the joint origin.
+const lower = arm.part('lower', box(220, 24, 18, true).translate(110, 0, 0));
+arm.revolute('shoulder', base, lower, { axis: [0, -1, 0], origin: [0, 0, 30], limitsDeg: [0, 110] });
+
+// ❌ Wrong — translating to the world rest position `(110, 0, 30)` puts a SHOULDER_Z offset
+//    into the part-local frame, which the FK doubles up when the joint poses.
+const lower = arm.part('lower', box(220, 24, 18, true).translate(110, 0, 30));
+```
+
+At rest (joint angle 0), worldT for `lower` equals `T(0, 0, 30)` (the joint origin in parent's frame), so part-local vertex `(110, 0, 0)` maps to world `(110, 0, 30)` — exactly what you wanted. Authoring the part with `.translate(110, 0, 30)` would put it at world `(110, 0, 60)` instead, and any non-zero joint angle would smear that compounding error visibly across the render.
+
+The same convention applies to child-of-child joints: the elbow's `origin` is expressed in the lower arm's part-local frame (`[220, 0, 0]` — at the lower arm's tip, NOT `[220, 0, 30]`).
+
 ```ts
 arm.revolute('base-yaw',       base,     shoulder, { axis: [0, 0, 1], origin: [45, 35, 8],  limitsDeg: [-120, 120] });
 arm.revolute('shoulder-pitch', shoulder, elbow,    { axis: [0, 1, 0], origin: [0, 0, 90],   limitsDeg: [-45, 135] });

--- a/src/agent/skills/kernelcad-kinematic/SKILL.md
+++ b/src/agent/skills/kernelcad-kinematic/SKILL.md
@@ -5,6 +5,23 @@ description: Use when verifying whether a moving assembly is buildable — sampl
 
 # kernelcad-kinematic — feasibility gates for moving assemblies
 
+## Units (read this first)
+
+Joint angles throughout the kinematic API are **degrees for revolute joints**
+and **millimetres for prismatic joints**. This matches the unit convention
+used by `arm.revolute({ limitsDeg })`, `arm.prismatic({ limitsMm })`, and
+`arm.solvedModel({poses})` — there is no degree-vs-radian split anywhere on
+the user-facing surface.
+
+That includes the IK seed: `kinematic.checkReachable({ seed: { shoulder: 60 } })`
+means 60 degrees, not 60 radians and not 60 of anything else. Authors porting
+code from URDF / MoveIt / ROS — where radians are conventional — must convert
+(`deg = rad * 180 / Math.PI`) before passing values to this API.
+
+A small seed value like `0.3` is interpreted as 0.3°, which is effectively
+zero — fine as a "near rest pose" hint, but not the ~17° you'd get if you
+were thinking in radians.
+
 ## When to load
 
 Load this skill whenever the user asks any of:

--- a/src/agent/skills/kernelcad-kinematic/cookbook/02-reachable-with-seed.kcad.ts
+++ b/src/agent/skills/kernelcad-kinematic/cookbook/02-reachable-with-seed.kcad.ts
@@ -46,8 +46,10 @@ const reachableTarget = [250, 100, 200] as const;
 
 // Seed pose hints the numeric path toward a nearby branch; the analytical
 // path ignores it (the closed-form solver returns its own branch choice).
+// Values are DEGREES (kernelCAD's joint-angle convention everywhere) — a
+// 17° / 11° / -11° hint, not radians. Use 0 for "no preference."
 const seed = {
-  shoulderYaw: 0.3, shoulderPitch: 0.2, elbowPitch: -0.2,
+  shoulderYaw: 17, shoulderPitch: 11, elbowPitch: -11,
   wristYaw: 0, wristPitch: 0, wristRoll: 0,
 };
 

--- a/src/agent/skills/kernelcad-nurbs/SKILL.md
+++ b/src/agent/skills/kernelcad-nurbs/SKILL.md
@@ -236,7 +236,7 @@ const rail = spline3d([
 ]);
 const slots = rail.analytics.divideByEqualArcLength(8);
 for (const { pt } of slots) {
-  body = body.cut(cylinder({ radius: 1, height: 5 }).translate(pt));
+  body = body.cut(cylinder(5, 1).translate(pt));
 }
 ```
 

--- a/src/kinematic/types.ts
+++ b/src/kinematic/types.ts
@@ -127,6 +127,12 @@ export interface ReachableOpts {
   readonly target: ReachableTarget;
   readonly preferSolver?: 'analytical' | 'numeric' | 'auto';
   readonly maxIterations?: number;
+  /** Optional warm-start pose for the numeric path. Units match
+   *  `NumericPoses`: **degrees for revolute joints, millimetres for prismatic
+   *  joints** — the same convention as `arm.solvedModel({poses})` and
+   *  `arm.revolute({ limitsDeg })`. Authors porting code from URDF/MoveIt/ROS
+   *  must convert radians → degrees before passing values here. The
+   *  analytical solver ignores the seed and returns its own branch choice. */
   readonly seed?: NumericPoses;
 }
 

--- a/src/modeling/api.ts
+++ b/src/modeling/api.ts
@@ -6,6 +6,7 @@ import { Sketch, makePath, type PathBuilder } from './capture/sketch';
 import type { SurfaceProxy } from './capture/surfaceProxy';
 import type { Curve3D } from './capture/curveProxy';
 import type { Param, Vec3, PlaneSpec } from '../shared/intent/types';
+import { isValidEditableNumber, formatScalarForError } from '../shared/intent/types';
 import {
   selectEdges as selectEdgesBackend,
   selectEdge as selectEdgeBackend,
@@ -360,6 +361,16 @@ export interface KernelCadApi {
 const mm = (n: Editable<number>): Param => toParam(n, 'mm');
 const ul = (n: Editable<number>): Param => toParam(n, 'unitless');
 
+function assertEditableNumber(featureKind: string, paramName: string, value: unknown): void {
+  if (isValidEditableNumber(value)) return;
+  throw new KernelError(
+    'feature.invalid-args',
+    `${featureKind}: ${paramName} must be a finite number or a numeric ParamRef; got ${formatScalarForError(value)}.`,
+    featureKind,
+    `Pass a number (or a ParamRef returned by param()) for ${paramName}; primitives do NOT accept an options object such as { radius, height }. Use the positional signature: ${featureKind}(...).`,
+  );
+}
+
 // === W1.3 NURBS surfaces validation helpers ===
 
 function isRectangularGrid(grid: unknown[][]): boolean {
@@ -423,6 +434,9 @@ export function createApi(ctx: ApiContext): KernelCadApi {
   const { session } = ctx;
   const api: KernelCadApi = {
     box(x, y, z, centered = false, opts) {
+      assertEditableNumber('box', 'x', x);
+      assertEditableNumber('box', 'y', y);
+      assertEditableNumber('box', 'z', z);
       const faceLabels = validateFaceLabels(opts?.faceLabels, 'box');
       return session.createShape({
         kind: 'box',
@@ -432,6 +446,8 @@ export function createApi(ctx: ApiContext): KernelCadApi {
       });
     },
     cylinder(h, r, _segments, opts) {
+      assertEditableNumber('cylinder', 'h', h);
+      assertEditableNumber('cylinder', 'r', r);
       const faceLabels = validateFaceLabels(opts?.faceLabels, 'cylinder');
       return session.createShape({
         kind: 'cylinder',
@@ -441,6 +457,7 @@ export function createApi(ctx: ApiContext): KernelCadApi {
       });
     },
     sphere(r, opts) {
+      assertEditableNumber('sphere', 'r', r);
       if (opts && 'faceLabels' in opts && opts.faceLabels !== undefined) {
         throw new KernelError(
           'feature.face-ref.not-applicable',

--- a/src/shared/intent/types.ts
+++ b/src/shared/intent/types.ts
@@ -193,6 +193,18 @@ export function isValidVec3(v: unknown): v is Vec3 {
   return Array.isArray(v) && v.length === 3 && v.every((n) => typeof n === 'number' && Number.isFinite(n));
 }
 
+/** Scalar input validator that accepts a finite number or ParamRef<number>.
+ *  Use at every capture-time entry point that takes an `Editable<number>`
+ *  (primitive dimensions, feature scalar params) so degenerate inputs (objects,
+ *  strings, NaN) are rejected with a clear `feature.invalid-args` rather than
+ *  reaching OCCT — which can recurse / overflow on garbage `evaluated` payloads. */
+export function isValidEditableNumber(v: unknown): boolean {
+  if (typeof v === 'number') return Number.isFinite(v);
+  if (typeof v !== 'object' || v === null) return false;
+  const o = v as { _brand?: unknown; _type?: unknown };
+  return o._brand === 'ParamRef' && o._type === 'number';
+}
+
 /** Vec3 input validator that accepts numbers or ParamRef<number> per coord.
  *  Use at every capture-time entry point that takes an EditableVec3 (assembly
  *  surfaces, transforms). Composes with `formatScalarForError` for diagnostics. */

--- a/src/studio/components/demoPlayer/DemoPlayerPage.tsx
+++ b/src/studio/components/demoPlayer/DemoPlayerPage.tsx
@@ -168,6 +168,10 @@ export interface DemoPlayerWindow {
     /** polygonOffset triple per sampled mesh material — used by tests to
      *  verify the renderer applies depth bias on assembly meshes. */
     samplePolygonOffsets: Array<{ enabled: boolean; factor: number; units: number }>;
+    /** Per-KCAD-feature group matrix (16 numbers column-major). Used by the
+     *  B3 regression test to verify worldTransform-bearing features land on
+     *  the group's matrix. */
+    kcadGroupMatrices: number[][];
   };
 }
 
@@ -985,6 +989,16 @@ export function DemoPlayerPage(): React.JSX.Element {
             );
             group.add(mesh);
           }
+          // Apply the per-feature world transform (e.g. solvedModel({poses}) FK
+          // for an assembly part). The centroid-recenter loop below composes the
+          // bbox offset on top, so worldTransform-bearing groups respect both
+          // the joint pose AND the scene-centering. Without this, agents
+          // returning arm.solvedModel({...}) rendered at rest pose. (B3 fix.)
+          if (fm.transform !== undefined) {
+            group.matrixAutoUpdate = false;
+            group.matrix.fromArray(fm.transform);
+            group.matrixWorldNeedsUpdate = true;
+          }
           scene.add(group);
           groupCount++;
         }
@@ -996,9 +1010,19 @@ export function DemoPlayerPage(): React.JSX.Element {
           const [minX, minY, minZ] = bounds.min;
           const [maxX, maxY, maxZ] = bounds.max;
           const cx = (minX + maxX) / 2, cy = (minY + maxY) / 2, cz = (minZ + maxZ) / 2;
+          // For groups carrying a baked worldTransform (assembly FK), compose
+          // the centroid offset onto the matrix instead of setting `position`
+          // — `position` is decoupled from `matrix` when matrixAutoUpdate=false,
+          // so position.set() would silently no-op on those groups.
+          const centroidOffset = new THREE.Matrix4().makeTranslation(-cx, -cy, -cz);
           for (const child of scene.children) {
             if (child instanceof THREE.Group && child.userData[KCAD_FEATURE_GROUP_KEY]) {
-              child.position.set(-cx, -cy, -cz);
+              if (child.matrixAutoUpdate === false) {
+                child.matrix.premultiply(centroidOffset);
+                child.matrixWorldNeedsUpdate = true;
+              } else {
+                child.position.set(-cx, -cy, -cz);
+              }
             }
           }
           // Stash the centroid offset so setRenderPose can translate a
@@ -1147,11 +1171,13 @@ export function DemoPlayerPage(): React.JSX.Element {
             cameraLookingAt: [0, 0, 0] as [number, number, number],
             sampleOpacities: [],
             samplePolygonOffsets: [],
+            kcadGroupMatrices: [],
           };
         }
         let meshCount = 0;
         const sampleOpacities: number[] = [];
         const samplePolygonOffsets: Array<{ enabled: boolean; factor: number; units: number }> = [];
+        const kcadGroupMatrices: number[][] = [];
         scene.traverse((obj) => {
           if (obj instanceof THREE.Mesh) {
             meshCount++;
@@ -1166,6 +1192,11 @@ export function DemoPlayerPage(): React.JSX.Element {
             }
           }
         });
+        for (const child of scene.children) {
+          if (child instanceof THREE.Group && child.userData[KCAD_FEATURE_GROUP_KEY]) {
+            kcadGroupMatrices.push(child.matrix.toArray());
+          }
+        }
         const lookDir = new THREE.Vector3();
         camera.getWorldDirection(lookDir);
         const lookAt: [number, number, number] = [
@@ -1180,6 +1211,7 @@ export function DemoPlayerPage(): React.JSX.Element {
           cameraLookingAt: lookAt,
           sampleOpacities,
           samplePolygonOffsets,
+          kcadGroupMatrices,
         };
       },
     };

--- a/tests/demo_player_smoke.spec.ts
+++ b/tests/demo_player_smoke.spec.ts
@@ -34,6 +34,68 @@ test('demo-player route renders without console errors', async ({ page }) => {
   expect(errors).toEqual([]);
 });
 
+test('demo-player applies per-feature worldTransform to THREE.Group (B3 regression)', async ({ page }) => {
+  // Regression for the borrow-integration B3 bug: when a script returns
+  // arm.solvedModel({ shoulder: 90 }) (degrees), each part's FK transform is
+  // serialized into FeatureMesh.transform and MUST be applied to the THREE
+  // group at construction. Before this fix, the matrix was rehydrated but
+  // never applied, so the headless render path showed every assembly at its
+  // rest pose regardless of solvedModel() args.
+  const errors: string[] = [];
+  page.on('pageerror', (e) => errors.push(e.message));
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text());
+  });
+
+  await page.goto('/demo-player');
+  await page.waitForFunction(() => window.__demoPlayer !== undefined, { timeout: 10000 });
+
+  const fakeFace = {
+    vertices: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+    indices: [0, 1, 2],
+    normals: [0, 0, 1, 0, 0, 1, 0, 0, 1],
+    faceId: 0,
+  };
+  // Translate-only column-major mat4: T(7, 0, 0). The matrix is row-major
+  // when read as [m00,m01,m02,m03, m10,m11,...]; THREE.Matrix4.fromArray
+  // expects column-major, so for translation x=7 the array is:
+  //   col0:[1,0,0,0]  col1:[0,1,0,0]  col2:[0,0,1,0]  col3:[7,0,0,1]
+  const translateXSeven = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 7, 0, 0, 1];
+  await page.evaluate(
+    ({ feats, b }) => window.__demoPlayer!.loadFeatureMeshes(feats, b),
+    {
+      feats: [
+        {
+          featureId: 'posed_part',
+          featureKind: 'assemblyPart',
+          predecessors: [],
+          faces: [fakeFace],
+          transform: translateXSeven,
+        },
+      ],
+      b: { min: [0, 0, 0] as [number, number, number], max: [10, 1, 1] as [number, number, number] },
+    },
+  );
+
+  // After loadFeatureMeshes returns, the KCAD group should have its matrix
+  // populated with the supplied translation (composed with the centroid
+  // recenter, but the X column should still record the translation magnitude).
+  const m = await page.evaluate(() => {
+    const groups = window.__demoPlayer!.dumpScene().kcadGroupMatrices;
+    return groups[0];
+  });
+  expect(m).toBeDefined();
+  // Element 12 is the column-major x-translation. With centroid recenter for
+  // bounds [0,10] × [0,1] × [0,1], cx = 5, so the composed translation x is
+  // (7 - 5) = 2. The exact value is less important than non-zero — a missing
+  // transform would leave m[12] = -5 (just the centroid). Be lenient on the
+  // exact value but assert direction:
+  expect(typeof m[12]).toBe('number');
+  expect(m[12]).toBeGreaterThan(0); // worldTransform translate moved the group +X past the centroid
+
+  expect(errors).toEqual([]);
+});
+
 test('demo-player can load the robot arm example through the dev mesh endpoint', async ({ page }) => {
   const errors: string[] = [];
   page.on('pageerror', (e) => errors.push(e.message));

--- a/tests/unit/modules/api.primitiveInputValidation.test.ts
+++ b/tests/unit/modules/api.primitiveInputValidation.test.ts
@@ -1,0 +1,85 @@
+// Regression: primitives (box, cylinder, sphere) must reject non-finite /
+// non-numeric inputs at capture time with a clear `feature.invalid-args`.
+// Until this was wired, `cylinder({ radius, height })` (a doc-example typo)
+// flowed an object through `toParam` and produced a degenerate Shape whose
+// downstream lowering recursed into a "Maximum call stack size exceeded" on
+// the assembly-clone path. Found while building the Luxo lamp demo
+// (2026-05-25), see kernelCAD-private/docs/lineage/2026-05-25-borrow-integration-bugs.md.
+import { describe, it, expect } from 'vitest';
+import { createApi } from '../../../src/modeling/api';
+import { CaptureSession } from '../../../src/modeling/capture/captureSession';
+
+describe('Primitive input validation — finite-number check', () => {
+  it('cylinder() rejects an object literal as `h`', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    expect(() => api.cylinder({ radius: 35, height: 60 } as unknown as number, 10))
+      .toThrowError(/cylinder: h must be a finite number/);
+  });
+
+  it('cylinder() rejects NaN as `r`', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    expect(() => api.cylinder(20, NaN)).toThrowError(/cylinder: r must be a finite number/);
+  });
+
+  it('cylinder() rejects Infinity as `h`', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    expect(() => api.cylinder(Infinity, 10)).toThrowError(/cylinder: h must be a finite number/);
+  });
+
+  it('cylinder() accepts positional numbers (no regression)', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    const s = api.cylinder(20, 10);
+    expect(s.id).toBeDefined();
+  });
+
+  it('cylinder() accepts ParamRef coords (no regression)', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    const h = api.param('height', 20);
+    const s = api.cylinder(h, 10);
+    expect(s.id).toBeDefined();
+  });
+
+  it('box() rejects an object literal as a dimension', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    expect(() => api.box({ w: 10 } as unknown as number, 20, 30))
+      .toThrowError(/box: x must be a finite number/);
+  });
+
+  it('box() rejects NaN', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    expect(() => api.box(10, NaN, 30)).toThrowError(/box: y must be a finite number/);
+  });
+
+  it('box() accepts positional numbers and ParamRefs (no regression)', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    const w = api.param('width', 100);
+    expect(() => api.box(w, 50, 25)).not.toThrow();
+  });
+
+  it('sphere() rejects an object literal', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    expect(() => api.sphere({ radius: 10 } as unknown as number))
+      .toThrowError(/sphere: r must be a finite number/);
+  });
+
+  it('sphere() rejects NaN', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    expect(() => api.sphere(NaN)).toThrowError(/sphere: r must be a finite number/);
+  });
+
+  it('sphere() accepts a positive finite number (no regression)', () => {
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    expect(() => api.sphere(10)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Two real bugs and one no-repro surfaced while building a Luxo lamp demo that exercises V (NURBS analytics), Q (Query DSL), and kinematic borrows together.

- **B1 — primitives input validation:** `box`/`cylinder`/`sphere` previously accepted any value as their dimension args. `cylinder({radius, height})` (object literal, a common typo against the positional `cylinder(h, r)` signature) flowed through `toParam` to `{evaluated: <obj>}`, and downstream lowering recursed into `Maximum call stack size exceeded` when the shape entered an `assembly().part()`. Now all three primitives reject non-finite / non-numeric inputs at capture time with a clear `feature.invalid-args` that names the bad arg and points at the correct positional signature.
- **B3 — `solvedModel(poses)` now reaches the render:** `DemoPlayerPage` rehydrated `fm.transform` and never applied it to the `THREE.Group`. Every assembly rendered at rest pose regardless of pose dict. Fixed by setting `group.matrix = transform` and composing the bbox centroid via `Matrix4.premultiply` (since `position.set` is decoupled from `matrix` when `matrixAutoUpdate=false`).
- **B2 — variableSweep + assembly render hang:** not reproducible on develop tip (verified 3× clean at 9.5–11.5s). Original hang was zombie-process / stale-build noise from extended iteration. No code change; documented in CHANGELOG.

## What changed

| File | Change |
|---|---|
| `src/shared/intent/types.ts` | Add `isValidEditableNumber` helper (number-or-ParamRef finite check) |
| `src/modeling/api.ts` | `assertEditableNumber` guard in `box`/`cylinder`/`sphere` |
| `src/studio/components/demoPlayer/DemoPlayerPage.tsx` | Apply `fm.transform` to `THREE.Group.matrix`; compose centroid via `premultiply`; expose `kcadGroupMatrices` in `dumpScene` |
| `src/agent/skills/kernelcad-nurbs/SKILL.md` | Fix `cylinder({…})` → `cylinder(5, 1)` doc example |
| `tests/unit/modules/api.primitiveInputValidation.test.ts` | 11 new unit tests for B1 (object, NaN, Infinity rejected; positional + ParamRef pass) |
| `tests/demo_player_smoke.spec.ts` | Playwright regression for B3 — load feature mesh with translate-7 transform, assert KCAD group records the offset |
| `CHANGELOG.md` | Three-paragraph fix entry |

## Test plan

- [x] `npx vitest run tests/unit/modules/api.primitiveInputValidation.test.ts` — 11/11 pass
- [x] `npx vitest run tests/unit/modules/api.test.ts tests/unit/assemblies tests/unit/diagnostics` — 146 tests pass
- [x] Manual: `evaluate /tmp/repro-b1-narrow.kcad.ts` now returns clear `feature.invalid-args` (was: stack overflow)
- [x] Manual: `render /tmp/repro-b3-degrees.kcad.ts` (single-joint, 90° shoulder) — arm now points straight up (was: horizontal rest pose)
- [x] Manual: 2-link arm authored at part-local origin renders posed correctly with both joints articulated
- [ ] CI: Playwright `demo-player applies per-feature worldTransform (B3 regression)` test passes

## Known follow-up (separate from this PR)

A 3-link Luxo-style arm authored with `.translate()` baking rest world position into part-local vertices (rather than at the joint pivot) currently shows visible disconnect under chained FK. This is a pre-existing kernel behaviour where `worldTransform` assumes part-local origin sits at the joint pivot; the cookbook robot-arm example sidesteps this because its rest pose is all-zeros. Filed for separate triage.