### PR TITLE
fix(studio): hosted Scene tab shows real feature tree, not the variable dump

### DIFF
--- a/site/scripts/build-gallery.ts
+++ b/site/scripts/build-gallery.ts
@@ -20,6 +20,9 @@ import { exportGlb } from '../../scripts/lib/exportGlb';
 import { loadScriptFeatures } from '../../src/modeling/runtime/scriptLoader';
 import { meshFeaturesPerFeature } from '../../src/modeling/capture/featureMeshing';
 import { serializeForBridge } from '../../src/modeling/capture/featureMeshSerialize';
+import { validateAssemblyWithMates } from '../../src/modeling/mates/validator';
+import type { Assembly } from '../../src/modeling/capture/assembly';
+import type { CaptureSession } from '../../src/modeling/capture/captureSession';
 
 export interface BuildGalleryOptions {
   entriesPath: string;
@@ -37,6 +40,44 @@ interface PublishedEntry extends Omit<GalleryEntry, 'video' | 'codeLocal'> {
 
 const GLB_SIZE_HARD_CAP = 500_000;
 const STUDIO_ORIGIN = 'https://app.kernelcad.com';
+/**
+ * Builds the `ScriptReviewSummary` the hosted Studio consumes (see
+ * GeometryContext) from the already-evaluated session — reusing the loaded
+ * assembly instead of re-running the script. Runs the fast structural
+ * validator (floating parts, orphans, mate validity) which carries the
+ * part/mate attribution SceneTab routes to severity dots. Skips the
+ * pose-envelope / interference sweep, which is too slow for a build step and
+ * cannot be interrupted on the single OCCT thread. Non-fatal: any failure
+ * yields a passing summary so the deploy never stalls and the Studio still
+ * shows the real feature tree.
+ */
+async function reviewFromLoadedSession(session: CaptureSession): Promise<Record<string, unknown>> {
+  try {
+    const arm = [...session.assemblies.values()][0] as Assembly | undefined;
+    if (!arm) return { ok: true, diagnostics: [] };
+    const validator = await validateAssemblyWithMates(arm);
+    const diagnostics = validator.diagnostics.map((d) => {
+      const entry: Record<string, unknown> = {
+        code: d.code,
+        severity: d.severity,
+        message: d.message,
+        hint: d.hint,
+      };
+      if (d.partName) entry.partName = d.partName;
+      if (d.mateName) entry.mateName = d.mateName;
+      if (d.partA) entry.partA = d.partA;
+      if (d.partB) entry.partB = d.partB;
+      return entry;
+    });
+    const ok = !validator.diagnostics.some((d) => d.severity === 'error');
+    return { ok, diagnostics };
+  } catch (err) {
+    console.warn(
+      `build-gallery: validity skipped — ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { ok: true, diagnostics: [] };
+  }
+}
 
 export async function buildGallery(opts: BuildGalleryOptions): Promise<void> {
   const raw = JSON.parse(readFileSync(opts.entriesPath, 'utf8'));
@@ -133,12 +174,18 @@ export async function buildGallery(opts: BuildGalleryOptions): Promise<void> {
             `build-gallery: ${entry.slug} precompute skipped — ${meshing.failedFeatureIds.length} feature(s) failed to mesh: ${meshing.failedFeatureIds.join(', ')}`,
           );
         } else {
+          // Bake the deterministic structural review so the hosted Studio
+          // shows the real adaptive feature tree (validity non-null) instead
+          // of the legacy code-history fallback, and the Validity tab reflects
+          // actual diagnostics. Reuses the loaded assembly — no re-evaluate.
+          const review = await reviewFromLoadedSession(loaded.session);
           const bridgePayload = {
             source: sourceText,
             features: meshing.features.map(serializeForBridge),
             featureRecords: loaded.features.map((f) => f.record),
             bounds: meshing.bounds,
             params: loaded.paramTable.serialize(),
+            review,
           };
           writeFileSync(path.join(meshOutDir, `${sha}.json`), JSON.stringify(bridgePayload));
         }

--- a/src/studio/adapters/reviewToValidity.ts
+++ b/src/studio/adapters/reviewToValidity.ts
@@ -47,6 +47,12 @@ function diagnosticFromReview(d: NonNullable<ScriptReviewSummary['diagnostics']>
         severity,
         message: d.message ?? '',
         hint: d.hint ?? '',
+        // Carry part/mate attribution so SceneTab can route each diagnostic
+        // to the right row's severity dot. Older payloads omit these.
+        ...(d.partName ? { partName: d.partName } : {}),
+        ...(d.mateName ? { mateName: d.mateName } : {}),
+        ...(d.partA ? { partA: d.partA } : {}),
+        ...(d.partB ? { partB: d.partB } : {}),
     };
 }
 

--- a/src/studio/context/GeometryContext.tsx
+++ b/src/studio/context/GeometryContext.tsx
@@ -18,7 +18,16 @@ export interface ExecutionRecord {
 
 export interface ScriptReviewSummary {
     ok: boolean;
-    diagnostics?: Array<{ code?: string; severity?: string; message?: string; hint?: string }>;
+    diagnostics?: Array<{
+        code?: string;
+        severity?: string;
+        message?: string;
+        hint?: string;
+        partName?: string;
+        mateName?: string;
+        partA?: string;
+        partB?: string;
+    }>;
     fitness?: {
         functional?: boolean;
         repairMode?: string;
@@ -497,6 +506,7 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
                     setGeometryTransformOverrides({});
                     setFeatureRecords((payload.featureRecords as FeatureRecord[]) ?? []);
                     setScriptParams(Object.values(payload.params ?? {}));
+                    setScriptReview(payload.review ?? { ok: true, diagnostics: [] });
                     setSketchesGeometries([]);
                     setPreviewGeometries([]);
                     setError(null);
@@ -663,6 +673,7 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
                 setGeometryTransformOverrides({});
                 setFeatureRecords((payload.featureRecords as FeatureRecord[]) ?? []);
                 setScriptParams(Object.values(payload.params ?? {}));
+                setScriptReview(payload.review ?? { ok: true, diagnostics: [] });
                 setSketchesGeometries([]);
                 setPreviewGeometries([]);
                 setError(null);

--- a/src/studio/scriptSource.ts
+++ b/src/studio/scriptSource.ts
@@ -1,5 +1,6 @@
 import { findGallerySourceUrl, galleryPrecomputedMeshUrl } from './gallerySource';
 import type { SerializedParamTable } from '../shared/runtime/paramTable';
+import type { ScriptReviewSummary } from './context/GeometryContext';
 
 export async function loadStudioScriptSource(script: string): Promise<string> {
   const response = await fetch(`/__kernelcad/source?script=${encodeURIComponent(script)}`);
@@ -31,6 +32,10 @@ export interface BackendMeshPayload {
   featureRecords?: unknown[];
   bounds: { min: [number, number, number]; max: [number, number, number] };
   params?: SerializedParamTable;
+  /** Deterministic review baked at build time (precompute) or returned by the
+   *  server mesh endpoint. Drives the adaptive scene tree + Validity tab on the
+   *  hosted deploy, which has no separate `/__kernelcad/review` fetch. */
+  review?: ScriptReviewSummary;
 }
 
 /**


### PR DESCRIPTION
## Summary
- On `app.kernelcad.com` the precompute set `scriptReview = null`, so `validity` was null and `SceneTab` permanently fell back to its **legacy code-history browser** — an AST dump of every `const`/loop-var in the source (`extractHistoryItems`), classified by the old replicad v0.1 API (`makeBox`/`Sketcher`) that modern kernelCAD scripts never trigger. It was never a real feature timeline.
- `build-gallery.ts` now runs the **structural validator** on the already-loaded assembly (no re-evaluate, no slow pose-envelope/interference sweep — that hung the build) and bakes a `ScriptReviewSummary` into each `_mesh` payload.
- The hosted `GeometryContext` branches (auto-run effect + Run button) consume `payload.review` (defaulting to a passing review), so `validity` is non-null → the **adaptive feature tree** (real part/joint/mate rows + severity dots) replaces the variable dump.
- Diagnostics keep `partName`/`mateName`/`partA`/`partB` so dots route to the right rows (`reviewToValidity` now preserves attribution).

## Verified locally
- [x] `tsc -b --noEmit` clean
- [x] `vitest run` studio adapters/tabs/context — 170 pass
- [x] `build-gallery` runs fast; all 6 `_mesh` payloads carry `review` (watch: ok, 0 diags / stool: ok, 26 info diags with mate attribution)
- [ ] Live: hosted Scene tab shows the real part tree after deploy