### PR TITLE
chore(lint): exclude .worktrees and nested dist from eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist', 'eval/runs/**', '.claude/worktrees/**']),
+  globalIgnores(['**/dist/**', 'eval/runs/**', '.claude/worktrees/**', '.worktrees/**']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [


### PR DESCRIPTION
## Summary
- Ignore patterns: \`dist\` → \`**/dist/**\`, plus add \`.worktrees/**\`.

## Why
Local git worktrees live at \`.worktrees/\` (not \`.claude/worktrees/\`), and \`dist\` was only ignored at root. Result: lint scanned every \`.worktrees/<branch>/dist/cli/index.js\` (15 MB bundled CLI) and produced 56 errors blocking \`npm run release patch\`.

After the fix: 0 errors, 15 warnings.

## Test plan
- [x] \`npm run lint\` passes (0 errors)