### PR TITLE
dx: don't block Studio CAD viewer on missing VITE_SUPABASE_*

### DIFF
--- a/src/studio/routes/__root.tsx
+++ b/src/studio/routes/__root.tsx
@@ -8,15 +8,35 @@ import { getSupabase } from '../../funnel/lib/supabaseClient';
 // access_token in the URL hash but the hash is never consumed because the
 // landing route doesn't import the auth hook. This call is safe (singleton).
 //
-// Skip in headless render mode (capture-demo, kernelcad render): those flows
-// don't need auth state and shouldn't require Supabase env vars to be present
-// on the rendering box (otherwise demo refresh hard-fails in any env without
-// .env.local — what broke the gallery between 2026-05-15 and 2026-05-18).
-// Detected via ?headless=1 to mirror isHeadlessRender() below.
+// Skip in two cases:
+//
+//   1. Headless render mode (kernelcad render / capture-demo): those flows
+//      don't need auth state and shouldn't require Supabase env vars to be
+//      present on the rendering box. Detected via ?headless=1.
+//   2. Local-dev with missing VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY:
+//      `getSupabase()` throws when env vars are missing, which breaks the
+//      Studio's CAD viewer (which doesn't use Supabase at all) for any
+//      developer who hasn't copied .env.example → .env.local. We log a
+//      one-time warn and skip OAuth wiring so the rest of the app boots.
+//      Auth-touching code paths (sign-in, billing) still throw via their
+//      own getSupabase() call sites — this only softens the boot-time
+//      eager init.
 if (typeof window !== 'undefined') {
   const isHeadless = new URLSearchParams(window.location.search).get('headless') === '1';
   if (!isHeadless) {
-    getSupabase();
+    const url = import.meta.env.VITE_SUPABASE_URL;
+    const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+    if (url && anonKey) {
+      getSupabase();
+    } else if (import.meta.env.DEV) {
+      // Module-level warn fires once per session; dev-only so production
+      // misconfigurations still surface via the strict getSupabase() throw
+      // on the first auth-path call.
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[supabase] VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY missing — OAuth redirect handling disabled. Copy .env.example to .env.local to enable sign-in.',
+      );
+    }
   }
 }
 

--- a/tests/funnel/supabaseBootSoftFail.test.ts
+++ b/tests/funnel/supabaseBootSoftFail.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+//
+// Regression: the Studio's `__root.tsx` boot-time eager call to `getSupabase()`
+// used to throw `Missing VITE_SUPABASE_URL` whenever a developer ran `npm run
+// dev` without an `.env.local`. The throw fired at module-load and bricked
+// the entire Studio (including the CAD viewer, which doesn't use Supabase at
+// all). The fix: at __root boot, check the env vars BEFORE calling
+// getSupabase, and log a one-time dev-mode warn when they're absent.
+//
+// This test asserts two things:
+//   1. The strict accessor `getSupabase()` still throws when env vars are
+//      missing — auth-required code paths must surface the misconfiguration.
+//   2. The strict accessor returns a client when env vars are present.
+//
+// The __root.tsx boot-time soft-fail itself is verified end-to-end via the
+// Studio loading in a Playwright/devtools session without .env.local
+// (`tests/demo_player_smoke.spec.ts` covers the headless-render variant; the
+// Studio main route was manually validated before this change shipped).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('Supabase env var handling', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('getSupabase() throws a clear error when VITE_SUPABASE_URL is missing', async () => {
+    vi.stubEnv('VITE_SUPABASE_URL', '');
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'placeholder');
+    const { getSupabase } = await import('../../src/funnel/lib/supabaseClient');
+    expect(() => getSupabase()).toThrowError(/Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY/);
+  });
+
+  it('getSupabase() throws when VITE_SUPABASE_ANON_KEY is missing', async () => {
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://placeholder.supabase.co');
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', '');
+    const { getSupabase } = await import('../../src/funnel/lib/supabaseClient');
+    expect(() => getSupabase()).toThrowError(/Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY/);
+  });
+
+  it('getSupabase() returns a client when both env vars are present', async () => {
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://placeholder.supabase.co');
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'placeholder-anon-key');
+    const { getSupabase } = await import('../../src/funnel/lib/supabaseClient');
+    const client = getSupabase();
+    expect(client).toBeDefined();
+    expect(typeof client.auth).toBe('object');
+  });
+
+  it('getSupabase() returns the same cached client across calls', async () => {
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://placeholder.supabase.co');
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'placeholder-anon-key');
+    const { getSupabase } = await import('../../src/funnel/lib/supabaseClient');
+    expect(getSupabase()).toBe(getSupabase());
+  });
+});


### PR DESCRIPTION
## Summary

Studio currently throws **`Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY`** at module load when a fresh checkout runs `npm run dev` without `.env.local` — black screen, even though the CAD viewer never touches Supabase. Surfaced this morning while debugging the Luxo lamp demo (linked the user to `localhost:5173/studio?script=...`, got "black screen, why?").

The throw fires from `src/studio/routes/__root.tsx`'s eager `getSupabase()` call (intentional: wires up OAuth `detectSessionInUrl` for redirect handling). The fix preserves that intent when env vars are present, but softens to a one-time `console.warn` in dev when they're not — so the CAD viewer (which has nothing to do with Supabase) keeps booting.

Production misconfigurations still fail loudly: the strict `getSupabase()` accessor used by sign-in / billing / `useSession` continues to throw on missing env vars, with the same diagnostic message. Only the boot-time eager init is softened.

## What changed

| File | Change |
|---|---|
| `src/studio/routes/__root.tsx` | At boot, gate the eager `getSupabase()` call on `VITE_SUPABASE_URL && VITE_SUPABASE_ANON_KEY`. If missing in dev mode, log a one-time `console.warn` explaining the consequence and skip OAuth wiring. Headless render path unchanged. |
| `tests/funnel/supabaseBootSoftFail.test.ts` | New: asserts the strict accessor's contract is unchanged — throws on missing env vars, returns a singleton when present. (4 tests) |

## Test plan

- [x] `npx vitest run tests/funnel/supabaseBootSoftFail.test.ts` — 4/4 pass
- [x] `npx vitest run tests/funnel` — full funnel suite 41/41 pass (no regression)
- [x] **Manual end-to-end:** removed `.env.local`, restarted `npm run dev`, opened `localhost:5173/studio` in chrome-devtools — Studio loads cleanly, console shows `[supabase] VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY missing — OAuth redirect handling disabled. Copy .env.example to .env.local to enable sign-in.`, scene tree populates with the default bracket example, no error.

## Why "dev:" not "fix:"

This is a developer-experience papercut, not a correctness bug — the Studio's auth/billing surface still requires Supabase config to work. The change just stops the missing config from also bricking the CAD-only paths.