### PR TITLE
chore(npm): add mcpName for MCP Registry npm-package discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "kernelcad",
+  "mcpName": "com.kernelcad/kernelcad",
   "private": false,
   "version": "0.11.1",
   "type": "module",


### PR DESCRIPTION
## Summary
- Adds `"mcpName": "com.kernelcad/kernelcad"` to `package.json`. No version bump.

## Why
The official MCP Registry validates that a listed npm package contains `mcpName` matching the server name before accepting a `packages` block in `server.json`. We dropped the `packages` block during the v0.11.1 publish because `kernelcad@0.11.1` lacked the field. Adding it now unblocks the next release to republish with an installable packages entry.

Downstream effect: Glama (and Smithery, mcp.so) currently classify kernelCAD as **Connector-only** because the registry exposes only the hosted endpoint. Once the registry carries the npm package too, they should add a parallel Server entry (with a score badge for Glama). That in turn unblocks awesome-mcp-servers PR #6892.

## Sequencing (after merge)
1. `npm run release patch` (bumps 0.11.1 → 0.11.2, tags, pushes)
2. `npm publish` (releases with mcpName in the live package.json)
3. Update `server.json` with the packages block + `mcp-publisher publish`
4. Wait ~1 day for Glama re-crawl
5. Update awesome-mcp-servers PR with the now-resolving badge

## Test plan
- [x] Edit is one line; package.json still parses
- [ ] Post-release: confirm `npm view kernelcad mcpName` returns `com.kernelcad/kernelcad`
- [ ] Post registry republish: confirm `https://registry.modelcontextprotocol.io/v0/servers?search=kernelcad` shows the `packages` block
- [ ] Post Glama re-crawl: confirm `https://glama.ai/mcp/servers/w1ne/kernelCAD-web/badges/score.svg` returns 200