### PR TITLE
gallery: take luxo-lamp down from public listing

### DIFF
--- a/site/gallery/entries.json
+++ b/site/gallery/entries.json
@@ -1,33 +1,6 @@
 {
   "entries": [
     {
-      "slug": "luxo-lamp",
-      "title": "Luxo Articulated Desk Lamp",
-      "author": {
-        "handle": "kernelcad",
-        "url": "https://x.com/kernelcad"
-      },
-      "version": "v0.11.1",
-      "prompt": "Build a Pixar-style Luxo articulated desk lamp as a kernelCAD assembly with a 3-DOF kinematic chain — shoulder, elbow, wrist all revolute around the lamp's Y axis. The base is a weighted steel disc with a small neck riser. The lower and upper arms are slim brass beams, each authored in its own part-local frame with origin at the joint it attaches to its parent (shoulder origin in world frame; elbow origin in the lower arm's local frame; wrist origin in the upper arm's local frame). Decorative knuckle spheres at each joint make the mechanism read as physically connected. The lamp head is a brass truncated cone — narrow ring at the wrist, opening to a wide shade rim along the wrist's local +X — built as a revolution of a trapezoidal profile around the +X axis. The model uses the `ignore` opt to silence the three intentional knuckle-touch pairs while keeping the validator hot for everything else; the Studio status-bar interference HUD updates live as the user drags the shoulder / elbow / wrist param sliders, so the param panel surfaces self-collision the instant a pose drives the head into the upper arm.",
-      "source": "curated",
-      "video": "../../docs/demos/gallery/luxo-lamp/demo.mp4",
-      "codeLocal": "../../examples/kinematic/luxo-lamp.kcad.ts",
-      "code": "https://github.com/w1ne/kernelCAD-web/blob/main/examples/kinematic/luxo-lamp.kcad.ts",
-      "tags": [
-        "mechanism",
-        "kinematic",
-        "joints",
-        "revolve",
-        "ignore-pairs",
-        "interactive-params",
-        "assembly",
-        "words-to-geometry"
-      ],
-      "featured": false,
-      "createdAt": "2026-05-25",
-      "appUrl": null
-    },
-    {
       "slug": "royal-pop-pocket-watch",
       "title": "Royal Pop Pocket Watch",
       "author": {


### PR DESCRIPTION
## Why

The shipped hero frame does not read as a Pixar Luxo lamp:

- **Base disconnected from the rest.** Column is 50 mm tall, hidden under the shoulder fork, so in the hero view the disc looks like a frisbee floating left of the arm assembly with no neck.
- **Wrong topology.** Plain single-beam articulated boom — the iconic Luxo / Anglepoise uses *parallelogram 4-bar linkages* with springs running parallel to each pair of beams.
- **Inverted proportions.** Shade Ø140 ≈ base Ø150; on a real Luxo the shade is much smaller than the base.
- **Springs read as scribbly black coils** at the chosen wire gauge / pitch / camera pose.

This is the second iteration of the same task and the second one to ship without a reference-image side-by-side check. Better to take it down than to have it stand on `kernelcad.com/gallery` as the most prominent recent entry.

## What

Removes the `luxo-lamp` entry from `site/gallery/entries.json`. Source file (`examples/kinematic/luxo-lamp.kcad.ts`), sidecar `examples/gallery/luxo-lamp/review.json`, and `docs/demos/gallery/luxo-lamp/` artifacts are kept on disk as the starting reference for the redesign — only the public-facing entry goes away.

## Test plan

- [x] `npx vitest run tests/unit/skill/skillAuthoringOperatingRules.test.ts scripts/lib/galleryEntryScoring.test.ts scripts/lib/galleryEntries.test.ts` (21/21 passing locally)
- [ ] After merge, trigger marketing deploy from the private workflow and confirm `kernelcad.com/gallery` no longer lists `luxo-lamp`