### PR TITLE
fix: Luxo lamp + Studio render modes + interactive interference visibility

### DIFF
--- a/examples/kinematic/luxo-lamp.kcad.ts
+++ b/examples/kinematic/luxo-lamp.kcad.ts
@@ -1,0 +1,254 @@
+// Pixar-style Luxo desk lamp — 3-DOF kinematic build.
+//
+// Three revolute joints around -Y (shoulder, elbow, wrist) drive a classic
+// Luxo silhouette: heavy disc base on the desk, slim arms folded over each
+// other, lamp shade tilted forward and down.
+//
+// Each link is authored in its OWN PART-LOCAL FRAME with origin at the joint
+// where the part attaches to its parent. The joint `origin` lives in the
+// PARENT's part-local frame.
+//
+// Convention discipline (kernelcad-assemblies / kernelcad-kinematic SKILLs):
+//   - axes in metres? NO — millimetres throughout
+//   - rotations in radians? NO — degrees throughout (revolute limitsDeg / pose)
+//   - child-shape author position does NOT include parent joint offset; that
+//     comes from `arm.revolute({ origin })`.
+
+// ---- pose parameters (live sliders, degrees) ----------------------------
+const shoulderDeg = param('shoulderDeg', 70,   { min: -10, max: 110 });
+const elbowDeg    = param('elbowDeg',   -120,  { min: -150, max: -30 });
+const wristDeg    = param('wristDeg',   -40,   { min: -90,  max:   0 });
+
+// ---- geometry ------------------------------------------------------------
+// Base disc (sits on z=0, generous radius so the lamp doesn't tip visually).
+const BASE_R   = 70;
+const BASE_H   = 14;
+
+// Neck riser (lifts the shoulder pivot above the disc).
+const NECK_R   = 14;
+const NECK_H   = 18;
+
+// Shoulder pivot Z in world frame.
+const SHOULDER_Z = BASE_H + NECK_H;       // 32 mm
+
+// Lower arm.
+const L_LOWER  = 200;
+const ARM_W    = 12;                       // Y dimension (cross-arm width)
+const ARM_T    = 10;                       // Z dimension (arm thickness)
+
+// Upper arm.
+const L_UPPER  = 170;
+
+// Lamp shade (truncated cone): narrow end at the wrist, wide end is the
+// opening. Authored as a revolved profile around the local Z axis, then
+// rotated so the shade's mouth points along +X in the wrist-local frame.
+const SHADE_R_SMALL = 22;
+const SHADE_R_LARGE = 55;
+const SHADE_LEN     = 70;
+const SHADE_T       = 2;   // shell thickness for the shade rim
+
+// Knuckle sphere radius (visual joint covers).
+const KNUCKLE_R = 12;
+
+// ---- BASE part (root, identity in world) --------------------------------
+// Disc base + neck riser, both authored stacked on the desk.
+const arm = assembly('luxo-lamp');
+
+const baseDisc = cylinder(BASE_H, BASE_R, 64)
+  .material({
+    baseColor: '#c8cdd3',     // light brushed-steel — visible on dark viewport
+    metalness: 0.4,
+    roughness: 0.55,
+  });
+
+const neckRiser = cylinder(NECK_H, NECK_R, 48)
+  .translate(0, 0, BASE_H)
+  .material({
+    baseColor: '#b8bdc3',
+    metalness: 0.4,
+    roughness: 0.55,
+  });
+
+// Shoulder knuckle sphere — sits at the shoulder pivot in world frame.
+const shoulderKnuckle = sphere(KNUCKLE_R)
+  .translate(0, 0, SHOULDER_Z)
+  .material({
+    baseColor: '#3a4250',
+    metalness: 0.9,
+    roughness: 0.35,
+  });
+
+const baseShape = baseDisc.union(neckRiser).union(shoulderKnuckle);
+const basePart = arm.part('base', baseShape);
+
+// ---- LOWER ARM (child of shoulder) --------------------------------------
+// Authored in lower-arm part-local frame: origin at shoulder pivot.
+// Arm extends along +X. Local rotation about -Y at the shoulder lifts the
+// lower arm up; that rotation is supplied by arm.revolute(shoulderDeg).
+//
+// Visual: slim rectangular bar with chamfered ends + an elbow knuckle sphere
+// at the distal tip so the shape reads as "arm" not "plank".
+const lowerArmBeam = box(L_LOWER, ARM_W, ARM_T, true)
+  .translate(L_LOWER / 2, 0, 0)
+  .material({
+    baseColor: '#c9c1a8',     // warm cream — Pixar Luxo arm tone
+    metalness: 0.25,
+    roughness: 0.55,
+  });
+
+const elbowKnuckle = sphere(KNUCKLE_R)
+  .translate(L_LOWER, 0, 0)
+  .material({
+    baseColor: '#3a4250',
+    metalness: 0.9,
+    roughness: 0.35,
+  });
+
+// Small cap at the shoulder end of the arm so the arm visibly meets the
+// shoulder knuckle even with the rotation extreme.
+const lowerShoulderCap = sphere(ARM_W * 0.7)
+  .translate(0, 0, 0)
+  .material({
+    baseColor: '#c9c1a8',
+    metalness: 0.25,
+    roughness: 0.55,
+  });
+
+const lowerArmShape = lowerArmBeam.union(elbowKnuckle).union(lowerShoulderCap);
+const lowerArmPart = arm.part('lower-arm', lowerArmShape);
+
+// ---- UPPER ARM (child of elbow) -----------------------------------------
+// Authored at part-local origin = elbow pivot. Extends along +X.
+// Adds a wrist knuckle at its tip.
+const upperArmBeam = box(L_UPPER, ARM_W, ARM_T, true)
+  .translate(L_UPPER / 2, 0, 0)
+  .material({
+    baseColor: '#c9c1a8',
+    metalness: 0.25,
+    roughness: 0.55,
+  });
+
+const wristKnuckle = sphere(KNUCKLE_R)
+  .translate(L_UPPER, 0, 0)
+  .material({
+    baseColor: '#3a4250',
+    metalness: 0.9,
+    roughness: 0.35,
+  });
+
+const upperShoulderCap = sphere(ARM_W * 0.7)
+  .translate(0, 0, 0)
+  .material({
+    baseColor: '#c9c1a8',
+    metalness: 0.25,
+    roughness: 0.55,
+  });
+
+const upperArmShape = upperArmBeam.union(wristKnuckle).union(upperShoulderCap);
+const upperArmPart = arm.part('upper-arm', upperArmShape);
+
+// ---- LAMP HEAD (child of wrist) -----------------------------------------
+// Authored at part-local origin = wrist pivot. The shade's narrow end is at
+// the wrist; the opening (wide end) faces +X in part-local frame so that
+// rotating the wrist around -Y tilts the opening downward.
+//
+// Build approach: revolve a trapezoid around Z to get a truncated cone whose
+// axis is +Z; then rotate the whole shape so the +Z axis maps to +X (i.e.
+// rotate -90 deg around Y). Origin stays at the small end (radius
+// SHADE_R_SMALL).
+const shadeProfile = path()
+  .moveTo(SHADE_R_SMALL, 0)
+  .lineTo(SHADE_R_LARGE, SHADE_LEN)
+  .lineTo(SHADE_R_LARGE - SHADE_T, SHADE_LEN)
+  .lineTo(SHADE_R_SMALL - SHADE_T * 0.6, 0)
+  .close();
+
+// Solid revolved cone (open via the trapezoid offset above — it's a
+// thin-walled shell).
+const shadeRaw = shadeProfile.revolve();
+
+// Rotate so the axis aligns with +X in part-local frame: shade narrow end
+// stays at origin, opens toward +X. Rotation of +90° about +Y maps the
+// original +Z direction (cone axis) to +X.
+const shade = shadeRaw
+  .rotate([0, 1, 0], 90)
+  .material({
+    baseColor: '#d8b85a',     // brass — classic Luxo head
+    metalness: 0.85,
+    roughness: 0.3,
+  });
+
+// A small neck collar where the head meets the wrist knuckle.
+const shadeCollar = cylinder(8, SHADE_R_SMALL + 2, 48)
+  .rotate([0, 1, 0], 90)
+  .translate(-4, 0, 0)
+  .material({
+    baseColor: '#3a4250',
+    metalness: 0.9,
+    roughness: 0.35,
+  });
+
+// Inner glow bulb — small bright sphere centered well inside the shade so
+// it reads as a bulb visible through the open end. Sits a third of the way
+// down the cone from the narrow (wrist) end so it's enveloped by the shade
+// from most viewing angles.
+const bulb = sphere(SHADE_R_SMALL * 0.55)
+  .translate(SHADE_LEN * 0.28, 0, 0)
+  .material({
+    baseColor: '#fff5d6',
+    metalness: 0.0,
+    roughness: 0.2,
+  });
+
+const headShape = shade.union(shadeCollar).union(bulb);
+const headPart = arm.part('lamp-head', headShape);
+
+// ---- JOINTS --------------------------------------------------------------
+// Body-tree FK convention: joint origin lives in the PARENT's local frame.
+
+arm.revolute('shoulder', basePart, lowerArmPart, {
+  axis: [0, -1, 0],
+  origin: [0, 0, SHOULDER_Z],
+  limitsDeg: [-10, 110],
+});
+
+arm.revolute('elbow', lowerArmPart, upperArmPart, {
+  axis: [0, -1, 0],
+  origin: [L_LOWER, 0, 0],
+  limitsDeg: [-150, -30],
+});
+
+arm.revolute('wrist', upperArmPart, headPart, {
+  axis: [0, -1, 0],
+  origin: [L_UPPER, 0, 0],
+  limitsDeg: [-90, 0],
+});
+
+// ---- POSE ---------------------------------------------------------------
+// The lamp's knuckle joints intentionally overlap by design: each arm carries
+// a small sphere cap at its proximal end that meshes into the parent's
+// knuckle sphere, so the silhouette reads as a continuous mechanical joint
+// instead of two visibly disjoint sticks. Those contacts are real BREP
+// overlaps and would otherwise trip `assembly.interference.overlap` under
+// `validate: 'error'` — we silence them granularly via `ignore` instead of
+// disabling the whole validator (`validate: 'off'`), so the rest of the
+// gates (mate types, joint limits, etc.) keep running.
+//
+// Studio HUD note: the status-bar interferences counter reads RAW pairs
+// (pre-filter), so the user still sees these knuckles + any extra clashes
+// they drive into via the Params slider. The Validity tab honors `ignore`
+// and only flags clashes the script didn't pre-approve.
+return arm.solvedModel(
+  {
+    shoulder: shoulderDeg,
+    elbow:    elbowDeg,
+    wrist:    wristDeg,
+  },
+  {
+    ignore: [
+      ['base', 'lower-arm'],       // shoulder knuckle on base meets lower-arm's shoulder cap
+      ['lower-arm', 'upper-arm'],  // elbow knuckle on lower-arm meets upper-arm's shoulder cap
+      ['upper-arm', 'lamp-head'],  // wrist knuckle on upper-arm meets lamp-head's collar
+    ],
+  },
+);

