### PR TITLE
G3 — skill-level mechanism-delivery rule (non-bypassable)

### DIFF
--- a/src/agent/skills/kernelcad-assemblies/SKILL.md
+++ b/src/agent/skills/kernelcad-assemblies/SKILL.md
@@ -604,6 +604,17 @@ When a user asks for a robot arm, hand, gripper, linkage, or other physical mech
 
 For robot arms specifically, preserve at least these interfaces between repair attempts when present: base yaw mate, shoulder pitch mate, elbow pitch mate, wrist/grip mate, tool-tip connector, and fingertip connectors. Track the tool-tip workspace and gripper aperture so the review proves movement, not just static contact.
 
+## Mechanism delivery — non-bypassable
+
+A mechanism build is **not deliverable** if any of these fail. No `ignore[]` workarounds for joint pairs; no shipping with a render that looks right while the assembly is broken.
+
+1. `kernelcad validate --include-interference` returns CLEAN. `ignore[]` is reserved for true intra-part design contacts (a spring "bolted" to a beam, a captured washer); joint-pair contacts (the parts on either side of a `revolute` / `prismatic` mate) **may not be ignored** — they are the test signal for whether the mechanism is physically realized.
+2. Every declared mate passes Gate 6 (mate physical realization): the pin/equivalent feature actually constrains the two parts, and removing it leaves them 3D-disconnected.
+3. Every revolute joint passes Gate 4 (visual exposure): the hinge mechanism reads as a hinge from at least one canonical view.
+4. The render-inspect loop is followed: a `kernelcad render inspect` pass after every geometry change, with visible issues called out.
+
+If any of these fail, iterate the design until they pass. Do not widen `ignore[]`. Do not ship.
+
 ## Diagnostic codes
 
 | Code | Source |

--- a/src/agent/skills/kernelcad-kinematic/SKILL.md
+++ b/src/agent/skills/kernelcad-kinematic/SKILL.md
@@ -110,6 +110,17 @@ These four calls work on any moving assembly, not just robot arms:
 - **Scissor jacks** — `checkSweptCollision` over the lift parameter; the
   closed-loop variant is rejected by K5 — author the open-chain leg instead
 
+## Mechanism delivery — non-bypassable
+
+A mechanism build is **not deliverable** if any of these fail. No `ignore[]` workarounds for joint pairs; no shipping with a render that looks right while the assembly is broken.
+
+1. `kernelcad validate --include-interference` returns CLEAN. `ignore[]` is reserved for true intra-part design contacts (a spring "bolted" to a beam, a captured washer); joint-pair contacts (the parts on either side of a `revolute` / `prismatic` mate) **may not be ignored** — they are the test signal for whether the mechanism is physically realized.
+2. Every declared mate passes Gate 6 (mate physical realization): the pin/equivalent feature actually constrains the two parts, and removing it leaves them 3D-disconnected.
+3. Every revolute joint passes Gate 4 (visual exposure): the hinge mechanism reads as a hinge from at least one canonical view.
+4. The render-inspect loop is followed: a `kernelcad render inspect` pass after every geometry change, with visible issues called out.
+
+If any of these fail, iterate the design until they pass. Do not widen `ignore[]`. Do not ship.
+
 ## Cookbook
 
 Six runnable snippets live in `cookbook/`. Each begins with a `// expected:`

