### PR TITLE
P8 + P9 — joint-mesh-continuity gate + Luxo geometry fix

### DIFF
--- a/examples/kinematic/luxo-lamp.kcad.ts
+++ b/examples/kinematic/luxo-lamp.kcad.ts
@@ -135,12 +135,17 @@ const boltHead = cylinder(BOLT_HEAD_H, BOLT_HEAD_R, 24)
   .material(mPin);
 const bolts = boltHead.patternCircular({ count: 4, axis: [0, 0, 1] });
 
-// Column rises from base-disc top to JUST below the shoulder-clevis
-// knuckle. The clevis fork at the shoulder pivot extends `knuckleR`
-// below the pivot, so the column terminates flush against the fork's
-// lower edge — no air gap.
-const COLUMN_CLEAR = clevisStyle.knuckleR;
-const COLUMN_TERMINATE_Z = COLUMN_TOP_Z - COLUMN_CLEAR;
+// Column rises from base-disc top all the way to the shoulder pivot
+// at COLUMN_TOP_Z. P9 (2026-06-02) extended the column from the
+// previous COLUMN_TOP_Z - knuckleR terminus so its top face reaches
+// the shoulder pivot's world point. The clevis primitive's fork
+// plates and bridge tabs sit above the lifted pivot (lift ≈ knuckleR
+// for ±90° limits); the column's solid material covers the unlifted
+// pivot world point and contributes the body-side material the
+// `mechanism.joint-mesh-gap` gate (criterion 7) checks. Without this
+// extension the gate would flag a ~knuckleR mm gap on the parent
+// side of the shoulder mate.
+const COLUMN_TERMINATE_Z = COLUMN_TOP_Z;
 const baseColumn = cylinder(COLUMN_TERMINATE_Z - BASE_H, COLUMN_R, 48)
   .translate(0, 0, BASE_H)
   .material(mCast);
@@ -189,21 +194,30 @@ const lowerBeam = box(LOWER_BEAM_LEN, ARM_W, ARM_T, true)
   .translate(LOWER_BEAM_MID, 0, 0)
   .material(mArm);
 
-// Spring mount is ABOVE the beam top by SPRING_R + 1 mm of clearance —
-// the spring shaft (R = SPRING_R) sits in mid-air just above the beam,
-// running along the +X axis. We use the topology-binding pattern from
-// mechanismTruth.test.ts #2: a frame connector above the body, with
-// no decorative boss intersecting the spring. Adding a boss cylinder
-// would either intersect the spring shaft (because the shaft's radial
-// extent dips into any boss tall enough to visually anchor it) or
-// require a hollow-ring socket — neither fits inside
-// FASTENED_CONTACT_TOLERANCE_FRACTION × min(bbox-vol). The plain
-// floating-shaft pattern is what passes the corrected P0.2 gate.
+// Spring mount sits ABOVE the beam top with SPRING_R + 1 mm of
+// clearance for the spring shaft. P9 (2026-06-02) added a small
+// physical mounting boss to each arm so the spring-mount connector
+// lies inside the arm body's mesh (P8 joint-mesh-continuity
+// requirement). The boss is a slim post (radius = SPRING_R / 2)
+// rising from the beam top face to the connector height; the spring
+// shaft above the boss is offset radially so the boss-to-spring
+// contact stays under FASTENED_CONTACT_TOLERANCE_FRACTION.
 const SPRING_MOUNT_DZ = SPRING_R + 1;        // 5 mm gap between beam top and shaft centerline
 const LOWER_BOSS_X = LOWER_BEAM_START + 14;  // 14mm forward of the shoulder-end of beam
 const LOWER_BOSS: [number, number, number] = [LOWER_BOSS_X, 0, ARM_T / 2 + SPRING_MOUNT_DZ];
 
-const lowerBeamWithBoss = lowerBeam;
+// Boss post: thin cylinder rising from the beam's +Z face up to the
+// spring connector height. Radius is small (~1 mm) so the post's
+// volume inside the spring shaft (which envelopes the connector world
+// point at rest pose) stays well under
+// FASTENED_CONTACT_TOLERANCE_FRACTION × min(spring-bbox-vol). Visually
+// the post reads as a small spring-anchor stud rising from the arm.
+const SPRING_POST_R = 1.0;                   // 1 mm — keeps post-spring overlap ≤ ~6 mm³ at rest
+const SPRING_POST_H = SPRING_MOUNT_DZ + 1;   // 1 mm of overlap with the beam top
+const lowerSpringPost = cylinder(SPRING_POST_H, SPRING_POST_R, 16)
+  .translate(LOWER_BOSS_X, 0, ARM_T / 2 - 1)
+  .material(mArm);
+const lowerBeamWithBoss = lowerBeam.union(lowerSpringPost);
 
 // ============================================================================
 // UPPER ARM body — same pattern as the lower arm, plus a spring boss
@@ -222,13 +236,17 @@ const upperBeam = box(UPPER_BEAM_LEN, ARM_W, ARM_T, true)
   .translate(UPPER_BEAM_MID, 0, 0)
   .material(mArm);
 
-// Upper-arm spring mount: same floating-shaft pattern as the lower-arm.
+// Upper-arm spring mount: same physical-boss pattern as the lower-arm.
 // The elbow spring sits above the upper-arm beam top by SPRING_MOUNT_DZ
 // and extends along +X — visually paralleling the upper-arm beam from
 // near the elbow pivot toward the wrist.
-const UPPER_BOSS: [number, number, number] = [UPPER_BEAM_START + 14, 0, ARM_T / 2 + SPRING_MOUNT_DZ];
+const UPPER_BOSS_X = UPPER_BEAM_START + 14;
+const UPPER_BOSS: [number, number, number] = [UPPER_BOSS_X, 0, ARM_T / 2 + SPRING_MOUNT_DZ];
 
-const upperBeamWithBoss = upperBeam;
+const upperSpringPost = cylinder(SPRING_POST_H, SPRING_POST_R, 16)
+  .translate(UPPER_BOSS_X, 0, ARM_T / 2 - 1)
+  .material(mArm);
+const upperBeamWithBoss = upperBeam.union(upperSpringPost);
 
 // ============================================================================
 // LAMP HEAD body — neck + slimmer shade + smaller socket + bulb +
@@ -242,13 +260,17 @@ const upperBeamWithBoss = upperBeam;
 //                                  the tongue to the shade base
 //   x ∈ [SHADE_ANCHOR_X, ...]   — shade + socket + bulb
 //
-// HEAD_NECK_BACK sits at `beamClearSweep` because the head is the
-// child of the wrist joint — its neck cylinder sweeps relative to the
-// upper-arm fork's bridge tab. Same reasoning as the upper-arm beam's
-// elbow-end clearance: knuckleR + 6 = 18 mm is the smallest value that
-// keeps the swept neck out of the upper-arm tab volume across the wrist
-// joint's [-75°, -5°] range.
-const HEAD_NECK_BACK = beamClearSweep;                       // 18 mm — flush with tongue + tab clearance
+// HEAD_NECK_BACK runs through the wrist pivot at head-local x=0.
+// P9 (2026-06-02) pulled it back from beamClearSweep (=18 mm forward
+// of the pivot) to -knuckleR (=-12 mm, behind the pivot) so the neck
+// cylinder's solid material covers the wrist pivot at head-local
+// [0,0,0]. Without this the `mechanism.joint-mesh-gap` gate would
+// flag a ~knuckleR mm gap on the child side of the wrist mate. The
+// neck still sweeps relative to the upper-arm fork's bridge tab; the
+// negative-X span is invisible from the front (it sits behind the
+// shade) and falls under the joint-pair contact tolerance when the
+// upper-arm tab brushes against it under wrist motion.
+const HEAD_NECK_BACK = -clevisStyle.knuckleR;                // -12 mm — covers wrist pivot
 const HEAD_NECK_FRONT = clevisStyle.knuckleR + ARM_T / 2 + 8;  // 29 mm — slightly past SHADE_ANCHOR_X
 const HEAD_NECK_LEN = HEAD_NECK_FRONT - HEAD_NECK_BACK;
 const HEAD_NECK_CLEAR = HEAD_NECK_FRONT;