--- a/src/agent/mcp/tools/reviewCad.ts
+++ b/src/agent/mcp/tools/reviewCad.ts
@@ -24,6 +24,10 @@ import {
 } from '../../../modeling/mates/mechanicalTransmission';
 import type { ValidatorDiagnostic, ValidatorStatus } from '../../../modeling/mates/validator';
 import { validateAssemblyWithMates } from '../../../modeling/mates/validator';
+import type { InterferencePair } from '../../../modeling/runtime/detectInterferences';
+import { detectInterferences } from '../../../modeling/runtime/detectInterferences';
+import { isSceneBackend } from '../../../kernel/backends/sceneBackend';
+import type { BuiltModel } from '../../../modeling/buildModel';
 import { clearActiveMcpSession, setActiveMcpSession } from '../activeSession';
 
 export interface ReviewCadInput {
@@ -70,6 +74,16 @@ export type ReviewCadOutput =
       gripperAperture?: PoseEnvelopeReviewResult['gripperAperture'];
       fitness: MechanismFitnessResult;
       repairContext: RepairContext;
+      /**
+       * Raw interference pairs detected at the script's default pose, BEFORE
+       * any `ignore` filtering applied by the validator. Used by interactive
+       * surfaces (e.g. the Studio status-bar HUD) that need to show the user
+       * what's overlapping right now, even when the script silences specific
+       * pairs via `assembly.solvedModel({ ignore: [...] })`. The validator's
+       * filtered diagnostic stream remains on `validator.diagnostics` for the
+       * Validity tab + throw path.
+       */
+      rawInterferencePairs: ReadonlyArray<InterferencePair>;
     }
   | {
       ok: false;
@@ -88,6 +102,12 @@ export type ReviewCadOutput =
       fitness?: MechanismFitnessResult;
       repairContext: RepairContext;
       suggestedRepairPrompt: string;
+      /**
+       * Raw interference pairs at the default pose (see the `ok: true`
+       * variant). Always present when an assembly was selected, even when
+       * `ok: false`, so the Studio HUD can still report the count.
+       */
+      rawInterferencePairs?: ReadonlyArray<InterferencePair>;
     };
 
 type ReviewDiagnostic =
@@ -132,7 +152,42 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
     };
   }
 
-  const validator = await validateAssemblyWithMates(arm);
+  // Raw default-pose interferences are surfaced separately so interactive
+  // surfaces (the Studio status-bar HUD) can show the user what's actually
+  // overlapping right now, even when the script silences specific pairs via
+  // `assembly.solvedModel({ ignore: [...] })`. The validator's diagnostics
+  // already respect that ignore list; this channel deliberately does NOT.
+  //
+  // We reuse `detectInterferencesForPoses` with an empty pose map (default
+  // pose). When the script has no live param overrides this matches the
+  // capture-time scene exactly; when params are live-edited via the SSE
+  // bridge, the session's paramTable carries the live value and detection
+  // runs against the current pose. That's what makes the HUD count update on
+  // slider drag.
+  //
+  // Respect `includeInterference: false` (and `includePoseEnvelope: false`
+  // when `includeInterference` is unset) to preserve back-compat with
+  // existing callers — notably the integration test fixtures that
+  // deliberately build clashing assemblies to exercise other validators.
+  // The default flow (both unset) runs detection so the Studio HUD sees real
+  // overlaps; opt-out paths skip it. The legacy "blind to overlaps"
+  // behaviour is preserved when either flag explicitly disables interference
+  // work.
+  const wantInterference =
+    input.includeInterference !== undefined
+      ? input.includeInterference
+      : input.includePoseEnvelope !== false;
+  const rawInterferencePairs: InterferencePair[] = wantInterference
+    ? safeDetectDefaultPoseInterferences(model, input.epsilonMm3)
+    : [];
+  const validator = await validateAssemblyWithMates(
+    arm,
+    wantInterference ? rawInterferencePairs : undefined,
+    undefined,
+    undefined,
+    undefined,
+    arm.__ignoreInterference(),
+  );
   const mechanicalPlausibility = await reviewMechanicalPlausibility(arm);
   const mechanicalIntent = await reviewMechanicalIntent(arm);
   const includePoseEnvelope = input.includePoseEnvelope ?? true;
@@ -185,6 +240,7 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
       ...(poseEnvelope?.gripperAperture !== undefined ? { gripperAperture: poseEnvelope.gripperAperture } : {}),
       fitness,
       repairContext,
+      rawInterferencePairs,
     };
   }
 
@@ -205,7 +261,39 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
     fitness,
     repairContext,
     suggestedRepairPrompt: buildSuggestedRepairPrompt(diagnostics, fitness, input),
+    rawInterferencePairs,
   };
+}
+
+/**
+ * Run pairwise BREP interference detection on the BuiltModel's tail scene
+ * for the Studio HUD's raw-count channel. We deliberately read from
+ * `model.tailShape` (the already-lowered scene returned by the script's
+ * own `arm.solvedModel(poses, ...)`) instead of calling
+ * `detectInterferencesForPoses(arm, {})` — the latter re-records a new
+ * `solvedAssembly` with EMPTY poses, which trips the lowerer's
+ * "joint requires a pose value" check for revolute/prismatic joints and
+ * silently returns []. The script's already-built scene carries the
+ * script's authored param defaults (the same ones the Studio render is
+ * showing), so reading them gives the user-visible state.
+ *
+ * Wrapped in try/catch so a kernel failure on a single detection can't
+ * bring down the entire review tool — the HUD just shows
+ * `interferences: 0` in that case and the validator's other diagnostics
+ * continue to surface the real problem.
+ */
+function safeDetectDefaultPoseInterferences(
+  model: BuiltModel,
+  epsilonMm3?: number,
+): InterferencePair[] {
+  try {
+    const tail = model.tailShape;
+    if (!tail || !isSceneBackend(tail)) return [];
+    const epsilon = epsilonMm3 ?? 0.01;
+    return detectInterferences(tail, epsilon, new Set<string>()).pairs;
+  } catch {
+    return [];
+  }
 }
 
 async function evaluateForReview(input: EvaluateInput) {

--- a/src/modeling/capture/assembly.ts
+++ b/src/modeling/capture/assembly.ts
@@ -416,6 +416,14 @@ export class Assembly {
   private readonly virtualJoints: VirtualJointRecord[] = [];
   private readonly groupStates: GroupStateRecord[] = [];
   private readonly disabledCollisions: DisabledCollisionRecord[] = [];
+  /**
+   * Latest known-acceptable interference pair list, as captured by the most
+   * recent `solvedModel({ ignore: [...] })` call. Read by external review
+   * surfaces (`reviewCadTool`) so the validator they run respects the same
+   * silencing the script's `solvedModel` did. The raw detection output stays
+   * unfiltered — only the validator's diagnostic emission honors this list.
+   */
+  private ignoreInterferenceList: ReadonlyArray<readonly [string, string]> = [];
 
   constructor(name: string, session: CaptureSession) {
     this.name = name;
@@ -1263,6 +1271,18 @@ export class Assembly {
     return this.disabledCollisions;
   }
 
+  /**
+   * Last `ignore` list passed to `solvedModel`. External review surfaces
+   * (`reviewCadTool`) read this so the validator they re-run honors the same
+   * known-acceptable contacts the script silenced. Empty when no
+   * `solvedModel({ ignore })` has been called yet. Mirrors the `__mates()` /
+   * `__parts()` underscore-prefixed convention; not part of the agent-facing
+   * surface.
+   */
+  __ignoreInterference(): ReadonlyArray<readonly [string, string]> {
+    return this.ignoreInterferenceList;
+  }
+
   __mechanicalJointIntents(): readonly MechanicalJointIntentRecord[] {
     return this.mechanicalJointIntents;
   }
@@ -1583,6 +1603,21 @@ export class Assembly {
        * composes Gate 3 with the v0.7.5 grounding gates.
        */
       externalLoads?: Readonly<Record<string, { force?: Vec3; torque?: Vec3 }>>;
+      /**
+       * Known-acceptable interference pairs. Symmetric matching: `[a, b]`
+       * silences both `(a, b)` and `(b, a)`. Pairs in `ignore` are still
+       * DETECTED by the runtime BREP sweep (so a Studio HUD reading the raw
+       * detection output still surfaces them on the status bar), but FILTERED
+       * out of the validator's `assembly.interference.overlap` diagnostic
+       * stream — they don't throw under `validate: 'error'` and don't appear
+       * in `scene.warnings` under `validate: 'warn'`.
+       *
+       * This is the granular alternative to `validate: 'off'`. Use it when a
+       * specific known-acceptable contact (e.g. a knuckle joint where two arm
+       * parts must touch by design) should not block the validator while
+       * still letting the rest of the validation gate run.
+       */
+      ignore?: ReadonlyArray<readonly [string, string]>;
     },
   ): Promise<Scene> {
     if (this.parts.length === 0) {
@@ -1592,6 +1627,19 @@ export class Assembly {
         undefined,
         'Call assembly.part(name, shape, opts?) before assembly.solvedModel(poses).',
       );
+    }
+    // Record the ignore list on the Assembly so external review surfaces
+    // (reviewCadTool) re-run validation with the same known-acceptable
+    // contacts the script silenced. The raw detection output stays
+    // unfiltered so HUD-style consumers can show the user every contact.
+    //
+    // Only OVERWRITE when an explicit `ignore` was passed. Internal callers
+    // like `detectInterferencesForPoses` re-invoke `solvedModel` without
+    // opts.ignore to read a freshly-posed scene; nuking the list there would
+    // wipe the agent-authored silencing every time the HUD re-detects on a
+    // slider drag.
+    if (opts?.ignore !== undefined) {
+      this.ignoreInterferenceList = opts.ignore;
     }
     // v0.7.4 — validate externalLoads keys at capture entry so agent typos
     // surface immediately, not silently. Per spec open-question 5 resolution
@@ -1724,6 +1772,7 @@ export class Assembly {
         undefined,
         opts?.externalLoads,
         envelopeResult?.connectorWorkspace,
+        opts?.ignore,
       );
       const envelopeDiagnostics: readonly PoseEnvelopeDiagnostic[] =
         envelopeResult ? envelopeResult.diagnostics : [];

--- a/src/modeling/mates/validator.test.ts
+++ b/src/modeling/mates/validator.test.ts
@@ -141,6 +141,58 @@ describe('validateAssembly', () => {
     });
     expect(r.status).toBe('error');
   });
+
+  it('filters interference pairs listed in `ignore` from the diagnostic stream', () => {
+    nextId = 0;
+    const a = mkPart('a');
+    const b = mkPart('b');
+    const j = mkJoint('a-b', a, b);
+    const r = validateAssembly({
+      records: [a, b, j],
+      interferencePairs: [{ a: 'a', b: 'b', volumeMm3: 42 }],
+      ignore: [['a', 'b']],
+    });
+    // The ignored pair must NOT emit a diagnostic. Without other errors, the
+    // assembly is solved (no floating, no orphan).
+    expect(r.diagnostics.find((d) => d.code === 'assembly.interference.overlap')).toBeUndefined();
+    expect(r.status).toBe('solved');
+  });
+
+  it('symmetric ignore: `[a, b]` also filters `(b, a)`', () => {
+    nextId = 0;
+    const a = mkPart('a');
+    const b = mkPart('b');
+    const j = mkJoint('a-b', a, b);
+    // detection happens to emit (b, a) — validator must still suppress it.
+    const r = validateAssembly({
+      records: [a, b, j],
+      interferencePairs: [{ a: 'b', b: 'a', volumeMm3: 5 }],
+      ignore: [['a', 'b']],
+    });
+    expect(r.diagnostics.find((d) => d.code === 'assembly.interference.overlap')).toBeUndefined();
+  });
+
+  it('only ignored pairs are filtered; other pairs still emit diagnostics', () => {
+    nextId = 0;
+    const a = mkPart('a');
+    const b = mkPart('b');
+    const c = mkPart('c');
+    const j1 = mkJoint('a-b', a, b);
+    const j2 = mkJoint('b-c', b, c);
+    const r = validateAssembly({
+      records: [a, b, c, j1, j2],
+      interferencePairs: [
+        { a: 'a', b: 'b', volumeMm3: 10 }, // ignored
+        { a: 'b', b: 'c', volumeMm3: 20 }, // NOT ignored — must error
+      ],
+      ignore: [['a', 'b']],
+    });
+    const overlaps = r.diagnostics.filter((d) => d.code === 'assembly.interference.overlap');
+    expect(overlaps).toHaveLength(1);
+    expect(overlaps[0].partA).toBe('b');
+    expect(overlaps[0].partB).toBe('c');
+    expect(r.status).toBe('error');
+  });
 });
 
 // v0.6 mate-aware entry point. Builds an Assembly via the public capture

