### PR TITLE
fix(connect): correct monetization copy for bring-your-own-Claude flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,10 @@ generated `kernelcad mcp --cloud --token <…>` snippet. The hosted surface adds
 `generate_kcad_from_prompt` (turn a natural-language brief into a `.kcad.ts`
 source) on top of the introspection and review tools, and serves the
 `kernelcad-authoring` skill as an MCP resource so Claude Desktop loads it
-automatically on connect. Free tier: 3 LLM-generated parts per month;
-introspection and review tools are unlimited.
+automatically on connect. Connecting your own Claude is unlimited — modeling,
+introspection, and review tools all run free, since your Claude bears the LLM
+cost. Paid plans cover only public project hosting and kernelCAD's own hosted
+agents.
 
 > A one-shot `kernelcad install --claude-desktop` command that edits this
 > config for you is on the next slice — until then the snippet above is the

--- a/scripts/staticGalleryLanding.test.ts
+++ b/scripts/staticGalleryLanding.test.ts
@@ -43,12 +43,13 @@ describe('static gallery landing page', () => {
     expect(stackBlock).toContain('href="/app/connect"');
     expect(stackBlock).toContain('Use with Claude Desktop');
 
-    // Free-tier caption sits near the install stack so the Claude Desktop CTA
-    // links to a page whose marketing matches what the hosted gateway delivers:
-    // 3 LLM-generated parts/month, unlimited introspection + review.
+    // Caption sits near the install stack so the Claude Desktop CTA links to a
+    // page whose marketing matches what the hosted gateway delivers: bringing
+    // your own Claude (Path A) is uncapped — generation, introspection, and
+    // review all run free. Only public hosting and hosted agents are paid.
     expect(html).toContain('id="claude-desktop-note"');
-    expect(html).toContain('3 LLM-generated parts per month');
-    expect(html).toContain('Introspection and review tools are unlimited');
+    expect(html).toContain('generation is unlimited');
+    expect(html).toContain('modeling, introspection, and review tools all run free');
   });
 
   it('documents the same full marketing build command used by deploy', () => {

--- a/site/index.html
+++ b/site/index.html
@@ -75,7 +75,7 @@
             <span class="copy">copy</span>
           </button>
         </div>
-        <p class="install-note" id="claude-desktop-note">Free tier: 3 LLM-generated parts per month. Introspection and review tools are unlimited.</p>
+        <p class="install-note" id="claude-desktop-note">Connect your own Claude and generation is unlimited — modeling, introspection, and review tools all run free. Paid plans cover only public project hosting and kernelCAD's own hosted agents.</p>
       </div>
       <div class="hero-proof" aria-label="kernelCAD generated artifact preview">
         <div class="demo-meta">

--- a/src/studio/routes/connect.tsx
+++ b/src/studio/routes/connect.tsx
@@ -60,6 +60,11 @@ function ConnectPage() {
             <div className="mt-6 flex justify-center">
               <SignInButton redirectTo={`${window.location.origin}/connect`} />
             </div>
+            <p className="text-ink-faint text-xs mt-4">
+              Power user? Skip the hosted kernel and run it locally — no account,
+              no token:{' '}
+              <code className="font-mono text-ink-soft">npx kernelcad mcp</code>
+            </p>
           </div>
         </div>
       </main>

--- a/src/studio/routes/connect.tsx
+++ b/src/studio/routes/connect.tsx
@@ -52,8 +52,10 @@ function ConnectPage() {
               Connect kernelCAD to Claude Desktop
             </h1>
             <p className="text-ink-soft text-sm mt-2">
-              Sign in to generate a hosted MCP token. Free tier: 3 LLM-generated
-              parts per month. Introspection and review tools are unlimited.
+              Sign in to generate a hosted MCP token. Connect your own Claude
+              and generation is unlimited — modeling, introspection, and review
+              tools all run free. Paid plans cover only public project hosting
+              and kernelCAD's own hosted agents.
             </p>
             <div className="mt-6 flex justify-center">
               <SignInButton redirectTo={`${window.location.origin}/connect`} />


### PR DESCRIPTION
## Summary
- The `/connect` page (and the homepage install caption + README) wrongly advertised a "Free tier: 3 LLM-generated parts per month" cap. `/connect` is the bring-your-own-model MCP onboarding flow, which is uncapped — the user's own model bears the generation cost.
- Rewrote the copy on the `/connect` signed-out CTA (`src/studio/routes/connect.tsx`), the homepage install caption (`site/index.html`), and the README to state that connecting your own model is unlimited (modeling, introspection, and review tools all run free), and that the only paid surfaces are public project hosting and kernelCAD's own hosted agents.
- Updated `scripts/staticGalleryLanding.test.ts` to assert the corrected caption and removed the stale rationale comment.

## Backend note
Audited the hosted gateway gating. The free-tier quota only debits on the single hosted-generation tool (`generate_kcad_from_prompt`), which runs kernelCAD's own hosted backend; all real modeling/introspection/review tools bypass the quota entirely. So the bring-your-own-model path is already uncapped server-side — no server change was needed; this PR is copy-only.

## Test plan
- [x] `npx eslint` on changed files — clean
- [x] `npm run typecheck` (`tsc -b --noEmit`) — passes
- [x] `vitest run scripts/staticGalleryLanding.test.ts` — 7 passed
- [ ] Visual inspection of the rendered `/connect` page and homepage caption before merge/deploy