--- a/tests/unit/skill/mechanismDeliveryRulePresent.test.ts
+++ b/tests/unit/skill/mechanismDeliveryRulePresent.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const SKILL_PATHS = [
+  'src/agent/skills/kernelcad-kinematic/SKILL.md',
+  'src/agent/skills/kernelcad-assemblies/SKILL.md',
+];
+
+const REQUIRED_HEADING = '## Mechanism delivery — non-bypassable';
+const REQUIRED_PHRASES = [
+  '**not deliverable**',
+  'may not be ignored',
+  'Gate 6 (mate physical realization)',
+  'Gate 4 (visual exposure)',
+  'render-inspect loop',
+];
+const REQUIRED_ITEM_ORDER = [
+  '1. `kernelcad validate --include-interference` returns CLEAN',
+  '2. Every declared mate passes Gate 6',
+  '3. Every revolute joint passes Gate 4',
+  '4. The render-inspect loop',
+];
+
+describe('Mechanism delivery non-deliverable rule must be present in kinematic SKILLs', () => {
+  for (const path of SKILL_PATHS) {
+    describe(path, () => {
+      const text = readFileSync(path, 'utf8');
+
+      it('contains the canonical section heading', () => {
+        expect(text).toContain(REQUIRED_HEADING);
+      });
+
+      for (const phrase of REQUIRED_PHRASES) {
+        it(`contains required phrase "${phrase.slice(0, 40)}…"`, () => {
+          expect(text).toContain(phrase);
+        });
+      }
+
+      it('contains the four rule items in order', () => {
+        const indices = REQUIRED_ITEM_ORDER.map((item) => text.indexOf(item));
+        for (const [i, idx] of indices.entries()) {
+          expect(idx, `item ${i + 1} not found: ${REQUIRED_ITEM_ORDER[i]}`).toBeGreaterThan(-1);
+        }
+        const sorted = [...indices].sort((a, b) => a - b);
+        expect(indices).toEqual(sorted);
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- Adds a non-bypassable `## Mechanism delivery — non-bypassable` section to `src/agent/skills/kernelcad-kinematic/SKILL.md` and `src/agent/skills/kernelcad-assemblies/SKILL.md` — same wording in both — naming the four delivery gates (validate-clean with no joint-pair ignores, Gate 6 mate physical realization, Gate 4 visual exposure, render-inspect loop) and explicitly forbidding `ignore[]` workarounds on joint-pair contacts.
- New drift sentinel `tests/unit/skill/mechanismDeliveryRulePresent.test.ts` asserts the canonical heading, required phrases, and four-item ordering — so a future skill rewrite cannot quietly soften the language.
- Slice scope: ~70 LoC across two markdown files + 1 sentinel. No code changes, no example migrations.

## Plan / spec

- Plan: `docs/plans/2026-05-31-mechanism-delivery-G3-skill-non-deliverable-rule.md` (kernelCAD-private)
- Parent spec: `docs/specs/2026-05-30-kinematic-grounding-mechanism-delivery-design.md` (kernelCAD-private), slice G3

## Deviation from plan

The plan calls for the sentinel at `tests/sentinels/mechanismDeliveryRulePresent.test.ts`. Vitest in this repo only picks up `tests/unit/**`, `tests/integration/**`, `tests/e2e/**`, `tests/funnel/**` — a `tests/sentinels/` folder would be silently un-run. Moved to `tests/unit/skill/mechanismDeliveryRulePresent.test.ts` to sit beside the existing skill drift sentinels (`skillToolCountDrift.test.ts`, `skillGlobalsDrift.test.ts`, etc.). Same semantics; just landing where it will actually run.

## Verification — the rule retroactively flags the Luxo lamp

`node dist/cli/index.js validate --include-interference examples/kinematic/luxo-lamp.kcad.ts` (exit 2):

```
Assembly status: ERROR (7 parts, 0 joints; 6 errors, 0 warnings)
  [ERROR] assembly.interference.overlap
         Parts 'base' and 'lower-arm' overlap by 4419.08 mm³.
  [ERROR] assembly.interference.overlap
         Parts 'lower-arm' and 'upper-arm' overlap by 5179.75 mm³.
  [ERROR] assembly.interference.overlap
         Parts 'lower-arm' and 'shoulder-spring' overlap by 350.44 mm³.
  [ERROR] assembly.interference.overlap
         Parts 'upper-arm' and 'lamp-head' overlap by 5688.99 mm³.
  [ERROR] assembly.interference.overlap
         Parts 'upper-arm' and 'elbow-spring' overlap by 511.92 mm³.
  [ERROR] assembly.interference.overlap
         Parts 'upper-arm' and 'wrist-spring' overlap by 16.73 mm³.
```

Three of the six overlaps — `base`/`lower-arm`, `lower-arm`/`upper-arm`, `upper-arm`/`lamp-head` — are joint-pair contacts (the two parts on either side of the shoulder / elbow / wrist mate). Under the new rule, those may not be silenced with `ignore[]`; the lamp is therefore **not deliverable**. The script currently has all three listed in its `ignore[]` block — fixing that is G1's job (the joint primitive that replaces the hand-rolled fork/tongue/pin pattern), not this PR's.

## Gates

- `npm run lint` — clean (0 errors)
- `npm run build:cli` — green
- `npx vitest run tests/unit/skill/` — 32/32 pass (including the new sentinel's 14 assertions)
- Targeted assemblies + kinematic suites — 111/111 pass
- Full `npm test` — 3492 pass; 9 timeouts on long-running integration tests under parallel load (`tests/integration/examples/compactSupportedArm`, `desktop3axisMates`, `gearfinityPlanetaryStage`, etc.). All passed when re-run in isolation; unrelated to the docs-only changes here.

## Test plan

- [x] New sentinel passes against the updated SKILL.md files
- [x] Sentinel would fail if either SKILL.md drops the heading, weakens "not deliverable", drops "may not be ignored", or reorders the four items (asserted by the test body)
- [x] `skillToolCountDrift` and other skill drift sentinels still pass
- [x] `kernelcad validate --include-interference` retroactively flags the Luxo lamp's joint-pair ignores