### PR TITLE
P5.1 — luxo beam-clevis gap fix + Studio background switcher

### DIFF
--- a/examples/kinematic/luxo-lamp.kcad.ts
+++ b/examples/kinematic/luxo-lamp.kcad.ts
@@ -137,11 +137,9 @@ const bolts = boltHead.patternCircular({ count: 4, axis: [0, 0, 1] });
 
 // Column rises from base-disc top to JUST below the shoulder-clevis
 // knuckle. The clevis fork at the shoulder pivot extends `knuckleR`
-// below the pivot, so the column needs only `knuckleR + 2` mm of
-// clearance below COLUMN_TOP_Z. The previous COLUMN_CLEAR reserved
-// `knuckleR + ARM_T + 2 = 32mm`, leaving the column terminate at
-// z=30 — only 18mm tall and invisible behind the base disc.
-const COLUMN_CLEAR = clevisStyle.knuckleR + 2;
+// below the pivot, so the column terminates flush against the fork's
+// lower edge — no air gap.
+const COLUMN_CLEAR = clevisStyle.knuckleR;
 const COLUMN_TERMINATE_Z = COLUMN_TOP_Z - COLUMN_CLEAR;
 const baseColumn = cylinder(COLUMN_TERMINATE_Z - BASE_H, COLUMN_R, 48)
   .translate(0, 0, BASE_H)
@@ -149,15 +147,46 @@ const baseColumn = cylinder(COLUMN_TERMINATE_Z - BASE_H, COLUMN_R, 48)
 
 const baseBodyRaw = baseDisc.union(feltPad).union(bolts).union(baseColumn);
 
-const beamClear = clevisStyle.knuckleR + ARM_T / 2 + 2;
+// Beam-to-clevis clearance per joint-side. The previous monolithic
+// `beamClear = knuckleR + ARM_T/2 + 2 = 23 mm` opened an 11 mm air gap
+// at every joint because the +ARM_T/2+2 paranoia margin assumed the
+// beam could collide with the fork's plates along Z — but the beam's
+// Z extent (±9) sits well inside the fork plate's Z extent (±knuckleR
+// = ±12). The real constraint is the fork's BRIDGE TAB, which sits at
+// radial distance knuckleR+1..knuckleR+1+plateT from the pivot along
+// -liftDir (see `clevis.buildFork`). Only the CHILD side of each joint
+// sweeps into the parent's bridge-tab volume, so we use a per-side
+// clearance:
+//
+//   - Child-side clearance (beam end NEAREST the tongue): must clear
+//     the parent fork's bridge tab over the full joint sweep. For the
+//     elbow's -135°…-45° range the smallest value is `knuckleR + 6`
+//     (= 18 mm). For the wrist's -75°…-5° range the same value is
+//     more than enough.
+//   - Parent-side / non-sweeping side (beam end NEAREST the fork): the
+//     beam only has to clear the fork's own knuckle radius, so `clear
+//     = knuckleR` butts the beam flush against the fork-plate's outer
+//     rim with no air gap.
+//   - Shoulder-side of the lower-arm beam: shoulder sweep [-5°…100°]
+//     never enters the base's tab volume (the tab is OFF the column
+//     axis, below z = COLUMN_TOP_Z − 13), so clearance `= knuckleR`
+//     is tight.
+const beamClearTight  = clevisStyle.knuckleR;       // 12 mm — tongue-knuckle butt fit
+const beamClearSweep  = clevisStyle.knuckleR + 6;   // 18 mm — clears parent fork's bridge tab under full sweep
 
 // ============================================================================
 // LOWER ARM body — cream-painted rectangular beam + spring boss under it.
 // ============================================================================
 
-const LOWER_BEAM_LEN = L_LOWER - 2 * beamClear;
+// Lower-arm beam: shoulder side (x=0) is tight (no sweep risk vs base
+// tab), elbow side (x=L_LOWER) butts against fork knuckle (parent side
+// of the elbow joint, also no sweep risk vs its own tab).
+const LOWER_BEAM_START = beamClearTight;
+const LOWER_BEAM_END   = L_LOWER - beamClearTight;
+const LOWER_BEAM_LEN   = LOWER_BEAM_END - LOWER_BEAM_START;
+const LOWER_BEAM_MID   = (LOWER_BEAM_START + LOWER_BEAM_END) / 2;
 const lowerBeam = box(LOWER_BEAM_LEN, ARM_W, ARM_T, true)
