### PR TITLE
chore: registry packages-block + auto-publish workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,62 @@
+name: Publish npm on tag
+
+# Auto-publishes the `kernelcad` package to npm when a v* tag is pushed.
+# Requires repo secret NPM_TOKEN — a Granular Access Token with read+write
+# on the `kernelcad` package AND "bypass two-factor authentication for
+# publishing" enabled (otherwise the publish step 403s on the 2FA check).
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to (re)publish (e.g. v0.11.2)'
+        required: true
+
+concurrency:
+  group: publish-npm-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: npm publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.22.0'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify package version matches tag
+        run: |
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "${{ inputs.tag }}" != "" ]; then
+            TAG_VERSION="${{ inputs.tag }}"
+            TAG_VERSION="${TAG_VERSION#v}"
+          fi
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::package.json version ($PKG_VERSION) does not match tag ($TAG_VERSION)"
+            exit 1
+          fi
+          echo "Publishing kernelcad@$PKG_VERSION"
+
+      - name: Publish
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/server.json
+++ b/server.json
@@ -6,7 +6,17 @@
     "url": "https://github.com/w1ne/kernelCAD-web",
     "source": "github"
   },
-  "version": "0.11.1",
+  "version": "0.11.2",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "kernelcad",
+      "version": "0.11.2",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ],
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
## Summary
- \`server.json\`: bump to v0.11.2 + add npm \`packages\` block (already published to MCP Registry on 2026-06-02 via \`mcp-publisher publish\`).
- \`.github/workflows/publish-npm.yml\`: future v* tag pushes auto-publish to npm using \`NPM_TOKEN\` repo secret.

## Why
- The official MCP Registry needs both \`packages\` and \`remotes\` to surface kernelCAD as both installable AND hosted. Without \`packages\`, downstream aggregators (Glama, mcp.so, Smithery) classified kernelCAD as Connector-only.
- Future releases shouldn't need manual \`npm publish\` runs.

## Notes
- Repo secret \`NPM_TOKEN\` is set (2026-06-02). It expires in ~30 days. Must be a granular token with **"bypass two-factor authentication for publishing"** enabled — the workflow will 403 on 2FA otherwise.
- Workflow guards against version drift: tag \`vX.Y.Z\` must match \`package.json\` version, else publish fails fast.

## Test plan
- [x] Validated server.json against the live registry schema (\`mcp-publisher validate\`).
- [x] \`mcp-publisher publish\` succeeded; \`curl https://registry.modelcontextprotocol.io/v0/servers?search=kernelcad\` confirms v0.11.2 with packages block.
- [x] \`npm view kernelcad version\` → \`0.11.2\`; \`npm view kernelcad mcpName\` → \`com.kernelcad/kernelcad\`.
- [ ] Workflow self-test: next tag push (v0.11.3+) auto-publishes.