--- a/src/modeling/mates/validator.ts
+++ b/src/modeling/mates/validator.ts
@@ -129,6 +129,38 @@ export interface ValidateAssemblyInput {
   /** Optional: results from `checkInterference()`. Folded into the
    *  diagnostic stream as `assembly.interference.overlap` items. */
   readonly interferencePairs?: readonly InterferencePair[];
+  /**
+   * Optional list of part-name pairs whose interferences are known-acceptable
+   * (e.g. a knuckle joint where the two arm parts must touch by design).
+   * Matching is SYMMETRIC: `[a, b]` silences both `(a, b)` and `(b, a)`.
+   *
+   * Pairs in `ignore` are filtered OUT of the validator's
+   * `assembly.interference.overlap` diagnostic stream — they don't throw under
+   * `validate: 'error'` and don't appear in `scene.warnings` under
+   * `validate: 'warn'`. The raw `interferencePairs` are NOT mutated; only the
+   * downstream diagnostic emission is filtered. Callers that want the raw
+   * pairs (e.g. the Studio HUD) should consume the unfiltered detection output
+   * directly, not the validator's diagnostics.
+   */
+  readonly ignore?: ReadonlyArray<readonly [string, string]>;
+}
+
+/**
+ * Returns true when `(a, b)` is symmetrically present in `ignoreList`.
+ * `[a, b]` and `[b, a]` both match. Exported so other modules
+ * (e.g. `Assembly.solvedModel`'s validator hand-off) can reuse the same
+ * symmetric semantics without re-implementing them.
+ */
+export function isPairIgnored(
+  a: string,
+  b: string,
+  ignoreList: ReadonlyArray<readonly [string, string]> | undefined,
+): boolean {
+  if (!ignoreList || ignoreList.length === 0) return false;
+  for (const pair of ignoreList) {
+    if ((pair[0] === a && pair[1] === b) || (pair[0] === b && pair[1] === a)) return true;
+  }
+  return false;
 }
 
 /** Run all MVP checks. Returns a status + diagnostic chain. Pure: no I/O. */
@@ -204,12 +236,20 @@ export function validateAssembly(input: ValidateAssemblyInput): ValidatorResult 
   // Check 3 — interference (promoted from checkInterference). Errors,
   // not warnings, because solid bodies sharing volume is mechanically
   // invalid (vs floating, which is a missing-information warning).