-  .translate(L_LOWER / 2, 0, 0)
+  .translate(LOWER_BEAM_MID, 0, 0)
   .material(mArm);
 
 // Spring mount is ABOVE the beam top by SPRING_R + 1 mm of clearance —
@@ -171,7 +200,7 @@ const lowerBeam = box(LOWER_BEAM_LEN, ARM_W, ARM_T, true)
 // FASTENED_CONTACT_TOLERANCE_FRACTION × min(bbox-vol). The plain
 // floating-shaft pattern is what passes the corrected P0.2 gate.
 const SPRING_MOUNT_DZ = SPRING_R + 1;        // 5 mm gap between beam top and shaft centerline
-const LOWER_BOSS_X = beamClear + 14;         // 14mm forward of the shoulder-end of beam
+const LOWER_BOSS_X = LOWER_BEAM_START + 14;  // 14mm forward of the shoulder-end of beam
 const LOWER_BOSS: [number, number, number] = [LOWER_BOSS_X, 0, ARM_T / 2 + SPRING_MOUNT_DZ];
 
 const lowerBeamWithBoss = lowerBeam;
@@ -181,16 +210,23 @@ const lowerBeamWithBoss = lowerBeam;
 // on the +Z side hosting the elbow-wrist spring.
 // ============================================================================
 
-const UPPER_BEAM_LEN = L_UPPER - 2 * beamClear;
+// Upper-arm beam: elbow side (x=0) sweeps relative to lower-arm so it
+// needs the bridge-tab clearance; wrist side (x=L_UPPER) is the parent
+// side of the wrist joint, no sweep risk against its own fork tab, so
+// it butts tight against the fork's outer knuckle rim.
+const UPPER_BEAM_START = beamClearSweep;
+const UPPER_BEAM_END   = L_UPPER - beamClearTight;
+const UPPER_BEAM_LEN   = UPPER_BEAM_END - UPPER_BEAM_START;
+const UPPER_BEAM_MID   = (UPPER_BEAM_START + UPPER_BEAM_END) / 2;
 const upperBeam = box(UPPER_BEAM_LEN, ARM_W, ARM_T, true)
-  .translate(L_UPPER / 2, 0, 0)
+  .translate(UPPER_BEAM_MID, 0, 0)
   .material(mArm);
 
 // Upper-arm spring mount: same floating-shaft pattern as the lower-arm.
 // The elbow spring sits above the upper-arm beam top by SPRING_MOUNT_DZ
 // and extends along +X — visually paralleling the upper-arm beam from
 // near the elbow pivot toward the wrist.
-const UPPER_BOSS: [number, number, number] = [beamClear + 14, 0, ARM_T / 2 + SPRING_MOUNT_DZ];
+const UPPER_BOSS: [number, number, number] = [UPPER_BEAM_START + 14, 0, ARM_T / 2 + SPRING_MOUNT_DZ];
 
 const upperBeamWithBoss = upperBeam;
 
@@ -206,11 +242,13 @@ const upperBeamWithBoss = upperBeam;
 //                                  the tongue to the shade base
 //   x ∈ [SHADE_ANCHOR_X, ...]   — shade + socket + bulb
 //
-// HEAD_NECK_BACK sits 0.5 mm forward of the fork's outer X edge so the
-// neck cylinder doesn't pierce the upper-arm fork plates. The 0.5 mm
-// gap is filled by the tongue knuckle, which is unioned into the head
-// at the same X span — visually continuous.
-const HEAD_NECK_BACK = clevisStyle.knuckleR + 5;             // 17 mm — clear of fork at all wrist poses
+// HEAD_NECK_BACK sits at `beamClearSweep` because the head is the
+// child of the wrist joint — its neck cylinder sweeps relative to the
+// upper-arm fork's bridge tab. Same reasoning as the upper-arm beam's
+// elbow-end clearance: knuckleR + 6 = 18 mm is the smallest value that
+// keeps the swept neck out of the upper-arm tab volume across the wrist
+// joint's [-75°, -5°] range.
+const HEAD_NECK_BACK = beamClearSweep;                       // 18 mm — flush with tongue + tab clearance
 const HEAD_NECK_FRONT = clevisStyle.knuckleR + ARM_T / 2 + 8;  // 29 mm — slightly past SHADE_ANCHOR_X
 const HEAD_NECK_LEN = HEAD_NECK_FRONT - HEAD_NECK_BACK;
 const HEAD_NECK_CLEAR = HEAD_NECK_FRONT;