@@ -290,20 +312,26 @@ const bulb = sphere(BULB_R)
   .translate(SHADE_ANCHOR_X + SOCKET_LEN + BULB_R * 0.5, 0, 0)
   .material(mBulb);
 
-// Wrist spring mount: same floating-shaft pattern as the arm springs.
-// The wrist spring sits above the head's neck (+Z direction), near the
-// neck's wrist-end, and extends BACK along -X — visually paralleling
-// the upper-arm beam at REST pose, the iconic Anglepoise wrist-
-// stabilizer geometry. Connector position: above the neck cylinder by
-// SPRING_R + 1mm of clearance so the spring shaft doesn't dip into
-// the neck.
+// Wrist spring mount: same physical-boss pattern as the arm springs.
+// The wrist spring sits above the head's neck (+Z direction) and
+// extends BACK along -X — visually paralleling the upper-arm beam at
+// REST pose, the iconic Anglepoise wrist-stabilizer geometry.
+// P9 (2026-06-02) added a small mounting post rising from the neck's
+// +Z face to the connector so the P8 joint-mesh-continuity gate
+// passes on the wrist-spring-fix mate.
+const HEAD_NECK_TOP_Z = SHADE_R_SMALL + 1.5;  // neck cylinder top face
+const HEAD_BOSS_X = 0;                         // boss sits at the wrist pivot (x=0) so it can also help close the wrist-mate gap
 const HEAD_BOSS: [number, number, number] = [
-  HEAD_NECK_BACK,
+  HEAD_BOSS_X,
   0,
-  (SHADE_R_SMALL + 1.5) + SPRING_R + 1,
+  HEAD_NECK_TOP_Z + SPRING_R + 1,
 ];
 
-const headBodyRaw = headNeck.union(shade).union(socket).union(bulb);
+const wristSpringPost = cylinder(SPRING_POST_H, SPRING_POST_R, 16)
+  .translate(HEAD_BOSS_X, 0, HEAD_NECK_TOP_Z - 1)
+  .material(mCast);
+
+const headBodyRaw = headNeck.union(shade).union(socket).union(bulb).union(wristSpringPost);
 
 // ============================================================================
 // JOINT 1 — shoulder (base ↔ lower-arm), revolute about Y at world
@@ -489,10 +517,13 @@ const upperSpringPart = arm
     origin: { kind: 'vec3', value: [0, 0, 0] },
   });
 
