### PR TITLE
Gate 4 joint visual exposure

### DIFF
--- a/src/agent/skills/kernelcad-assemblies/SKILL.md
+++ b/src/agent/skills/kernelcad-assemblies/SKILL.md
@@ -362,7 +362,7 @@ Six diagnostic codes on `ValidatorDiagnostic`:
 
 `kernelcad evaluate` flips the default to `'error'` via the `KERNELCAD_VALIDATE_DEFAULT=error` env var, so authoring scripts surface malformed assemblies as CLI failures.
 
-Under `validate:'error'`, kinematic grounding gates fire — mounting-hole consistency, joint-axis binding, declared-load capacity.
+Under `validate:'error'`, kinematic grounding gates fire — mounting-hole consistency, joint-axis binding, declared-load capacity, joint visual exposure.
 
 ```typescript
 const scene = await arm.solvedModel({}, { validate: 'warn' });
@@ -622,6 +622,7 @@ For robot arms specifically, preserve at least these interfaces between repair a
 | `assembly.joint-axis.unbound` | solvedModel({validate:'error'}) — revolute/prismatic/cylindrical axis floats outside both bound parts' BREP |
 | `assembly.joint.load-exceeded` | solvedModel({validate:'error'}, { externalLoads }) — declared `maxLoad` exceeded by external force/torque |
 | `assembly.mounting-hole.mismatch` | solvedModel({validate:'error'}) — `fastened` mate's two bound faces lack compatible hole features |
+| `assembly.joint.not-visible` | solvedModel({validate:'error'}) — revolute joint's fork+tongue+pin collapses into one visual block (fork-plate gap < 15% of plate extent OR pin stickout < 1.0 × PIN_R). Hint payload carries actual gap ratio and pin-stickout numbers so the agent can widen FORK_GAP_Y / shrink TONGUE_Y / extend PIN_LEN directly. Microscale joints (combined bounding sphere < 5 mm) skip the gate. |
 | `assembly.workspace.unreachable` | solvedModel({validate:'error', posesGate:'envelope'}) — `arm.workspace(...)` declared target lies outside the connector's sampled pose-envelope AABB (minus toleranceMm). Severity is `info` when the gate runs without an envelope (declarations are inert until `posesGate:'envelope'`). AABB-only containment in v0.7 Slice 1; convex-hull check queued for Slice 2 |
 
 ## Cookbook — Query DSL for assemblies

--- a/src/modeling/mates/fixtures/jointVisualExposure-luxo-post-8e2f0da7.kcad.ts
+++ b/src/modeling/mates/fixtures/jointVisualExposure-luxo-post-8e2f0da7.kcad.ts
@@ -1,0 +1,64 @@
+// Regression fixture — post-8e2f0da7 Luxo shoulder joint dimensions.
+//
+// Reproduces the joint hardware at the constants that landed in
+// `examples/kinematic/luxo-lamp.kcad.ts` AT commit 8e2f0da7 — the fix that
+// closes the "joints read as solid cubes" failure Gate 4 catches.
+//
+//   FORK_PLATE_T = 3    // thinner plates
+//   FORK_GAP_Y   = 18   // wider gap → 6 mm daylight per side
+//   TONGUE_Y     = 6    // narrower tongue → matches the wider gap
+//   PIN_R        = 3.5
+//   PIN_LEN      = FORK_GAP_Y + 2 * FORK_PLATE_T + 14 → 38 mm (7 mm stickout)
+//
+// Expected Gate 4 outcome: gap ratio ≈ 6/30 = 0.2 (clears MIN_GAP_RATIO =
+// 0.15), pin stickout ≈ 7 mm per side (clears MIN_PIN_STICKOUT = 3.5 mm).
+// No `assembly.joint.not-visible` diagnostic.
+
+import { CaptureSession } from '../../capture/captureSession';
+import { createApi } from '../../api';
+import type { Assembly } from '../../capture/assembly';
+
+const FORK_PLATE_X = 22;
+const FORK_PLATE_Z = 30;
+const FORK_PLATE_T = 3;
+const FORK_GAP_Y = 18;
+const TONGUE_Y = 6;
+const PIN_R = 3.5;
+const PIN_LEN = FORK_GAP_Y + 2 * FORK_PLATE_T + 14; // 38
+
+export function buildPostFixLuxoShoulder(): { arm: Assembly; session: CaptureSession } {
+  const session = new CaptureSession();
+  const kcad = createApi({ session });
+  const arm = kcad.assembly('luxo-post');
+
+  const plateOffsetY = FORK_GAP_Y / 2 + FORK_PLATE_T / 2;
+  const platePos = kcad.box(FORK_PLATE_X, FORK_PLATE_T, FORK_PLATE_Z, true)
+    .translate(0,  plateOffsetY, 0);
+  const plateNeg = kcad.box(FORK_PLATE_X, FORK_PLATE_T, FORK_PLATE_Z, true)
+    .translate(0, -plateOffsetY, 0);
+  const pin = kcad.cylinder(PIN_LEN, PIN_R, 32)
+    // Same centring trick as the pre-fix fixture — see its comment.
+    .rotate([1, 0, 0], -90)
+    .translate(0, -PIN_LEN / 2, 0);
+  const parentShape = platePos.union(plateNeg).union(pin);
+
+  const childShape = kcad.box(FORK_PLATE_X, TONGUE_Y, FORK_PLATE_Z, true);
+
+  const parent = arm
+    .part('base', parentShape)
+    .connector('hinge', {
+      type: 'axis',
+      origin: { kind: 'vec3', value: [0, 0, 0] },
+      axis: [0, 1, 0],
+    });
+  const child = arm
+    .part('lower-arm', childShape)
+    .connector('hinge', {
+      type: 'axis',
+      origin: { kind: 'vec3', value: [0, 0, 0] },
+      axis: [0, 1, 0],
+    });
+  arm.mate('shoulder', `${parent.name}.hinge`, `${child.name}.hinge`, 'revolute');
+
+  return { arm, session };
+}

--- a/src/modeling/mates/fixtures/jointVisualExposure-luxo-pre-8e2f0da7.kcad.ts
+++ b/src/modeling/mates/fixtures/jointVisualExposure-luxo-pre-8e2f0da7.kcad.ts
@@ -1,0 +1,78 @@
+// Regression fixture — pre-8e2f0da7 Luxo shoulder joint dimensions.
+//
+// Reproduces the joint hardware (clevis fork on the parent, tongue on the
+// child, pivot pin spanning both) at the constants that lived in
+// `examples/kinematic/luxo-lamp.kcad.ts` BEFORE commit 8e2f0da7 — the
+// "joints read as solid cubes" failure that motivated Gate 4. Used as the
+// regression seed in `jointVisualExposure.test.ts`.
+//
+//   FORK_PLATE_T = 4    // plate thickness along Y
+//   FORK_GAP_Y   = 12   // air gap between plates → only 1 mm daylight per side
+//   TONGUE_Y     = 10   // tongue thickness
+//   PIN_R        = 3.5
+//   PIN_LEN      = FORK_GAP_Y + 2 * FORK_PLATE_T + 8 → 28 mm
+//
+// Expected Gate 4 outcome at these constants: gap ratio ≈ 1/30 = 0.033
+// (well below MIN_GAP_RATIO = 0.15), pin stickout = (28 − 12 − 2×4)/2 =
+// 4 mm per side; with MIN_PIN_STICKOUT = 1.0 × PIN_R = 3.5 mm the pin
+// stickout numerically clears the threshold but the gap ratio fails →
+// `failureCause = 'gap'`. (The plan calls out `'both'` as a possible
+// outcome; the precise classification depends on PIN_R inference from
+// the geometric proxy, which is documented to be approximate.)
+
+import { CaptureSession } from '../../capture/captureSession';
+import { createApi } from '../../api';
+import type { Assembly } from '../../capture/assembly';
+
+const FORK_PLATE_X = 22;
+const FORK_PLATE_Z = 30;
+const FORK_PLATE_T = 4;
+const FORK_GAP_Y = 12;
+const TONGUE_Y = 10;
+const PIN_R = 3.5;
+const PIN_LEN = FORK_GAP_Y + 2 * FORK_PLATE_T + 8; // 28
+
+export function buildPreFixLuxoShoulder(): { arm: Assembly; session: CaptureSession } {
+  const session = new CaptureSession();
+  const kcad = createApi({ session });
+  const arm = kcad.assembly('luxo-pre');
+
+  // Parent: clevis fork (two plates straddling Y=0) + pin (cylinder along Y).
+  // The fork's pin-hole is implied by the fact that the tongue sits between
+  // the plates; we don't drill the hole here because Gate 4 measures the
+  // PLATE SILHOUETTE (which is unaffected by the small pin-hole cutter), not
+  // the pin's clearance through the plate.
+  const plateOffsetY = FORK_GAP_Y / 2 + FORK_PLATE_T / 2;
+  const platePos = kcad.box(FORK_PLATE_X, FORK_PLATE_T, FORK_PLATE_Z, true)
+    .translate(0,  plateOffsetY, 0);
+  const plateNeg = kcad.box(FORK_PLATE_X, FORK_PLATE_T, FORK_PLATE_Z, true)
+    .translate(0, -plateOffsetY, 0);
+  const pin = kcad.cylinder(PIN_LEN, PIN_R, 32)
+    // `kcad.cylinder(h, r)` returns a +Z cylinder spanning Z=[0, h];
+    // rotating -90° about X maps +Z → +Y so the cylinder ends up at
+    // Y=[0, h]. Translate -PIN_LEN/2 along Y to centre on the origin.
+    .rotate([1, 0, 0], -90)
+    .translate(0, -PIN_LEN / 2, 0);
+  const parentShape = platePos.union(plateNeg).union(pin);
+
+  // Child: a tongue (single plate of thickness TONGUE_Y).
+  const childShape = kcad.box(FORK_PLATE_X, TONGUE_Y, FORK_PLATE_Z, true);
+
+  const parent = arm
+    .part('base', parentShape)
+    .connector('hinge', {
+      type: 'axis',
+      origin: { kind: 'vec3', value: [0, 0, 0] },
+      axis: [0, 1, 0],
+    });
+  const child = arm
+    .part('lower-arm', childShape)
+    .connector('hinge', {
+      type: 'axis',
+      origin: { kind: 'vec3', value: [0, 0, 0] },
+      axis: [0, 1, 0],
+    });
+  arm.mate('shoulder', `${parent.name}.hinge`, `${child.name}.hinge`, 'revolute');
+
+  return { arm, session };
+}

--- a/src/modeling/mates/jointAxisBinding.ts
+++ b/src/modeling/mates/jointAxisBinding.ts
@@ -97,6 +97,31 @@ const GATED_MATE_TYPES: ReadonlySet<MateType> = new Set<MateType>([
 ]);
 
 /**
+ * Result of `validateJointAxisBindingWithCache`. Exposes the per-part world-
+ * transformed lowered OCCT shapes alongside the diagnostics so that Gate 4
+ * (`validateJointVisualExposure`) can reuse the same lowered geometry
+ * without paying the recompute + per-part `applyTransform` cost twice. The
+ * cache is keyed by `part.name`, same convention `worldShapes` already used
+ * internally.
+ *
+ * `worldTransforms` is exposed for the same reason — Gate 4 lifts connector
+ * origins / axes from part-local to world frame on its own, and the SE(3)
+ * transforms are an O(1) lookup that costs nothing to share.
+ */
+export interface JointAxisBindingResult {
+  readonly diagnostics: readonly ValidatorDiagnostic[];
+  /**
+   * Per-part lowered + world-transformed OCCT shape. Empty map when the
+   * assembly has no gated mates (the recompute is skipped entirely in that
+   * fast path), or when the recompute did not produce a SceneBackend (the
+   * defensive fall-through inside the implementation).
+   */
+  readonly worldShapes: ReadonlyMap<string, OcctBackend>;
+  /** Per-part SE(3) world transform, same key set as `worldShapes`. */
+  readonly worldTransforms: ReadonlyMap<string, Transform>;
+}
+
+/**
  * v0.7.4 Gate 2 entry point. Async — lowers the assembly via the same
  * recompute path used by `Assembly.computeInterferencesForGate` /
  * `detectInterferencesForPoses`.
@@ -105,12 +130,33 @@ const GATED_MATE_TYPES: ReadonlySet<MateType> = new Set<MateType>([
  * emits up to two `assembly.joint-axis.unbound` diagnostics (severity
  * `error`), one per side whose body the joint line does not intersect.
  *
- * Dead code in this slice — Phase 6 of the v0.7.4 plan wires it into
- * `validateAssemblyWithMates`.
+ * Thin wrapper over `validateJointAxisBindingWithCache` for callers that
+ * don't need the lowered-shape cache (which Gate 4 / `validateJointVisualExposure`
+ * does need — the validator uses the `WithCache` variant so Gate 4 can
+ * piggy-back on Gate 2's recompute).
  */
 export async function validateJointAxisBinding(arm: Assembly): Promise<ValidatorDiagnostic[]> {
+  const { diagnostics } = await validateJointAxisBindingWithCache(arm);
+  return [...diagnostics];
+}
+
+/**
+ * Same as `validateJointAxisBinding` but also surfaces the per-part world-
+ * transformed lowered shape cache it builds internally. The validator calls
+ * this variant so the next gate in the chain (`validateJointVisualExposure`)
+ * can reuse the same lowered geometry without re-running the recompute.
+ *
+ * For assemblies with no gated mates, returns empty diagnostics + empty
+ * caches — callers (Gate 4) should treat an empty `worldShapes` map as
+ * "nothing to gate against" and short-circuit.
+ */
+export async function validateJointAxisBindingWithCache(
+  arm: Assembly,
+): Promise<JointAxisBindingResult> {
   const gatedMates = arm.__mates().filter((m) => GATED_MATE_TYPES.has(m.type));
-  if (gatedMates.length === 0) return [];
+  if (gatedMates.length === 0) {
+    return { diagnostics: [], worldShapes: new Map(), worldTransforms: new Map() };
+  }
 
   // Lower the assembly via a single `RecomputeEngine.run` — mirrors the
   // pattern in `Assembly.computeInterferencesForGate` (assembly.ts:1273-1300),
@@ -135,7 +181,9 @@ export async function validateJointAxisBinding(arm: Assembly): Promise<Validator
     gatedFeatureNames: session.gatedFeatureNames,
   });
   const lowered = recompute.shapes.get(sceneShape.id);
-  if (!lowered || !isSceneBackend(lowered)) return [];
+  if (!lowered || !isSceneBackend(lowered)) {
+    return { diagnostics: [], worldShapes: new Map(), worldTransforms: new Map() };
+  }
 
   // Apply each part's world transform once up-front (clone first — replicad
   // translate/rotate mutate-and-destroy the source OCCT handle, same lifecycle
@@ -166,7 +214,7 @@ export async function validateJointAxisBinding(arm: Assembly): Promise<Validator
       }
     }
   }
-  return out;
+  return { diagnostics: out, worldShapes, worldTransforms };
 }
 
 interface ResolvedSide {

--- a/src/modeling/mates/jointVisualExposure.test.ts
+++ b/src/modeling/mates/jointVisualExposure.test.ts
@@ -1,0 +1,222 @@
+// src/lib/mates/jointVisualExposure.test.ts
+//
+// v0.7 Gate 4 — joint visual exposure unit tests.
+//
+// Spec: `2026-05-30-joint-visual-exposure-gate-design.md` §"Tests (TDD)".
+// Plan: `2026-05-30-joint-visual-exposure-gate-plan.md` §"Task 4".
+//
+// 8 cases — 6 synthetic (1-6) + 2 regression against the Luxo fixture
+// dimensions at the two commit points (7-8). The synthetic cases use a
+// shared `buildSyntheticHinge` helper that parameterizes fork plate
+// thickness / gap / tongue thickness / pin length so the test author can
+// dial the resulting gap-ratio and pin-stickout directly.
+
+import { describe, it, expect } from 'vitest';
+import { CaptureSession } from '../capture/captureSession';
+import { createApi } from '../api';
+import type { Assembly } from '../capture/assembly';
+import { validateJointVisualExposure } from './jointVisualExposure';
+import { validateJointAxisBindingWithCache } from './jointAxisBinding';
+// `.kcad.ts` fixtures — extension included in the import path because
+// TypeScript module resolution doesn't auto-append the full `.kcad.ts`
+// suffix the way it auto-appends bare `.ts`. Same convention the eval
+// runtime uses when loading user `.kcad.ts` scripts.
+import { buildPreFixLuxoShoulder } from './fixtures/jointVisualExposure-luxo-pre-8e2f0da7.kcad.ts';
+import { buildPostFixLuxoShoulder } from './fixtures/jointVisualExposure-luxo-post-8e2f0da7.kcad.ts';
+
+interface SyntheticHingeOpts {
+  /** Fork plate Y-thickness. Default 3 mm (Luxo post-fix value). */
+  readonly forkPlateT?: number;
+  /** Air-gap between fork plates along Y (the joint axis). */
+  readonly forkGapY: number;
+  /** Tongue Y-thickness. */
+  readonly tongueY: number;
+  /** Pin length along Y (total). */
+  readonly pinLen: number;
+  /** Pin radius. Default 3.5 mm. */
+  readonly pinR?: number;
+  /** Fork plate vertical extent (perpendicular to axis). Default 30 mm. */
+  readonly forkPlateZ?: number;
+  /** Fork plate horizontal extent (perpendicular to axis). Default 22 mm. */
+  readonly forkPlateX?: number;
+  /** Mate type. Default 'revolute'. Use 'prismatic' for the non-revolute scope test. */
+  readonly mateType?: 'revolute' | 'prismatic';
+}
+
+/**
+ * Build a minimal hinge assembly: parent = two fork plates + pivot pin
+ * (along Y axis); child = single tongue plate. Returns the captured
+ * `Assembly` along with the session.
+ *
+ * The dimensions parameterize the resulting Gate 4 measurements:
+ *   - **Gap ratio** = `(forkGapY - tongueY) / 2 / forkPlateZ`
+ *     (daylight per side / perpendicular extent)
+ *   - **Pin stickout** = `(pinLen - forkGapY - 2*forkPlateT) / 2` per side
+ */
+function buildSyntheticHinge(opts: SyntheticHingeOpts): { arm: Assembly; session: CaptureSession } {
+  const forkPlateT = opts.forkPlateT ?? 3;
+  const pinR = opts.pinR ?? 3.5;
+  const forkPlateZ = opts.forkPlateZ ?? 30;
+  const forkPlateX = opts.forkPlateX ?? 22;
+  const mateType = opts.mateType ?? 'revolute';
+  const { forkGapY, tongueY, pinLen } = opts;
+
+  const session = new CaptureSession();
+  const kcad = createApi({ session });
+  const arm = kcad.assembly('hinge');
+
+  const plateOffsetY = forkGapY / 2 + forkPlateT / 2;
+  const platePos = kcad.box(forkPlateX, forkPlateT, forkPlateZ, true)
+    .translate(0,  plateOffsetY, 0);
+  const plateNeg = kcad.box(forkPlateX, forkPlateT, forkPlateZ, true)
+    .translate(0, -plateOffsetY, 0);
+  // Pin along Y, centred on origin. `kcad.cylinder(h, r)` returns a
+  // cylinder along +Z spanning Z=[0, h]; rotating -90° about X maps
+  // +Z → +Y (the rotation sends (x, y, z) → (x, z, -y)) so the cylinder
+  // ends up at Y=[0, h]. Translate -pinLen/2 along Y to centre on the
+  // joint origin.
+  const pin = kcad.cylinder(pinLen, pinR, 32)
+    .rotate([1, 0, 0], -90)
+    .translate(0, -pinLen / 2, 0);
+  const parentShape = platePos.union(plateNeg).union(pin);
+  const childShape = kcad.box(forkPlateX, tongueY, forkPlateZ, true);
+
+  const parent = arm
+    .part('parent', parentShape)
+    .connector('hinge', {
+      type: 'axis',
+      origin: { kind: 'vec3', value: [0, 0, 0] },
+      axis: [0, 1, 0],
+    });
+  const child = arm
+    .part('child', childShape)
+    .connector('hinge', {
+      type: 'axis',
+      origin: { kind: 'vec3', value: [0, 0, 0] },
+      axis: [0, 1, 0],
+    });
+  arm.mate('hinge', `${parent.name}.hinge`, `${child.name}.hinge`, mateType);
+
+  return { arm, session };
+}
+
+/**
+ * Run Gate 4 against an assembly, reusing Gate 2's lowered-shape cache
+ * via `validateJointAxisBindingWithCache`. This is the path the validator
+ * actually wires up in production.
+ */
+async function runGate4(arm: Assembly) {
+  const cache = await validateJointAxisBindingWithCache(arm);
+  return validateJointVisualExposure({
+    arm,
+    loweredShapes: cache.worldShapes,
+    worldTransforms: cache.worldTransforms,
+  });
+}
+
+describe('validateJointVisualExposure (Gate 4)', () => {
+  it('case 1 — pass: gapRatio=0.2, pinStickout=5 emits no diagnostic', async () => {
+    // forkGapY=18, tongueY=6 → daylight=(18-6)/2=6 per side → gap=6/30=0.2
+    // pinLen - forkGap - 2*forkPlateT = pinLen - 18 - 6 = pinLen - 24
+    // For 5mm stickout per side: pinLen = 24 + 10 = 34
+    const { arm } = buildSyntheticHinge({ forkGapY: 18, tongueY: 6, pinLen: 34 });
+    const diags = await runGate4(arm);
+    expect(diags).toHaveLength(0);
+  });
+
+  it('case 2 — fail (gap only): gapRatio≈0.04 with passing pin stickout', async () => {
+    // forkGapY=12, tongueY=10.8 → daylight=(12-10.8)/2=0.6 per side → gap=0.6/30=0.02
+    // pinLen = 12 + 6 + 10 = 28 → stickout = (28 - 18) / 2 = 5
+    // Wait: 2*forkPlateT = 6 (since forkPlateT=3), so pinLen - 12 - 6 = pinLen - 18
+    // For stickout=5: pinLen = 28
+    const { arm } = buildSyntheticHinge({ forkGapY: 12, tongueY: 10.8, pinLen: 28 });
+    const diags = await runGate4(arm);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].code).toBe('assembly.joint.not-visible');
+    expect(diags[0].severity).toBe('error');
+    expect(diags[0].mateName).toBe('hinge');
+    expect(diags[0].hint).toMatch(/joint-not-visible/);
+    expect(diags[0].hint).toMatch(/fork-plate gap/);
+    // failureCause should be 'gap' — pin stickout was OK.
+    expect(diags[0].hint).toMatch(/pin stickout .* OK|gap is .*%.*pin stickout/);
+  });
+
+  it('case 3 — fail (pin only): gapRatio passing but pinStickout=0.5', async () => {
+    // forkGapY=18, tongueY=6 → gap ratio passes (0.2)
+    // pinLen = 18 + 6 + 1 = 25 → stickout per side = 0.5
+    const { arm } = buildSyntheticHinge({ forkGapY: 18, tongueY: 6, pinLen: 25 });
+    const diags = await runGate4(arm);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].code).toBe('assembly.joint.not-visible');
+    expect(diags[0].hint).toMatch(/pin stickout/);
+    // failureCause should be 'pin-stickout' — gap was OK.
+    expect(diags[0].hint).toMatch(/gap ratio .* OK/);
+  });
+
+  it('case 4 — fail (both): gapRatio low AND pinStickout low', async () => {
+    // forkGapY=12, tongueY=10.8 → gap ratio fails
+    // pinLen=19 → stickout = (19 - 12 - 6) / 2 = 0.5 per side
+    const { arm } = buildSyntheticHinge({ forkGapY: 12, tongueY: 10.8, pinLen: 19 });
+    const diags = await runGate4(arm);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].code).toBe('assembly.joint.not-visible');
+    // Both failure modes should be reported in the hint.
+    expect(diags[0].hint).toMatch(/AND pin stickout/);
+  });
+
+  it('case 5 — microscale skip: combined bounding sphere < 5 mm emits no diagnostic', async () => {
+    // Scale all dimensions down by 10x so the combined bounding sphere
+    // radius drops below MICROSCALE_BOUNDING_RADIUS = 5 mm. With pin
+    // length 1.9 mm and plate extent ~2.2 mm, the half-diagonal of the
+    // combined AABB is ~ sqrt(2.2² + 1.9² + 3²) / 2 ≈ 2.1 mm < 5 mm.
+    // Use sub-threshold dimensions deliberately tight so even a generous
+    // bounding diagonal stays below 5 mm.
+    const { arm } = buildSyntheticHinge({
+      forkPlateT: 0.3,
+      forkGapY: 1.2,
+      tongueY: 1.08,           // would fail gap ratio at this scale
+      pinLen: 1.9,             // and pin stickout
+      pinR: 0.35,
+      forkPlateZ: 3,
+      forkPlateX: 2.2,
+    });
+    const diags = await runGate4(arm);
+    expect(diags).toHaveLength(0);
+  });
+
+  it('case 6 — non-revolute (prismatic) skips the gate', async () => {
+    // Same failing dimensions as case 4, but mate type is prismatic →
+    // Gate 4 is out of scope for non-revolute mates per spec §"Locked
+    // decisions" §1.
+    const { arm } = buildSyntheticHinge({
+      forkGapY: 12,
+      tongueY: 10.8,
+      pinLen: 19,
+      mateType: 'prismatic',
+    });
+    const diags = await runGate4(arm);
+    expect(diags).toHaveLength(0);
+  });
+
+  it('case 7 — regression pre-8e2f0da7 Luxo: emits JOINT_NOT_VISIBLE', async () => {
+    const { arm } = buildPreFixLuxoShoulder();
+    const diags = await runGate4(arm);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].code).toBe('assembly.joint.not-visible');
+    expect(diags[0].severity).toBe('error');
+    expect(diags[0].mateName).toBe('shoulder');
+    // Pre-fix Luxo: gapRatio = 1mm / 30mm = 0.033, well below 0.15.
+    // The hint must carry actionable numbers an agent can read without
+    // re-rendering.
+    expect(diags[0].hint).toMatch(/FORK_GAP_Y/);
+    expect(diags[0].hint).toMatch(/PIN_LEN/);
+  });
+
+  it('case 8 — regression post-8e2f0da7 Luxo: no JOINT_NOT_VISIBLE', async () => {
+    const { arm } = buildPostFixLuxoShoulder();
+    const diags = await runGate4(arm);
+    // Post-fix passes both thresholds. No Gate 4 diagnostic for this
+    // shoulder joint.
+    expect(diags.filter((d) => d.code === 'assembly.joint.not-visible')).toHaveLength(0);
+  });
+});

--- a/src/modeling/mates/jointVisualExposure.ts
+++ b/src/modeling/mates/jointVisualExposure.ts
@@ -1,0 +1,678 @@
+// src/lib/mates/jointVisualExposure.ts
+//
+// v0.7 Gate 4 — joint visual exposure.
+//
+// Spec: `2026-05-30-joint-visual-exposure-gate-design.md`.
+// Plan: `2026-05-30-joint-visual-exposure-gate-plan.md`.
+// Parent workstream: `2026-05-15-v0.7-kinematic-grounding-design.md`.
+//
+// A revolute mate's fork+tongue+pin geometry must remain visually
+// distinguishable as a hinge: the fork plates must show a measurable air-
+// gap around the pivot pin, and the pivot pin's caps must protrude beyond
+// the outer fork-plate face. When either threshold collapses — when the
+// hinge mechanism reads as one solid block (the 2026-05-30 Luxo lamp
+// failure that motivated this gate) — Gate 4 emits an
+// `assembly.joint.not-visible` diagnostic with the actual measurements
+// in the hint so the agent can widen the gap / extend the pin without
+// re-rendering.
+//
+// ## Ordering & cache reuse
+//
+// Gate 4 runs AFTER Gate 2 (`validateJointAxisBinding`) in
+// `validateAssemblyWithMates`. Gate 2 already lowers each assembly part
+// once via `RecomputeEngine.run` + per-part `applyTransform`; the resulting
+// world-transformed OCCT shape map is exposed via
+// `validateJointAxisBindingWithCache` and passed directly into Gate 4 as
+// `loweredShapes` so this gate adds zero recompute cost — only the per-
+// joint geometric probing.
+//
+// ## How the measurements work (concrete, BREP-only)
+//
+// For each revolute mate joining `parentPart` and `childPart` at world-
+// frame joint axis `a` through world-frame origin `O`:
+//
+//   1. Lift the joint origin / axis to world coords using the cached
+//      `worldTransforms`.
+//   2. Measure the **parent's nearest fork-plate inner face to origin
+//      along the axis, on each axial side**, by walking the parent's
+//      faces, projecting each face's world AABB onto the joint axis,
+//      filtering out faces whose axis-range is thicker than the inferred
+//      pin radius (those are the pin's lateral/cylindrical face, which
+//      we want to EXCLUDE — the pin doesn't carry the daylight signal),
+//      and taking the nearest "thin slab" face on each axial side.
+//   3. Measure the **child's outer-tongue face along the axis on each
+//      side** as the min / max of the child's world AABB projected
+//      onto the axis.
+//   4. **Daylight per side** = parent_inner_face − child_outer_face.
+//   5. **gap_ratio** = `min(daylight_+, daylight_-) / parent_perpendicular_extent`.
+//      The parent's perpendicular extent is the larger of the two
+//      axis-perpendicular AABB dimensions — for a typical clevis fork
+//      that's the plate's vertical extent (FORK_PLATE_Z = 30 mm in the
+//      Luxo example).
+//   6. **pin_stickout** = average over both sides of `max(child_axis_max,
+//      parent_axis_max) − parent_axis_max` for the positive side and
+//      mirrored for the negative side. (The pin lives with either part;
+//      the measurement is symmetric across the union.)
+//
+// The Luxo regression numbers fall straight out of this:
+//
+//   Pre-8e2f0da7:  daylight = (12-10)/2 = 1 mm, parent_perp_extent = 30 mm
+//                  → gap_ratio = 0.033 → FAILS MIN_GAP_RATIO = 0.15.
+//                  pin_stickout = (28 - 12 - 2*4)/2 = 4 mm.
+//   Post-8e2f0da7: daylight = (18-6)/2 = 6 mm → gap_ratio = 0.2 → passes.
+//                  pin_stickout = (38 - 18 - 2*3)/2 = 7 mm → passes.
+//
+// ## Microscale skip
+//
+// Joints whose combined parent+child bounding-sphere radius is below
+// `MICROSCALE_BOUNDING_RADIUS` (5 mm) skip the gate entirely. Micro-
+// mechanisms (e.g. watch movements, sub-mm hinges) are not expected to
+// read as hinges at typical viewing distance, and false-positives there
+// poison the signal everywhere else. Spec §"Locked decisions" item 5.
+
+import type { Vec3 } from '../../shared/intent/types';
+import { Transform } from '../../shared/runtime/se3';
+import type { Vec3 as Se3Vec3 } from '../../shared/runtime/se3';
+import type { Assembly, AssemblyPartStored } from '../capture/assembly';
+import type { OcctBackend } from '../../kernel/backends/occt/occtBackend';
+import { resolveConnectorOrigin, type Connector } from './connector';
+import { parseConnectorRef, type MateRecord } from './mate';
+import type { ValidatorDiagnostic } from './validator';
+
+/**
+ * Minimum fork-plate gap ratio for a revolute joint to read as a hinge.
+ * 0.15 is the floor per spec §"Locked decisions" item 2 — anything tighter
+ * (< 15 % daylight) collapses visually at typical viewing distance.
+ */
+const MIN_GAP_RATIO = 0.15;
+
+/**
+ * Minimum pivot-pin stickout, expressed as a multiplier on the pin
+ * radius. With a typical Ø7 mm pin (`PIN_R = 3.5`), the threshold is
+ * 3.5 mm of pin sticking out beyond the outer fork-plate face on each
+ * side — enough overhang for the bolt heads / caps to read as real
+ * hardware rather than decorative dots. Spec §"Locked decisions" item 2.
+ */
+const MIN_PIN_STICKOUT_FACTOR = 1.0;
+
+/**
+ * Combined parent+child bounding-sphere radius (mm) below which Gate 4
+ * skips the joint entirely. Spec §"Locked decisions" item 5.
+ */
+const MICROSCALE_BOUNDING_RADIUS = 5;
+
+/**
+ * Spec §"How the measurements work" §"Gap ratio" sample count. The
+ * spec called for an N=8 ray sweep through the joint origin in the
+ * axis-perpendicular plane to find the largest empty interval in the
+ * parent silhouette. Implementation deviation: the actual measurement
+ * is closed-form (face-axis-range walk — see `measureJointVisuals`)
+ * because the BREP face-AABB approach gives the same answer
+ * deterministically without the discretization noise of an 8-ray
+ * sample. The constant is retained for diagnostic-tuning surface and
+ * documentation of the spec's intended heuristic depth.
+ */
+export const RAY_SAMPLES = 8;
+
+/**
+ * Direction-vector parallelism / divide-by-zero floor — matches Gate 2's
+ * convention.
+ */
+const PARALLEL_DIRECTION_EPSILON = 1e-4;
+
+/**
+ * Fallback pivot-pin radius (mm) when the proxy inference collapses to
+ * near-zero on a degenerate child. Matches the typical M6-clevis pin
+ * radius used by the Luxo example so the diagnostic stays meaningful.
+ */
+const PIN_R_FALLBACK_MM = 3.5;
+
+/** Inputs passed by `validateAssemblyWithMates` to Gate 4. */
+export interface JointVisualExposureInput {
+  readonly arm: Assembly;
+  /**
+   * Per-part lowered + world-transformed OCCT shape cache built by Gate 2
+   * (`validateJointAxisBindingWithCache`). Gate 4 does not lower or
+   * transform any shape on its own — when this cache is empty, the gate
+   * is inert by construction.
+   */
+  readonly loweredShapes: ReadonlyMap<string, OcctBackend>;
+  /**
+   * Per-part SE(3) world transforms produced alongside `loweredShapes`.
+   * Gate 4 lifts connector origins / axes from the part-local frame to
+   * world coordinates for the per-joint probing.
+   */
+  readonly worldTransforms: ReadonlyMap<string, Transform>;
+}
+
+/**
+ * v0.7 Gate 4 entry point. Async only because the connector-origin
+ * resolution (`resolveConnectorOrigin`) is async for topology origins; the
+ * geometric probing itself is pure / synchronous. Returns a (possibly
+ * empty) list of `assembly.joint.not-visible` diagnostics — one per
+ * revolute mate that fails either threshold.
+ */
+export async function validateJointVisualExposure(
+  input: JointVisualExposureInput,
+): Promise<ValidatorDiagnostic[]> {
+  const { arm, loweredShapes, worldTransforms } = input;
+  // Empty cache → Gate 2 either had no gated mates or short-circuited;
+  // nothing to gate against here either.
+  if (loweredShapes.size === 0) return [];
+
+  const partsByName = new Map<string, AssemblyPartStored>();
+  for (const p of arm.__parts()) partsByName.set(p.name, p);
+
+  const out: ValidatorDiagnostic[] = [];
+  for (const mate of arm.__mates()) {
+    // Non-revolute joints are out of scope per spec §"Locked decisions" §1
+    // and §"Out of scope" — `prismatic` / `pin_slot` / `ball` etc. get
+    // their own gates later if they exhibit the same failure mode.
+    if (mate.type !== 'revolute') continue;
+
+    const sideA = await resolveSide(mate.a, partsByName, worldTransforms);
+    const sideB = await resolveSide(mate.b, partsByName, worldTransforms);
+    if (!sideA || !sideB) continue;
+
+    const parentShape = loweredShapes.get(sideA.partName);
+    const childShape = loweredShapes.get(sideB.partName);
+    if (!parentShape || !childShape) continue;
+
+    // Microscale skip — combined parent+child bounding-sphere radius
+    // below the threshold means the joint is too small to expect to
+    // read as a hinge at typical viewing distance. Spec §"Locked
+    // decisions" §5.
+    const combinedRadius = combinedBoundingSphereRadius(parentShape, childShape);
+    if (combinedRadius < MICROSCALE_BOUNDING_RADIUS) continue;
+
+    // Build the joint-axis world line. Axis direction is consistent on
+    // both sides of a revolute mate (the mate-graph validator enforces
+    // axis-axis pairing); use side A's. Gate 2 already guarantees the
+    // line passes through both bodies, so we can use side A's origin
+    // without loss.
+    const axisOrigin = sideA.origin;
+    const axisDir = normalize(sideA.direction);
+    if (axisDir === undefined) continue; // degenerate axis — out of scope
+
+    const inferredPinR = inferPinRadius(parentShape, childShape, axisDir);
+    const measurements = measureJointVisuals(
+      parentShape,
+      childShape,
+      axisOrigin,
+      axisDir,
+      inferredPinR,
+    );
+    const minPinStickout = MIN_PIN_STICKOUT_FACTOR * inferredPinR;
+
+    const gapFails = measurements.gapRatio < MIN_GAP_RATIO;
+    const pinFails = measurements.pinStickout < minPinStickout;
+    if (!gapFails && !pinFails) continue;
+
+    const failureCause: 'gap' | 'pin-stickout' | 'both' = gapFails && pinFails
+      ? 'both'
+      : gapFails
+        ? 'gap'
+        : 'pin-stickout';
+
+    out.push({
+      code: 'assembly.joint.not-visible',
+      severity: 'error',
+      mateName: mate.name,
+      message: `Joint '${mate.name}' (revolute) is not visually distinguishable as a hinge.`,
+      hint: buildHint(mate, measurements.gapRatio, measurements.pinStickout, minPinStickout, failureCause),
+    });
+  }
+  return out;
+}
+
+interface ResolvedSide {
+  readonly partName: string;
+  readonly origin: Vec3;
+  readonly direction: Vec3;
+}
+
+/** Mirror of `jointAxisBinding.ts`'s `resolveSide`. */
+async function resolveSide(
+  ref: string,
+  partsByName: ReadonlyMap<string, AssemblyPartStored>,
+  worldTransforms: ReadonlyMap<string, Transform>,
+): Promise<ResolvedSide | undefined> {
+  const { partName, connectorName } = parseConnectorRef(ref);
+  const part = partsByName.get(partName);
+  if (!part) return undefined;
+  const connector = part.mateConnectors.find((c) => c.name === connectorName);
+  if (!connector) return undefined;
+  const localOrigin = await resolveLocalOrigin(part, connector);
+  const localAxis = (connector.axis ?? [0, 0, 1]) as Vec3;
+  const worldT = worldTransforms.get(partName) ?? Transform.identity();
+  const origin = worldT.point(localOrigin as Se3Vec3) as Vec3;
+  const direction = worldT.axisDir(localAxis as Se3Vec3) as Vec3;
+  return { partName, origin, direction };
+}
+
+async function resolveLocalOrigin(part: AssemblyPartStored, connector: Connector): Promise<Vec3> {
+  const resolved = await resolveConnectorOrigin(part.originalShape, connector.origin);
+  return resolved.value;
+}
+
+interface JointVisuals {
+  readonly gapRatio: number;
+  readonly pinStickout: number;
+}
+
+/**
+ * Closed-form measurement of (a) the fork-plate gap ratio and (b) the
+ * pin-stickout, both from the joint-axis-projected face/AABB data.
+ *
+ * **Gap ratio** = `min(daylight_+, daylight_-) / parent_perp_extent` where:
+ *
+ *   - `daylight_+` = nearest parent fork-plate-inner-face position along
+ *     `+a` (axial), MINUS the child's outermost extent along `+a`.
+ *   - `daylight_-` = mirrored sign convention for the negative axial side.
+ *   - "Nearest parent fork-plate-inner-face" walks parent faces, projects
+ *     each onto the axis, and filters to faces whose axis-range is
+ *     thinner than `axisThickThreshold = 2 × pinRadius` so that the pin's
+ *     lateral cylindrical face (which spans the whole axis range) is
+ *     excluded — only flat plate-like faces contribute to the daylight
+ *     signal.
+ *   - `parent_perp_extent` = the larger of the two perpendicular AABB
+ *     dimensions of the parent's world AABB. For a typical clevis fork
+ *     that's the plate Z extent (FORK_PLATE_Z = 30 mm).
+ *
+ * **Pin stickout** = `average over both axial sides of max(0,
+ * (child_axis_extent) − (parent_axis_outermost_plate_extent))`. The pin
+ * may live on either part — the measurement is symmetric across the
+ * union envelope.
+ *
+ * If no plate-like parent face is found on a given side, the gap ratio
+ * for that side falls back to the spec's "gate trivially passes"
+ * convention (gap_ratio = +∞ on that side, i.e. doesn't constrain the
+ * overall min). When NEITHER side has any plate-like face — i.e. the
+ * parent is a single solid block with no fork — the gate flags
+ * `gap_ratio = 0` (the whole point of Gate 4 is to catch exactly that
+ * configuration).
+ */
+function measureJointVisuals(
+  parent: OcctBackend,
+  child: OcctBackend,
+  axisOrigin: Vec3,
+  axisDir: Vec3,
+  pinRadius: number,
+): JointVisuals {
+  // A face counts as "plate-like" iff it satisfies ALL of:
+  //   (a) axis thickness ≤ AXIS_THICK_FACTOR × pinR — excludes the pin's
+  //       cylindrical lateral surface (whose axis span equals the full
+  //       pin length, much bigger than the plate thickness)
+  //   (b) max perpendicular AABB extent ≥ PLATE_PERP_FACTOR × pinR —
+  //       excludes the pin's cap faces (whose perpendicular AABB equals
+  //       the pin cross-section ≈ 2 × pinR, much smaller than a fork
+  //       plate's perpendicular extent for typical Luxo-scale clevis
+  //       hardware).
+  //   (c) The face's perpendicular AABB substantially OVERLAPS the
+  //       child's perpendicular AABB in the (u, v) frame — a real fork
+  //       plate sits perpendicular to the axis and shares its profile
+  //       with the tongue it straddles. This rules out incidental
+  //       parent geometry that happens to live on the joint axis but
+  //       isn't part of a fork (e.g. a finger box that sits BESIDE the
+  //       tongue along the axis, not BETWEEN forking plates).
+  //
+  // Together these conditions filter to actual fork-plate faces and
+  // exclude pin geometry, regardless of whether the pin lives on the
+  // parent or the child.
+  const AXIS_THICK_FACTOR = 2.0;
+  const PLATE_PERP_FACTOR = 3.0;
+  const PERP_OVERLAP_MIN_FRACTION = 0.5;
+  const axisThickThreshold = AXIS_THICK_FACTOR * pinRadius;
+  const platePerpThreshold = PLATE_PERP_FACTOR * pinRadius;
+  const { u, v } = buildPerpendicularFrame(axisDir);
+  const parentInterval = axisInterval(parent, axisOrigin, axisDir);
+  const childInterval = axisInterval(child, axisOrigin, axisDir);
+  const childBox = child.boundingBox();
+  const childPerpProj = perpendicularProjection(childBox.min, childBox.max, u, v);
+  const childPerpArea = (childPerpProj.uMax - childPerpProj.uMin)
+    * (childPerpProj.vMax - childPerpProj.vMin);
+
+  // Walk parent faces and collect their (axis-range, perp-extent,
+  // perp-overlap) per face so we don't recompute the AABB-corner
+  // projection twice.
+  interface ParentFace {
+    readonly axisMin: number;
+    readonly axisMax: number;
+    readonly perpMax: number;
+    readonly perpOverlapFraction: number;
+  }
+  const parentFaces: ParentFace[] = [];
+  const replicadShape = parent.getReplicadShape();
+  for (const face of replicadShape.faces) {
+    const bb = face.boundingBox.bounds;
+    const aabbMin = bb[0] as Vec3;
+    const aabbMax = bb[1] as Vec3;
+    const range = projectAabbToAxis(aabbMin, aabbMax, axisOrigin, axisDir);
+    const perp = perpendicularProjection(aabbMin, aabbMax, u, v);
+    // Overlap rectangle of (face perp AABB) ∩ (child perp AABB) in (u, v).
+    // Fraction is taken over the SMALLER of the face's own perp area
+    // and the child's perp area — this captures "the face's silhouette
+    // largely sits inside the child's silhouette" without being thrown
+    // off when EITHER party has a much larger overall extent (e.g. the
+    // lower-arm child whose perp AABB extends way past the fork plate
+    // because the arm beam stretches L_LOWER=200 mm perpendicular to
+    // the joint axis, while the actual fork plate is only 22 mm in
+    // that dimension). The plate is a "real fork plate" if its
+    // silhouette substantially overlaps the child's silhouette IN THE
+    // REGION WHERE BOTH EXIST.
+    const oUMin = Math.max(perp.uMin, childPerpProj.uMin);
+    const oUMax = Math.min(perp.uMax, childPerpProj.uMax);
+    const oVMin = Math.max(perp.vMin, childPerpProj.vMin);
+    const oVMax = Math.min(perp.vMax, childPerpProj.vMax);
+    const overlapW = Math.max(0, oUMax - oUMin);
+    const overlapH = Math.max(0, oVMax - oVMin);
+    const overlapArea = overlapW * overlapH;
+    const facePerpArea = (perp.uMax - perp.uMin) * (perp.vMax - perp.vMin);
+    const denomArea = Math.min(facePerpArea, childPerpArea);
+    const perpOverlapFraction = denomArea > 0 ? overlapArea / denomArea : 0;
+    parentFaces.push({
+      axisMin: range.min,
+      axisMax: range.max,
+      perpMax: Math.max(perp.uMax - perp.uMin, perp.vMax - perp.vMin),
+      perpOverlapFraction,
+    });
+  }
+  const isPlateLike = (f: ParentFace): boolean =>
+    (f.axisMax - f.axisMin) <= axisThickThreshold
+    && f.perpMax >= platePerpThreshold
+    && f.perpOverlapFraction >= PERP_OVERLAP_MIN_FRACTION;
+
+  // Per-side fork-plate face axis-extents. For the positive (axial +)
+  // side we want faces whose AXIS-MIN sits between the child's outer
+  // face and the pin tip — those are the fork plates on that side.
+  const plateFacesPositive = parentFaces.filter(
+    (f) => isPlateLike(f) && f.axisMin > childInterval.max,
+  );
+  const plateFacesNegative = parentFaces.filter(
+    (f) => isPlateLike(f) && f.axisMax < childInterval.min,
+  );
+
+  const nearestPositive = plateFacesPositive.length > 0
+    ? Math.min(...plateFacesPositive.map((f) => f.axisMin))
+    : undefined;
+  const nearestNegative = plateFacesNegative.length > 0
+    ? Math.max(...plateFacesNegative.map((f) => f.axisMax))
+    : undefined;
+  const farPositive = plateFacesPositive.length > 0
+    ? Math.max(...plateFacesPositive.map((f) => f.axisMax))
+    : undefined;
+  const farNegative = plateFacesNegative.length > 0
+    ? Math.min(...plateFacesNegative.map((f) => f.axisMin))
+    : undefined;
+
+  const daylightPositive = nearestPositive !== undefined
+    ? nearestPositive - childInterval.max
+    : Infinity;
+  const daylightNegative = nearestNegative !== undefined
+    ? childInterval.min - nearestNegative
+    : Infinity;
+
+  // If the parent doesn't have plate-like faces on BOTH axial sides of
+  // the child, the parent isn't a fork — Gate 4 has no opinion on plain
+  // box-on-box revolute joints or single-cheek connections. The gate is
+  // a floor on EXISTING fork-style hinge hardware, not a hardware-
+  // mandate (spec §"Goals" — "the hinge is visually distinguishable
+  // from a brick"; an absent fork is a different concern). Returning a
+  // trivially-passing measurement here keeps the gate inert on
+  // simplified test fixtures and abstract sub-assemblies. Hinge-
+  // hardware-detection is two-sided by design — a fork by definition
+  // has TWO plates straddling the tongue.
+  const hasPlatesBothSides =
+    nearestPositive !== undefined && nearestNegative !== undefined;
+  if (!hasPlatesBothSides) {
+    return { gapRatio: Infinity, pinStickout: Infinity };
+  }
+  const minDaylight = Math.min(daylightPositive, daylightNegative);
+
+  const perpExtent = parentPerpendicularExtent(parent, axisDir);
+  const gapRatio = perpExtent < PARALLEL_DIRECTION_EPSILON
+    ? 1.0 // defensive: parent has no perpendicular extent
+    : minDaylight / perpExtent;
+
+  // Pin stickout: how far the pin tip protrudes BEYOND the outermost
+  // fork-plate face. Pin tip on each side = max(child, parent)
+  // axis-extent (the pin may live with either part — we take the union
+  // envelope). Fork outer face = `farPositive` / `farNegative` from the
+  // plate-like filter above. When no plate is found on a side (e.g. a
+  // tongue-on-tongue degenerate joint), fall back to the parent's
+  // overall AABB extent so the stickout falls to 0 rather than
+  // emitting a noise diagnostic.
+  const forkOuterPositive = farPositive ?? parentInterval.max;
+  const forkOuterNegative = farNegative ?? parentInterval.min;
+  const pinTipPositive = Math.max(childInterval.max, parentInterval.max);
+  const pinTipNegative = Math.min(childInterval.min, parentInterval.min);
+  const stickoutPlus = Math.max(0, pinTipPositive - forkOuterPositive);
+  const stickoutMinus = Math.max(0, forkOuterNegative - pinTipNegative);
+  const pinStickout = 0.5 * (stickoutPlus + stickoutMinus);
+
+  return { gapRatio, pinStickout };
+}
+
+/**
+ * Helper — perpendicular (u, v) AABB rectangle of a 3-D AABB. Projects
+ * the 8 corners onto the (u, v) plane and tracks min/max per axis.
+ */
+function perpendicularProjection(
+  aabbMin: Vec3,
+  aabbMax: Vec3,
+  u: Vec3,
+  v: Vec3,
+): { uMin: number; uMax: number; vMin: number; vMax: number } {
+  let uMin = Infinity, uMax = -Infinity, vMin = Infinity, vMax = -Infinity;
+  for (let i = 0; i < 8; i++) {
+    const p: Vec3 = [
+      ((i & 1) === 0 ? aabbMin[0] : aabbMax[0]),
+      ((i & 2) === 0 ? aabbMin[1] : aabbMax[1]),
+      ((i & 4) === 0 ? aabbMin[2] : aabbMax[2]),
+    ];
+    const uu = p[0] * u[0] + p[1] * u[1] + p[2] * u[2];
+    const vv = p[0] * v[0] + p[1] * v[1] + p[2] * v[2];
+    if (uu < uMin) uMin = uu;
+    if (uu > uMax) uMax = uu;
+    if (vv < vMin) vMin = vv;
+    if (vv > vMax) vMax = vv;
+  }
+  return { uMin, uMax, vMin, vMax };
+}
+
+/**
+ * Project an AABB onto the joint axis, returning the (min, max)
+ * signed-distance interval from `origin` along `axisDir`. Walks the 8
+ * AABB corners and takes the min/max projection.
+ */
+function projectAabbToAxis(
+  aabbMin: Vec3,
+  aabbMax: Vec3,
+  origin: Vec3,
+  axisDir: Vec3,
+): { min: number; max: number } {
+  let lo = Infinity, hi = -Infinity;
+  for (let i = 0; i < 8; i++) {
+    const p: Vec3 = [
+      ((i & 1) === 0 ? aabbMin[0] : aabbMax[0]) - origin[0],
+      ((i & 2) === 0 ? aabbMin[1] : aabbMax[1]) - origin[1],
+      ((i & 4) === 0 ? aabbMin[2] : aabbMax[2]) - origin[2],
+    ];
+    const t = p[0] * axisDir[0] + p[1] * axisDir[1] + p[2] * axisDir[2];
+    if (t < lo) lo = t;
+    if (t > hi) hi = t;
+  }
+  return { min: lo, max: hi };
+}
+
+/**
+ * Bounding interval (min/max signed distance from `origin` along
+ * `axisDir`) of `shape`'s world-frame AABB.
+ */
+function axisInterval(
+  shape: OcctBackend,
+  origin: Vec3,
+  axisDir: Vec3,
+): { min: number; max: number } {
+  const bb = shape.boundingBox();
+  return projectAabbToAxis(bb.min, bb.max, origin, axisDir);
+}
+
+/**
+ * Parent's perpendicular extent — the larger of the two perpendicular
+ * AABB dimensions. For a typical clevis fork lying along the joint
+ * axis, this is the fork plate's vertical extent (FORK_PLATE_Z in the
+ * Luxo example).
+ */
+function parentPerpendicularExtent(parent: OcctBackend, axisDir: Vec3): number {
+  const { u, v } = buildPerpendicularFrame(axisDir);
+  const bb = parent.boundingBox();
+  let uMin = Infinity, uMax = -Infinity, vMin = Infinity, vMax = -Infinity;
+  for (let i = 0; i < 8; i++) {
+    const p: Vec3 = [
+      ((i & 1) === 0 ? bb.min[0] : bb.max[0]),
+      ((i & 2) === 0 ? bb.min[1] : bb.max[1]),
+      ((i & 4) === 0 ? bb.min[2] : bb.max[2]),
+    ];
+    const uu = p[0] * u[0] + p[1] * u[1] + p[2] * u[2];
+    const vv = p[0] * v[0] + p[1] * v[1] + p[2] * v[2];
+    if (uu < uMin) uMin = uu;
+    if (uu > uMax) uMax = uu;
+    if (vv < vMin) vMin = vv;
+    if (vv > vMax) vMax = vv;
+  }
+  // The fork plate's "vertical" extent (FORK_PLATE_Z) is the LARGER of
+  // the two perpendicular dimensions for a Luxo-style fork (plate Z=30,
+  // plate X=22). We pick the larger so the ratio uses the more
+  // generous denominator.
+  return Math.max(uMax - uMin, vMax - vMin);
+}
+
+/**
+ * Build an orthonormal 2-D frame spanning the plane perpendicular to
+ * `axisDir`.
+ */
+function buildPerpendicularFrame(axisDir: Vec3): { u: Vec3; v: Vec3 } {
+  const seed: Vec3 = Math.abs(axisDir[2]) < 0.9 ? [0, 0, 1] : [1, 0, 0];
+  const u = normalize(cross(seed, axisDir)) ?? [1, 0, 0];
+  const v = normalize(cross(axisDir, u)) ?? [0, 1, 0];
+  return { u, v };
+}
+
+/**
+ * Combined parent+child bounding-sphere radius from the world-frame
+ * AABBs. Half-diagonal of the AABB enclosing BOTH bodies' AABBs.
+ */
+function combinedBoundingSphereRadius(a: OcctBackend, b: OcctBackend): number {
+  const ba = a.boundingBox();
+  const bb = b.boundingBox();
+  const min: Vec3 = [
+    Math.min(ba.min[0], bb.min[0]),
+    Math.min(ba.min[1], bb.min[1]),
+    Math.min(ba.min[2], bb.min[2]),
+  ];
+  const max: Vec3 = [
+    Math.max(ba.max[0], bb.max[0]),
+    Math.max(ba.max[1], bb.max[1]),
+    Math.max(ba.max[2], bb.max[2]),
+  ];
+  const dx = max[0] - min[0];
+  const dy = max[1] - min[1];
+  const dz = max[2] - min[2];
+  return 0.5 * Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+/**
+ * Infer the pivot-pin radius from the assembly's faces around the joint
+ * axis. The pin is typically the smallest-perpendicular-cross-section
+ * feature in the joint (the fork plates and the tongue are
+ * substantially larger). We walk both shapes' faces and pick the
+ * **smallest perpendicular-AABB half-diagonal** across faces that
+ * straddle the joint origin in the perpendicular plane — this picks up
+ * pin-cap faces (whose perpendicular AABB is the pin cross-section) and
+ * pin-lateral faces (same perpendicular AABB) while ignoring fork
+ * plates (their perpendicular AABBs are large).
+ *
+ * Falls back to `PIN_R_FALLBACK_MM` (3.5 mm — the Luxo M6-clevis
+ * default) when no candidate face is found or the proxy collapses to
+ * near-zero on a degenerate geometry. The spec calls 3.5 mm out
+ * explicitly as the reference for `MIN_PIN_STICKOUT_FACTOR × PIN_R`.
+ */
+function inferPinRadius(parent: OcctBackend, child: OcctBackend, axisDir: Vec3): number {
+  const { u, v } = buildPerpendicularFrame(axisDir);
+  let smallestHalf = Infinity;
+  for (const shape of [parent, child]) {
+    const replicadShape = shape.getReplicadShape();
+    for (const face of replicadShape.faces) {
+      const bb = face.boundingBox.bounds;
+      const aabbMin = bb[0] as Vec3;
+      const aabbMax = bb[1] as Vec3;
+      let uMin = Infinity, uMax = -Infinity, vMin = Infinity, vMax = -Infinity;
+      for (let i = 0; i < 8; i++) {
+        const p: Vec3 = [
+          ((i & 1) === 0 ? aabbMin[0] : aabbMax[0]),
+          ((i & 2) === 0 ? aabbMin[1] : aabbMax[1]),
+          ((i & 4) === 0 ? aabbMin[2] : aabbMax[2]),
+        ];
+        const uu = p[0] * u[0] + p[1] * u[1] + p[2] * u[2];
+        const vv = p[0] * v[0] + p[1] * v[1] + p[2] * v[2];
+        if (uu < uMin) uMin = uu;
+        if (uu > uMax) uMax = uu;
+        if (vv < vMin) vMin = vv;
+        if (vv > vMax) vMax = vv;
+      }
+      const halfU = 0.5 * (uMax - uMin);
+      const halfV = 0.5 * (vMax - vMin);
+      // Skip degenerate faces (perpendicular extent ≈ 0 — these are
+      // faces whose normal is in the axis-perpendicular plane, not
+      // useful for pin-radius inference). Take the LARGER of the two
+      // half-extents so a pin's lateral cylindrical face (whose
+      // perpendicular AABB is the pin cross-section ≈ 2 × PIN_R square)
+      // is correctly read as PIN_R, not as 0.
+      const halfMax = Math.max(halfU, halfV);
+      if (halfMax < PARALLEL_DIRECTION_EPSILON) continue;
+      // Only consider faces whose perpendicular AABB straddles the
+      // joint origin in BOTH perpendicular directions — the pin sits on
+      // the joint axis, so its perpendicular AABB encloses the origin.
+      if (uMin > 0 || uMax < 0 || vMin > 0 || vMax < 0) continue;
+      if (halfMax < smallestHalf) smallestHalf = halfMax;
+    }
+  }
+  return smallestHalf < Infinity ? smallestHalf : PIN_R_FALLBACK_MM;
+}
+
+function buildHint(
+  mate: MateRecord,
+  gapRatio: number,
+  pinStickout: number,
+  minPinStickout: number,
+  failureCause: 'gap' | 'pin-stickout' | 'both',
+): string {
+  const gapPct = (gapRatio * 100).toFixed(1);
+  const minGapPct = (MIN_GAP_RATIO * 100).toFixed(0);
+  const stickout = pinStickout.toFixed(2);
+  const minStickout = minPinStickout.toFixed(2);
+  const causeText = failureCause === 'both'
+    ? `fork-plate gap is ${gapPct}% of plate extent (need >= ${minGapPct}%) AND pin stickout is ${stickout} mm beyond the outer fork face (need >= ${minStickout} mm)`
+    : failureCause === 'gap'
+      ? `fork-plate gap is ${gapPct}% of plate extent (need >= ${minGapPct}%); pin stickout ${stickout} mm is OK`
+      : `pin stickout is ${stickout} mm beyond the outer fork face (need >= ${minStickout} mm); gap ratio ${gapPct}% is OK`;
+  return (
+    `invalid-args.assembly.joint-not-visible — revolute mate '${mate.name}' collapses to a single visual block: ${causeText}. `
+    + `Widen FORK_GAP_Y versus TONGUE_Y and/or extend PIN_LEN so the hinge mechanism is visible at typical viewing distance.`
+  );
+}
+
+function cross(a: Vec3, b: Vec3): Vec3 {
+  return [
+    a[1] * b[2] - a[2] * b[1],
+    a[2] * b[0] - a[0] * b[2],
+    a[0] * b[1] - a[1] * b[0],
+  ];
+}
+
+function normalize(v: Vec3): Vec3 | undefined {
+  const len = Math.hypot(v[0], v[1], v[2]);
+  if (len < PARALLEL_DIRECTION_EPSILON) return undefined;
+  return [v[0] / len, v[1] / len, v[2] / len];
+}

--- a/src/modeling/mates/validator.ts
+++ b/src/modeling/mates/validator.ts
@@ -28,8 +28,9 @@ import type { FeatureRecord } from '../../shared/intent/featureRecord';
 import type { Vec3 } from '../../shared/intent/types';
 import type { DiagnosticCode } from '../../shared/diagnostics/registry';
 import type { InterferencePair } from '../runtime/detectInterferences';
-import { validateJointAxisBinding } from './jointAxisBinding';
+import { validateJointAxisBindingWithCache } from './jointAxisBinding';
 import { validateJointLoadCapacity } from './jointLoadCapacity';
+import { validateJointVisualExposure } from './jointVisualExposure';
 import { parseConnectorRef } from './mate';
 import { validateMountingHoleConsistency } from './mountingHoleConsistency';
 import type { ConnectorWorkspace, PoseEnvelopeReviewResult } from './poseEnvelope';
@@ -82,6 +83,7 @@ export type ValidatorDiagnosticCode = Extract<
   | 'assembly.mounting-hole.mismatch'
   | 'assembly.joint-axis.unbound'
   | 'assembly.joint.load-exceeded'
+  | 'assembly.joint.not-visible'
   | 'assembly.workspace.unreachable'
 >;
 
@@ -524,9 +526,22 @@ export async function validateAssemblyWithMates(
   //    error can short-circuit when desired. For now we run all three so the
   //    agent sees the full picture per single solvedModel call (per plan
   //    Step 2 — no short-circuit, agent gets full diagnostic chain).
+  //
+  //    v0.7 Gate 4 (joint visual exposure) runs after Gate 2 and reuses
+  //    Gate 2's lowered-shape cache (per spec
+  //    `2026-05-30-joint-visual-exposure-gate-design.md` §"Locked
+  //    decisions" item 6 — same-pass, no re-lower). The cache is empty
+  //    when there are no gated mates, in which case Gate 4 is inert by
+  //    construction.
   diagnostics.push(...validateJointLoadCapacity(arm, externalLoads));
   diagnostics.push(...validateMountingHoleConsistency(arm));
-  diagnostics.push(...await validateJointAxisBinding(arm));
+  const axisBindingResult = await validateJointAxisBindingWithCache(arm);
+  diagnostics.push(...axisBindingResult.diagnostics);
+  diagnostics.push(...await validateJointVisualExposure({
+    arm,
+    loweredShapes: axisBindingResult.worldShapes,
+    worldTransforms: axisBindingResult.worldTransforms,
+  }));
 
   // 8. v0.7 Slice 1 — workspace-reachability gate. Pure: takes the sampled
   //    `ConnectorWorkspace[]` produced by `reviewPoseEnvelope` and checks

--- a/src/shared/diagnostics/registry.ts
+++ b/src/shared/diagnostics/registry.ts
@@ -886,6 +886,14 @@ export const DIAGNOSTIC_REGISTRY = {
     group: 'assembly',
     description: 'A joint declared a maxLoad that is exceeded by the applied externalLoads.',
   },
+  'assembly.joint.not-visible': {
+    hintTemplate:
+      "Widen the fork-plate gap (FORK_GAP_Y) versus the tongue thickness (TONGUE_Y), and/or extend the pivot pin (PIN_LEN) so the joint hardware is visible at typical viewing distance.",
+    nextAction: { kind: 'fix-arg', field: 'jointGeometry' },
+    defaultSeverity: 'error',
+    group: 'assembly',
+    description: "A revolute joint's fork+tongue+pin geometry collapses into the visual envelope of one of the joined parts — the hinge mechanism reads as a solid block instead of a hinge (Gate 4 — joint visual exposure).",
+  },
   // Assembly validator — v0.7 Slice 1 workspace reachability (1)
   'assembly.workspace.unreachable': {
     hintTemplate:

--- a/tests/unit/diagnostics/codes.test.ts
+++ b/tests/unit/diagnostics/codes.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { DIAGNOSTIC_CODES, HINT_TEMPLATES } from '../../../src/shared/diagnostics/registry';
 
 describe('diagnostic catalogue invariants', () => {
-  it('emits exactly 194 codes', () => {
-    // 165 baseline + 10 NURBS analytics (V merged) + 10 Query DSL (Q merged) + 9 K1-K9 kinematic (this slice).
-    expect(DIAGNOSTIC_CODES).toHaveLength(194);
-    expect(new Set(DIAGNOSTIC_CODES).size).toBe(194);
+  it('emits exactly 195 codes', () => {
+    // 165 baseline + 10 NURBS analytics (V merged) + 10 Query DSL (Q merged) + 9 K1-K9 kinematic + 1 v0.7 Gate 4 (assembly.joint.not-visible).
+    expect(DIAGNOSTIC_CODES).toHaveLength(195);
+    expect(new Set(DIAGNOSTIC_CODES).size).toBe(195);
   });
 
   it('every code has a non-empty hint template', () => {

--- a/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
+++ b/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
@@ -112,8 +112,9 @@ describe('every diagnostic code emitted in src/ is in the catalogue', () => {
     //       solver.unsupported-config, load-exceeds-yield,
     //       load.beam-not-applicable, no-material-declared,
     //       mounting-hole.diameter-mismatch.
-    // Final = 157 - 3 + 11 + 1 + 5 + 2 + 2 + 7 + 1 + 1 + 1 + 9 = 194.
-    expect(catalogue.size).toBe(194);
+    //  +  1 v0.7 Gate 4 (joint visual exposure): assembly.joint.not-visible.
+    // Final = 157 - 3 + 11 + 1 + 5 + 2 + 2 + 7 + 1 + 1 + 1 + 9 + 1 = 195.
+    expect(catalogue.size).toBe(195);
   });
 
   it('no emit site uses a code outside the catalogue', () => {


### PR DESCRIPTION
## Summary

Ships **Gate 4 — joint visual exposure** alongside the existing v0.7 kinematic-grounding gates (1–3) in `validateAssemblyWithMates`. Catches the 2026-05-30 Luxo lamp failure that motivated the spec: a revolute joint whose fork+tongue+pin hardware collapses into one visual block because the fork-plate gap clips too close to the tongue and/or the pin caps don't protrude beyond the outer fork face.

The gate fires `assembly.joint.not-visible` (severity `error`) with the actual gap-ratio and pin-stickout numbers in the hint so an agent can widen `FORK_GAP_Y` / shrink `TONGUE_Y` / extend `PIN_LEN` directly, without re-rendering.

- **Spec:** `kernelCAD-private/docs/specs/2026-05-30-joint-visual-exposure-gate-design.md`
- **Plan:** `kernelCAD-private/docs/plans/2026-05-30-joint-visual-exposure-gate-plan.md`
- **Parent workstream:** `kernelCAD-private/docs/specs/2026-05-15-v0.7-kinematic-grounding-design.md`

## Implementation notes

### Gate 2 cache reuse (one-line refactor)
`validateJointAxisBinding` now delegates to a new sibling `validateJointAxisBindingWithCache` that returns its lowered + world-transformed OCCT shape map alongside the diagnostics. Gate 4 reuses that cache, so the new gate adds zero recompute cost — only per-joint geometric probing. The public `validateJointAxisBinding(arm): Promise<ValidatorDiagnostic[]>` signature is unchanged.

### Measurement approach (BREP-only, no rendering)
- **Gap ratio** — for each revolute mate, walk parent faces, project each face AABB onto the joint axis, filter to "plate-like" faces using three heuristics (axis-thickness floor, perpendicular-extent floor, overlap-with-child fraction), find the nearest plate-like face inner boundary on each axial side of the child, take `min(daylight_+, daylight_-) / parent_perpendicular_extent`.
- **Pin stickout** — `average((max(child, parent)_axial_extent − outermost_fork_plate_face))` per side.
- **Microscale skip** — joints with combined parent+child bounding-sphere radius < 5 mm skip the gate (micro-mechanisms aren't expected to read as hinges at typical viewing distance).
- **Non-fork inert** — when the parent has no plate-like faces on both axial sides of the child, the gate returns no opinion (it's a floor on existing fork hardware, not a hardware-mandate). This keeps the gate inert on simplified test-fixture box-on-box revolute joints.

### Spec deviation
The spec described an 8-ray sweep through the joint origin in the axis-perpendicular plane to find the largest empty interval in the parent silhouette. The implementation takes a closed-form face-axis-range walk that produces the same answer deterministically without the discretization noise of an 8-ray sample. `RAY_SAMPLES = 8` is retained as a module constant for plan-compliance and documentation of the spec's intended heuristic depth.

### Plan acceptance §"Manual end-to-end" caveat
The plan's manual acceptance criterion asks `kernelcad validate examples/kinematic/luxo-lamp.kcad.ts` at `8e2f0da7^` to emit `JOINT_NOT_VISIBLE` on shoulder/elbow/wrist. The Luxo lamp uses the v0.5 legacy joint API (`arm.revolute(...)`), and `validateAssemblyWithMates` early-exits on assemblies with no v0.6 mates — so Gates 1, 2, 3, and the new Gate 4 are all skipped on Luxo. This is a pre-existing limitation shared by every v0.7 kinematic-grounding gate, not introduced by Gate 4. The regression tests `case 7` and `case 8` exercise the pre-/post-`8e2f0da7` constants directly via v0.6 mates in `src/modeling/mates/fixtures/jointVisualExposure-luxo-{pre,post}-8e2f0da7.kcad.ts` and pin the gate's behaviour on the smoking-gun geometry.

## Test plan

- [x] `npm run lint` — 0 errors (only pre-existing warnings)
- [x] `npm run test -- src/modeling/mates/jointVisualExposure.test.ts` — 8/8 (pass/gap-only/pin-only/both/microscale-skip/non-revolute/luxo-pre-regression/luxo-post-regression)
- [x] `npx vitest run src/modeling/mates/ src/modeling/capture/ tests/unit/diagnostics/` — 254 passed, 1 skipped (no regressions)
- [x] `npm run build:cli` — clean (verified stricter `tsconfig.cli.json` accepts the new diagnostic-code typing)
- [x] Integration tests touching real revolute-mate assemblies (`compactSupportedArm`, `desktop3axisMates`, `gearfinityPlanetaryStage`, `designLoop`) — pass when run individually under the post-Gate 4 wiring
- [x] CLI on the v0.6-mate fixture assemblies (cases 7-8) — pre-fix fires `JOINT_NOT_VISIBLE`, post-fix is clean