--- a/src/shared/types/viewMode.ts
+++ b/src/shared/types/viewMode.ts
@@ -12,3 +12,12 @@ export interface ViewModeConfig {
     icon: LucideIcon;
     description: string;
 }
+
+/**
+ * Viewport background modes for the Studio 3D view.
+ *   - `dark`       — opaque dark grey (default; preserves current behaviour).
+ *   - `light`      — opaque near-white surface.
+ *   - `checkered`  — alternating two-grey checker pattern (transparency-style),
+ *                    useful when judging silhouettes against a neutral pattern.
+ */
+export type ViewportBackground = 'dark' | 'light' | 'checkered';

--- a/src/studio/components/Layout/Header.tsx
+++ b/src/studio/components/Layout/Header.tsx
@@ -1,9 +1,10 @@
 import { useWorkbench } from '../../context/WorkbenchContext';
-import { Loader2, Download, FileDown, Undo2, Redo2, Box, Grid as GridIcon, Circle, FolderOpen } from 'lucide-react';
+import { Loader2, Download, FileDown, Undo2, Redo2, Box, Grid as GridIcon, Circle, FolderOpen, Moon, Sun, LayoutGrid } from 'lucide-react';
 import { exportSTEP, exportSTL } from '../../../shared/worker/geometryEngine';
 import { formatTooltip, SHORTCUT_HINTS } from '../../../shared/constants/shortcuts';
 import { useProject } from '../../context/ProjectContext';
 import { useStudioChrome } from '../../context/StudioChromeContext';