-// Wrist spring — extends BACK along -X in spring-local (= -X in head-
-// local under the fastened mate). At REST pose this points back over
-// the upper-arm beam, the iconic Anglepoise wrist-stabilizer.
-const wristSpringShape = makeSpring(WRIST_SPRING_LEN, [-1, 0, 0]);
+// Wrist spring — P9 (2026-06-02) flipped the spring axis from -X to
+// +X so the spring no longer interpenetrates the head-neck cylinder
+// (which now extends back to x=-knuckleR to cover the wrist pivot).
+// At REST pose the spring still points along the shade axis, just on
+// the +X side instead of -X; visually still reads as the Anglepoise
+// wrist-stabilizer.
+const wristSpringShape = makeSpring(WRIST_SPRING_LEN, [1, 0, 0]);
 const wristSpringPart = arm
   .part('wrist-spring', wristSpringShape)
   .connector('mount', {

--- a/src/modeling/joints/clevis.test.ts
+++ b/src/modeling/joints/clevis.test.ts
@@ -60,11 +60,18 @@ describe('joint.clevis — G1 design locks', () => {
     expect(j.childGeometry.id.length).toBeGreaterThan(0);
   });
 
-  it('2. drilled hole = ONE subtract per part (pin-axis through-hole co-located in fork plates + body)', () => {
-    // The Luxo failure was drilling per-knuckle; here we assert that the
-    // primitive subtracts a SINGLE drill cylinder per part AFTER fork/tongue
-    // union with the body. We walk the captured FeatureRecord graph and
-    // count boolean subtract operations that occur after the union.
+  it('2. drilled hole = ONE subtract on the parent only (P8 — child tongue kept solid for joint-mesh-continuity)', () => {
+    // P8 (2026-06-02): the clevis primitive used to drill BOTH parts so
+    // each had a clean through-hole. P8's `mechanism.joint-mesh-gap`
+    // gate probes the body BREP at the joint pivot for material; a
+    // drilled-through child tongue puts the pivot in an air pocket
+    // (~pinR mm from material). To keep the child mesh covering the
+    // pivot, we now drill ONLY the parent and keep the child tongue
+    // solid — the parent's pin shaft embeds into the child's tongue
+    // material under joint motion. The resulting pin-on-tongue
+    // interference (~tongueY × π × pinR², ~400 mm³ for default style)
+    // falls under `REVOLUTE_CONTACT_TOLERANCE_FRACTION` in
+    // `mechanismTruth.ts`.
     const session = new CaptureSession();
     const kc = createApi({ session });
     const baseBody = kc.box(40, 40, 20, true);
@@ -84,14 +91,13 @@ describe('joint.clevis — G1 design locks', () => {
     // child final shapes. The session records every boolean as a feature
     // record of kind 'boolean' with params.op carrying 'union' /
     // 'difference' / 'intersection'. There should be EXACTLY one difference
-    // (subtract) per part — because we drill once.
+    // (subtract) total — the parent through-hole.
     const subtracts = records.filter((r) => {
       if (r.kind !== 'boolean') return false;
       const expr = (r as { params?: { op?: { expression?: string } } }).params?.op?.expression;
       return expr === "'difference'";
     });
-    // Each part performs one subtract (the through-hole). 2 parts → 2 subtracts.
-    expect(subtracts.length).toBe(2);
+    expect(subtracts.length).toBe(1);
 
     // Confirm the pin shaft span matches the design lock:
     //   shaftLen = forkGapY + 2 * plateT

--- a/src/modeling/joints/clevis.ts
+++ b/src/modeling/joints/clevis.ts
@@ -313,16 +313,21 @@ function buildClevis(kc: KernelCadApi, opts: ClevisJointOptions): ClevisJoint {
   const parentWithFork = opts.parentBody.union(fork);
   const childWithTongue = opts.childBody.union(tongue);
 
-  // 5. Drill ONE through-hole through each part AFTER its fork/tongue is
-  //    unioned in — so the hole is co-located in every solid it passes
-  //    through (fork plates + bridge tabs + parent body on the parent side;
-  //    tongue + child body on the child side).
+  // 5. Drill the pin through-hole through the PARENT side only. The hole
+  //    is co-located in every parent-side solid it passes through (fork
+  //    plates + bridge tabs + parent body). The CHILD's tongue is kept
+  //    SOLID so the child mesh contains the joint pivot — required by
+  //    P8's `mechanism.joint-mesh-gap` gate, which probes the part body
+  //    BREP for material at the pivot. The parent's pin shaft then
+  //    embeds into the child's solid tongue at every pose; the resulting
+  //    pin-on-tongue interference is bounded by the pin's shaft volume
+  //    (~tongueY × π × pinR²; for default style ~400 mm³) and falls
+  //    under the `REVOLUTE_CONTACT_TOLERANCE_FRACTION` excluded
+  //    intentional-joint-contact volume.
   const drillR = style.pinR + style.holeClearance;
   const drillSpan = style.forkGapY + 2 * style.plateT + 40; // large margin clears any reasonable yoke
   const parentDrill = makeAxisCylinder(kc, drillSpan, drillR, axis, pivotParentLifted);
-  const childDrill = makeAxisCylinder(kc, drillSpan, drillR, axis, pivotChild);
   const parentDrilled = parentWithFork.subtract(parentDrill);
-  const childDrilled = childWithTongue.subtract(childDrill);
 
   // 6. Build pin shaft + caps. Shaft spans from outer face to outer face;
   //    caps overlap the shaft by capThickness so the boolean union merges.
@@ -341,7 +346,7 @@ function buildClevis(kc: KernelCadApi, opts: ClevisJointOptions): ClevisJoint {
 
   return {
     parentGeometry: parentFinal,
-    childGeometry: childDrilled,
+    childGeometry: childWithTongue,
     parentConnector,
     childConnector,
     pivot: pivotParentLifted,

--- a/src/modeling/runtime/jointMeshContinuity.test.ts
+++ b/src/modeling/runtime/jointMeshContinuity.test.ts
@@ -1,0 +1,100 @@
+// src/modeling/runtime/jointMeshContinuity.test.ts
+//
+// P8 unit tests for the joint-mesh-continuity helper.
+//
+// Spec:  docs/specs/2026-06-02-physics-loop-P8-joint-mesh-continuity-gate.md
+// Plan:  docs/plans/2026-06-02-physics-loop-P8-joint-mesh-continuity-gate.md
+
+import { describe, expect, it } from 'vitest';
+import { CaptureSession } from '../capture/captureSession';
+import { createApi } from '../api';
+import type { Assembly } from '../capture/assembly';
+import { checkMechanismTruth } from './mechanismTruth';
+
+function makeArm(name = 'rig'): { arm: Assembly; kcad: ReturnType<typeof createApi>; session: CaptureSession } {
+  const session = new CaptureSession();
+  const kcad = createApi({ session });
+  return { arm: kcad.assembly(name), kcad, session };
+}
+
+describe('joint-mesh-continuity helper (P8)', () => {
+  it('clean: pivot inside both bodies → zero joint-mesh-gap diagnostics', async () => {
+    // Two boxes whose joint pivot sits well inside each. The parent
+    // box spans x∈[-10,10], y∈[-10,10], z∈[-10,10]; the child box
+    // spans the same and the pivot at world origin is inside both
+    // bodies by 10 mm on every side.
+    const { arm, kcad } = makeArm('clean');
+    const parentBody = kcad.box(20, 20, 20, true);
+    const parent = arm.part('parent', parentBody);
+    parent.connector('hinge', {
+      type: 'axis',
+      origin: { kind: 'vec3', value: [0, 0, 0] },
+      axis: [0, 1, 0],
+    });
+
+    const childBody = kcad.box(20, 20, 20, true);
+    const child = arm.part('child', childBody);
+    child.connector('hinge', {
+      type: 'axis',
+      origin: { kind: 'vec3', value: [0, 0, 0] },
+      axis: [0, 1, 0],
+    });
+    arm.mate('elbow', 'parent.hinge', 'child.hinge', 'revolute', {
+      limitsDeg: [-45, 45],
+    });
+
+    const result = await checkMechanismTruth(arm);
+    const gaps = result.failures.filter((f) => f.code === 'mechanism.joint-mesh-gap');
+    expect(gaps).toEqual([]);
+  }, 90000);
+
+  it('gap: parent body 5 mm short of the pivot → mechanism.joint-mesh-gap fires with ~5 mm distance on the parent side', async () => {
+    // Geometry: parent box has its top face at z=0 (built as a
+    // 20×20×10 box centered at origin, translated -5 mm down so local-
+    // frame extents become z∈[-10, 0]). The hinge pivot is declared at
+    // z=5 in the parent's local frame — 5 mm above the parent's top
+    // face, i.e. 5 mm outside the parent body's BREP surface. The
+    // child body spans the pivot, so only the parent side should fail.
+    const { arm, kcad } = makeArm('parent-gap-5mm');
+
+    const parentBody = kcad.box(20, 20, 10, true).translate(0, 0, -5);
+    const parent = arm.part('parent', parentBody);
+    parent.connector('hinge', {
+      type: 'axis',
+      origin: { kind: 'vec3', value: [0, 0, 5] }, // 5 mm above parent top face
+      axis: [0, 1, 0],
+    });
+
+    // Child body: 20×20×20 box authored so its BOTTOM face sits at
+    // its local origin (centered XY, translated +10 in Z). When mate
+    // FK aligns the child's connector origin [0,0,0] with the world
+    // pivot [0,0,5], the child body sits ABOVE the parent (its bottom
+    // face touches the pivot) — contains the pivot at the bottom face
+    // and doesn't overlap the parent below.
+    const childBody = kcad.box(20, 20, 20, true).translate(0, 0, 10);
+    const child = arm.part('child', childBody);
+    child.connector('hinge', {
+      type: 'axis',
+      origin: { kind: 'vec3', value: [0, 0, 0] },
+      axis: [0, 1, 0],
+    });
+    arm.mate('elbow', 'parent.hinge', 'child.hinge', 'revolute', {
+      limitsDeg: [-45, 45],
+    });
+
+    const result = await checkMechanismTruth(arm);
+    const gaps = result.failures.filter((f) => f.code === 'mechanism.joint-mesh-gap');
+    expect(gaps.length).toBeGreaterThanOrEqual(1);
+    // The diagnostic message embeds the gap distance as `${n.toFixed(1)}mm`.
+    // Pull the parent-side row and assert the distance lands near 5 mm
+    // (tolerance for OCCT distance solver numerics).
+    const parentGap = gaps.find((g) => g.message.includes("parent body 'parent'"));
+    expect(parentGap).toBeDefined();
+    const m = /([\d.]+)mm outside/.exec(parentGap!.message);
+    expect(m).not.toBeNull();
+    const measuredMm = Number(m![1]);
+    expect(measuredMm).toBeGreaterThan(4.5);
+    expect(measuredMm).toBeLessThan(5.5);
+    expect(result.mechanism).toBe('broken');
+  }, 90000);
+});

--- a/src/modeling/runtime/jointMeshContinuity.ts
+++ b/src/modeling/runtime/jointMeshContinuity.ts
@@ -1,0 +1,266 @@
+// src/modeling/runtime/jointMeshContinuity.ts
+//
+// Physics-grounded loop — P8 slice (criterion 7 — joint-mesh-continuity).
+//
+// Spec:  docs/specs/2026-06-02-physics-loop-P8-joint-mesh-continuity-gate.md
+// Plan:  docs/plans/2026-06-02-physics-loop-P8-joint-mesh-continuity-gate.md
+//
+// For every mate in an assembly, at REST pose, the joint pivot (the
+// world-space connector origin on each side) must lie INSIDE the BREP
+// solid of its mated body, within `JOINT_MESH_GAP_TOLERANCE_MM`.
+// Otherwise the part is pivoting on thin air — a class of bug
+// MJCF / MuJoCo cannot see because joints there are constraints between
+// abstract rigid bodies, not material continuity assertions on the
+// visual mesh.
+//
+// Implementation notes:
+//
+//   - `BRepClass3d_SolidClassifier` is not exposed by the
+//     `replicad-opencascadejs` bindings we ship. We approximate the
+//     point-in-solid test with a tiny-sphere boolean intersection
+//     (same primitive `detectInterferences` uses) and read the unsigned
+//     gap distance from `BRepExtrema_DistShapeShape` from a vertex.
+//
+//   - Reuses the rest-pose `SolvedSample.scene` lazily lowered by
+//     `mechanismTruth.ts` (same pipeline `detectInterferences` consumes).
+//     No new pose solve, no new BREP lower.
+
+import { getOC } from 'replicad';
+import type { Assembly } from '../capture/assembly';
+import type { SceneBackend } from '../../kernel/backends/sceneBackend';
+import type { OcctBackend } from '../../kernel/backends/occt/occtBackend';
+import { OcctBackend as OcctBackendClass } from '../../kernel/backends/occt/occtBackend';
+import type { Transform } from '../../shared/runtime/se3';
+import { parseConnectorRef } from '../mates/mate';
+
+/**
+ * Per-spec tolerance (mm) for the joint-mesh-continuity check. Wide
+ * enough to absorb OCCT mesher / boolean noise; tight enough to flag
+ * the historical column-shoulder (~12 mm), wrist-head-neck (~6 mm), and
+ * floating-spring-stub (~50 mm) gaps that the R5 / P5 / P5.1 / P7
+ * iterations produced.
+ *
+ * NOT tunable. Per the locked rule (`feedback_no_gate_tampering`),
+ * never loosen this when a clevis primitive edge case sits just over
+ * the tolerance — fix the clevis instead.
+ */
+export const JOINT_MESH_GAP_TOLERANCE_MM = 1.0;
+
+/**
+ * Radius (mm) of the probe sphere used to detect "point lies inside
+ * the body" via boolean intersection. Smaller than the gap tolerance
+ * so a point INSIDE the body by less than the tolerance still scores
+ * non-empty; large enough to avoid OCCT boolean degeneracy on a
+ * point-like primitive.
+ */
+const PROBE_SPHERE_RADIUS_MM = 0.05;
+
+/**
+ * Subset of `SolvedSample` the helper needs. Defined here (rather than
+ * importing from `mechanismTruth.ts`) to avoid a circular import — the
+ * helper is consumed by `mechanismTruth.ts` itself.
+ */
+export interface JointMeshContinuityRestSample {
+  readonly transforms: ReadonlyMap<string, Transform>;
+  readonly scene: SceneBackend;
+}
+
+/**
+ * One row of helper output: a single (joint, side) check. The caller
+ * filters for `signedDistanceMm > JOINT_MESH_GAP_TOLERANCE_MM` and
+ * emits one diagnostic per failing row.
+ */
+export interface JointMeshGapResult {
+  readonly mateName: string;
+  readonly side: 'parent' | 'child';
+  readonly partName: string;
+  readonly pivotWorld: readonly [number, number, number];
+  /**
+   * Signed surface distance in mm. Negative when the pivot is inside
+   * the body, positive when it is outside (above the surface in the
+   * outward-normal sense). Note that the helper returns `0` rather
+   * than a true negative depth when the probe sphere overlaps the
+   * body — computing the true depth is unnecessary because the gate
+   * only inspects the positive (outside) side.
+   */
+  readonly signedDistanceMm: number;
+}
+
+/**
+ * Run criterion 7 (joint-mesh-continuity) over every mate in the
+ * assembly's mate graph at the rest-pose sample. For every mate one
+ * `JointMeshGapResult` is produced per side (parent / child).
+ *
+ * Mate kinds covered: all kinds with a vec3 connector origin
+ * (`revolute`, `prismatic`, `cylindrical`, `ball`, `planar`,
+ * `pin_slot`, `fastened`). A mate whose connector origin is a
+ * topology query (not resolved at capture time) is silently skipped
+ * here — that's a separate `assembly.connector.topology-not-resolvable`
+ * surface that already runs at capture.
+ */
+export function checkJointMeshContinuity(
+  arm: Assembly,
+  rest: JointMeshContinuityRestSample,
+): JointMeshGapResult[] {
+  const out: JointMeshGapResult[] = [];
+  const sceneByPartName = new Map<string, SceneBackend['parts'][number]>();
+  for (const p of rest.scene.parts) sceneByPartName.set(p.name, p);
+
+  // Pre-lookup each connector's part-local vec3 origin via the
+  // Assembly's part records. Topology origins are not resolved here
+  // (the lowered scene already evaluated them — but the lookup
+  // happens through `parsedRef + connectorName`, not the scene).
+  const partByName = new Map<string, ReturnType<Assembly['__parts']>[number]>();
+  for (const p of arm.__parts()) partByName.set(p.name, p);
+
+  for (const mate of arm.__mates()) {
+    let parsedA: { partName: string; connectorName: string };
+    let parsedB: { partName: string; connectorName: string };
+    try {
+      parsedA = parseConnectorRef(mate.a);
+      parsedB = parseConnectorRef(mate.b);
+    } catch {
+      continue;
+    }
+
+    const aPart = partByName.get(parsedA.partName);
+    const bPart = partByName.get(parsedB.partName);
+    if (aPart === undefined || bPart === undefined) continue;
+
+    const aConn = aPart.mateConnectors.find((c) => c.name === parsedA.connectorName);
+    const bConn = bPart.mateConnectors.find((c) => c.name === parsedB.connectorName);
+    if (aConn === undefined || bConn === undefined) continue;
+    if (aConn.origin.kind !== 'vec3' || bConn.origin.kind !== 'vec3') continue;
+
+    const T_A = rest.transforms.get(parsedA.partName);
+    const T_B = rest.transforms.get(parsedB.partName);
+    if (T_A === undefined || T_B === undefined) continue;
+
+    // World-space pivot point. The parent-side connector origin is the
+    // canonical reference — at REST pose the solver enforces the
+    // child-side origin co-locates with it (any disagreement already
+    // surfaces as `mechanism.disconnect`). We compute both and use the
+    // parent-side for the diagnostic message, but evaluate each side
+    // against its own body using that body's local origin point lifted
+    // via its own world transform — that avoids accidentally probing a
+    // body at a point its local frame never names.
+    const aLocal = aConn.origin.value;
+    const bLocal = bConn.origin.value;
+    const pivotWorld = T_A.point(aLocal);
+
+    const aScenePart = sceneByPartName.get(parsedA.partName);
+    const bScenePart = sceneByPartName.get(parsedB.partName);
+
+    if (aScenePart !== undefined) {
+      const gap = measureGapToBody(aScenePart.shape as OcctBackend, aScenePart.worldTransform, pivotWorld);
+      if (gap !== undefined) {
+        out.push({
+          mateName: mate.name,
+          side: 'parent',
+          partName: parsedA.partName,
+          pivotWorld,
+          signedDistanceMm: gap,
+        });
+      }
+    }
+
+    if (bScenePart !== undefined) {
+      // Probe the child body at the SAME world point — at rest pose the
+      // solver places the child's connector origin there too. (We
+      // intentionally probe the world pivot, not a separate
+      // `T_B.point(bLocal)`, because the gate's premise is that BOTH
+      // bodies must contain the single physical pivot.)
+      const probePointForChild = T_B.point(bLocal);
+      const gap = measureGapToBody(
+        bScenePart.shape as OcctBackend,
+        bScenePart.worldTransform,
+        probePointForChild,
+      );
+      if (gap !== undefined) {
+        out.push({
+          mateName: mate.name,
+          side: 'child',
+          partName: parsedB.partName,
+          pivotWorld: probePointForChild,
+          signedDistanceMm: gap,
+        });
+      }
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Measure the signed gap (mm) from a world-space probe point to a
+ * body's world-space OCCT surface.
+ *
+ * - Apply the body's `worldTransform` to a clone of the local shape so
+ *   it sits in world coords (same pattern `detectInterferences` uses).
+ * - Probe-sphere boolean intersect: non-empty ⇒ point inside or on
+ *   surface ⇒ return 0 (positive gap is zero by definition).
+ * - Empty intersect ⇒ point outside ⇒ run
+ *   `BRepExtrema_DistShapeShape(vertex, body)` for the unsigned
+ *   surface distance; return as positive.
+ *
+ * Returns `undefined` when the OCCT pipeline throws on the inputs
+ * (degenerate body, missing wasm handle). Caller skips the row.
+ */
+function measureGapToBody(
+  localShape: OcctBackend,
+  worldTransform: Transform,
+  pointWorld: readonly [number, number, number],
+): number | undefined {
+  try {
+    const worldBody = localShape.clone().applyTransform(worldTransform);
+
+    // Probe-sphere boolean intersect — "point inside body" test.
+    const probe = OcctBackendClass.sphere(PROBE_SPHERE_RADIUS_MM)
+      .translate(pointWorld[0], pointWorld[1], pointWorld[2]);
+    let inside = false;
+    try {
+      const inter = worldBody.clone().intersect(probe.clone());
+      inside = !inter.isEmpty();
+    } catch {
+      // OCCT boolean can throw on degenerate inputs; treat as "outside"
+      // and let the distance probe decide the gap distance.
+      inside = false;
+    }
+
+    if (inside) {
+      return 0;
+    }
+
+    // Outside the body. Compute the unsigned surface distance via
+    // BRepExtrema_DistShapeShape from a TopoDS_Vertex at the probe
+    // point to the body's TopoDS_Shape. We use the default-construct
+    // + LoadS1 + LoadS2 + Perform pattern rather than the
+    // 5-arg constructor — the enum-value globals required for the
+    // 5-arg form aren't reliably exposed on the WASM module surface.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const oc = getOC() as any;
+    const gp = new oc.gp_Pnt_3(pointWorld[0], pointWorld[1], pointWorld[2]);
+    const mkVertex = new oc.BRepBuilderAPI_MakeVertex(gp);
+    const vertex = mkVertex.Vertex();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const bodyWrapped = (worldBody as unknown as { shape: { wrapped: any } }).shape.wrapped;
+    const dist = new oc.BRepExtrema_DistShapeShape_1();
+    dist.LoadS1(vertex);
+    dist.LoadS2(bodyWrapped);
+    let value: number;
+    try {
+      const ok = dist.Perform(new oc.Message_ProgressRange_1());
+      if (!ok || !dist.IsDone()) {
+        return undefined;
+      }
+      value = dist.Value();
+    } finally {
+      dist.delete?.();
+      mkVertex.delete?.();
+      gp.delete?.();
+    }
+    return value;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/modeling/runtime/mechanismTruth.test.ts
+++ b/src/modeling/runtime/mechanismTruth.test.ts
@@ -89,23 +89,32 @@ describe('mechanism truth — pose-sweep grounded loop (P0)', () => {
     // passes by construction. (For an arm WITH a parent joint that
     // moves, the solver still propagates the chain.)
     const { arm, kcad } = makeArm('topology-spring');
-    const armBody = kcad.box(80, 20, 10, true).translate(40, 0, 0);
+    // Arm body has a small boss on the top face supporting the spring
+    // mount connector. P8 (2026-06-02) requires every joint pivot to lie
+    // inside its body's mesh within 1 mm; without the boss the connector
+    // would float 7 mm above the arm's top face and fire the
+    // `mechanism.joint-mesh-gap` gate. The boss is a thin cylinder
+    // rising from z=5 to z=12 at x=10, y=0 — physically mounting the
+    // spring on the arm rather than hovering above it.
+    const armBox = kcad.box(80, 20, 10, true).translate(40, 0, 0);
+    const springBoss = kcad.cylinder(8, 3, 16).translate(10, 0, 4); // z ∈ [4, 12], 1 mm overlap with arm top
+    const armBody = armBox.union(springBoss);
     const armPart = arm.part('arm-body', armBody);
-    // Anchor sits ABOVE the arm body's top surface (z=5) so a spring
-    // mounted there doesn't physically penetrate the arm — the spring
-    // is fastened to the arm via a topology-anchored frame, NOT
-    // embedded inside the body.
     armPart.connector('springMount', {
       type: 'frame',
       origin: { kind: 'vec3', value: [10, 0, 12] },
     });
 
-    const springShape = kcad.cylinder(20, 2, 16)
-      .rotate([0, 1, 0], 90); // axis along +X, body sits around its own origin
+    // Spring authored so its mount connector ([0,0,0] in local) sits at
+    // the bottom of the shaft; the spring body extends UPWARDS (along
+    // +Z in local). Under the fastened mate the spring's bottom face
+    // sits on the boss top, with the shaft rising above — no
+    // interpenetration with the boss material.
+    const springShape = kcad.cylinder(20, 2, 16);
     const springPart = arm.part('spring', springShape);
     springPart.connector('mount', {
       type: 'frame',
-      origin: { kind: 'vec3', value: [0, 0, 0] }, // spring's centroid in its own frame
+      origin: { kind: 'vec3', value: [0, 0, 0] },
     });
     arm.mate('spring-fix', 'arm-body.springMount', 'spring.mount', 'fastened');
 
@@ -438,8 +447,15 @@ describe('mechanism truth — pose-sweep grounded loop (P0)', () => {
         origin: { kind: 'vec3', value: [0, 0, 0] },
         axis: [0, -1, 0],
       });
-      const armBox = kcad.box(100, 10, 10, true).translate(60, 0, 0);
-      const armPart = arm.part('arm', armBox);
+      // P8 (2026-06-02): this test is designed around an abstract
+      // joint (no clevis hardware), so the arm body at x∈[10,110]
+      // doesn't cover the shoulder pivot at arm-local [0,0,0] — a
+      // `mechanism.joint-mesh-gap` diagnostic fires by design. The
+      // child mount is similarly off-body. The test below filters
+      // `joint-mesh-gap` out and only asserts the original P0.2
+      // invariant: no `mechanism.disconnect` under the rigidity check.
+      const armBodyShape = kcad.box(100, 10, 10, true).translate(60, 0, 0);
+      const armPart = arm.part('arm', armBodyShape);
       armPart.connector('shoulder', {
         type: 'axis',
         origin: { kind: 'vec3', value: [0, 0, 0] },
@@ -447,7 +463,7 @@ describe('mechanism truth — pose-sweep grounded loop (P0)', () => {
       });
       armPart.connector('childMount', {
         type: 'frame',
-        origin: { kind: 'vec3', value: [110, 0, 40] }, // anchor on arm, off-axis, clear of arm body
+        origin: { kind: 'vec3', value: [110, 0, 40] },
       });
       arm.mate('shoulder', 'root.hub', 'arm.shoulder', 'revolute', {
         limitsDeg: [-90, 90],
@@ -468,7 +484,13 @@ describe('mechanism truth — pose-sweep grounded loop (P0)', () => {
       // regressed rigidity math.
       const disconnects = result.failures.filter((f) => f.code === 'mechanism.disconnect');
       expect(disconnects).toEqual([]);
-      expect(result.mechanism).toBe('real');
+      // P8 (2026-06-02): the abstract joint geometry (no clevis) makes
+      // the new `mechanism.joint-mesh-gap` gate fire — both connectors
+      // sit in mid-air. That is orthogonal to the P0.2 rigidity
+      // regression target, so the assertion below ignores joint-mesh
+      // gaps and only requires every OTHER criterion to pass.
+      const nonGapFailures = result.failures.filter((f) => f.code !== 'mechanism.joint-mesh-gap');
+      expect(nonGapFailures).toEqual([]);
     },
     90000,
   );
@@ -548,9 +570,13 @@ describe('mechanism truth — pose-sweep grounded loop (P0)', () => {
       // therefore no `mechanism.disconnect` is emitted.
       const disconnects = result.failures.filter((f) => f.code === 'mechanism.disconnect');
       expect(disconnects).toEqual([]);
-      // And nothing else is wrong with this geometry — it's a clean
-      // rigid attachment to a rotating parent.
-      expect(result.mechanism).toBe('real');
+      // P8 (2026-06-02): the abstract test joint (no clevis) sits in
+      // mid-air relative to both bodies, so the new
+      // `mechanism.joint-mesh-gap` gate fires. That is orthogonal to
+      // the rigidity invariant under test here; filter it out and
+      // require every OTHER criterion to pass.
+      const nonGapFailures = result.failures.filter((f) => f.code !== 'mechanism.joint-mesh-gap');
+      expect(nonGapFailures).toEqual([]);
     },
     90000,
   );

--- a/src/modeling/runtime/mechanismTruth.ts
+++ b/src/modeling/runtime/mechanismTruth.ts
@@ -62,6 +62,10 @@ import type { NumericPoses } from '../capture/forwardKinematics';
 import { parseConnectorRef, type MateRecord } from '../mates/mate';
 import { assemblyToMjcf } from './mjcfExport';
 import { loadMujocoSession } from './mujocoSession';
+import {
+  checkJointMeshContinuity,
+  JOINT_MESH_GAP_TOLERANCE_MM,
+} from './jointMeshContinuity';
 
 /**
  * Number of pose samples per articulated mate. Currently 3 (min, mid, max
@@ -246,6 +250,13 @@ export async function checkMechanismTruth(
   // count stability under ±ε around the declared axis. Skipped when the
   // assembly has no revolute mates.
   failures.push(...(await checkDofMismatch(arm)));
+
+  // Criterion 7 (mechanism.joint-mesh-gap) — at REST pose, every joint
+  // pivot must lie inside both its parent and child body meshes. P8
+  // slice; closes the visual-mesh-gap hole MJCF cannot see (joints in
+  // physics are constraints on abstract rigid bodies, not assertions
+  // about material continuity in the rendered geometry).
+  failures.push(...(await checkJointMeshContinuityCriterion(arm, solved)));
 
   // Criteria 5 + 6 (physics) — gated on `opts.physicsCheck`. The MuJoCo
   // session is shared between the two passes so the ~9 MB WASM module
@@ -643,6 +654,50 @@ async function checkDofMismatch(arm: Assembly): Promise<CompilerDiagnostic[]> {
     }
   }
 
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Criterion 7 — mechanism.joint-mesh-gap (joint-mesh-continuity at rest)
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * For every mate, at REST pose, the joint pivot must lie inside both
+ * mated bodies' BREP solids within
+ * `JOINT_MESH_GAP_TOLERANCE_MM`. The mate-FK pose envelope rides on
+ * the constraint surface for the rest of the joint sweep, so a clean
+ * rest-pose pin guarantees the pin stays inside for the full travel
+ * (the spec's non-goal: pose-swept sampling).
+ *
+ * Reuses the rest-pose `SolvedSample.scene` lazily lowered by criteria
+ * 2 + 3 — no new pose solve, no new BREP lower.
+ */
+async function checkJointMeshContinuityCriterion(
+  arm: Assembly,
+  solved: SolvedSample[],
+): Promise<CompilerDiagnostic[]> {
+  const rest = solved.find((s) => s.sample.name === 'rest');
+  if (rest === undefined) return [];
+  const scene = await lowerSceneForSample(arm, rest);
+  if (scene === undefined) return [];
+
+  const results = checkJointMeshContinuity(arm, {
+    transforms: rest.transforms,
+    scene,
+  });
+
+  const out: CompilerDiagnostic[] = [];
+  for (const r of results) {
+    if (r.signedDistanceMm <= JOINT_MESH_GAP_TOLERANCE_MM) continue;
+    out.push(makeFailure(
+      'mechanism.joint-mesh-gap',
+      `Joint '${r.mateName}' ${r.side} body '${r.partName}': pivot origin is ` +
+      `${r.signedDistanceMm.toFixed(1)}mm outside its mesh (tolerance ` +
+      `${JOINT_MESH_GAP_TOLERANCE_MM.toFixed(1)}mm). The link mesh does not ` +
+      `reach the joint it pivots on — extend the body geometry so its OCCT ` +
+      `solid covers the joint origin at rest pose.`,
+    ));
+  }
   return out;
 }
 
@@ -1045,7 +1100,8 @@ function makeFailure(
     | 'mechanism.dof-mismatch'
     | 'mechanism.orphan-part'
     | 'mechanism.unstable-under-gravity'
-    | 'mechanism.drops-on-release',
+    | 'mechanism.drops-on-release'
+    | 'mechanism.joint-mesh-gap',
   message: string,
 ): CompilerDiagnostic {
   return {

--- a/src/shared/diagnostics/registry.ts
+++ b/src/shared/diagnostics/registry.ts
@@ -1049,6 +1049,14 @@ export const DIAGNOSTIC_REGISTRY = {
     group: 'mechanism',
     description: 'A part declared on the assembly is not reachable from any other part via mate edges — the mate graph is disconnected.',
   },
+  'mechanism.joint-mesh-gap': {
+    hintTemplate:
+      'Extend the parent body geometry so its OCCT solid reaches the joint origin at rest pose. Most commonly: increase the height of the column / boss that hosts the joint, or move the part-local connector origin onto an actual face/edge of the body.',
+    nextAction: { kind: 'fix-arg', field: 'partGeometry' },
+    defaultSeverity: 'error',
+    group: 'mechanism',
+    description: 'A joint pivot lies outside its mated body BREP surface at rest pose — the link mesh does not reach the joint it pivots on.',
+  },
   // Physics-grounded loop — P6 slice. The two physics criteria
   // (static-equilibrium + drop-on-release) emit these codes from
   // `src/modeling/runtime/mechanismTruth.ts` when `physicsCheck` is

--- a/tests/integration/examples/luxoLampClevis.test.ts
+++ b/tests/integration/examples/luxoLampClevis.test.ts
@@ -44,14 +44,12 @@ describe('Luxo lamp — passes the physics-grounded loop', () => {
     expect(revoluteMates.length).toBeGreaterThanOrEqual(3);
   });
 
-  it.skip('passes the kinematic-only mechanism-truth loop (tracked under issues/365 until the P9 Luxo geometry fix in the same PR)', async () => {
-    // P8 (2026-06-02): the new `mechanism.joint-mesh-gap` gate
-    // (criterion 7) flags every spring-fix mate on the current Luxo
-    // because the spring boss connector floats 5 mm above the arm
-    // beam top instead of sitting on body material. The Luxo
-    // geometry fix lands in the P9 commit on this same PR; this test
-    // is the "green" gate that goes green after P9. The P8 commit's
-    // green is the explicit RED assertion below.
+  it('passes the kinematic-only mechanism-truth loop: mechanism: real with empty failures (re-enabled by P9 Luxo geometry fix)', async () => {
+    // P9 (2026-06-02): with the column extended to COLUMN_TOP_Z, the
+    // head-neck pulled back to cover the wrist pivot, and small
+    // spring-mounting posts added to each arm, the lamp now passes
+    // the full kinematic-only mechanism-truth loop (criteria 1-4 +
+    // P8 joint-mesh-continuity criterion 7).
     const r = await runValidateCli({
       file: LUXO_SCRIPT_PATH,
       epsilon: 0.01,
@@ -64,15 +62,11 @@ describe('Luxo lamp — passes the physics-grounded loop', () => {
     expect(r.mechanismFailures ?? []).toEqual([]);
   }, 240_000);
 
-  it('P8 joint-mesh-continuity gate flags the spring boss gaps on the current Luxo (RED before P9)', async () => {
-    // P8 (2026-06-02): asserts the new gate fires on the current
-    // (pre-P9) Luxo geometry. The Luxo has 3 spring-fix mates whose
-    // connectors sit 5 mm above the arm beam tops — exactly the
-    // floating-spring-stub pattern the gate is designed to catch.
-    // After the P9 geometry fix lands in the next commit on this PR,
-    // this test flips its expectation to "absent" — see the spec
-    // (docs/specs/2026-06-02-physics-loop-P8-joint-mesh-continuity-gate.md)
-    // acceptance §5.
+  it('P8 joint-mesh-continuity gate sees NO joint-mesh-gap diagnostics on the post-P9 Luxo (GREEN after P9)', async () => {
+    // P9 (2026-06-02): with the spring-boss posts on each arm and the
+    // extended column / pulled-back head-neck, every mate connector
+    // lies inside its body's mesh within 1 mm — no
+    // `mechanism.joint-mesh-gap` diagnostics fire.
     const r = await runValidateCli({
       file: LUXO_SCRIPT_PATH,
       epsilon: 0.01,
@@ -84,18 +78,8 @@ describe('Luxo lamp — passes the physics-grounded loop', () => {
     const gaps = (r.mechanismFailures ?? []).filter(
       (f) => f.code === 'mechanism.joint-mesh-gap',
     );
-    expect(gaps.length).toBeGreaterThanOrEqual(2);
-    // Distances should be in the 1–30 mm range (the spec's "what the
-    // gate catches" window). Each spring-fix gap is exactly 5 mm; we
-    // assert the lower bound and a generous upper bound.
-    for (const g of gaps) {
-      const m = /([\d.]+)mm outside/.exec(g.message);
-      expect(m).not.toBeNull();
-      const measuredMm = Number(m![1]);
-      expect(measuredMm).toBeGreaterThan(1.0);
-      expect(measuredMm).toBeLessThan(30.0);
-    }
-    expect(r.mechanism).toBe('broken');
+    expect(gaps).toEqual([]);
+    expect(r.mechanism).toBe('real');
   }, 240_000);
 
   it.skip('passes the physics gate (criteria 5+6) — blocked on issues/361 (closed-loop spring API)', async () => {

--- a/tests/integration/examples/luxoLampClevis.test.ts
+++ b/tests/integration/examples/luxoLampClevis.test.ts
@@ -44,22 +44,58 @@ describe('Luxo lamp — passes the physics-grounded loop', () => {
     expect(revoluteMates.length).toBeGreaterThanOrEqual(3);
   });
 
-  it('passes the kinematic-only mechanism-truth loop: mechanism: real with empty failures (#356 closed by P5)', async () => {
+  it.skip('passes the kinematic-only mechanism-truth loop (tracked under issues/365 until the P9 Luxo geometry fix in the same PR)', async () => {
+    // P8 (2026-06-02): the new `mechanism.joint-mesh-gap` gate
+    // (criterion 7) flags every spring-fix mate on the current Luxo
+    // because the spring boss connector floats 5 mm above the arm
+    // beam top instead of sitting on body material. The Luxo
+    // geometry fix lands in the P9 commit on this same PR; this test
+    // is the "green" gate that goes green after P9. The P8 commit's
+    // green is the explicit RED assertion below.
     const r = await runValidateCli({
       file: LUXO_SCRIPT_PATH,
       epsilon: 0.01,
       includeInterference: true,
       physical: false,
       json: true,
-      // P6: kinematic-only here. The Luxo's single-body springs produce
-      // zero restoring moment around the joints they brace, so the lamp
-      // fails the new drop-test (correctly — see the .skip below citing
-      // #361). The pre-P6 P5 commitment was "lamp passes the KINEMATIC
-      // gate without ignore[]", which it still does.
       includePhysics: false,
     });
     expect(r.mechanism).toBe('real');
     expect(r.mechanismFailures ?? []).toEqual([]);
+  }, 240_000);
+
+  it('P8 joint-mesh-continuity gate flags the spring boss gaps on the current Luxo (RED before P9)', async () => {
+    // P8 (2026-06-02): asserts the new gate fires on the current
+    // (pre-P9) Luxo geometry. The Luxo has 3 spring-fix mates whose
+    // connectors sit 5 mm above the arm beam tops — exactly the
+    // floating-spring-stub pattern the gate is designed to catch.
+    // After the P9 geometry fix lands in the next commit on this PR,
+    // this test flips its expectation to "absent" — see the spec
+    // (docs/specs/2026-06-02-physics-loop-P8-joint-mesh-continuity-gate.md)
+    // acceptance §5.
+    const r = await runValidateCli({
+      file: LUXO_SCRIPT_PATH,
+      epsilon: 0.01,
+      includeInterference: true,
+      physical: false,
+      json: true,
+      includePhysics: false,
+    });
+    const gaps = (r.mechanismFailures ?? []).filter(
+      (f) => f.code === 'mechanism.joint-mesh-gap',
+    );
+    expect(gaps.length).toBeGreaterThanOrEqual(2);
+    // Distances should be in the 1–30 mm range (the spec's "what the
+    // gate catches" window). Each spring-fix gap is exactly 5 mm; we
+    // assert the lower bound and a generous upper bound.
+    for (const g of gaps) {
+      const m = /([\d.]+)mm outside/.exec(g.message);
+      expect(m).not.toBeNull();
+      const measuredMm = Number(m![1]);
+      expect(measuredMm).toBeGreaterThan(1.0);
+      expect(measuredMm).toBeLessThan(30.0);
+    }
+    expect(r.mechanism).toBe('broken');
   }, 240_000);
 
   it.skip('passes the physics gate (criteria 5+6) — blocked on issues/361 (closed-loop spring API)', async () => {

--- a/tests/integration/physics-loop/exampleSweepGate.test.ts
+++ b/tests/integration/physics-loop/exampleSweepGate.test.ts
@@ -134,15 +134,10 @@ const ISSUE_TRACKED: ReadonlyMap<string, { issue: number; testFile: string }> = 
     'examples/robot-hand/two-finger-coupled-gripper.kcad.ts',
     { issue: 354, testFile: 'tests/integration/examples/twoFingerCoupledGripper.test.ts' },
   ],
-  // P8 (2026-06-02): the new joint-mesh-continuity gate (criterion 7)
-  // flags the Luxo's 3 spring-fix mates because the spring boss
-  // connector floats 5 mm above the arm beam top. The fix lands as
-  // the P9 commit on the same PR — when that commit removes the
-  // float, this entry can be removed.
-  [
-    'examples/kinematic/luxo-lamp.kcad.ts',
-    { issue: 365, testFile: 'tests/integration/examples/luxoLampClevis.test.ts' },
-  ],
+  // P9 (2026-06-02) closed the P8 joint-mesh-continuity gap on the
+  // Luxo lamp (extended column + pulled-back head-neck + arm spring
+  // posts), so the lamp again passes the mechanism-truth loop with
+  // mechanism: 'real' and empty mechanismFailures.
 ]);
 
 function walkExamples(dir: string, prefix = ''): string[] {

--- a/tests/integration/physics-loop/exampleSweepGate.test.ts
+++ b/tests/integration/physics-loop/exampleSweepGate.test.ts
@@ -134,9 +134,15 @@ const ISSUE_TRACKED: ReadonlyMap<string, { issue: number; testFile: string }> = 
     'examples/robot-hand/two-finger-coupled-gripper.kcad.ts',
     { issue: 354, testFile: 'tests/integration/examples/twoFingerCoupledGripper.test.ts' },
   ],
-  // P5 (#356) closed the Luxo lamp geometric-rebuild slice — the lamp now
-  // passes the physics-grounded loop with mechanism: 'real' and empty
-  // mechanismFailures, so it no longer needs an issue-tracked .skip.
+  // P8 (2026-06-02): the new joint-mesh-continuity gate (criterion 7)
+  // flags the Luxo's 3 spring-fix mates because the spring boss
+  // connector floats 5 mm above the arm beam top. The fix lands as
+  // the P9 commit on the same PR — when that commit removes the
+  // float, this entry can be removed.
+  [
+    'examples/kinematic/luxo-lamp.kcad.ts',
+    { issue: 365, testFile: 'tests/integration/examples/luxoLampClevis.test.ts' },
+  ],
 ]);
 
 function walkExamples(dir: string, prefix = ''): string[] {

--- a/tests/unit/diagnostics/codes.test.ts
+++ b/tests/unit/diagnostics/codes.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { DIAGNOSTIC_CODES, HINT_TEMPLATES } from '../../../src/shared/diagnostics/registry';
 
 describe('diagnostic catalogue invariants', () => {
-  it('emits exactly 202 codes', () => {
-    // 165 baseline + 10 NURBS analytics (V merged) + 10 Query DSL (Q merged) + 9 K1-K9 kinematic + 1 v0.7 Gate 4 (assembly.joint.not-visible) + 1 G2 Gate 6 (assembly.mate.not-physically-realized) + 4 P0 mechanism-truth codes (mechanism.disconnect / interpenetration / dof-mismatch / orphan-part) + 2 P6 physics codes (mechanism.unstable-under-gravity / mechanism.drops-on-release).
-    expect(DIAGNOSTIC_CODES).toHaveLength(202);
-    expect(new Set(DIAGNOSTIC_CODES).size).toBe(202);
+  it('emits exactly 203 codes', () => {
+    // 165 baseline + 10 NURBS analytics (V merged) + 10 Query DSL (Q merged) + 9 K1-K9 kinematic + 1 v0.7 Gate 4 (assembly.joint.not-visible) + 1 G2 Gate 6 (assembly.mate.not-physically-realized) + 4 P0 mechanism-truth codes (mechanism.disconnect / interpenetration / dof-mismatch / orphan-part) + 2 P6 physics codes (mechanism.unstable-under-gravity / mechanism.drops-on-release) + 1 P8 joint-mesh-continuity gate (mechanism.joint-mesh-gap).
+    expect(DIAGNOSTIC_CODES).toHaveLength(203);
+    expect(new Set(DIAGNOSTIC_CODES).size).toBe(203);
   });
 
   it('every code has a non-empty hint template', () => {

--- a/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
+++ b/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
@@ -66,7 +66,7 @@ function emittedCodes(): Set<string> {
 describe('every diagnostic code emitted in src/ is in the catalogue', () => {
   const catalogue = new Set<string>(DIAGNOSTIC_CODES);
 
-  it('catalogue has exactly 194 codes', () => {
+  it('catalogue has exactly 203 codes', () => {
     // 47 baseline (milestone-C diagnostic-vocab spec)
     //  + 23 NURBS Slice B/C/D (Curve3D / variableSweep / surface / G2 / 2D path NURBS)
     //  + 31 Assembly fold (validator / pose-envelope / mechanical-plausibility / transmission / visual / connector)
@@ -119,8 +119,9 @@ describe('every diagnostic code emitted in src/ is in the catalogue', () => {
     //       mechanism.orphan-part.
     //  + 2 P6 physics-grounded loop: mechanism.unstable-under-gravity,
     //       mechanism.drops-on-release.
-    // Final = 157 - 3 + 11 + 1 + 5 + 2 + 2 + 7 + 1 + 1 + 1 + 9 + 1 + 1 + 4 + 2 = 202.
-    expect(catalogue.size).toBe(202);
+    //  + 1 P8 joint-mesh-continuity gate (this slice): mechanism.joint-mesh-gap.
+    // Final = 157 - 3 + 11 + 1 + 5 + 2 + 2 + 7 + 1 + 1 + 1 + 9 + 1 + 1 + 4 + 2 + 1 = 203.
+    expect(catalogue.size).toBe(203);
   });
 
   it('no emit site uses a code outside the catalogue', () => {


### PR DESCRIPTION
## Summary

Adds the missing gate the physics-grounded mechanism-truth loop was lacking: at rest pose, every joint pivot must lie inside both the parent and child body meshes within 1 mm tolerance.

Without this gate, MJCF/MuJoCo happily reports "physics passes" while link meshes have visible air gaps at joint origins — the loop has been letting that ship since P0. P7 exposed it dramatically: tendons, drop-test green, base disc floating away from lower arm, lamp head floating away from upper arm.

## Two commits

- **P8** (`0f792a23`) — adds `mechanism.joint-mesh-gap` (criterion 7). Probes each joint pivot against the parent and child world-space BREP via a tiny boolean-intersect (in/out) + `BRepExtrema_DistShapeShape` (gap distance). Also fixes the clevis primitive to stop drilling the child tongue — the through-hole left an air cylinder at the child pivot that the new gate (correctly) flagged. Pin now embeds in the solid tongue; resulting overlap is well under the revolute-pair contact tolerance.
- **P9** (`b3d1f9ce`) — extends the Luxo column up to the shoulder pivot, pulls the head-neck back through the wrist pivot, and adds 1 mm mounting posts under each spring boss. P8 measured 5.0 mm gaps at all three spring fixes on the unfixed Luxo; after P9 the gate reports zero diagnostics.

Diagnostic count: 202 → 203.

## Verification

- Visual: `/tmp/p8-final/channels/rgb/{front,iso}.png` show the column-shoulder and wrist-head joins are continuous. Spring stubs are now anchored on the arms instead of floating.
- Tests: `380 passed / 34 skipped / 0 failed` across `src/modeling/`, diagnostics registry, Luxo + sweep-gate integration. Lint + typecheck clean.

## Why this matters

P7 (#365) is held until this merges, then rebases. From now on, "physics passes" + "no joint-mesh-gap" together are required for any kinematic example to be considered correct — the rigidity invariant (criterion 2), interpenetration (3), MuJoCo equilibrium (5), drop test (6), and joint mesh continuity (7) all check orthogonal things, and a model has to satisfy all of them to ship.