+  //
+  // The optional `ignore` list silences known-acceptable contacts (e.g. a
+  // knuckle joint where two arm parts touch by design). Matching is
+  // SYMMETRIC — `[a, b]` filters both `(a, b)` and `(b, a)` — and applies
+  // only to the diagnostic emission below; the raw `interferencePairs` the
+  // caller passed in remain untouched so HUD-style consumers can still read
+  // them via the unfiltered detection output.
   for (const pair of input.interferencePairs ?? []) {
+    if (isPairIgnored(pair.a, pair.b, input.ignore)) continue;
     diagnostics.push({
       code: 'assembly.interference.overlap',
       severity: 'error',
       message: `Parts '${pair.a}' and '${pair.b}' overlap by ${pair.volumeMm3.toFixed(2)} mm³.`,
-      hint: `invalid-args.assembly.interference — translate one part along its mating direction, or add a coupling part (washer / spacer / bracket) to clear the overlap. Use --ignore '${pair.a},${pair.b}' on kernelcad interference if the contact is intentional.`,
+      hint: `invalid-args.assembly.interference — translate one part along its mating direction, or add a coupling part (washer / spacer / bracket) to clear the overlap. Pass { ignore: [['${pair.a}', '${pair.b}']] } to assembly.solvedModel(...) if the contact is intentional.`,
       partA: pair.a,
       partB: pair.b,
       volumeMm3: pair.volumeMm3,
@@ -337,6 +377,14 @@ export async function validateAssemblyWithMates(
   // assembly has workspace targets, the gate emits info-severity diagnostics
   // pointing the agent at `posesGate: 'envelope'`.
   connectorWorkspace?: readonly ConnectorWorkspace[],
+  // Known-acceptable interference pairs to filter out of the
+  // `assembly.interference.overlap` diagnostic stream. Symmetric matching:
+  // `[a, b]` silences both `(a, b)` and `(b, a)`. The raw
+  // `interferencePairs` argument is NOT mutated — only the validator's
+  // diagnostic emission is filtered, so HUD-style consumers can still read
+  // the unfiltered detection output. See `Assembly.solvedModel`'s `ignore`
+  // option for the user-facing entry point.
+  ignoreInterference?: ReadonlyArray<readonly [string, string]>,
 ): Promise<ValidatorResult> {
   // 1. Run the v0.5 base checks (floating / orphan / interference). Reuse
   //    the same code path — do not duplicate. Filter the session's records
@@ -349,6 +397,7 @@ export async function validateAssemblyWithMates(
   const base = validateAssembly({
     records,
     ...(interferencePairs !== undefined ? { interferencePairs } : {}),
+    ...(ignoreInterference !== undefined ? { ignore: ignoreInterference } : {}),
   });
 
   // 2. Build the diagnostics chain starting from v0.5 results. We may

--- a/src/studio/StudioShell.tsx
+++ b/src/studio/StudioShell.tsx
@@ -147,9 +147,14 @@ export function StudioShell() {
         export: <ExportTab />,
     };
 
-    const interferenceCount = recompute.validity?.diagnostics.filter(
-        (d) => d.code === 'assembly.interference.overlap',
-    ).length ?? 0;
+    // HUD reads RAW interference pairs (pre-filter), not the validator's
+    // diagnostics. Scripts can silence known-acceptable contacts via
+    // `assembly.solvedModel({ ignore: [...] })` — that hides them from the
+    // validator throw path and the Validity tab, but the user must still see
+    // every live overlap on the status bar (especially when they drag a
+    // Studio param slider into a colliding pose). The two channels are
+    // wired separately on `useRecomputeResult` for exactly this reason.
+    const interferenceCount = recompute.rawInterferencePairs?.length ?? 0;
 
     return (
         <div

--- a/src/studio/__tests__/StudioShell.status.test.tsx
+++ b/src/studio/__tests__/StudioShell.status.test.tsx
@@ -4,6 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 let workbenchComputing = false;
 let agentRailOpen = false;
+let recomputeRawPairs: Array<{ a: string; b: string; volumeMm3: number }> = [];
+let recomputeValidity: { diagnostics: { code: string; severity: string }[] } | null = null;
 
 vi.mock('../context/WorkbenchContext', () => ({
     useWorkbench: () => ({
@@ -36,11 +38,12 @@ vi.mock('../hooks/useRecomputeResult', () => ({
     useRecomputeResult: () => ({
         features: [],
         geometries: [],
-        validity: null,
+        validity: recomputeValidity,
         paramTable: null,
         diagnostics: [],
         recomputeMs: 0,
         joints: [],
+        rawInterferencePairs: recomputeRawPairs,
     }),
 }));
 
@@ -56,8 +59,11 @@ vi.mock('../AgentRail', () => ({ AgentRail: () => <div data-testid="agent-rail" 
 vi.mock('../BottomDrawer', () => ({ BottomDrawer: () => <div data-testid="bottom-drawer" /> }));
 vi.mock('../components/Dialogs/ProjectManagerDialog', () => ({ default: () => null }));
 vi.mock('../components/Layout/StatusBar', () => ({
-    StatusBar: ({ isComputing }: { isComputing: boolean }) => (
-        <div data-testid="status-is-computing">{String(isComputing)}</div>
+    StatusBar: ({ isComputing, interferences }: { isComputing: boolean; interferences?: number }) => (
+        <>
+            <div data-testid="status-is-computing">{String(isComputing)}</div>
+            <div data-testid="status-interferences">{String(interferences ?? 0)}</div>
+        </>
     ),
 }));
 
@@ -68,6 +74,8 @@ afterEach(() => cleanup());
 beforeEach(() => {
     workbenchComputing = false;
     agentRailOpen = false;
+    recomputeRawPairs = [];
+    recomputeValidity = null;
 });
 
 describe('StudioShell status plumbing', () => {
@@ -87,5 +95,33 @@ describe('StudioShell status plumbing', () => {
         const rail = screen.getByTestId('agent-rail');
         const viewport = screen.getByTestId('viewport');
         expect(rail.compareDocumentPosition(viewport) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
+    it('HUD interference count reads RAW pairs (pre-filter), not validator diagnostics', () => {
+        // Simulate the lamp scenario: the script silences 3 known-acceptable
+        // pairs via `ignore`, so the validator's diagnostic stream is empty
+        // for `assembly.interference.overlap` — but the raw detection found
+        // 3 contacts. The HUD MUST show 3, not 0.
+        recomputeRawPairs = [
+            { a: 'base', b: 'lower-arm', volumeMm3: 12 },
+            { a: 'lower-arm', b: 'upper-arm', volumeMm3: 14 },
+            { a: 'upper-arm', b: 'lamp-head', volumeMm3: 8 },
+        ];
+        recomputeValidity = { diagnostics: [] };
+
+        render(<StudioShell />);
+
+        expect(screen.getByTestId('status-interferences').textContent).toBe('3');
+    });
+
+    it('HUD shows 0 when raw pairs is empty, even if validator has unrelated diagnostics', () => {
+        recomputeRawPairs = [];
+        recomputeValidity = {
+            diagnostics: [{ code: 'assembly.part.floating', severity: 'warning' }],
+        };
+
+        render(<StudioShell />);
+
+        expect(screen.getByTestId('status-interferences').textContent).toBe('0');
     });
 });

--- a/src/studio/__tests__/tabs/ParamsTab.test.tsx
+++ b/src/studio/__tests__/tabs/ParamsTab.test.tsx
@@ -20,6 +20,8 @@ function emptyResult(): StudioRecomputeResult {
         paramTable: null,
         diagnostics: [],
         recomputeMs: 0,
+        rawInterferencePairs: [],
+        joints: [],
     };
 }
 
@@ -120,6 +122,109 @@ describe('ParamsTab', () => {
 
         expect(screen.getByTestId('param-row-heightAdjustMm')).toBeTruthy();
         expect(screen.getByTestId('scrub-slider-heightAdjustMm')).toBeTruthy();
+    });
+
+    describe('interference indicator', () => {
+        const headArmPair = { a: 'head', b: 'upper-arm', volumeMm3: 142 };
+
+        function joint(name: string, a: string, b: string, paramName: string): import('../../adapters/featureRecordsToMates').JointPoseSnapshot {
+            return {
+                mate: {
+                    name,
+                    a,
+                    b,
+                    type: 'revolute',
+                    limitsDeg: [-90, 90],
+                },
+                pose: 0,
+                poseParamNames: [paramName],
+            };
+        }
+
+        it('marks the slider implicated in an interference with a red track + "!" badge', () => {
+            const table = new ParamTable();
+            table.declare('shoulderDeg', 'number', 45, { min: -90, max: 90 });
+            table.declare('twistDeg', 'number', 0, { min: -90, max: 90 });
+            mockUseRecomputeResult.mockReturnValue({
+                ...withTable(table),
+                rawInterferencePairs: [headArmPair],
+                joints: [
+                    // shoulder joint: head ↔ upper-arm — implicated by interference
+                    joint('shoulder', 'head.bottom', 'upper-arm.top', 'shoulderDeg'),
+                    // twist joint on an unrelated subassembly — NOT implicated
+                    joint('twist', 'cap.top', 'mount.base', 'twistDeg'),
+                ],
+            });
+
+            render(<ParamsTab />);
+
+            // The implicated slider should carry the badge.
+            expect(screen.getByTestId('scrub-interference-badge-shoulderDeg')).toBeTruthy();
+            expect(screen.getByTestId('scrub-shoulderDeg').getAttribute('data-colliding')).toBe('true');
+
+            // The unrelated slider should NOT carry it (neither cap nor mount appears in the pair).
+            expect(screen.queryByTestId('scrub-interference-badge-twistDeg')).toBeNull();
+            expect(screen.getByTestId('scrub-twistDeg').getAttribute('data-colliding')).toBeNull();
+
+            // No banner fallback when at least one param could be implicated.
+            expect(screen.queryByTestId('params-interference-banner')).toBeNull();
+        });
+
+        it('implicates every joint that touches a colliding part (loose heuristic, lamp-chain case)', () => {
+            // Lamp-style kinematic chain: base ↔ arm ↔ head. Collision is
+            // arm ↔ head. The arm-joint connects base↔arm, the head-joint
+            // connects arm↔head. Both joints touch a colliding part, so
+            // both sliders flag as potentially-implicated.
+            const table = new ParamTable();
+            table.declare('armDeg', 'number', 0, { min: -90, max: 90 });
+            table.declare('headDeg', 'number', 0, { min: -90, max: 90 });
+            mockUseRecomputeResult.mockReturnValue({
+                ...withTable(table),
+                rawInterferencePairs: [{ a: 'arm', b: 'head', volumeMm3: 50 }],
+                joints: [
+                    joint('armPivot', 'base.top', 'arm.bottom', 'armDeg'),
+                    joint('headPivot', 'arm.top', 'head.base', 'headDeg'),
+                ],
+            });
+
+            render(<ParamsTab />);
+
+            expect(screen.getByTestId('scrub-interference-badge-armDeg')).toBeTruthy();
+            expect(screen.getByTestId('scrub-interference-badge-headDeg')).toBeTruthy();
+        });
+
+        it('falls back to a top-of-panel banner when interferences exist but no joint binds to a slider', () => {
+            const table = new ParamTable();
+            table.declare('wallThickness', 'number', 2.5, { min: 1, max: 5 });
+            mockUseRecomputeResult.mockReturnValue({
+                ...withTable(table),
+                rawInterferencePairs: [headArmPair],
+                joints: [],
+            });
+
+            render(<ParamsTab />);
+
+            const banner = screen.getByTestId('params-interference-banner');
+            expect(banner).toBeTruthy();
+            expect(banner.textContent).toContain('1 interference in current pose');
+            // No per-slider badge — banner is the only signal here.
+            expect(screen.queryByTestId('scrub-interference-badge-wallThickness')).toBeNull();
+        });
+
+        it('clears the indicator when there are no interference pairs', () => {
+            const table = new ParamTable();
+            table.declare('shoulderDeg', 'number', 45, { min: -90, max: 90 });
+            mockUseRecomputeResult.mockReturnValue({
+                ...withTable(table),
+                rawInterferencePairs: [],
+                joints: [joint('shoulder', 'head.bottom', 'upper-arm.top', 'shoulderDeg')],
+            });
+
+            render(<ParamsTab />);
+
+            expect(screen.queryByTestId('scrub-interference-badge-shoulderDeg')).toBeNull();
+            expect(screen.queryByTestId('params-interference-banner')).toBeNull();
+        });
     });
 
     it('does not rebuild on every slider tick and flushes the final value on release', () => {

--- a/src/studio/__tests__/useRecomputeResult.test.tsx
+++ b/src/studio/__tests__/useRecomputeResult.test.tsx
@@ -81,6 +81,42 @@ describe('useRecomputeResult — Slice 1.2 data wiring', () => {
         expect(result.current.recomputeMs).toBe(0);
     });
 
+    it('forwards rawInterferencePairs from scriptReview unchanged', async () => {
+        // The HUD reads `.length` of this directly. It's the RAW detection
+        // output — populated regardless of whether the script's
+        // `solvedModel` set an `ignore` list. Validator filtering happens
+        // upstream and lands on `validity.diagnostics`, NOT here.
+        workbenchValue.featureRecords = [];
+        workbenchValue.scriptReview = {
+            ok: false,
+            diagnostics: [],
+            rawInterferencePairs: [
+                { a: 'base', b: 'lower-arm', volumeMm3: 12 },
+                { a: 'lower-arm', b: 'upper-arm', volumeMm3: 14 },
+            ],
+        };
+
+        const { useRecomputeResult } = await import('../hooks/useRecomputeResult');
+        const { result } = renderHook(() => useRecomputeResult());
+
+        expect(result.current.rawInterferencePairs).toHaveLength(2);
+        expect(result.current.rawInterferencePairs[0]).toEqual({
+            a: 'base',
+            b: 'lower-arm',
+            volumeMm3: 12,
+        });
+    });
+
+    it('rawInterferencePairs defaults to empty when scriptReview is null', async () => {
+        workbenchValue.featureRecords = [];
+        workbenchValue.scriptReview = null;
+
+        const { useRecomputeResult } = await import('../hooks/useRecomputeResult');
+        const { result } = renderHook(() => useRecomputeResult());
+
+        expect(result.current.rawInterferencePairs).toEqual([]);
+    });
+
     it('exposes updateParam from the workbench so ParamsTab can drive live edits', async () => {
         // Slice 2E.bridge: WorkbenchContext owns the sessionToken + SSE stream
         // and exposes `updateParam(edits)` that POSTs to /__kernelcad/params.

--- a/src/studio/components/inputs/NumericScrubInput.tsx
+++ b/src/studio/components/inputs/NumericScrubInput.tsx
@@ -1,6 +1,22 @@
 import { useState } from 'react';
 import type { JSX } from 'react';
 
+/**
+ * When set, this param is implicated in one or more interference pairs at
+ * the current pose. The slider track turns red and a "!" badge with a
+ * tooltip listing the colliding pairs is shown. v0.7 — wired from
+ * ParamsTab's `rawInterferencePairs` channel + joints adapter so the user
+ * gets a slider-level signal that dragging put the model into a self-
+ * colliding pose, instead of relying on the small footer counter.
+ */
+export interface ScrubInterference {
+    readonly collidingPairs: readonly {
+        readonly a: string;
+        readonly b: string;
+        readonly volumeMm3: number;
+    }[];
+}
+
 export interface NumericScrubInputProps {
     /** Human-readable name (used for accessibility labels). */
     readonly name: string;
@@ -20,10 +36,19 @@ export interface NumericScrubInputProps {
     readonly unit?: string;
     /** Marks on the slider track at these positions (used for joint limits). */
     readonly limitMarks?: readonly { at: number; label?: string }[];
+    /** When set, render the slider in "this param is implicated in an
+     *  interference at the current pose" state — red track + badge. */
+    readonly interference?: ScrubInterference;
 }
 
 export function NumericScrubInput(props: NumericScrubInputProps): JSX.Element {
-    const { name, value, onChange, onCommit, min, max, step: stepProp, unit, limitMarks } = props;
+    const { name, value, onChange, onCommit, min, max, step: stepProp, unit, limitMarks, interference } = props;
+    const isColliding = !!interference && interference.collidingPairs.length > 0;
+    const interferenceTitle = isColliding
+        ? `current pose collides:\n${interference.collidingPairs
+              .map((p) => `  ${p.a} ↔ ${p.b} — ${p.volumeMm3.toFixed(1)} mm³`)
+              .join('\n')}`
+        : undefined;
     const hasRange = typeof min === 'number' && typeof max === 'number' && max > min;
     const rawStep = stepProp ?? (hasRange ? Math.max((max - min) / 100, 0.01) : 1);
     // Guard: step must be > 0 for a sensible slider/scrub increment.
@@ -110,10 +135,14 @@ export function NumericScrubInput(props: NumericScrubInputProps): JSX.Element {
         : undefined;
 
     return (
-        <div className="flex flex-col gap-1 px-3 py-2" data-testid={`scrub-${name}`}>
+        <div
+            className="flex flex-col gap-1 px-3 py-2"
+            data-testid={`scrub-${name}`}
+            data-colliding={isColliding ? 'true' : undefined}
+        >
             <div className="flex items-center justify-between gap-2">
                 <span
-                    className="text-xs text-gray-300 truncate cursor-ew-resize select-none border-b border-dashed border-gray-700"
+                    className="text-xs text-gray-300 truncate cursor-ew-resize select-none border-b border-dashed border-gray-700 flex items-center gap-1"
                     title={`${name} (drag to scrub, ⌥ fine, ⇧ coarse)`}
                     onPointerDown={handlePointerDown}
                     onPointerMove={handlePointerMove}
@@ -122,6 +151,16 @@ export function NumericScrubInput(props: NumericScrubInputProps): JSX.Element {
                     data-testid={`scrub-handle-${name}`}
                 >
                     {name}
+                    {isColliding && (
+                        <span
+                            className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-red-600 text-white text-[10px] font-bold leading-none cursor-help"
+                            title={interferenceTitle}
+                            aria-label={`${name} is implicated in an interference at the current pose`}
+                            data-testid={`scrub-interference-badge-${name}`}
+                        >
+                            !
+                        </span>
+                    )}
                 </span>
                 <div className="flex items-center gap-1">
                     <input
@@ -169,9 +208,19 @@ export function NumericScrubInput(props: NumericScrubInputProps): JSX.Element {
                         aria-valuetext={`${displayValue}${unit ?? ''}`}
                     />
                     <div className="absolute inset-0 pointer-events-none flex items-center">
-                        <div className="h-1.5 w-full bg-[#1f1f1f] rounded relative">
+                        <div
+                            className={
+                                isColliding
+                                    ? 'h-1.5 w-full bg-red-950 rounded relative ring-1 ring-red-500'
+                                    : 'h-1.5 w-full bg-[#1f1f1f] rounded relative'
+                            }
+                            title={interferenceTitle}
+                            data-testid={`scrub-track-${name}`}
+                        >
                             <div
-                                className="h-full bg-[#4a9eff] rounded"
+                                className={
+                                    isColliding ? 'h-full bg-red-500 rounded' : 'h-full bg-[#4a9eff] rounded'
+                                }
                                 style={{ width: `${pct * 100}%` }}
                             />
                             {limitMarks?.map((m, i) => {

--- a/src/studio/components/viewer/entities/ShapeGeometry.test.tsx
+++ b/src/studio/components/viewer/entities/ShapeGeometry.test.tsx
@@ -6,7 +6,7 @@ import type { FaceGeometry, GeometryResult } from '../../../../shared/worker/geo
 
 let FaceSelectionOverlay: typeof import('./ShapeGeometry').FaceSelectionOverlay;
 let GhostShape: typeof import('./ShapeGeometry').GhostShape;
-let buildShapeMaterial: typeof import('./ShapeGeometry').buildShapeMaterial;
+let buildShapeMaterial: typeof import('./buildShapeMaterial').buildShapeMaterial;
 
 const faceA: FaceGeometry = {
     vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
@@ -25,7 +25,8 @@ const faceB: FaceGeometry = {
 describe('ShapeGeometry disposable overlays', () => {
     beforeAll(async () => {
         vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-        ({ FaceSelectionOverlay, GhostShape, buildShapeMaterial } = await import('./ShapeGeometry'));
+        ({ FaceSelectionOverlay, GhostShape } = await import('./ShapeGeometry'));
+        ({ buildShapeMaterial } = await import('./buildShapeMaterial'));
     });
 
     beforeEach(() => {
@@ -66,7 +67,7 @@ describe('ShapeGeometry disposable overlays', () => {
 
 describe('buildShapeMaterial — viewMode3D produces visually-distinct materials', () => {
     beforeAll(async () => {
-        ({ buildShapeMaterial } = await import('./ShapeGeometry'));
+        ({ buildShapeMaterial } = await import('./buildShapeMaterial'));
     });
 
     // Regression test for the toolbar render-mode bug: clicking Wireframe / Shaded /

--- a/src/studio/components/viewer/entities/ShapeGeometry.test.tsx
+++ b/src/studio/components/viewer/entities/ShapeGeometry.test.tsx
@@ -6,6 +6,7 @@ import type { FaceGeometry, GeometryResult } from '../../../../shared/worker/geo
 
 let FaceSelectionOverlay: typeof import('./ShapeGeometry').FaceSelectionOverlay;
 let GhostShape: typeof import('./ShapeGeometry').GhostShape;
+let buildShapeMaterial: typeof import('./ShapeGeometry').buildShapeMaterial;
 
 const faceA: FaceGeometry = {
     vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
@@ -24,7 +25,7 @@ const faceB: FaceGeometry = {
 describe('ShapeGeometry disposable overlays', () => {
     beforeAll(async () => {
         vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-        ({ FaceSelectionOverlay, GhostShape } = await import('./ShapeGeometry'));
+        ({ FaceSelectionOverlay, GhostShape, buildShapeMaterial } = await import('./ShapeGeometry'));
     });
 
     beforeEach(() => {
@@ -60,5 +61,63 @@ describe('ShapeGeometry disposable overlays', () => {
 
         unmount();
         expect(disposeSpy).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('buildShapeMaterial — viewMode3D produces visually-distinct materials', () => {
+    beforeAll(async () => {
+        ({ buildShapeMaterial } = await import('./ShapeGeometry'));
+    });
+
+    // Regression test for the toolbar render-mode bug: clicking Wireframe / Shaded /
+    // Shaded with Edges flipped the React state but the material never reflected it,
+    // so all three modes rendered identically.
+
+    it('shaded — wireframe off, flatShading off (fallback Lambert)', () => {
+        const mat = buildShapeMaterial(undefined, false, 0xc8d2e0, 'shaded');
+        expect(mat).toBeInstanceOf(THREE.MeshLambertMaterial);
+        expect((mat as THREE.MeshLambertMaterial).wireframe).toBe(false);
+        expect((mat as THREE.MeshLambertMaterial).flatShading).toBe(false);
+    });
+
+    it('wireframe — wireframe ON (fallback Lambert)', () => {
+        const mat = buildShapeMaterial(undefined, false, 0xc8d2e0, 'wireframe');
+        expect((mat as THREE.MeshLambertMaterial).wireframe).toBe(true);
+        expect((mat as THREE.MeshLambertMaterial).flatShading).toBe(false);
+    });
+
+    it('shadedWithEdges — wireframe off, flatShading ON (fallback Lambert)', () => {
+        const mat = buildShapeMaterial(undefined, false, 0xc8d2e0, 'shadedWithEdges');
+        expect((mat as THREE.MeshLambertMaterial).wireframe).toBe(false);
+        expect((mat as THREE.MeshLambertMaterial).flatShading).toBe(true);
+    });
+
+    it('wireframe propagates to PBR MeshPhysicalMaterial', () => {
+        const pbr: NonNullable<GeometryResult['material']> = {
+            baseColor: '#c8d2e0',
+            metalness: 0.1,
+            roughness: 0.6,
+        };
+        const shaded = buildShapeMaterial(pbr, false, 0xc8d2e0, 'shaded');
+        const wire = buildShapeMaterial(pbr, false, 0xc8d2e0, 'wireframe');
+        const edges = buildShapeMaterial(pbr, false, 0xc8d2e0, 'shadedWithEdges');
+        expect(shaded).toBeInstanceOf(THREE.MeshPhysicalMaterial);
+        expect((shaded as THREE.MeshPhysicalMaterial).wireframe).toBe(false);
+        expect((shaded as THREE.MeshPhysicalMaterial).flatShading).toBe(false);
+        expect((wire as THREE.MeshPhysicalMaterial).wireframe).toBe(true);
+        expect((edges as THREE.MeshPhysicalMaterial).wireframe).toBe(false);
+        expect((edges as THREE.MeshPhysicalMaterial).flatShading).toBe(true);
+    });
+
+    it('selected shapes use the selection-colour Lambert regardless of view mode, wireframe still honoured', () => {
+        const pbr: NonNullable<GeometryResult['material']> = {
+            baseColor: '#aabbcc',
+        };
+        // When isSelected=true, the PBR branch is skipped and we fall through to the
+        // Lambert highlight. Wireframe still must propagate so a selected shape in
+        // wireframe mode shows lines, not solid surface.
+        const wire = buildShapeMaterial(pbr, true, 0xff0000, 'wireframe');
+        expect(wire).toBeInstanceOf(THREE.MeshLambertMaterial);
+        expect((wire as THREE.MeshLambertMaterial).wireframe).toBe(true);
     });
 });

--- a/src/studio/components/viewer/entities/ShapeGeometry.tsx
+++ b/src/studio/components/viewer/entities/ShapeGeometry.tsx
@@ -8,7 +8,7 @@ import { useUI } from "../../../context/UIContext";
 import { CAD_COLORS, CAD_COLORS_HEX } from "../../../../shared/constants/colors";
 import { useConsolidatedGeometry } from "../../../hooks/viewer/useConsolidatedGeometry";
 import { DEFAULT_COLOR, resolveColor } from "../../../../shared/render/palette";
-import { buildMaterialFromPBR } from "../../demoPlayer/buildMaterialFromPBR";
+import { buildShapeMaterial } from "./buildShapeMaterial";
 import { matrixFromGeometryTransform } from "./geometryTransform";
 
 interface ShapeProps {
@@ -25,39 +25,6 @@ function bufferGeometryFromFace(face: FaceGeometry): THREE.BufferGeometry {
     geometry.setAttribute('normal', new THREE.BufferAttribute(face.normals, 3));
     geometry.setIndex(new THREE.BufferAttribute(face.indices, 1));
     return geometry;
-}
-
-/**
- * Build the THREE material for a shape given the geometry record, selection state,
- * resolved fallback color, and the active 3D view mode.
- *
- * Exported so unit tests can verify the (viewMode3D → material flags) mapping without
- * mounting an R3F Canvas. The three modes are:
- *  - `'shaded'`             — smooth shading, no wireframe, no edge overlay
- *  - `'wireframe'`          — `material.wireframe = true`, surfaces drawn as lines
- *  - `'shadedWithEdges'`    — flat shading + black edge overlay rendered separately
- */
-export function buildShapeMaterial(
-    pbr: GeometryResult['material'],
-    isSelected: boolean,
-    color: number | string,
-    viewMode3D: ViewMode3D,
-): THREE.Material {
-    const isWireframe = viewMode3D === 'wireframe';
-    const flatShading = viewMode3D === 'shadedWithEdges';
-    if (pbr && !isSelected) {
-        const pbrMaterial = buildMaterialFromPBR(pbr) as THREE.MeshPhysicalMaterial;
-        pbrMaterial.flatShading = flatShading;
-        pbrMaterial.wireframe = isWireframe;
-        pbrMaterial.side = THREE.DoubleSide;
-        pbrMaterial.depthWrite = (pbr.opacity ?? 1) >= 1;
-        return pbrMaterial;
-    }
-    return new THREE.MeshLambertMaterial({
-        color,
-        flatShading,
-        wireframe: isWireframe,
-    });
 }
 
 function GhostFaceMesh({ face }: { face: FaceGeometry }) {

--- a/src/studio/components/viewer/entities/ShapeGeometry.tsx
+++ b/src/studio/components/viewer/entities/ShapeGeometry.tsx
@@ -27,6 +27,39 @@ function bufferGeometryFromFace(face: FaceGeometry): THREE.BufferGeometry {
     return geometry;
 }
 
+/**
+ * Build the THREE material for a shape given the geometry record, selection state,
+ * resolved fallback color, and the active 3D view mode.
+ *
+ * Exported so unit tests can verify the (viewMode3D → material flags) mapping without
+ * mounting an R3F Canvas. The three modes are:
+ *  - `'shaded'`             — smooth shading, no wireframe, no edge overlay
+ *  - `'wireframe'`          — `material.wireframe = true`, surfaces drawn as lines
+ *  - `'shadedWithEdges'`    — flat shading + black edge overlay rendered separately
+ */
+export function buildShapeMaterial(
+    pbr: GeometryResult['material'],
+    isSelected: boolean,
+    color: number | string,
+    viewMode3D: ViewMode3D,
+): THREE.Material {
+    const isWireframe = viewMode3D === 'wireframe';
+    const flatShading = viewMode3D === 'shadedWithEdges';
+    if (pbr && !isSelected) {
+        const pbrMaterial = buildMaterialFromPBR(pbr) as THREE.MeshPhysicalMaterial;
+        pbrMaterial.flatShading = flatShading;
+        pbrMaterial.wireframe = isWireframe;
+        pbrMaterial.side = THREE.DoubleSide;
+        pbrMaterial.depthWrite = (pbr.opacity ?? 1) >= 1;
+        return pbrMaterial;
+    }
+    return new THREE.MeshLambertMaterial({
+        color,
+        flatShading,
+        wireframe: isWireframe,
+    });
+}
+
 function GhostFaceMesh({ face }: { face: FaceGeometry }) {
     const geometry = useMemo(() => bufferGeometryFromFace(face), [face]);
 
@@ -151,19 +184,10 @@ export function ConsolidatedShape({
 
     const resolvedColor = resolveColor(geometry.color) ?? DEFAULT_COLOR;
     const color = isSelected ? CAD_COLORS.selection : resolvedColor;
-    const material = useMemo(() => {
-        if (geometry.material && !isSelected) {
-            const pbrMaterial = buildMaterialFromPBR(geometry.material) as THREE.MeshPhysicalMaterial;
-            pbrMaterial.flatShading = viewMode3D === 'shadedWithEdges';
-            pbrMaterial.side = THREE.DoubleSide;
-            pbrMaterial.depthWrite = (geometry.material.opacity ?? 1) >= 1;
-            return pbrMaterial;
-        }
-        return new THREE.MeshLambertMaterial({
-            color,
-            flatShading: viewMode3D === 'shadedWithEdges'
-        });
-    }, [geometry.material, isSelected, color, viewMode3D]);
+    const material = useMemo(
+        () => buildShapeMaterial(geometry.material, isSelected, color, viewMode3D),
+        [geometry.material, isSelected, color, viewMode3D],
+    );
 
     if (!mergedGeometry) return null;
 

--- a/src/studio/components/viewer/entities/buildShapeMaterial.ts
+++ b/src/studio/components/viewer/entities/buildShapeMaterial.ts
@@ -1,0 +1,41 @@
+import * as THREE from 'three';
+import type { GeometryResult } from '../../../../shared/worker/geometryEngine';
+import type { ViewMode3D } from '../../../../shared/types/viewMode';
+import { buildMaterialFromPBR } from '../../demoPlayer/buildMaterialFromPBR';
+
+/**
+ * Build the THREE material for a shape given the geometry record, selection
+ * state, resolved fallback color, and the active 3D view mode.
+ *
+ * Lives in its own module so the (viewMode3D → material flags) mapping can be
+ * unit-tested without mounting an R3F Canvas, and so ShapeGeometry.tsx stays
+ * a pure component module (Fast Refresh requires component files not to
+ * export non-component values).
+ *
+ * Three view modes:
+ *  - `'shaded'`           — smooth shading, no wireframe, no edge overlay
+ *  - `'wireframe'`        — `material.wireframe = true`, surfaces drawn as lines
+ *  - `'shadedWithEdges'`  — flat shading + black edge overlay rendered separately
+ */
+export function buildShapeMaterial(
+    pbr: GeometryResult['material'],
+    isSelected: boolean,
+    color: number | string,
+    viewMode3D: ViewMode3D,
+): THREE.Material {
+    const isWireframe = viewMode3D === 'wireframe';
+    const flatShading = viewMode3D === 'shadedWithEdges';
+    if (pbr && !isSelected) {
+        const pbrMaterial = buildMaterialFromPBR(pbr) as THREE.MeshPhysicalMaterial;
+        pbrMaterial.flatShading = flatShading;
+        pbrMaterial.wireframe = isWireframe;
+        pbrMaterial.side = THREE.DoubleSide;
+        pbrMaterial.depthWrite = (pbr.opacity ?? 1) >= 1;
+        return pbrMaterial;
+    }
+    return new THREE.MeshLambertMaterial({
+        color,
+        flatShading,
+        wireframe: isWireframe,
+    });
+}

--- a/src/studio/context/GeometryContext.test.tsx
+++ b/src/studio/context/GeometryContext.test.tsx
@@ -356,7 +356,11 @@ describe('GeometryContext latest-intent-wins', () => {
     expect(screen.getByTestId('script-review-repair').textContent).toContain('supported clevis');
   });
 
-  it('refreshes mesh but skips review when params relower over SSE', async () => {
+  it('refreshes mesh AND review when params relower over SSE', async () => {
+    // PR #315 / I1: relower MUST re-run review so the StudioShell HUD
+    // (interferences: N) reflects the post-param model. Old behavior
+    // (skipReview: true) made the HUD stale and was the root cause of
+    // "param sliders create colliding models" silently passing.
     window.history.pushState(
       {},
       '',
@@ -409,6 +413,14 @@ describe('GeometryContext latest-intent-wins', () => {
             },
           },
         }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          diagnostics: [],
+          suggestedRepairPrompt: 'post-relower review',
+        }),
       } as Response);
 
     render(
@@ -432,16 +444,22 @@ describe('GeometryContext latest-intent-wins', () => {
       await Promise.resolve();
       await Promise.resolve();
       await Promise.resolve();
+      await Promise.resolve();
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
     expect(fetchUrl(fetchMock, 4)).toBe('/__kernelcad/mesh?session=tok-abc');
     expectFetchSignal(fetchMock, 4);
     expect(screen.getByTestId('script-param-name').textContent).toBe('heightAdjustMm');
-    expect(screen.getByTestId('script-review-repair').textContent).toBe('initial review');
+    // 5th fetch is the review re-run that updates the HUD interference count.
+    expect(screen.getByTestId('script-review-repair').textContent).toBe('post-relower review');
   });
 
-  it('coalesces relower bursts into one active mesh fetch plus one trailing fetch', async () => {
+  it('coalesces relower bursts into one active mesh+review fetch pair plus one trailing pair', async () => {
+    // PR #315 / I1: relower now fires mesh AND review (to keep the HUD
+    // interference count live). Coalescing semantics unchanged: 3 burst
+    // triggers still collapse to 1 active + 1 trailing — but each step is
+    // now a (mesh, review) pair instead of mesh-only.
     window.history.pushState(
       {},
       '',
@@ -482,7 +500,25 @@ describe('GeometryContext latest-intent-wins', () => {
         }),
       } as Response)
       .mockImplementationOnce(() => firstRelower.promise)
-      .mockImplementationOnce(() => secondRelower.promise);
+      // Review after first relower mesh.
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          diagnostics: [],
+          suggestedRepairPrompt: 'first relower review',
+        }),
+      } as Response)
+      .mockImplementationOnce(() => secondRelower.promise)
+      // Review after trailing relower mesh.
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          diagnostics: [],
+          suggestedRepairPrompt: 'trailing relower review',
+        }),
+      } as Response);
 
     render(
       <GeometryProvider code={'const ignored = 1;'}>
@@ -507,6 +543,8 @@ describe('GeometryContext latest-intent-wins', () => {
       await Promise.resolve();
     });
 
+    // Burst of 3 still collapses to 1 in-flight mesh fetch — review hasn't
+    // fired yet because the mesh promise is still pending.
     expect(fetchMock).toHaveBeenCalledTimes(4);
 
     await act(async () => {
@@ -528,9 +566,12 @@ describe('GeometryContext latest-intent-wins', () => {
       await Promise.resolve();
       await Promise.resolve();
       await Promise.resolve();
+      await Promise.resolve();
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(5);
+    // After the first mesh resolves: review fires (5) and the queued
+    // trailing mesh starts (6).
+    expect(fetchMock).toHaveBeenCalledTimes(6);
 
     await act(async () => {
       secondRelower.resolve({
@@ -550,9 +591,11 @@ describe('GeometryContext latest-intent-wins', () => {
       } as Response);
       await Promise.resolve();
       await Promise.resolve();
+      await Promise.resolve();
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(5);
+    // After the trailing mesh resolves: trailing review fires (7).
+    expect(fetchMock).toHaveBeenCalledTimes(7);
     expect(screen.getByTestId('script-param-name').textContent).toBe('width');
     expect(screen.getByTestId('execution-count').textContent).toBe('3');
   });

--- a/src/studio/context/GeometryContext.tsx
+++ b/src/studio/context/GeometryContext.tsx
@@ -34,6 +34,20 @@ export interface ScriptReviewSummary {
         blockingReasons?: Array<{ code?: string; message?: string; repairHint?: string }>;
     };
     suggestedRepairPrompt?: string;
+    /**
+     * Raw pairwise interference results at the script's current/default pose,
+     * BEFORE any `ignore` filtering applied by `assembly.solvedModel`. The
+     * Studio status-bar HUD reads `.length` of this for the interferences
+     * counter so users see what's overlapping right now even when the script
+     * silences a known-acceptable pair (e.g. an elbow knuckle). The validator's
+     * filtered diagnostics still flow through `diagnostics` above for the
+     * Validity tab and the `validate: 'error'` throw path.
+     */
+    rawInterferencePairs?: Array<{
+        a: string;
+        b: string;
+        volumeMm3: number;
+    }>;
 }
 
 export interface GeometryContextType {
@@ -386,7 +400,14 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
         const url = `/__kernelcad/events?session=${encodeURIComponent(sessionToken)}`;
         const es = new EventSource(url);
         const onRelower = () => {
-            requestMeshAndReview(studioScript, sessionToken, { keepExistingOnError: true, skipReview: true });
+            // Re-fetch BOTH mesh AND review on relower. The review side carries
+            // the live `rawInterferencePairs` channel the Studio status-bar
+            // HUD reads — without re-fetching review on each param change the
+            // HUD never updates and the user can drag a slider into a clipping
+            // pose with the indicator stuck at the original count. (The prior
+            // `skipReview: true` flag was a perf optimisation that predated
+            // the live-interference channel.)
+            requestMeshAndReview(studioScript, sessionToken, { keepExistingOnError: true });
         };
         es.addEventListener('relower', onRelower);
         // The browser auto-reconnects on transient drops; we only log here.

--- a/src/studio/hooks/useRecomputeResult.ts
+++ b/src/studio/hooks/useRecomputeResult.ts
@@ -34,6 +34,17 @@ export function useRecomputeResult(): StudioRecomputeResult {
         [workbench.scriptReview],
     );
 
+    // Raw interference pairs are read directly from the script review payload
+    // (filtering is applied at the validator layer, not here). Empty array
+    // when scriptReview is null OR when the server omitted the field — the
+    // Studio HUD treats that as "interferences: 0" rather than a missing
+    // signal. See StudioRecomputeResult.rawInterferencePairs JSDoc for why
+    // the HUD reads this and not validity.diagnostics.
+    const rawInterferencePairs = useMemo(
+        () => workbench.scriptReview?.rawInterferencePairs ?? [],
+        [workbench.scriptReview],
+    );
+
     const paramTable = useMemo(
         () => serializedParamsToTable(workbench.scriptParams ?? []),
         [workbench.scriptParams],
@@ -72,6 +83,7 @@ export function useRecomputeResult(): StudioRecomputeResult {
             diagnostics,
             recomputeMs: workbench.recomputeMs ?? 0,
             joints,
+            rawInterferencePairs,
             updateParam,
             setGeometryTransformOverride,
             clearGeometryTransformOverrides,
@@ -85,6 +97,7 @@ export function useRecomputeResult(): StudioRecomputeResult {
             paramTable,
             diagnostics,
             joints,
+            rawInterferencePairs,
             setGeometryTransformOverride,
             clearGeometryTransformOverrides,
         ],

--- a/src/studio/tabs/ParamsTab.tsx
+++ b/src/studio/tabs/ParamsTab.tsx
@@ -162,7 +162,7 @@ function buildInterferenceIndex(
     byParam: Map<string, ScrubInterference>;
     allPairs: readonly RawPair[];
 } {
-    const pairs: RawPair[] = rawPairs.slice();
+    const pairs: RawPair[] = (rawPairs ?? []).slice();
     const byParam = new Map<string, RawPair[]>();
     if (pairs.length === 0 || !joints || joints.length === 0) {
         return { byParam: new Map(), allPairs: pairs };

--- a/src/studio/tabs/ParamsTab.tsx
+++ b/src/studio/tabs/ParamsTab.tsx
@@ -2,7 +2,9 @@ import type { JSX } from 'react';
 import { useRecomputeResult } from '../hooks/useRecomputeResult';
 import { useParamUpdate, type ParamUpdater } from '../hooks/useParamUpdate';
 import type { ParamEntry } from '../../shared/runtime/paramTable';
-import { NumericScrubInput } from '../components/inputs/NumericScrubInput';
+import { NumericScrubInput, type ScrubInterference } from '../components/inputs/NumericScrubInput';
+import type { JointPoseSnapshot } from '../adapters/featureRecordsToMates';
+import type { StudioRecomputeResult } from '../types';
 
 /**
  * Inspector tab listing script-declared params from `param()`.
@@ -11,9 +13,21 @@ import { NumericScrubInput } from '../components/inputs/NumericScrubInput';
  * commit through `updateParam` from `useRecomputeResult`, which POSTs to
  * `/__kernelcad/params`; the SSE `relower` event re-fetches mesh +
  * review so the param table refreshes with the new value.
+ *
+ * v0.7 — interference-on-slider indicator. We read live interference
+ * pairs from `recompute.rawInterferencePairs` (the pre-filter HUD channel,
+ * not the validator's filtered diagnostic stream — so a slider pulling
+ * the model into a clash flags even when the script `ignore`s known-
+ * acceptable contacts) and cross-reference each pair's parts with the
+ * joint adapter's `poseParamNames` to figure out which params drive a
+ * colliding pose. Implicated rows render the slider track red and show a
+ * "!" badge with a tooltip listing the colliding pairs. If interferences
+ * exist but no param can be implicated (e.g. all parts are joint-less /
+ * numeric-literal poses) we fall back to a top-of-panel warning so the
+ * user still gets a Params-tab signal, not just the small footer counter.
  */
 export function ParamsTab(): JSX.Element {
-    const { paramTable, updateParam } = useRecomputeResult();
+    const { paramTable, updateParam, rawInterferencePairs, joints } = useRecomputeResult();
     // Single shared updater for every row in this tab. Numeric scrubs get
     // a debounced send so slider drag doesn't fire one POST + one full
     // relower per pointer-move; boolean toggles are single high-intent
@@ -23,6 +37,9 @@ export function ParamsTab(): JSX.Element {
     const entries: ParamEntry[] = paramTable && paramTable.size() > 0
         ? paramTable.list()
         : [];
+
+    const { byParam, allPairs } = buildInterferenceIndex(rawInterferencePairs, joints);
+    const unattributedPairs = allPairs.length > 0 && byParam.size === 0 ? allPairs : [];
 
     if (entries.length === 0) {
         return (
@@ -37,9 +54,35 @@ export function ParamsTab(): JSX.Element {
 
     return (
         <div className="flex flex-col" data-testid="params-tab">
+            {unattributedPairs.length > 0 && (
+                <div
+                    className="flex items-start gap-2 px-3 py-2 text-[11px] text-red-200 bg-red-950/40 border-b border-red-900"
+                    data-testid="params-interference-banner"
+                    title={unattributedPairs
+                        .map((p) => `${p.a} ↔ ${p.b} — ${p.volumeMm3.toFixed(1)} mm³`)
+                        .join('\n')}
+                >
+                    <span
+                        className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-red-600 text-white text-[10px] font-bold leading-none flex-shrink-0"
+                        aria-hidden="true"
+                    >
+                        !
+                    </span>
+                    <span className="leading-tight">
+                        {unattributedPairs.length === 1
+                            ? '1 interference in current pose'
+                            : `${unattributedPairs.length} interferences in current pose`}
+                    </span>
+                </div>
+            )}
             <ul className="flex flex-col divide-y divide-[#1f1f1f]">
                 {entries.map((entry) => (
-                    <ParamRow key={entry.name} entry={entry} updater={updater} />
+                    <ParamRow
+                        key={entry.name}
+                        entry={entry}
+                        updater={updater}
+                        interference={byParam.get(entry.name)}
+                    />
                 ))}
             </ul>
         </div>
@@ -49,9 +92,10 @@ export function ParamsTab(): JSX.Element {
 interface ParamRowProps {
     readonly entry: ParamEntry;
     readonly updater: ParamUpdater;
+    readonly interference?: ScrubInterference;
 }
 
-function ParamRow({ entry, updater }: ParamRowProps): JSX.Element {
+function ParamRow({ entry, updater, interference }: ParamRowProps): JSX.Element {
     if (entry.type === 'boolean') {
         return (
             <li
@@ -88,6 +132,7 @@ function ParamRow({ entry, updater }: ParamRowProps): JSX.Element {
                 value={value}
                 min={min}
                 max={max}
+                interference={interference}
                 onChange={(next) => {
                     updater.commitDebounced([{ name: entry.name, value: next }]);
                 }}
@@ -95,4 +140,68 @@ function ParamRow({ entry, updater }: ParamRowProps): JSX.Element {
             />
         </li>
     );
+}
+
+type RawPair = StudioRecomputeResult['rawInterferencePairs'][number];
+
+/**
+ * Cross-reference current-pose interference pairs with the assembly's
+ * joint→param map to figure out which Params-tab sliders are implicated in
+ * a colliding pose.
+ *
+ * Returns:
+ *  - `byParam` — param name → `ScrubInterference` (subset of pairs the
+ *    param's joint touches). Empty when no joint binds to any pair part.
+ *  - `allPairs` — every interference pair, used for the top-of-panel
+ *    fallback banner when none could be attributed to a slider.
+ */
+function buildInterferenceIndex(
+    rawPairs: StudioRecomputeResult['rawInterferencePairs'],
+    joints: readonly JointPoseSnapshot[] | undefined,
+): {
+    byParam: Map<string, ScrubInterference>;
+    allPairs: readonly RawPair[];
+} {
+    const pairs: RawPair[] = rawPairs.slice();
+    const byParam = new Map<string, RawPair[]>();
+    if (pairs.length === 0 || !joints || joints.length === 0) {
+        return { byParam: new Map(), allPairs: pairs };
+    }
+    // For each joint, look at the parts it connects (split connector refs on
+    // the first dot). A param is implicated in an interference pair when at
+    // least one of the colliding parts appears in that joint's pair. This is
+    // intentionally a loose heuristic — a kinematic chain like
+    // base↔arm + arm↔head means moving the shoulder param shifts head
+    // relative to other parts too, even though the shoulder joint's pair is
+    // base↔arm. Strict "both-parts-in-joint" matching missed the obvious
+    // culprit in the Luxo lamp case (shoulder joint = base↔arm, collision =
+    // head↔arm). Some false positives are acceptable — the badge says "this
+    // slider can move into / out of the collision," which is still true.
+    for (const joint of joints) {
+        const partA = joint.mate.a.split('.')[0];
+        const partB = joint.mate.b.split('.')[0];
+        const jointParts = new Set([partA, partB]);
+        const paramNames = joint.poseParamNames.filter(
+            (n): n is string => typeof n === 'string',
+        );
+        if (paramNames.length === 0) continue;
+        for (const pair of pairs) {
+            if (!jointParts.has(pair.a) && !jointParts.has(pair.b)) continue;
+            for (const paramName of paramNames) {
+                let list = byParam.get(paramName);
+                if (!list) {
+                    list = [];
+                    byParam.set(paramName, list);
+                }
+                if (!list.some((p) => p.a === pair.a && p.b === pair.b)) {
+                    list.push(pair);
+                }
+            }
+        }
+    }
+    const out = new Map<string, ScrubInterference>();
+    for (const [name, list] of byParam) {
+        out.set(name, { collidingPairs: list });
+    }
+    return { byParam: out, allPairs: pairs };
 }

--- a/src/studio/types.ts
+++ b/src/studio/types.ts
@@ -45,6 +45,21 @@ export interface StudioRecomputeResult {
     readonly diagnostics: readonly CompilerDiagnostic[];
     readonly recomputeMs: number;
     /**
+     * Raw pairwise interference pairs at the current pose, BEFORE any `ignore`
+     * filtering done by `assembly.solvedModel({ ignore: [...] })`. The status
+     * bar HUD reads `.length` of this so users see the real overlap count
+     * even when the script silences specific known-acceptable contacts. The
+     * `validity` field (above) carries the validator's FILTERED diagnostic
+     * stream — i.e. ignored pairs do not appear there. The two channels are
+     * deliberately decoupled: validator runs filtered (Validity tab + throw
+     * path), HUD shows raw (so authors can never accidentally blind the user).
+     */
+    readonly rawInterferencePairs: ReadonlyArray<{
+        readonly a: string;
+        readonly b: string;
+        readonly volumeMm3: number;
+    }>;
+    /**
      * Slice 2C — assembly joints with declared pose, extracted from
      * `solvedAssembly` FeatureRecords. Empty array when the script doesn't
      * build an assembly, or builds one with no posed mates. JointsTab uses

--- a/tests/unit/assemblies/solvedModelValidate.test.ts
+++ b/tests/unit/assemblies/solvedModelValidate.test.ts
@@ -138,6 +138,76 @@ describe('Assembly.solvedModel({validate:"error"}) — interference hard gate', 
     // The two boxes touch on a face (zero overlap volume) — should NOT register.
     await expect(arm.solvedModel({}, { validate: 'error' })).resolves.not.toThrow();
   }, 60_000);
+
+  it('granular `ignore` silences a single clashing pair under validate:"error"', async () => {
+    // Two fully-overlapping boxes — would throw under bare validate:'error'.
+    // Passing the pair on `ignore` must let the call resolve while leaving
+    // the validation gate live for everything else.
+    const { arm, kcad } = makeArm();
+    arm
+      .part('a', kcad.box(10, 10, 10))
+      .connector('o', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 0] } });
+    arm
+      .part('b', kcad.box(10, 10, 10))
+      .connector('o', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 0] } });
+    arm.mate('m', 'a.o', 'b.o', 'fastened');
+    await expect(
+      arm.solvedModel({}, { validate: 'error', ignore: [['a', 'b']] }),
+    ).resolves.not.toThrow();
+  }, 60_000);
+
+  it('`ignore` matches symmetrically: `[a, b]` also covers `(b, a)`', async () => {
+    // Even if the underlying detector emitted the pair in the other order,
+    // the validator's filter must catch it.
+    const { arm, kcad } = makeArm();
+    arm
+      .part('a', kcad.box(10, 10, 10))
+      .connector('o', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 0] } });
+    arm
+      .part('b', kcad.box(10, 10, 10))
+      .connector('o', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 0] } });
+    arm.mate('m', 'a.o', 'b.o', 'fastened');
+    await expect(
+      arm.solvedModel({}, { validate: 'error', ignore: [['b', 'a']] }),
+    ).resolves.not.toThrow();
+  }, 60_000);
+
+  it('`ignore` does NOT silence non-listed clashing pairs', async () => {
+    // Three boxes: a-b overlap (ignored), a-c overlap (NOT ignored). The
+    // a-c pair must still throw.
+    const { arm, kcad } = makeArm();
+    arm
+      .part('a', kcad.box(10, 10, 10))
+      .connector('o', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 0] } });
+    arm
+      .part('b', kcad.box(10, 10, 10))
+      .connector('o', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 0] } });
+    arm
+      .part('c', kcad.box(10, 10, 10))
+      .connector('o', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 0] } });
+    arm.mate('m1', 'a.o', 'b.o', 'fastened');
+    arm.mate('m2', 'a.o', 'c.o', 'fastened');
+    await expect(
+      arm.solvedModel({}, { validate: 'error', ignore: [['a', 'b']] }),
+    ).rejects.toThrow(/overlap|interference/i);
+  }, 60_000);
+
+  it('`ignore` under validate:"warn" drops the matched diagnostic from scene.warnings', async () => {
+    const { arm, kcad } = makeArm();
+    arm
+      .part('a', kcad.box(10, 10, 10))
+      .connector('o', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 0] } });
+    arm
+      .part('b', kcad.box(10, 10, 10))
+      .connector('o', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 0] } });
+    arm.mate('m', 'a.o', 'b.o', 'fastened');
+    // warn mode doesn't auto-run interference detection (see the test above),
+    // so there's no overlap diagnostic on the warnings either way. This test
+    // is a belt-and-suspenders check that adding `ignore` doesn't introduce
+    // a regression in warn mode either.
+    const scene = await arm.solvedModel({}, { validate: 'warn', ignore: [['a', 'b']] });
+    expect(scene.warnings.some((w) => w.code === 'assembly.interference.overlap')).toBe(false);
+  }, 60_000);
 });
 
 describe('Assembly.solvedModel — mate-driven placement (Pattern A)', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -331,11 +331,53 @@ function kernelCadMeshEndpoint(): Plugin {
           }
 
           const { reviewCadTool } = await import('./src/agent/mcp/tools/reviewCad');
+          const { detectInterferences } = await import('./src/modeling/runtime/detectInterferences');
+          const { isSceneBackend } = await import('./src/kernel/backends/sceneBackend');
+
+          // When a session token is present, recompute raw interferences
+          // against the LIVE pooled session's tail scene — that captures the
+          // user's current Params-tab edits via the SSE relower path. The
+          // base reviewCadTool still re-evaluates from the script source so
+          // its validator + envelope output stays comparable across reloads;
+          // we overlay the live raw count on top for the Studio HUD's
+          // slider-drag responsiveness.
+          const sessionToken = url.searchParams.get('session');
           const review = await reviewCadTool({
             file: scriptPath,
             includePoseEnvelope: true,
             includeInterference: true,
           });
+
+          if (sessionToken) {
+            try {
+              const bundle = await getPoolBundle();
+              const entry = bundle.pool.get(sessionToken);
+              // After `session.params.update`, the pool entry's `model.tailShape`
+              // can be stale — `updateModelParams` returns a fresh BuiltModel
+              // but doesn't write back to the pool. The session's
+              // `cachedShapes` map IS updated though, so we read the latest
+              // tail from there directly to capture the user's live Params
+              // edits.
+              const session = entry?.model.session as unknown as {
+                cachedShapes?: Map<string, unknown>;
+              } | undefined;
+              const tailId = entry?.model.tailId;
+              const liveTail = tailId && session?.cachedShapes?.get(tailId);
+              const tail = liveTail ?? entry?.model.tailShape;
+              if (tail && isSceneBackend(tail as { parts?: unknown })) {
+                const livePairs = detectInterferences(
+                  tail as Parameters<typeof detectInterferences>[0],
+                  0.01,
+                  new Set<string>(),
+                ).pairs;
+                (review as { rawInterferencePairs?: unknown }).rawInterferencePairs = livePairs;
+              }
+            } catch {
+              // Session-side overlay failed; fall back to the script-eval pairs
+              // already on `review`. The HUD will show the default-pose count
+              // instead of the live count, but the request still succeeds.
+            }
+          }
 
           res.statusCode = 200;
           res.setHeader('content-type', 'application/json');


### PR DESCRIPTION
## Summary

Surfaced while trying to actually build a Luxo desk lamp end-to-end in Studio. Each of the four fixes below is a separable user-visible defect; bundled because they were all discovered in one session against the lamp eval, and the lamp serves as the ground-truth for verifying them together.

| # | Fix |
|---|---|
| **L1** | Luxo lamp redesign — iconic features (disc base, slim arms, knuckle spheres, revolved truncated-cone shade). Prev attempt was "a chevron of tan boards with a tomato can." |
| **L2** | Studio Shaded / Wireframe / Shaded-with-Edges toolbar buttons actually do something. Root cause: `ShapeGeometry.tsx`'s material factory only honored `shadedWithEdges`; `wireframe` case never set `material.wireframe`. |
| **I1** | `Assembly.solvedModel(poses, { ignore: [['a','b']] })` — granular silencing replacement for blunt `validate: 'off'`. **Studio HUD** now reads raw interference count from `rawInterferencePairs` (sourced from `detectInterferences` before validator filtering) instead of the validator's filtered diagnostics. |
| **I2** | **Params tab** slider gets a red track + "!" badge when its bound joint is implicated in a current-pose collision. Fallback: "⚠ N interferences in current pose" banner at the top of the panel when joint attribution isn't possible. |

## Why this matters

The user dragged a Studio Params slider into a clipping pose and the HUD still read "interferences: 0." Their words: "what is wrong with our approach!"

Root cause was a design gap: every kinematic gate kernelCAD has (`checkSweptCollision`, `validate`, etc.) is single-pose at evaluate time, and `validate: 'off'` is the only knob authors had to silence a known contact. Together that means an author silencing one pair to ship the eval was also silencing the live-user feedback channel. Fix: separate detection (always on, feeds HUD) from validator filtering (governed by `ignore` + `validate`), and propagate live re-detection through to the slider UI.

## What changed

- `src/modeling/capture/assembly.ts` + `src/modeling/mates/validator.ts` — `ignore: Array<[string, string]>` opt; symmetric pair match.
- `src/agent/mcp/tools/reviewCad.ts` — new `rawInterferencePairs` field; reads `model.tailShape` directly so the recompute pipeline can re-detect on every Params edit.
- `src/studio/StudioShell.tsx`, `src/studio/hooks/useRecomputeResult.ts`, `src/studio/types.ts`, `src/studio/context/GeometryContext.tsx` — plumbed `rawInterferencePairs` through to the HUD; dropped `skipReview: true` on SSE relower that was masking live updates.
- `src/studio/components/viewer/entities/ShapeGeometry.tsx` — extracted `buildShapeMaterial(pbr, isSelected, color, viewMode3D)` honoring all 3 view modes for both PBR and Lambert branches.
- `src/studio/tabs/ParamsTab.tsx` + `src/studio/components/inputs/NumericScrubInput.tsx` — implicated-slider indicator (red track + badge + tooltip listing pairs) with v0.5 fallback banner.
- `examples/kinematic/luxo-lamp.kcad.ts` — new file; uses `ignore: [...]` not `validate: 'off'`.
- `vite.config.ts` — review endpoint overlays live raw pairs from the pooled session.

## Tests (all pass)

- 65 test files / 409 tests pass across `src/modeling/mates`, `src/studio/__tests__`, `tests/unit/assemblies`, `tests/unit/diagnostics`.
- 4 new validator unit tests (ignore + symmetric match)
- 4 new solvedModel API tests (ignore + validate=error doesn't throw on ignored)
- 2 new useRecomputeResult tests + 2 new StudioShell HUD tests
- 5 new ShapeGeometry buildShapeMaterial unit tests
- 4 new ParamsTab interference-indicator tests + 7 ShapeGeometry tests

## Manual verification

- Studio loads at `/studio?script=examples/kinematic/luxo-lamp.kcad.ts`. HUD reads "interferences: 3" (the 3 knuckle contacts the lamp silences via `ignore`). Validity tab still green because `ignore` filters them out of the diagnostic stream.
- Click Wireframe / Shaded / Shaded-with-Edges — each produces a visibly different render.
- Open Params tab — sees red banner "⚠ 3 interferences in current pose" at the top, sliders themselves don't fire the per-slider badge in this case because the lamp uses `solvedModel({...})` literal pose (not `poseRef`), so joint-to-param attribution can't resolve. Fallback banner serves the purpose.
- Screenshots in `/tmp/lamp-final-*.png`, `/tmp/params-tab-final.png`, `/tmp/render-mode-final-*.png`.

## Memory saved

`feedback_visual_taste_over_metric_success` — for any visible-output task, `evaluate ok / 0 diagnostics / gates green` is necessary but not sufficient; list iconic features first, compare to mental/reference image, don't rationalize broken renders. Logged after I shipped the chevron-with-tomato-can as "the Luxo lamp" earlier in the session.