+import { useUI } from '../../context/UIContext';
 
 export function Header() {
     const { headerLeft, headerRight } = useStudioChrome();
@@ -11,6 +12,7 @@ export function Header() {
         viewMode3D, setViewMode3D,
         isComputing, code, commandManager, setActiveDialog
     } = useWorkbench();
+    const { viewportBackground, setViewportBackground } = useUI();
 
     const { activeProject } = useProject();
 
@@ -89,6 +91,37 @@ export function Header() {
                         aria-label="Shaded"
                     >
                         <Circle size={14} />
+                    </button>
+                </div>
+
+                {/* Viewport background switcher (dark / light / checkered) */}
+                <div className="flex bg-[#222] rounded p-0.5" data-testid="viewport-background-toggle">
+                    <button
+                        onClick={() => setViewportBackground('dark')}
+                        className={`p-1 rounded text-xs flex items-center gap-1 ${viewportBackground === 'dark' ? 'bg-[#444] text-white shadow' : 'text-gray-400 hover:text-white'}`}
+                        title="Dark background"
+                        aria-label="Dark background"
+                        data-testid="viewport-background-dark"
+                    >
+                        <Moon size={14} />
+                    </button>
+                    <button
+                        onClick={() => setViewportBackground('light')}
+                        className={`p-1 rounded text-xs flex items-center gap-1 ${viewportBackground === 'light' ? 'bg-[#444] text-white shadow' : 'text-gray-400 hover:text-white'}`}
+                        title="Light background"
+                        aria-label="Light background"
+                        data-testid="viewport-background-light"
+                    >
+                        <Sun size={14} />
+                    </button>
+                    <button
+                        onClick={() => setViewportBackground('checkered')}
+                        className={`p-1 rounded text-xs flex items-center gap-1 ${viewportBackground === 'checkered' ? 'bg-[#444] text-white shadow' : 'text-gray-400 hover:text-white'}`}
+                        title="Checkered background"
+                        aria-label="Checkered background"
+                        data-testid="viewport-background-checkered"
+                    >
+                        <LayoutGrid size={14} />
                     </button>
                 </div>
 

--- a/src/studio/components/Viewer.tsx
+++ b/src/studio/components/Viewer.tsx
@@ -23,6 +23,7 @@ import { InteractionHandler } from "./viewer/controllers/InteractionHandler";
 import { SnapIndicator } from "./viewer/overlays/SnapIndicator";
 import { HighlightOverlay } from "./viewer/overlays/HighlightOverlay";
 import { SelectionOutline } from "./viewer/overlays/SelectionOutline";
+import { SceneBackground } from "./viewer/SceneBackground";
 
 // Constants
 export const SKETCH_FOV = 40;
@@ -51,7 +52,7 @@ export default function Viewer({ geometries, previewGeometries, sketchesGeometri
         setHoveredItemId
     } = useWorkbench();
 
-    const { setContextMenu } = useUI();
+    const { setContextMenu, viewportBackground } = useUI();
 
     const itemNames = useMemo(() => {
         return (codeContext?.returnedVariables as (string | null)[]) || [];
@@ -107,6 +108,7 @@ export default function Viewer({ geometries, previewGeometries, sketchesGeometri
                 }}
             >
                 <RendererSnapshotPublisher />
+                <SceneBackground mode={viewportBackground} />
 
                 <ambientLight intensity={0.5} />
                 <directionalLight position={[10, 20, 10]} intensity={0.7} />

--- a/src/studio/components/viewer/SceneBackground.test.ts
+++ b/src/studio/components/viewer/SceneBackground.test.ts
@@ -1,0 +1,52 @@
+/** @vitest-environment happy-dom */
+import { describe, expect, it, beforeAll } from 'vitest';
+import * as THREE from 'three';
+import { makeCheckerTexture, CHECKER_TILE_PX } from './sceneBackgroundTexture';
+
+// Happy-dom / jsdom both ship a no-op 2D canvas context — `getContext('2d')`
+// returns `null` rather than a stub. We patch a minimal CanvasRenderingContext2D
+// shim onto HTMLCanvasElement.prototype so `makeCheckerTexture` can run.
+// Tests then verify the texture's filter/wrap/colorSpace wiring, which is
+// the failure mode three.js minor versions actually break.
+
+beforeAll(() => {
+    // Minimal shim — just enough for `fillStyle = ...; fillRect(...)`.
+    const proto = HTMLCanvasElement.prototype as unknown as {
+        getContext: (type: string) => unknown;
+    };
+    proto.getContext = function getContext(type: string) {
+        if (type !== '2d') return null;
+        return {
+            fillStyle: '#000',
+            fillRect: () => {},
+            getImageData: () => ({ data: new Uint8ClampedArray(4) }),
+        } as unknown as CanvasRenderingContext2D;
+    };
+});
+
+describe('sceneBackgroundTexture.makeCheckerTexture', () => {
+    it('returns a CanvasTexture sized 2*tile by 2*tile', () => {
+        const tex = makeCheckerTexture();
+        expect(tex).toBeInstanceOf(THREE.CanvasTexture);
+        const img = tex.image as HTMLCanvasElement;
+        expect(img.width).toBe(CHECKER_TILE_PX * 2);
+        expect(img.height).toBe(CHECKER_TILE_PX * 2);
+    });
+
+    it('uses RepeatWrapping on both axes so the pattern tiles across the viewport', () => {
+        const tex = makeCheckerTexture();
+        expect(tex.wrapS).toBe(THREE.RepeatWrapping);
+        expect(tex.wrapT).toBe(THREE.RepeatWrapping);
+    });
+
+    it('uses NearestFilter for crisp checker squares (no bilinear blur)', () => {
+        const tex = makeCheckerTexture();
+        expect(tex.magFilter).toBe(THREE.NearestFilter);
+        expect(tex.minFilter).toBe(THREE.NearestFilter);
+    });
+
+    it('uses sRGB color space so checker greys read as the chosen luma values', () => {
+        const tex = makeCheckerTexture();
+        expect(tex.colorSpace).toBe(THREE.SRGBColorSpace);
+    });
+});

--- a/src/studio/components/viewer/SceneBackground.tsx
+++ b/src/studio/components/viewer/SceneBackground.tsx
@@ -1,0 +1,60 @@
+import { useThree } from '@react-three/fiber';
+import { useEffect } from 'react';
+import * as THREE from 'three';
+import type { ViewportBackground } from '../../../shared/types/viewMode';
+import {
+  BACKGROUND_DARK_HEX,
+  BACKGROUND_LIGHT_HEX,
+  CHECKER_TILE_PX,
+  makeCheckerTexture,
+  setSceneBackground,
+} from './sceneBackgroundTexture';
+
+interface Props {
+  mode: ViewportBackground;
+}
+
+/**
+ * In-Canvas R3F component that drives the active scene's `background`
+ * property from the selected viewport background mode. Renders nothing.
+ *
+ *  - `dark`       — opaque dark grey (preserves historical Studio look).
+ *  - `light`      — opaque near-white surface.
+ *  - `checkered`  — two-tone grey checker (transparency-style); useful when
+ *                   judging part silhouettes against a neutral pattern.
+ *
+ * The checker texture is created once per mount and disposed on unmount or
+ * when the user switches mode.
+ */
+export function SceneBackground({ mode }: Props) {
+  const { scene, size } = useThree();
+
+  useEffect(() => {
+    if (mode === 'dark') {
+      setSceneBackground(scene, new THREE.Color(BACKGROUND_DARK_HEX));
+      return;
+    }
+    if (mode === 'light') {
+      setSceneBackground(scene, new THREE.Color(BACKGROUND_LIGHT_HEX));
+      return;
+    }
+    // Checkered.
+    const tex = makeCheckerTexture();
+    const tileTotalPx = CHECKER_TILE_PX * 2;
+    tex.repeat.set(size.width / tileTotalPx, size.height / tileTotalPx);
+    setSceneBackground(scene, tex);
+    return () => {
+      tex.dispose();
+    };
+  }, [mode, scene, size.width, size.height]);
+
+  // Always restore to null when this component unmounts so callers that
+  // remove the switcher reset to the canvas's transparent default.
+  useEffect(() => {
+    return () => {
+      setSceneBackground(scene, null);
+    };
+  }, [scene]);
+
+  return null;
+}

--- a/src/studio/components/viewer/sceneBackgroundTexture.ts
+++ b/src/studio/components/viewer/sceneBackgroundTexture.ts
@@ -1,0 +1,71 @@
+import * as THREE from 'three';
+
+/**
+ * Assign a value to a three.js scene's `background` slot. Three's API is
+ * designed-mutable, but eslint's react-hooks immutability rule treats
+ * useThree()-returned scenes as readonly; this helper is the single
+ * choke-point where we cross that boundary, so the type erasure stays
+ * out of the React component.
+ */
+export function setSceneBackground(
+  scene: THREE.Scene,
+  value: THREE.Color | THREE.Texture | null,
+): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (scene as any).background = value;
+}
+
+/** Default opaque dark color — matches the historical Studio look. */
+export const BACKGROUND_DARK_HEX = 0x202126;
+
+/** Light surface — near-white, easy on lamps and metallic finishes. */
+export const BACKGROUND_LIGHT_HEX = 0xf0f0f0;
+
+/** Two greys for the checker pattern (lighter / darker). */
+export const CHECKER_LIGHT_HEX = 0x808080;
+export const CHECKER_DARK_HEX  = 0x606060;
+
+/** Tile size in pixels per checker square; full tile = 2*TILE px. */
+export const CHECKER_TILE_PX = 16;
+
+/**
+ * Build the checker pattern as a `THREE.CanvasTexture`. The texture is 2-cell
+ * wide so the repeat wrapping produces an infinite checker; callers set
+ * `texture.repeat` based on the viewport size so squares stay pixel-square
+ * regardless of the canvas resolution.
+ *
+ * Lives in its own module (not co-located with the React component) so the
+ * react-refresh rule can fast-refresh the component without rebuilding the
+ * texture helper too, and so the unit test imports the helper without
+ * pulling the R3F hook chain in.
+ */
+export function makeCheckerTexture(
+  tilePx: number = CHECKER_TILE_PX,
+  lightHex: number = CHECKER_LIGHT_HEX,
+  darkHex: number = CHECKER_DARK_HEX,
+): THREE.CanvasTexture {
+  // 2-cell tile so wrapping = checker.
+  const size = tilePx * 2;
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  if (ctx === null) {
+    throw new Error('SceneBackground: 2D context unavailable');
+  }
+  const light = '#' + lightHex.toString(16).padStart(6, '0');
+  const dark  = '#' + darkHex.toString(16).padStart(6, '0');
+  ctx.fillStyle = light;
+  ctx.fillRect(0, 0, size, size);
+  ctx.fillStyle = dark;
+  ctx.fillRect(0, 0, tilePx, tilePx);
+  ctx.fillRect(tilePx, tilePx, tilePx, tilePx);
+
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.wrapS = THREE.RepeatWrapping;
+  tex.wrapT = THREE.RepeatWrapping;
+  tex.magFilter = THREE.NearestFilter;
+  tex.minFilter = THREE.NearestFilter;
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}

--- a/src/studio/context/UIContext.test.tsx
+++ b/src/studio/context/UIContext.test.tsx
@@ -39,3 +39,36 @@ describe('UIContext layout mode', () => {
         expect(next.current.layoutMode).toBe('viewport');
     });
 });
+
+describe('UIContext viewport background', () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+    });
+
+    it('defaults to dark', () => {
+        const { result } = renderHook(() => useUI(), { wrapper });
+        expect(result.current.viewportBackground).toBe('dark');
+    });
+
+    it('persists across remount via localStorage', () => {
+        const { result, unmount } = renderHook(() => useUI(), { wrapper });
+
+        act(() => {
+            result.current.setViewportBackground('checkered');
+        });
+
+        expect(result.current.viewportBackground).toBe('checkered');
+        expect(window.localStorage.getItem('kernelcad:viewportBackground')).toBe('checkered');
+
+        unmount();
+
+        const { result: next } = renderHook(() => useUI(), { wrapper });
+        expect(next.current.viewportBackground).toBe('checkered');
+    });
+
+    it('falls back to dark on a garbage localStorage value', () => {
+        window.localStorage.setItem('kernelcad:viewportBackground', 'rainbow');
+        const { result } = renderHook(() => useUI(), { wrapper });
+        expect(result.current.viewportBackground).toBe('dark');
+    });
+});

