### PR TITLE
revert(site): privacy data controller block (#323)

### DIFF
--- a/site/privacy.html
+++ b/site/privacy.html
@@ -47,9 +47,6 @@
 
       <p>This policy explains what data kernelCAD ("we", "us") collects when you use the kernelCAD website (<code>kernelcad.com</code>), the hosted Studio (<code>app.kernelcad.com</code>), the hosted MCP server (<code>mcp.kernelcad.com</code>), and the <code>kernelcad</code> tooling — and how we use it.</p>
 
-      <h2>Data controller</h2>
-      <p>kernelCAD is operated by Andrii Shylenko, an individual sole proprietor based in Hungary. Contact: <a href="mailto:andrii@shylenko.com">andrii@shylenko.com</a>.</p>
-
       <h2>What we collect</h2>
       <ul>
         <li><strong>Account &amp; identity.</strong> When you sign in, we authenticate you through Google via Supabase Auth and store your email address and account identifier.</li>


### PR DESCRIPTION
Reverts #323. Data controller / jurisdiction phrasing being reconsidered before publishing.