--- a/src/studio/context/UIContext.tsx
+++ b/src/studio/context/UIContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import type { StudioLayoutMode } from '../../shared/types/layout';
-import type { ViewMode3D } from '../../shared/types/viewMode';
+import type { ViewMode3D, ViewportBackground } from '../../shared/types/viewMode';
 
 export interface UIContextType {
     viewMode: 'code' | 'gui';
@@ -9,6 +9,8 @@ export interface UIContextType {
     setLayoutMode: (mode: StudioLayoutMode) => void;
     viewMode3D: ViewMode3D;
     setViewMode3D: (mode: ViewMode3D) => void;
+    viewportBackground: ViewportBackground;
+    setViewportBackground: (mode: ViewportBackground) => void;
     activeDialog: string | null;
     setActiveDialog: (dialogId: string | null) => void;
     sidePanelVisible: boolean;
@@ -29,6 +31,7 @@ const STORAGE_KEYS = {
     viewMode: 'kernelcad:viewMode',
     layoutMode: 'kernelcad:layoutMode',
     viewMode3D: 'kernelcad:viewMode3D',
+    viewportBackground: 'kernelcad:viewportBackground',
     sidePanelVisible: 'kernelcad:sidePanelVisible',
 } as const;
 
@@ -56,10 +59,17 @@ function readStoredViewMode3D(): ViewMode3D {
     return raw === 'shadedWithEdges' || raw === 'wireframe' || raw === 'shaded' ? raw : 'shadedWithEdges';
 }
 
+function readStoredViewportBackground(): ViewportBackground {
+    if (typeof window === 'undefined') return 'dark';
+    const raw = window.localStorage.getItem(STORAGE_KEYS.viewportBackground);
+    return raw === 'light' || raw === 'checkered' || raw === 'dark' ? raw : 'dark';
+}
+
 export function UIProvider({ children }: { children: ReactNode }) {
     const [viewMode, setViewMode] = useState<'code' | 'gui'>(() => readStoredViewMode());
     const [layoutMode, setLayoutMode] = useState<StudioLayoutMode>(() => readStoredLayoutMode());
     const [viewMode3D, setViewMode3D] = useState<ViewMode3D>(() => readStoredViewMode3D());
+    const [viewportBackground, setViewportBackground] = useState<ViewportBackground>(() => readStoredViewportBackground());
     const [sidePanelVisible, setSidePanelVisible] = useState(() => readStoredSidePanelVisible());
     const [contextMenu, setContextMenu] = useState<{ visible: boolean; position: { x: number, y: number } | null; type: 'FACE' | 'EDGE' | 'VERTEX' | 'SKETCH' }>({
         visible: false,
@@ -121,6 +131,11 @@ export function UIProvider({ children }: { children: ReactNode }) {
 
     useEffect(() => {
         if (typeof window === 'undefined') return;
+        window.localStorage.setItem(STORAGE_KEYS.viewportBackground, viewportBackground);
+    }, [viewportBackground]);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
         window.localStorage.setItem(STORAGE_KEYS.sidePanelVisible, String(sidePanelVisible));
     }, [sidePanelVisible]);
 
@@ -131,6 +146,8 @@ export function UIProvider({ children }: { children: ReactNode }) {
         setLayoutMode,
         viewMode3D,
         setViewMode3D,
+        viewportBackground,
+        setViewportBackground,
         activeDialog,
         setActiveDialog,
         sidePanelVisible,
@@ -141,7 +158,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
         closePanel,
         contextMenu,
         setContextMenu,
-    }), [viewMode, layoutMode, viewMode3D, activeDialog, setActiveDialog, sidePanelVisible, toggleSidePanel, state.activePanels, openPanel, closePanel, contextMenu]);
+    }), [viewMode, layoutMode, viewMode3D, viewportBackground, activeDialog, setActiveDialog, sidePanelVisible, toggleSidePanel, state.activePanels, openPanel, closePanel, contextMenu]);
 
     return <UIContext.Provider value={value}>{children}</UIContext.Provider>;
 }

--- a/src/studio/context/WorkbenchContext.tsx
+++ b/src/studio/context/WorkbenchContext.tsx
@@ -183,6 +183,8 @@ function WorkbenchInnerProvider({ children }: { children: ReactNode }) {
         uiCtx.setLayoutMode,
         uiCtx.viewMode3D,
         uiCtx.setViewMode3D,
+        uiCtx.viewportBackground,
+        uiCtx.setViewportBackground,
         uiCtx.activeDialog,
         uiCtx.setActiveDialog,
         uiCtx.sidePanelVisible,

--- a/src/studio/context/WorkbenchContext.tsx
+++ b/src/studio/context/WorkbenchContext.tsx
@@ -89,6 +89,8 @@ function WorkbenchInnerProvider({ children }: { children: ReactNode }) {
         setLayoutMode: uiCtx.setLayoutMode,
         viewMode3D: uiCtx.viewMode3D,
         setViewMode3D: uiCtx.setViewMode3D,
+        viewportBackground: uiCtx.viewportBackground,
+        setViewportBackground: uiCtx.setViewportBackground,
         activeDialog: uiCtx.activeDialog,
         setActiveDialog: uiCtx.setActiveDialog,
         sidePanelVisible: uiCtx.sidePanelVisible,


### PR DESCRIPTION
## Summary

Two changes bundled into one PR:

- **Task 1 — luxo beam-clevis gap.** The previous build used a uniform `beamClear = knuckleR + ARM_T/2 + 2 = 23 mm` clearance at every joint, which opened an 11 mm visible air gap on each side of every clevis. That `+ ARM_T/2 + 2` margin assumed a Z-axis fork-plate collision that the geometry already prevents (beam Z ±9 mm fits inside fork plate Z ±knuckleR=12 mm). The real constraint is the fork's bridge tab — and only the **child side** of each joint can sweep into the parent's tab volume. The fix splits clearance into `beamClearTight = knuckleR = 12 mm` (parent / non-sweeping side, flush fit) and `beamClearSweep = knuckleR + 6 = 18 mm` (child-side, clears bridge tab under full sweep). The base column gets the same flush fit. `mechanism: real`, exit 0.
- **Task 2 — Studio viewport background switcher.** Adds a 3-state toggle (dark / light / checkered) next to the existing 3D view-mode cluster in the Studio header. Default is `dark` (matches historical look). Persisted via `localStorage`; checkered uses a 16-px alternating two-grey `THREE.CanvasTexture`. Studio-only — CLI rendering is unchanged.

## Test plan

- [x] `npm run lint` — clean (0 errors, 15 pre-existing warnings)
- [x] `npm run build:cli` — green
- [x] `vitest run src/studio/` — 324 / 324 pass (includes new `SceneBackground.test.ts` and `UIContext.test.tsx` cases for the switcher)
- [x] `vitest run tests/integration/examples/` — 27 / 27 pass, `luxoLampClevis.test.ts` reports `mechanism: real`, empty `mechanismFailures`
- [x] `vitest run tests/integration/physics-loop/` — luxo + so100 sweep gates green
- [x] `node dist/cli/index.js validate --include-interference examples/kinematic/luxo-lamp.kcad.ts` → `Assembly validates clean (7 parts, 0 joints)`, exit 0
- [x] `kernelcad render inspect …` — visual confirm: beams meet the clevis tongue at every joint with no visible air gap (residual ≤ 6 mm machined fit where sweep clearance is mandatory)