### PR TITLE
Tendon API — Assembly.tendon, MJCF spatial tendon, Studio + CLI rendering

### DIFF
--- a/src/agent/render/headlessRender.ts
+++ b/src/agent/render/headlessRender.ts
@@ -149,7 +149,12 @@ export async function headlessRender(opts: HeadlessRenderOpts): Promise<Headless
     (channel): channel is HeadlessAuxInspectionChannel => channel === 'depth' || channel === 'normals',
   );
 
-  // 1. Mesh on Node side — same path captureDemo uses.
+  // 1. Mesh on Node side — same path captureDemo uses. The CaptureSession's
+  // `assemblies` map (live `Assembly` handles by name) is consumed inside
+  // `meshFeaturesPerFeature` to synthesise tendon FeatureMeshes for each
+  // declared `arm.tendon(...)` record (P7) — so the closed-loop balance
+  // springs render as visible cylinders in the headless CLI inspect path
+  // and in any Studio recompute that runs through the same meshing helper.
   const loaded = await loadScriptFeatures(opts.scriptPath);
   const meshing = await meshFeaturesPerFeature(
     loaded.features.map((f) => f.record),

--- a/src/modeling/capture/assembly.ts
+++ b/src/modeling/capture/assembly.ts
@@ -2063,6 +2063,7 @@ export class Assembly {
       sceneFeatureId,
       this.mates.length > 0 ? [...this.mates] : undefined,
       warnings,
+      this.tendons.length > 0 ? [...this.tendons] : undefined,
     );
   }
 }

--- a/src/modeling/capture/assembly.ts
+++ b/src/modeling/capture/assembly.ts
@@ -20,6 +20,11 @@ import {
 } from '../mates/mate';
 import { isCompatiblePair, type MateType } from '../mates/mateTypes';
 import {
+  TENDON_DEFAULT_VISUAL_DIAMETER_MM,
+  type TendonOptions,
+  type TendonRecord,
+} from '../mates/tendon';
+import {
   reviewPoseEnvelope,
   type PoseEnvelopeDiagnostic,
 } from '../mates/poseEnvelope';
@@ -394,6 +399,14 @@ export class Assembly {
    *  Surfaced on `Scene.mates` returned by `model()` / `solvedModel()`. */
   private readonly mates: MateRecord[] = [];
   private readonly mateCouplings: MateCouplingRecord[] = [];
+  /**
+   * P7: closed-loop balance-spring records declared via
+   * `arm.tendon(name, opts)`. Each tendon spans two connectors on
+   * different parts; mapped to MJCF `<tendon><spatial>` at physics-gate
+   * export time. The capture-side store is a flat array; uniqueness
+   * (name) + endpoint-connector existence are validated at insert.
+   */
+  private readonly tendons: TendonRecord[] = [];
   private readonly mechanicalJointIntents: MechanicalJointIntentRecord[] = [];
   private readonly transmissionIntents: TransmissionIntentRecord[] = [];
   /**
@@ -807,6 +820,104 @@ export class Assembly {
   }
 
   /**
+   * P7 — declare a passive balance spring (tendon) spanning two connectors
+   * on different parts. The tendon applies a restoring force
+   * `F = stiffness·(L − restLength) + damping·dL/dt` whenever the
+   * endpoint-to-endpoint distance L differs from the rest length, where
+   * L is recomputed each MuJoCo step from the live world positions of
+   * the two referenced connectors.
+   *
+   * Unlike `mate(...)`, a tendon is NOT a kinematic constraint — it
+   * doesn't add or remove DOFs. kernelCAD's spanning-tree FK ignores
+   * tendons entirely; they only fire under `validate --include-physics`,
+   * which feeds the assembly to MuJoCo via `mjcfExport`.
+   *
+   * Both endpoints must reference connectors already declared on parts
+   * already added to this assembly. The two connectors must be on
+   * DIFFERENT parts — mounting both ends to the same body produces zero
+   * net moment, which is the bug pattern that motivated P7 in the first
+   * place.
+   *
+   * Errors:
+   *   - duplicate tendon name                → feature.invalid-args
+   *   - malformed ref / unknown part / unknown connector
+   *                                          → assembly.tendon.connector-not-found
+   *   - both endpoints on same part          → assembly.tendon.same-body-endpoints
+   *   - restLengthMm <= 0 or non-finite      → assembly.tendon.invalid-rest-length
+   *   - stiffnessNmm <= 0 or non-finite      → assembly.tendon.invalid-stiffness
+   *   - dampingNsmm < 0 or non-finite        → assembly.tendon.invalid-damping
+   *   - visualDiameterMm <= 0 or non-finite  → assembly.tendon.invalid-visual-diameter
+   *
+   * Surfaced via `__tendons()` for the MJCF exporter and Studio renderer.
+   */
+  tendon(name: string, opts: TendonOptions): this {
+    if (this.tendons.some((t) => t.name === name)) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `assembly.tendon.duplicate-name: tendon '${name}' is already declared on assembly '${this.name}'.`,
+        undefined,
+        `invalid-args.assembly.tendon-duplicate-name — pick a unique tendon name, or remove the earlier arm.tendon('${name}', ...) call.`,
+      );
+    }
+    // Resolve both endpoints. Reuse the same "<part>.<connector>" grammar
+    // as mates so the agent surface is consistent.
+    const fromRes = this.resolveTendonEndpoint(name, 'from', opts.from);
+    const toRes = this.resolveTendonEndpoint(name, 'to', opts.to);
+    if (fromRes.partName === toRes.partName) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `assembly.tendon.same-body-endpoints: tendon '${name}' has both endpoints on part '${fromRes.partName}'. A tendon must span TWO different parts to produce a restoring moment around the joint between them.`,
+        undefined,
+        `invalid-args.assembly.tendon-same-body-endpoints — pick connectors on DIFFERENT parts. The canonical pattern is one connector on the parent arm and one on the child arm of the joint the spring spans.`,
+      );
+    }
+    if (!Number.isFinite(opts.restLengthMm) || opts.restLengthMm <= 0) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `assembly.tendon.invalid-rest-length: tendon '${name}' restLengthMm must be a positive finite number; got ${formatScalarForError(opts.restLengthMm)}.`,
+        undefined,
+        `invalid-args.assembly.tendon-invalid-rest-length — pass restLengthMm: <positive mm>. Typical Anglepoise rest length is 25-50 mm depending on the joint.`,
+      );
+    }
+    if (!Number.isFinite(opts.stiffnessNmm) || opts.stiffnessNmm <= 0) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `assembly.tendon.invalid-stiffness: tendon '${name}' stiffnessNmm must be a positive finite number; got ${formatScalarForError(opts.stiffnessNmm)}.`,
+        undefined,
+        `invalid-args.assembly.tendon-invalid-stiffness — pass stiffnessNmm: <positive N/mm>. Typical Anglepoise spring stiffness is 0.3-1.0 N/mm.`,
+      );
+    }
+    const damping = opts.dampingNsmm ?? 0;
+    if (!Number.isFinite(damping) || damping < 0) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `assembly.tendon.invalid-damping: tendon '${name}' dampingNsmm must be a non-negative finite number; got ${formatScalarForError(damping)}.`,
+        undefined,
+        `invalid-args.assembly.tendon-invalid-damping — pass dampingNsmm: <non-negative N·s/mm>, or omit it to default to 0.`,
+      );
+    }
+    const visualDiameter = opts.visualDiameterMm ?? TENDON_DEFAULT_VISUAL_DIAMETER_MM;
+    if (!Number.isFinite(visualDiameter) || visualDiameter <= 0) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `assembly.tendon.invalid-visual-diameter: tendon '${name}' visualDiameterMm must be a positive finite number; got ${formatScalarForError(visualDiameter)}.`,
+        undefined,
+        `invalid-args.assembly.tendon-invalid-visual-diameter — pass visualDiameterMm: <positive mm>, or omit it to default to ${TENDON_DEFAULT_VISUAL_DIAMETER_MM} mm.`,
+      );
+    }
+    this.tendons.push({
+      name,
+      from: opts.from,
+      to: opts.to,
+      restLengthMm: opts.restLengthMm,
+      stiffnessNmm: opts.stiffnessNmm,
+      dampingNsmm: damping,
+      visualDiameterMm: visualDiameter,
+    });
+    return this;
+  }
+
+  /**
    * v0.7 Slice 1 — declarative workspace-reachability targets.
    *
    * Persists "this connector MUST be able to reach these world-frame points
@@ -1141,6 +1252,50 @@ export class Assembly {
   }
 
   /**
+   * Resolve a tendon endpoint ref. Mirrors `resolveMateConnector` but
+   * emits tendon-flavored diagnostics so authoring scripts get advice
+   * about `arm.tendon(...)` specifically rather than mate connectors.
+   * The connector type is intentionally NOT constrained — any connector
+   * (frame/axis/planar/ball) is a valid tendon anchor.
+   */
+  private resolveTendonEndpoint(
+    tendonName: string,
+    side: 'from' | 'to',
+    ref: string,
+  ): { partName: string; connectorName: string } {
+    let parsed: { partName: string; connectorName: string };
+    try {
+      parsed = parseConnectorRef(ref);
+    } catch {
+      throw new KernelError(
+        'feature.invalid-args',
+        `assembly.tendon.connector-not-found: tendon '${tendonName}' ${side}: '${ref}' is not a 'partName.connectorName' reference.`,
+        undefined,
+        `invalid-args.assembly.tendon-connector-not-found — pass ${side}: '<partName>.<connectorName>' where both names are declared on this assembly.`,
+      );
+    }
+    const part = this.parts.find((p) => p.name === parsed.partName);
+    if (!part) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `assembly.tendon.connector-not-found: tendon '${tendonName}' ${side}: part '${parsed.partName}' is not declared on assembly '${this.name}'.`,
+        undefined,
+        `invalid-args.assembly.tendon-connector-not-found — declare the part via arm.part('${parsed.partName}', ...) before referencing it in a tendon.`,
+      );
+    }
+    const connector = part.mateConnectors.find((c) => c.name === parsed.connectorName);
+    if (!connector) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `assembly.tendon.connector-not-found: tendon '${tendonName}' ${side}: connector '${parsed.connectorName}' is not declared on part '${parsed.partName}'.`,
+        part.id,
+        `invalid-args.assembly.tendon-connector-not-found — register the connector via partRef.connector('${parsed.connectorName}', { type, origin, ... }) before referencing it in a tendon.`,
+      );
+    }
+    return parsed;
+  }
+
+  /**
    * Internal accessor — read-only view of the registered parts for the v0.6
    * mate solver (`src/lib/mates/solver.ts`). Underscore-prefixed: not part of
    * the agent-facing surface. Mirrors `Scene.__sourceFeatureId` convention.
@@ -1176,6 +1331,16 @@ export class Assembly {
 
   __mateCouplings(): readonly MateCouplingRecord[] {
     return this.mateCouplings;
+  }
+
+  /**
+   * P7: read-only view of declared tendon records. Consumed by
+   * `assemblyToMjcf` (physics-gate export) and the Studio
+   * TendonRenderer. Mirrors the `__mates()` underscore convention; the
+   * agent-facing surface is `arm.tendon(...)` declaration only.
+   */
+  __tendons(): readonly TendonRecord[] {
+    return this.tendons;
   }
 
   /**

--- a/src/modeling/capture/featureMeshing.ts
+++ b/src/modeling/capture/featureMeshing.ts
@@ -7,6 +7,7 @@ import type { PBRMaterial } from '../../shared/intent/material';
 import type { ReferenceImageMetadata } from '../../shared/intent/referenceImageRecord';
 import type { RenderEnvironmentMetadata } from '../../shared/intent/renderEnvironmentRecord';
 import type { CameraTargetMetadata } from '../../shared/intent/cameraTargetRecord';
+import type { Vec3 } from '../../shared/intent/types';
 import { OcctLowerer } from '../backends/occt/occtLowerer';
 import { OcctBackend, initOcct, pbrFromMetadata } from '../../kernel/backends/occt/occtBackend';
 import { RecomputeEngine } from '../compute/recomputeEngine';
@@ -225,6 +226,245 @@ function metadataNameOf(record: FeatureRecord | undefined): string | undefined {
   return typeof name === 'string' && name.length > 0 ? name : undefined;
 }
 
+/**
+ * Structural shape used to access the Assembly's tendon + part surface
+ * without importing the concrete `Assembly` class (avoids the
+ * capture/featureMeshing → capture/assembly cycle CaptureSession
+ * already avoids via `Map<string, unknown>` for `assemblies`).
+ */
+interface AssemblyLikeForTendons {
+  __tendons(): readonly {
+    readonly name: string;
+    readonly from: string;
+    readonly to: string;
+    readonly visualDiameterMm: number;
+  }[];
+  __parts(): readonly {
+    readonly name: string;
+    readonly mateConnectors: readonly {
+      readonly name: string;
+      readonly origin:
+        | { kind: 'vec3'; value: Vec3 }
+        | { kind: 'topology'; query: unknown };
+    }[];
+  }[];
+}
+
+function isAssemblyLikeForTendons(value: unknown): value is AssemblyLikeForTendons {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as { __tendons?: unknown; __parts?: unknown };
+  return typeof v.__tendons === 'function' && typeof v.__parts === 'function';
+}
+
+/** Apply a column-major 4x4 transform to a Vec3 point. */
+function applyMat4ToPoint(m: readonly number[], local: Vec3): Vec3 {
+  const lx = local[0], ly = local[1], lz = local[2];
+  return [
+    m[0] * lx + m[4] * ly + m[8] * lz + m[12],
+    m[1] * lx + m[5] * ly + m[9] * lz + m[13],
+    m[2] * lx + m[6] * ly + m[10] * lz + m[14],
+  ];
+}
+
+/**
+ * Build a triangle mesh for a cylinder spanning two world-frame
+ * endpoints. The cylinder is built directly with WORLD-FRAME vertices
+ * (no transform), so the consumer can treat it as a regular feature
+ * mesh and the SceneBackend fan-out's bounds aggregation picks it up
+ * for free. 16-segment cap-less cylinder — matches Studio's
+ * `CylinderGeometry(1,1,1,16)` topology.
+ */
+function buildCylinderFaceWorld(
+  fromWorld: Vec3,
+  toWorld: Vec3,
+  diameterMm: number,
+  segments = 16,
+): FaceGeometry | null {
+  const dx = toWorld[0] - fromWorld[0];
+  const dy = toWorld[1] - fromWorld[1];
+  const dz = toWorld[2] - fromWorld[2];
+  const length = Math.sqrt(dx * dx + dy * dy + dz * dz);
+  if (length < 1e-6 || diameterMm <= 0) return null;
+  const axis: Vec3 = [dx / length, dy / length, dz / length];
+  // Build an orthonormal basis (u, v) perpendicular to axis.
+  const seed: Vec3 = Math.abs(axis[2]) > 0.9 ? [1, 0, 0] : [0, 0, 1];
+  // u = axis × seed (normalised), v = axis × u
+  const ux = axis[1] * seed[2] - axis[2] * seed[1];
+  const uy = axis[2] * seed[0] - axis[0] * seed[2];
+  const uz = axis[0] * seed[1] - axis[1] * seed[0];
+  const uLen = Math.sqrt(ux * ux + uy * uy + uz * uz) || 1;
+  const u: Vec3 = [ux / uLen, uy / uLen, uz / uLen];
+  const v: Vec3 = [
+    axis[1] * u[2] - axis[2] * u[1],
+    axis[2] * u[0] - axis[0] * u[2],
+    axis[0] * u[1] - axis[1] * u[0],
+  ];
+  const radius = diameterMm / 2;
+
+  // 2 * segments vertices (one ring per end). Vertex layout:
+  //   ring 0 (i ∈ [0, segments)):    ring around `fromWorld`
+  //   ring 1 (i ∈ [segments, 2N)):   ring around `toWorld`
+  const vertCount = segments * 2;
+  const vertices = new Float32Array(vertCount * 3);
+  const normals = new Float32Array(vertCount * 3);
+  for (let i = 0; i < segments; i++) {
+    const theta = (i * 2 * Math.PI) / segments;
+    const cosT = Math.cos(theta);
+    const sinT = Math.sin(theta);
+    const nx = u[0] * cosT + v[0] * sinT;
+    const ny = u[1] * cosT + v[1] * sinT;
+    const nz = u[2] * cosT + v[2] * sinT;
+    // bottom ring (around `fromWorld`)
+    vertices[i * 3 + 0] = fromWorld[0] + nx * radius;
+    vertices[i * 3 + 1] = fromWorld[1] + ny * radius;
+    vertices[i * 3 + 2] = fromWorld[2] + nz * radius;
+    normals[i * 3 + 0] = nx;
+    normals[i * 3 + 1] = ny;
+    normals[i * 3 + 2] = nz;
+    // top ring (around `toWorld`)
+    const ti = (segments + i) * 3;
+    vertices[ti + 0] = toWorld[0] + nx * radius;
+    vertices[ti + 1] = toWorld[1] + ny * radius;
+    vertices[ti + 2] = toWorld[2] + nz * radius;
+    normals[ti + 0] = nx;
+    normals[ti + 1] = ny;
+    normals[ti + 2] = nz;
+  }
+  // Two triangles per side quad.
+  const indices = new Uint32Array(segments * 6);
+  for (let i = 0; i < segments; i++) {
+    const next = (i + 1) % segments;
+    const a = i;
+    const b = next;
+    const c = segments + i;
+    const d = segments + next;
+    indices[i * 6 + 0] = a;
+    indices[i * 6 + 1] = c;
+    indices[i * 6 + 2] = b;
+    indices[i * 6 + 3] = b;
+    indices[i * 6 + 4] = c;
+    indices[i * 6 + 5] = d;
+  }
+  return {
+    vertices,
+    indices,
+    normals,
+    faceId: 0,
+  };
+}
+
+/**
+ * P7 — read the Assembly's declared tendons (if any) and pack them into
+ * synthetic FeatureMesh records the renderer can hang cylinder geometry
+ * off. World-frame triangle mesh is baked HERE so the browser renderer
+ * draws each cylinder as a normal feature group (no special path) and
+ * the centroid-shift recentering composes onto it identically to the
+ * SceneBackend part fan-outs.
+ *
+ * Skips silently when:
+ *   - The SceneBackend's `assemblyName` doesn't resolve to an Assembly
+ *     in `session.assemblies` (e.g. the lowerer ran without a
+ *     captureSession hook, or the assembly was renamed mid-flight).
+ *   - A tendon endpoint references a connector whose origin is a
+ *     `topology` query rather than a vec3. Topology origins resolve on
+ *     the LOWERED backend (a future slice can plumb them; for v1 of the
+ *     visual emit we accept the vec3-fast-path and emit a console
+ *     warning so authors notice). Per-endpoint validity is enforced by
+ *     `Assembly.resolveTendonEndpoint` at capture time.
+ *   - Both endpoints resolve to the same world point (degenerate
+ *     cylinder; capture validation already enforces same-body-endpoints
+ *     rejection but FK could still collapse the endpoints under poses).
+ */
+function collectTendonMeshes(
+  sceneShape: unknown,
+  sceneFeatureId: FeatureId,
+  assemblies: ReadonlyMap<string, unknown> | undefined,
+): FeatureMesh[] {
+  if (assemblies === undefined) return [];
+  const scene = sceneShape as {
+    assemblyName?: string;
+    parts?: readonly { readonly name: string; readonly worldTransform: { toMat4(): readonly number[] } }[];
+  };
+  const assemblyName = scene.assemblyName;
+  if (typeof assemblyName !== 'string' || assemblyName.length === 0) return [];
+  const arm = assemblies.get(assemblyName);
+  if (!isAssemblyLikeForTendons(arm)) return [];
+  const tendons = arm.__tendons();
+  if (tendons.length === 0) return [];
+
+  // (partName.connectorName) → vec3 origin lookup.
+  const originByRef = new Map<string, Vec3>();
+  for (const part of arm.__parts()) {
+    for (const conn of part.mateConnectors) {
+      if (conn.origin.kind === 'vec3') {
+        originByRef.set(`${part.name}.${conn.name}`, conn.origin.value);
+      }
+    }
+  }
+
+  // partName → world transform (column-major Mat4) lookup, derived from
+  // the SceneBackend's already-resolved per-part transforms.
+  const transformByPart = new Map<string, readonly number[]>();
+  for (const part of scene.parts ?? []) {
+    transformByPart.set(part.name, part.worldTransform.toMat4());
+  }
+
+  const meshes: FeatureMesh[] = [];
+  for (const t of tendons) {
+    const fromOrigin = originByRef.get(t.from);
+    const toOrigin = originByRef.get(t.to);
+    if (fromOrigin === undefined || toOrigin === undefined) {
+      console.warn(
+        `meshFeaturesPerFeature: tendon '${t.name}' has a topology-origin connector; visual cylinder skipped (vec3 origins only in v1).`,
+      );
+      continue;
+    }
+    const [fromPartName] = splitConnectorRef(t.from);
+    const [toPartName] = splitConnectorRef(t.to);
+    if (fromPartName === undefined || toPartName === undefined) continue;
+    const fromT = transformByPart.get(fromPartName);
+    const toT = transformByPart.get(toPartName);
+    if (fromT === undefined || toT === undefined) continue;
+    const fromWorld = applyMat4ToPoint(fromT, fromOrigin);
+    const toWorld = applyMat4ToPoint(toT, toOrigin);
+    const face = buildCylinderFaceWorld(fromWorld, toWorld, t.visualDiameterMm);
+    if (face === null) continue;
+    const tendonId = `${sceneFeatureId}__tendon__${t.name}`;
+    // Dark metallic PBR — matches Studio's `TendonRenderer.tsx`.
+    const tendonMaterial: PBRMaterial = {
+      baseColor: '#2a2e36',
+      metalness: 0.85,
+      roughness: 0.4,
+    };
+    meshes.push({
+      featureId: tendonId,
+      // Reuse the SceneBackend's feature-kind so the renderer's existing
+      // construction-closure / tail-feature filters treat this group the
+      // same way they treat normal assembly-fanout part groups.
+      featureKind: 'solvedAssembly',
+      predecessors: [sceneFeatureId],
+      faces: [face],
+      assemblyFeatureId: sceneFeatureId,
+      assemblyPartName: `__tendon__${t.name}`,
+      displayName: `tendon:${t.name}`,
+      filterNames: uniqueStrings([
+        tendonId,
+        t.name,
+        `tendon:${t.name}`,
+        'tendon',
+      ]),
+      material: tendonMaterial,
+    });
+  }
+  return meshes;
+}
+
+function splitConnectorRef(ref: string): [string | undefined, string | undefined] {
+  const dot = ref.indexOf('.');
+  if (dot <= 0 || dot === ref.length - 1) return [undefined, undefined];
+  return [ref.slice(0, dot), ref.slice(dot + 1)];
+}
+
 function meshIdentityFields(args: {
   featureId: FeatureId;
   featureKind: FeatureKind;
@@ -279,6 +519,15 @@ export async function meshFeaturesPerFeature(
      *  via the assembly fan-out and (b) non-assembly records whose cached
      *  `FeatureMesh` can be re-emitted directly. */
     cachedShapes?: Map<FeatureId, ShapeBackend>;
+    /** P7: live `Assembly` instances keyed by assembly name. Stored as
+     *  `unknown` on CaptureSession to avoid a TS cycle with the assembly
+     *  module; this hook lets the SceneBackend fan-out look up the
+     *  matching Assembly handle and emit one synthetic tendon
+     *  FeatureMesh per declared `arm.tendon(...)` record so the
+     *  rendered scene visibly shows the closed-loop balance springs.
+     *  Optional — scripts without `arm.tendon(...)` (or that don't
+     *  expose an assemblies map) render unchanged. */
+    assemblies?: ReadonlyMap<string, unknown>;
   },
 ): Promise<MeshFeaturesResult> {
   await initOcct();
@@ -368,6 +617,7 @@ export async function meshFeaturesPerFeature(
     | Map<FeatureId, Map<string, { faces: FaceGeometry[]; volume?: number; edges?: Float32Array }>>
     | undefined;
   const cachedShapesIn = session?.cachedShapes;
+  const assembliesIn = session?.assemblies;
 
   // Derive the seedShapes set for `engine.run`. A record can be safely
   // skipped from re-lowering when its cached lowered shape is still in
@@ -485,6 +735,25 @@ export async function meshFeaturesPerFeature(
           // emitted mesh local for viewport-side transforms.
           const transformed = transformFeatureMesh(local, part.worldTransform);
           for (const f of transformed.faces) {
+            for (let i = 0; i < f.vertices.length; i += 3) {
+              const x = f.vertices[i], y = f.vertices[i + 1], z = f.vertices[i + 2];
+              if (x < minX) minX = x; if (x > maxX) maxX = x;
+              if (y < minY) minY = y; if (y > maxY) maxY = y;
+              if (z < minZ) minZ = z; if (z > maxZ) maxZ = z;
+            }
+          }
+        }
+        // P7 — emit one synthetic tendon FeatureMesh per declared
+        // `arm.tendon(...)` record on the owning Assembly. The cylinder
+        // geometry is baked in WORLD frame here so it lands as a normal
+        // feature group in the renderer (no special path needed) and the
+        // centroid-recentre loop composes onto it identically to part
+        // groups. Cylinder span uses each owner part's `worldTransform`
+        // sourced directly off the SceneBackend.
+        const tendonMeshes = collectTendonMeshes(event.shape, event.featureId, assembliesIn);
+        for (const tm of tendonMeshes) {
+          features.push(tm);
+          for (const f of tm.faces) {
             for (let i = 0; i < f.vertices.length; i += 3) {
               const x = f.vertices[i], y = f.vertices[i + 1], z = f.vertices[i + 2];
               if (x < minX) minX = x; if (x > maxX) maxX = x;

--- a/src/modeling/mates/tendon.test.ts
+++ b/src/modeling/mates/tendon.test.ts
@@ -1,0 +1,183 @@
+// src/modeling/mates/tendon.test.ts
+//
+// P7 — capture-side validation for `arm.tendon(name, opts)`. Verifies the
+// minimum invariants that keep the MJCF emitter and Studio renderer
+// downstream safe: unique tendon name, both endpoints reference declared
+// connectors on different parts, and all numeric inputs are positive
+// (damping >= 0).
+
+import { describe, it, expect } from 'vitest';
+import { CaptureSession } from '../capture/captureSession';
+import { createApi } from '../api';
+
+function makeArm() {
+  const session = new CaptureSession();
+  const kcad = createApi({ session });
+  const arm = kcad.assembly('test');
+  // Two boxes with one frame-connector each; enough to attach a tendon
+  // between them.
+  const a = kcad.box(10, 10, 10);
+  const b = kcad.box(5, 5, 5);
+  arm
+    .part('a', a)
+    .connector('topA', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 10] } });
+  arm
+    .part('b', b)
+    .connector('topB', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 5] } });
+  return arm;
+}
+
+describe('arm.tendon(name, opts) — capture validation', () => {
+  it('records a tendon between two declared connectors', () => {
+    const arm = makeArm();
+    arm.tendon('spring-1', {
+      from: 'a.topA',
+      to: 'b.topB',
+      restLengthMm: 30,
+      stiffnessNmm: 0.5,
+    });
+    const tendons = arm.__tendons();
+    expect(tendons).toHaveLength(1);
+    expect(tendons[0].name).toBe('spring-1');
+    expect(tendons[0].from).toBe('a.topA');
+    expect(tendons[0].to).toBe('b.topB');
+    expect(tendons[0].restLengthMm).toBe(30);
+    expect(tendons[0].stiffnessNmm).toBe(0.5);
+    expect(tendons[0].dampingNsmm).toBe(0); // default
+    expect(tendons[0].visualDiameterMm).toBe(3); // default
+  });
+
+  it('honors explicit damping + visualDiameter', () => {
+    const arm = makeArm();
+    arm.tendon('s', {
+      from: 'a.topA',
+      to: 'b.topB',
+      restLengthMm: 30,
+      stiffnessNmm: 0.5,
+      dampingNsmm: 0.02,
+      visualDiameterMm: 4,
+    });
+    const t = arm.__tendons()[0];
+    expect(t.dampingNsmm).toBe(0.02);
+    expect(t.visualDiameterMm).toBe(4);
+  });
+
+  it('rejects duplicate tendon name', () => {
+    const arm = makeArm();
+    arm.tendon('s', { from: 'a.topA', to: 'b.topB', restLengthMm: 30, stiffnessNmm: 0.5 });
+    expect(() =>
+      arm.tendon('s', { from: 'a.topA', to: 'b.topB', restLengthMm: 30, stiffnessNmm: 0.5 }),
+    ).toThrow(/assembly\.tendon\.duplicate-name/);
+  });
+
+  it('rejects malformed connector ref', () => {
+    const arm = makeArm();
+    expect(() =>
+      arm.tendon('s', { from: 'no-dot', to: 'b.topB', restLengthMm: 30, stiffnessNmm: 0.5 }),
+    ).toThrow(/assembly\.tendon\.connector-not-found/);
+  });
+
+  it('rejects unknown part name', () => {
+    const arm = makeArm();
+    expect(() =>
+      arm.tendon('s', { from: 'ghost.topA', to: 'b.topB', restLengthMm: 30, stiffnessNmm: 0.5 }),
+    ).toThrow(/assembly\.tendon\.connector-not-found/);
+  });
+
+  it('rejects unknown connector on declared part', () => {
+    const arm = makeArm();
+    expect(() =>
+      arm.tendon('s', { from: 'a.missing', to: 'b.topB', restLengthMm: 30, stiffnessNmm: 0.5 }),
+    ).toThrow(/assembly\.tendon\.connector-not-found/);
+  });
+
+  it('rejects both endpoints on the same part', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('t');
+    arm
+      .part('lone', kcad.box(10, 10, 10))
+      .connector('c1', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 0] } })
+      .connector('c2', { type: 'frame', origin: { kind: 'vec3', value: [5, 0, 0] } });
+    expect(() =>
+      arm.tendon('s', { from: 'lone.c1', to: 'lone.c2', restLengthMm: 30, stiffnessNmm: 0.5 }),
+    ).toThrow(/assembly\.tendon\.same-body-endpoints/);
+  });
+
+  it('rejects non-positive rest length', () => {
+    const arm = makeArm();
+    expect(() =>
+      arm.tendon('s', { from: 'a.topA', to: 'b.topB', restLengthMm: 0, stiffnessNmm: 0.5 }),
+    ).toThrow(/assembly\.tendon\.invalid-rest-length/);
+    expect(() =>
+      arm.tendon('s2', { from: 'a.topA', to: 'b.topB', restLengthMm: -5, stiffnessNmm: 0.5 }),
+    ).toThrow(/assembly\.tendon\.invalid-rest-length/);
+    expect(() =>
+      arm.tendon('s3', { from: 'a.topA', to: 'b.topB', restLengthMm: Number.NaN, stiffnessNmm: 0.5 }),
+    ).toThrow(/assembly\.tendon\.invalid-rest-length/);
+  });
+
+  it('rejects non-positive stiffness', () => {
+    const arm = makeArm();
+    expect(() =>
+      arm.tendon('s', { from: 'a.topA', to: 'b.topB', restLengthMm: 30, stiffnessNmm: 0 }),
+    ).toThrow(/assembly\.tendon\.invalid-stiffness/);
+    expect(() =>
+      arm.tendon('s2', { from: 'a.topA', to: 'b.topB', restLengthMm: 30, stiffnessNmm: -1 }),
+    ).toThrow(/assembly\.tendon\.invalid-stiffness/);
+  });
+
+  it('rejects negative damping', () => {
+    const arm = makeArm();
+    expect(() =>
+      arm.tendon('s', {
+        from: 'a.topA',
+        to: 'b.topB',
+        restLengthMm: 30,
+        stiffnessNmm: 0.5,
+        dampingNsmm: -0.1,
+      }),
+    ).toThrow(/assembly\.tendon\.invalid-damping/);
+  });
+
+  it('rejects non-positive visualDiameter', () => {
+    const arm = makeArm();
+    expect(() =>
+      arm.tendon('s', {
+        from: 'a.topA',
+        to: 'b.topB',
+        restLengthMm: 30,
+        stiffnessNmm: 0.5,
+        visualDiameterMm: 0,
+      }),
+    ).toThrow(/assembly\.tendon\.invalid-visual-diameter/);
+  });
+
+  it('accepts damping = 0 explicitly', () => {
+    const arm = makeArm();
+    arm.tendon('s', {
+      from: 'a.topA',
+      to: 'b.topB',
+      restLengthMm: 30,
+      stiffnessNmm: 0.5,
+      dampingNsmm: 0,
+    });
+    expect(arm.__tendons()[0].dampingNsmm).toBe(0);
+  });
+
+  it('returns `this` for chaining', () => {
+    const arm = makeArm();
+    const result = arm.tendon('s', {
+      from: 'a.topA',
+      to: 'b.topB',
+      restLengthMm: 30,
+      stiffnessNmm: 0.5,
+    });
+    expect(result).toBe(arm);
+  });
+
+  it('__tendons() returns empty array when no tendon declared', () => {
+    const arm = makeArm();
+    expect(arm.__tendons()).toEqual([]);
+  });
+});

--- a/src/modeling/mates/tendon.ts
+++ b/src/modeling/mates/tendon.ts
@@ -1,0 +1,69 @@
+// src/modeling/mates/tendon.ts
+//
+// P7 — closed-loop balance-spring primitive. A tendon is a passive spring
+// that spans TWO connectors on DIFFERENT parts; under gravity (or any
+// applied force) it produces a restoring moment around the joint(s)
+// between those connectors. Implemented at solve / export time as a
+// MuJoCo `<tendon><spatial>` — the connector frames become MJCF `<site>`
+// elements on their owning bodies, and the spatial tendon's stiffness +
+// rest length apply the spring force.
+//
+// kernelCAD's spanning-tree FK still treats every part as singly-rooted;
+// the tendon is a FORCE constraint, not a kinematic one. The capture
+// surface is intentionally minimal — two endpoints, rest length,
+// stiffness, optional damping. No pulleys (3+ sites), no actuators, no
+// contact wrapping (those are post-P7 slices).
+//
+// Why this lives next to `mate.ts`:
+//   - Same `<partName>.<connectorName>` ref grammar (uses `parseConnectorRef`).
+//   - Same Assembly-record shape: capture-time validation + `__tendons()`
+//     read-side accessor mirroring `__mates()`.
+//   - The MJCF emitter (`runtime/mjcfExport.ts`) reads both arrays from
+//     the same Assembly handle.
+
+/**
+ * Capture-time record. Mirrors `MateRecord` for ergonomics — Assembly
+ * stores an array of these and surfaces via `__tendons()`. Unlike
+ * mates the two endpoints don't have a parent / child relationship —
+ * the order of `from` / `to` is for the agent's reading convenience
+ * only; physically the spring pulls each endpoint toward the other
+ * symmetrically.
+ */
+export interface TendonRecord {
+    /** Unique tendon name. Surfaced in diagnostics + MJCF site / spatial
+     *  identifiers. */
+    readonly name: string;
+    /** "<partName>.<connectorName>" — first endpoint. The named
+     *  connector must already be declared on the named part. */
+    readonly from: string;
+    /** "<partName>.<connectorName>" — second endpoint. */
+    readonly to: string;
+    /** Resting length of the spring (mm). Spring force is zero when the
+     *  endpoint-to-endpoint distance equals this. >0. */
+    readonly restLengthMm: number;
+    /** Spring stiffness (N/mm). MJCF emits this as N/m (×1000). >0. */
+    readonly stiffnessNmm: number;
+    /** Optional viscous damping (N·s/mm). MJCF emits this as N·s/m
+     *  (×1000). >=0; defaults to 0. */
+    readonly dampingNsmm: number;
+    /** Visual cylinder diameter (mm) for Studio rendering. The cylinder
+     *  scales endpoint-to-endpoint; this is only the diameter. Defaults
+     *  to 3 mm if not set by the agent. >0. */
+    readonly visualDiameterMm: number;
+}
+
+/**
+ * Agent-facing options for `arm.tendon(name, opts)`. `dampingNsmm` and
+ * `visualDiameterMm` are optional and default to 0 / 3 respectively.
+ */
+export interface TendonOptions {
+    readonly from: string;
+    readonly to: string;
+    readonly restLengthMm: number;
+    readonly stiffnessNmm: number;
+    readonly dampingNsmm?: number;
+    readonly visualDiameterMm?: number;
+}
+
+/** Default visual diameter (mm) used when the agent doesn't pass one. */
+export const TENDON_DEFAULT_VISUAL_DIAMETER_MM = 3;

--- a/src/modeling/runtime/mjcfExport.test.ts
+++ b/src/modeling/runtime/mjcfExport.test.ts
@@ -152,4 +152,125 @@ describe('assemblyToMjcf', () => {
 
         await expect(assemblyToMjcf(arm)).rejects.toThrow(/multiple parents|cycle/);
     }, 60000);
+
+    it('P7: emits <site> + <tendon><spatial> and tendon length matches site-to-site distance', async () => {
+        await initOcct();
+        const session = new CaptureSession();
+        const kcad = createApi({ session });
+        const arm = kcad.assembly('tendon-roundtrip');
+
+        // Two boxes joined by a revolute joint; one tendon between
+        // anchor connectors on each body.
+        const baseBody = kcad.box(40, 40, 30, true).translate(0, 0, -15);
+        const armBody = kcad.box(120, 20, 20, true).translate(70, 0, 0);
+        const j = kcad.joint.clevis({
+            parentBody: baseBody,
+            childBody: armBody,
+            axis: 'Y',
+            pivotParent: [0, 0, 15],
+            pivotChild: [0, 0, 0],
+            limitsDeg: [-45, 45],
+        });
+        arm
+            .part('base', j.parentGeometry)
+            .connector('hinge', {
+                type: 'axis',
+                origin: { kind: 'vec3', value: j.parentConnector.origin },
+                axis: j.parentConnector.axis,
+            })
+            // Anchor for the tendon — 20 mm above the pivot, parent-local.
+            .connector('anchor', {
+                type: 'frame',
+                origin: { kind: 'vec3', value: [0, 0, 35] },
+            });
+        arm
+            .part('lower-arm', j.childGeometry)
+            .connector('hinge', {
+                type: 'axis',
+                origin: { kind: 'vec3', value: j.childConnector.origin },
+                axis: j.childConnector.axis,
+            })
+            // Anchor for the tendon — 30 mm forward of the pivot, child-local.
+            .connector('anchor', {
+                type: 'frame',
+                origin: { kind: 'vec3', value: [30, 0, 0] },
+            });
+        arm.mate('elbow', 'base.hinge', 'lower-arm.hinge', 'revolute', {
+            limitsDeg: [-45, 45],
+        });
+        arm.tendon('spring', {
+            from: 'base.anchor',
+            to: 'lower-arm.anchor',
+            restLengthMm: 50,
+            stiffnessNmm: 0.5,
+            dampingNsmm: 0.01,
+        });
+
+        const { mjcf } = await assemblyToMjcf(arm);
+
+        // Sites emitted in the right places.
+        expect(mjcf).toMatch(/<site name="spring__from"/);
+        expect(mjcf).toMatch(/<site name="spring__to"/);
+        // Spatial tendon block emitted.
+        expect(mjcf).toMatch(/<tendon>/);
+        expect(mjcf).toMatch(/<spatial name="spring"/);
+        // Unit conversions: restLengthMm 50 → springlength 0.05;
+        // stiffnessNmm 0.5 → 500 N/m; dampingNsmm 0.01 → 10 N·s/m.
+        expect(mjcf).toMatch(/springlength="0\.050000"/);
+        expect(mjcf).toMatch(/stiffness="500\.000000"/);
+        expect(mjcf).toMatch(/damping="10\.000000"/);
+
+        // Round-trip through MuJoCo: at rest pose (qpos=0), the model
+        // should have exactly one tendon and ten_length matching the
+        // site-to-site Euclidean distance in world frame.
+        //
+        // Site 'spring__from' world pos: parent-local [0, 0, 35] with the
+        //   base body at pos [0, 0, -15] m? No — for this assembly, root
+        //   bodies use part.at, which is undefined here (j.parentGeometry
+        //   sits at its CAD-local origin). Let's check ten_length is
+        //   POSITIVE and FINITE — the exact value depends on FK details
+        //   we don't reproduce inline. We DO assert sites are 2 in number
+        //   and ten_length is finite at the world-frame distance the
+        //   model computes itself.
+        const mujoco = (await loadMujocoInNode()) as {
+            MjModel: { from_xml_string: (s: string) => unknown };
+            MjData: new (m: unknown) => unknown;
+            mj_forward: (m: unknown, d: unknown) => void;
+        };
+        const model = mujoco.MjModel.from_xml_string(mjcf);
+        const data = new mujoco.MjData(model);
+        try {
+            mujoco.mj_forward(model, data);
+            const m = model as { ntendon: number; nsite: number };
+            expect(m.ntendon).toBe(1);
+            expect(m.nsite).toBe(2);
+            // Compare to MuJoCo's own site_xpos[] to validate the
+            // tendon segment length is consistent.
+            const siteXpos = (data as { site_xpos: ArrayLike<number> }).site_xpos;
+            const dx = siteXpos[0] - siteXpos[3];
+            const dy = siteXpos[1] - siteXpos[4];
+            const dz = siteXpos[2] - siteXpos[5];
+            const expectedLen = Math.hypot(dx, dy, dz);
+            const tenLen = (data as { ten_length: ArrayLike<number> }).ten_length;
+            expect(tenLen.length).toBe(1);
+            expect(Math.abs(tenLen[0] - expectedLen)).toBeLessThan(1e-6);
+        } finally {
+            (data as { delete: () => void }).delete();
+            (model as { delete: () => void }).delete();
+        }
+    }, 60000);
+
+    it('P7: omits the <tendon> block entirely when no tendons declared', async () => {
+        await initOcct();
+        const session = new CaptureSession();
+        const kcad = createApi({ session });
+        const arm = kcad.assembly('no-tendons');
+
+        const a = kcad.box(20, 20, 20, true);
+        arm.part('a', a).connector('o', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 0] } });
+
+        const { mjcf } = await assemblyToMjcf(arm);
+        expect(mjcf).not.toMatch(/<tendon>/);
+        expect(mjcf).not.toMatch(/<site /);
+    }, 60000);
 });

--- a/src/modeling/runtime/mjcfExport.ts
+++ b/src/modeling/runtime/mjcfExport.ts
@@ -59,6 +59,7 @@ import type { MateRecord } from '../mates/mate';
 import { parseConnectorRef } from '../mates/mate';
 import type { Connector } from '../mates/connector';
 import { resolveConnectorOrigin } from '../mates/connector';
+import type { TendonRecord } from '../mates/tendon';
 import type { OcctBackend } from '../../kernel/backends/occt/occtBackend';
 import type { Vec3 } from '../../shared/intent/types';
 
@@ -101,6 +102,7 @@ export interface MjcfExportResult {
 export async function assemblyToMjcf(arm: Assembly): Promise<MjcfExportResult> {
     const parts = arm.__parts();
     const mates = arm.__mates();
+    const tendons = arm.__tendons();
     if (parts.length === 0) {
         throw new Error('assemblyToMjcf: assembly has no parts; nothing to physics-check.');
     }
@@ -196,6 +198,58 @@ export async function assemblyToMjcf(arm: Assembly): Promise<MjcfExportResult> {
         resolvedMateAxes.set(m.name, { origin: resolved.value, axis });
     }
 
+    // P7: pre-resolve every tendon endpoint to (partName, site name,
+    // local-frame mm position). The site goes inside the owner body's
+    // `<body>` element; the `<spatial>` tendon references the sites by
+    // name. Mirror the mate-resolver pattern above — both use the same
+    // `resolveConnectorOrigin` to honor topology-bound connectors.
+    interface ResolvedTendonEndpoint {
+        readonly partName: string;
+        readonly siteName: string;
+        readonly localPosMm: Vec3;
+    }
+    interface ResolvedTendon {
+        readonly record: TendonRecord;
+        readonly endpoints: readonly [ResolvedTendonEndpoint, ResolvedTendonEndpoint];
+    }
+    async function resolveTendonEndpoint(
+        tendon: TendonRecord,
+        side: 'from' | 'to',
+    ): Promise<ResolvedTendonEndpoint> {
+        const ref = side === 'from' ? tendon.from : tendon.to;
+        const parsed = parseConnectorRef(ref);
+        const part = partByName.get(parsed.partName);
+        if (part === undefined) {
+            throw new Error(
+                `assemblyToMjcf: tendon '${tendon.name}' ${side} references unknown part '${parsed.partName}'.`,
+            );
+        }
+        const connector = part.mateConnectors.find((c) => c.name === parsed.connectorName);
+        if (connector === undefined) {
+            throw new Error(
+                `assemblyToMjcf: tendon '${tendon.name}' ${side} references unknown connector '${parsed.connectorName}' on part '${parsed.partName}'.`,
+            );
+        }
+        const resolved = await resolveConnectorOrigin(part.originalShape, connector.origin);
+        return {
+            partName: part.name,
+            siteName: `${tendon.name}__${side}`,
+            localPosMm: resolved.value,
+        };
+    }
+    const resolvedTendons: ResolvedTendon[] = [];
+    const sitesByPart = new Map<string, ResolvedTendonEndpoint[]>();
+    for (const t of tendons) {
+        const fromE = await resolveTendonEndpoint(t, 'from');
+        const toE = await resolveTendonEndpoint(t, 'to');
+        resolvedTendons.push({ record: t, endpoints: [fromE, toE] });
+        for (const ep of [fromE, toE]) {
+            const list = sitesByPart.get(ep.partName) ?? [];
+            list.push(ep);
+            sitesByPart.set(ep.partName, list);
+        }
+    }
+
     // Emit MJCF by recursive body-tree walk.
     const jointOrder: { mjcfName: string; mateName: string }[] = [];
     const bodyOrder: string[] = [];
@@ -259,6 +313,18 @@ export async function assemblyToMjcf(arm: Assembly): Promise<MjcfExportResult> {
             for (const j of jointXml) lines.push(`${indent}  ${j}`);
         }
 
+        // P7: tendon endpoints owned by this body. Each <site> sits in
+        // the body's local frame; the spatial tendon (outside the
+        // worldbody) references these sites by name and computes
+        // segment length from their world-frame positions each step.
+        const sitesHere = sitesByPart.get(partName) ?? [];
+        for (const ep of sitesHere) {
+            const sitePosM = ep.localPosMm.map((v) => v * MM_TO_M);
+            lines.push(
+                `${indent}  <site name="${escapeXml(ep.siteName)}" pos="${sitePosM.map(fmtNum).join(' ')}"/>`,
+            );
+        }
+
         // Geometry — we don't emit visual meshes; the physics gate only
         // needs inertia + joint topology. Adding meshes would require
         // exporting STL per-part on every validate call (heavy). MuJoCo
@@ -279,6 +345,32 @@ export async function assemblyToMjcf(arm: Assembly): Promise<MjcfExportResult> {
         worldbodyBlocks.push(emitBody(root.name, undefined, '    '));
     }
 
+    // P7: emit the <tendon> block AFTER <worldbody>. Each spatial
+    // tendon references two sites by name; the sites were emitted
+    // inside their owner bodies above. Unit conversion:
+    //   restLengthMm    → springlength (m)   = mm × 1e-3
+    //   stiffnessNmm    → stiffness   (N/m)  = N/mm × 1e3
+    //   dampingNsmm     → damping     (N·s/m) = N·s/mm × 1e3
+    const tendonBlockLines: string[] = [];
+    if (resolvedTendons.length > 0) {
+        tendonBlockLines.push('  <tendon>');
+        for (const rt of resolvedTendons) {
+            const t = rt.record;
+            const springLenM = t.restLengthMm * MM_TO_M;
+            const stiffnessNm = t.stiffnessNmm * 1000;
+            const dampingNsm = t.dampingNsmm * 1000;
+            const dampingAttr = dampingNsm > 0 ? ` damping="${fmtNum(dampingNsm)}"` : '';
+            tendonBlockLines.push(
+                `    <spatial name="${escapeXml(t.name)}" springlength="${fmtNum(springLenM)}" stiffness="${fmtNum(stiffnessNm)}"${dampingAttr}>`,
+            );
+            for (const ep of rt.endpoints) {
+                tendonBlockLines.push(`      <site site="${escapeXml(ep.siteName)}"/>`);
+            }
+            tendonBlockLines.push('    </spatial>');
+        }
+        tendonBlockLines.push('  </tendon>');
+    }
+
     const mjcf = [
         '<?xml version="1.0" ?>',
         `<mujoco model="${escapeXml(arm.name)}">`,
@@ -287,6 +379,7 @@ export async function assemblyToMjcf(arm: Assembly): Promise<MjcfExportResult> {
         '  <worldbody>',
         ...worldbodyBlocks,
         '  </worldbody>',
+        ...tendonBlockLines,
         '</mujoco>',
         '',
     ].join('\n');

--- a/src/modeling/runtime/mujocoTendon.test.ts
+++ b/src/modeling/runtime/mujocoTendon.test.ts
@@ -98,8 +98,7 @@ describe('MuJoCo spatial tendon (P7 Task 0)', () => {
             // The session API doesn't expose ten_length directly; instead, we
             // round-trip-read from the data buffer (loadMujocoSession returns
             // a typed wrapper; the underlying MjData has a `ten_length` view).
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const data = (session as unknown as { data: any }).data;
+            const data = (session as unknown as { data: { ten_length: ArrayLike<number> } }).data;
             const tenLen = data.ten_length;
             expect(tenLen.length).toBe(1);
             expect(Math.abs(tenLen[0] - expectedLen)).toBeLessThan(1e-6);

--- a/src/modeling/runtime/mujocoTendon.test.ts
+++ b/src/modeling/runtime/mujocoTendon.test.ts
@@ -1,0 +1,110 @@
+// src/modeling/runtime/mujocoTendon.test.ts
+//
+// P7 Task 0 — verify MuJoCo's <tendon><spatial> primitive applies force on
+// a minimal 1-DoF pendulum running in Node via @mujoco/mujoco. This is the
+// prerequisite for the kernelCAD `arm.tendon(...)` API: if MuJoCo can't
+// hold a non-vertical equilibrium under a spatial tendon's restoring
+// force, the whole closed-loop spring approach is broken.
+//
+// Setup:
+//   - World +Z up, gravity (0, 0, -9.81).
+//   - One body hanging from a hinge at the world origin with axis Y.
+//     The body's geometry is a 0.1 m rod pointing along +X with its CoM
+//     at (0.05, 0, 0). Inertia: m=0.1 kg, ixx=iyy=izz=8.3e-4 kg·m² (a
+//     thin rod, ~1/12 m L² ≈ 8.3e-4).
+//   - A spatial tendon between world-frame site (0, 0, 0.05) and body
+//     site at (0.05, 0, 0) — i.e. the tendon pulls the bar's tip toward
+//     a point 5 cm above the hinge. Rest length 0.05 m, stiffness 50 N/m.
+//
+// Pure-gravity equilibrium (no tendon) would be θ=-90° (hanging straight
+// down along -Z). With the tendon pulling the tip up, equilibrium sits
+// between 0 (horizontal, max restoring torque from spring stretched
+// upward) and -90° (purely vertical, no spring help). We just assert
+// the final θ is strictly less negative than -π/2 + small margin AND
+// strictly more negative than 0 — i.e. the spring measurably altered
+// equilibrium. That's the qualitative confirmation we need.
+//
+// Why this test gates everything: if MuJoCo's tendon doesn't fire here,
+// P7 stops — we'd be building MJCF emission + Studio render against a
+// primitive that doesn't behave the way the MuJoCo docs promise.
+
+import { describe, it, expect } from 'vitest';
+import { loadMujocoSession } from './mujocoSession';
+
+const TENDON_PENDULUM_MJCF = `<?xml version="1.0" ?>
+<mujoco model="pendulum-with-tendon">
+  <option gravity="0 0 -9.81" timestep="0.001"/>
+  <compiler angle="radian"/>
+  <worldbody>
+    <site name="anchor" pos="0 0 0.05"/>
+    <body name="rod" pos="0 0 0">
+      <joint name="hinge" type="hinge" axis="0 1 0" pos="0 0 0"/>
+      <inertial pos="0.05 0 0" mass="0.1" fullinertia="0.000001 0.000833 0.000833 0 0 0"/>
+      <site name="tip" pos="0.05 0 0"/>
+    </body>
+  </worldbody>
+  <tendon>
+    <spatial name="spring" springlength="0.05" stiffness="50" damping="0.5">
+      <site site="anchor"/>
+      <site site="tip"/>
+    </spatial>
+  </tendon>
+</mujoco>
+`;
+
+describe('MuJoCo spatial tendon (P7 Task 0)', () => {
+    it('applies restoring force on a 1-DoF pendulum: equilibrium is non-vertical', async () => {
+        const session = await loadMujocoSession(
+            TENDON_PENDULUM_MJCF,
+            ['rod'],
+            [{ mjcfName: 'hinge', mateName: 'hinge' }],
+        );
+        try {
+            // Start at θ = 0 (rod horizontal along +X). With damping = 0.5 N·s/m
+            // and 5 seconds of simulated time the pendulum should settle.
+            session.setPose([0]);
+            session.forward();
+            const { qpos } = session.step(5.0, 0.001);
+            const theta = qpos[0];
+
+            // Pure gravity (no tendon) would settle at θ = -π/2 (rod hanging
+            // straight down -Z). The spring pulls the tip toward (0, 0, 0.05),
+            // i.e. UP, so with stiffness 50 N/m vs the rod's m·g·L/2 ≈ 0.05 N·m
+            // gravitational torque the spring dominates and equilibrium sits
+            // ABOVE horizontal — θ near +0.5 rad (~+28°). The qualitative
+            // confirmation is: tendon force is being applied (otherwise
+            // equilibrium would be -π/2). Assert strict non-vertical.
+            const collapsedDown = Math.abs(theta + Math.PI / 2) < 0.1;
+            expect(collapsedDown).toBe(false);
+            // And the rod stayed within ±π/2 of its initial θ=0 (no
+            // numerical blow-up).
+            expect(Math.abs(theta)).toBeLessThan(Math.PI / 2);
+        } finally {
+            session.dispose();
+        }
+    }, 60_000);
+
+    it('tendon length matches site-to-site distance after a forward call', async () => {
+        const session = await loadMujocoSession(
+            TENDON_PENDULUM_MJCF,
+            ['rod'],
+            [{ mjcfName: 'hinge', mateName: 'hinge' }],
+        );
+        try {
+            session.setPose([0]); // θ = 0 — tip at (0.05, 0, 0), anchor at (0, 0, 0.05)
+            session.forward();
+            // Expected tendon length = sqrt(0.05² + 0.05²) = 0.0707 m
+            const expectedLen = Math.hypot(0.05, 0.05);
+            // The session API doesn't expose ten_length directly; instead, we
+            // round-trip-read from the data buffer (loadMujocoSession returns
+            // a typed wrapper; the underlying MjData has a `ten_length` view).
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const data = (session as unknown as { data: any }).data;
+            const tenLen = data.ten_length;
+            expect(tenLen.length).toBe(1);
+            expect(Math.abs(tenLen[0] - expectedLen)).toBeLessThan(1e-6);
+        } finally {
+            session.dispose();
+        }
+    }, 60_000);
+});

--- a/src/modeling/validation/scene.ts
+++ b/src/modeling/validation/scene.ts
@@ -14,6 +14,7 @@ import type { Shape } from '../capture/proxy';
 import type { Connector } from '../mates/connector';
 import type { MateRecord } from '../mates/mate';
 import type { PoseEnvelopeDiagnostic } from '../mates/poseEnvelope';
+import type { TendonRecord } from '../mates/tendon';
 import type { ValidatorDiagnostic } from '../mates/validator';
 import type { Transform } from '../../shared/runtime/se3';
 import type { Vec3 } from '../../shared/intent/types';
@@ -76,6 +77,12 @@ export class Scene implements Iterable<ScenePart> {
    *  mates, omitted from the field set for parity with the optional
    *  `ScenePart.connectors` surface. */
   readonly mates?: readonly MateRecord[];
+  /** P7: closed-loop balance-spring records declared via
+   *  `arm.tendon(...)`. Undefined when none were declared. Surfaced for
+   *  the Studio's `TendonRenderer` and the MJCF physics-gate exporter.
+   *  Each tendon's endpoint connectors must exist on the part-side
+   *  `connectors` arrays surfaced above. */
+  readonly tendons?: readonly TendonRecord[];
   /** Validator diagnostics attached by `Assembly.solvedModel({validate: 'warn'})`
    *  (v0.6 Task 9). Populated from `validateAssemblyWithMates(arm)` when the
    *  gate is in `warn` mode; empty when validation is skipped (`mode: 'off'`)
@@ -104,6 +111,7 @@ export class Scene implements Iterable<ScenePart> {
     sourceFeatureId?: string,
     mates?: readonly MateRecord[],
     warnings?: readonly SceneDiagnostic[],
+    tendons?: readonly TendonRecord[],
   ) {
     this.assemblyName = assemblyName;
     this.parts = Object.freeze([...parts]);
@@ -112,6 +120,9 @@ export class Scene implements Iterable<ScenePart> {
     this._sourceFeatureId = sourceFeatureId;
     if (mates !== undefined && mates.length > 0) {
       this.mates = Object.freeze([...mates]);
+    }
+    if (tendons !== undefined && tendons.length > 0) {
+      this.tendons = Object.freeze([...tendons]);
     }
     // `warnings` is always present (possibly empty) — keep it a frozen array
     // so callers can `.some(...)` / iterate without a null-check. Inserted as

--- a/src/studio/components/demoPlayer/DemoPlayerPage.tsx
+++ b/src/studio/components/demoPlayer/DemoPlayerPage.tsx
@@ -906,7 +906,10 @@ export function DemoPlayerPage(): React.JSX.Element {
 
         let groupCount = 0;
         // Separate virtual referenceImage / renderEnvironment / cameraTarget
-        // records from geometry records.
+        // records from geometry records. Tendon FeatureMeshes carry a
+        // baked world-frame cylinder mesh emitted by `meshFeaturesPerFeature`
+        // (P7); they fall through to the geometry path and render as
+        // ordinary kCAD feature groups, so no separate routing here.
         const geometryFeatures: typeof perFeature = [];
         const referenceImageFeatures: typeof perFeature = [];
         let renderEnvSpec: RenderEnvironmentSpec | null = null;

--- a/src/studio/components/viewer/entities/TendonRenderer.tsx
+++ b/src/studio/components/viewer/entities/TendonRenderer.tsx
@@ -1,0 +1,91 @@
+// src/studio/components/viewer/entities/TendonRenderer.tsx
+//
+// P7 — Studio render for closed-loop balance-spring tendons declared
+// via `arm.tendon(...)`. Each tendon visualises as a thin dark-metallic
+// cylinder spanning its two endpoints. The endpoints' world positions
+// recompute on every recompute (the live FK per-part transforms feed in
+// from GeometryContext); the resulting cylinder visibly stretches /
+// contracts as the user drags joint pose sliders.
+//
+// Geometry pipeline:
+//   - A single `THREE.CylinderGeometry(1, 1, 1, 16)` (unit-radius +Y) is
+//     shared across all tendons.
+//   - Per-tendon: position / rotation / scale come from
+//     `tendonTransform`. `scale = (diameter/2, length, diameter/2)`.
+//   - Material: a shared MeshStandardMaterial picked to read as "iconic
+//     Anglepoise dark metallic spring". Matches the existing `mSpring`
+//     palette used by single-body decorative springs in v0.7 examples.
+
+import { useMemo } from 'react';
+import * as THREE from 'three';
+import { applyTransform, tendonTransform } from './tendonTransform';
+import type { Vec3 } from '../../../../shared/intent/types';
+
+/**
+ * Per-tendon descriptor passed to `TendonRenderer`. The Studio's
+ * recompute loop builds these from the live `Scene.tendons` field + the
+ * per-part FK transforms.
+ *
+ * `fromLocalMm` / `toLocalMm` are the connector origins in their owner
+ * part's LOCAL frame (mm). `fromTransform4x4` / `toTransform4x4` are
+ * the owner parts' world transforms (column-major 4×4); the renderer
+ * resolves the world-frame endpoint by `applyTransform(transform,
+ * localMm)`.
+ */
+export interface RenderableTendon {
+    readonly name: string;
+    readonly fromLocalMm: Vec3;
+    readonly toLocalMm: Vec3;
+    /** Column-major 4×4 transform from `from` part's local to world. */
+    readonly fromTransform4x4: readonly number[];
+    /** Column-major 4×4 transform from `to`   part's local to world. */
+    readonly toTransform4x4: readonly number[];
+    readonly visualDiameterMm: number;
+}
+
+interface TendonRendererProps {
+    tendons: readonly RenderableTendon[];
+}
+
+/**
+ * One Three.js Mesh per tendon, drawn under the existing parts in the
+ * Studio viewer. The shared geometry / material instances live for the
+ * lifetime of the Studio session (the component memoises both); per
+ * tendon, only the SE(3) attributes (position / rotation / scale) flow
+ * through React props.
+ */
+export function TendonRenderer({ tendons }: TendonRendererProps) {
+    const geometry = useMemo(() => new THREE.CylinderGeometry(1, 1, 1, 16), []);
+    const material = useMemo(
+        () => new THREE.MeshStandardMaterial({
+            color: 0x2a2e36,
+            metalness: 0.85,
+            roughness: 0.4,
+        }),
+        [],
+    );
+    return (
+        <>
+            {tendons.map((t) => {
+                const fromWorld = applyTransform(t.fromTransform4x4, t.fromLocalMm);
+                const toWorld = applyTransform(t.toTransform4x4, t.toLocalMm);
+                const { position, quaternion, scale } = tendonTransform(
+                    fromWorld,
+                    toWorld,
+                    t.visualDiameterMm,
+                );
+                return (
+                    <mesh
+                        key={t.name}
+                        geometry={geometry}
+                        material={material}
+                        position={position}
+                        quaternion={quaternion}
+                        scale={scale}
+                        userData={{ type: 'TENDON', name: t.name }}
+                    />
+                );
+            })}
+        </>
+    );
+}

--- a/src/studio/components/viewer/entities/tendonTransform.test.ts
+++ b/src/studio/components/viewer/entities/tendonTransform.test.ts
@@ -1,0 +1,110 @@
+// src/studio/components/viewer/entities/tendonTransform.test.ts
+//
+// P7 Task 3 smoke tests for the pure-geometry side of the Studio tendon
+// renderer. No R3F harness — exercises the transform math directly.
+
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { applyTransform, tendonTransform } from './tendonTransform';
+
+describe('tendonTransform', () => {
+    it('positions the cylinder midpoint between endpoints', () => {
+        const r = tendonTransform([0, 0, 0], [10, 0, 0], 3);
+        expect(r.position.x).toBeCloseTo(5);
+        expect(r.position.y).toBeCloseTo(0);
+        expect(r.position.z).toBeCloseTo(0);
+    });
+
+    it('scales the cylinder length to the endpoint distance', () => {
+        const r = tendonTransform([0, 0, 0], [0, 0, 30], 4);
+        expect(r.lengthMm).toBeCloseTo(30);
+        expect(r.scale.y).toBeCloseTo(30);
+    });
+
+    it('scales X/Z by half the visual diameter (so radius = diameter/2)', () => {
+        const r = tendonTransform([0, 0, 0], [10, 0, 0], 6);
+        expect(r.scale.x).toBeCloseTo(3);
+        expect(r.scale.z).toBeCloseTo(3);
+    });
+
+    it('rotates +Y to the endpoint→endpoint direction', () => {
+        // Endpoints along +X: the +Y axis of the cylinder should map to +X.
+        const r = tendonTransform([0, 0, 0], [10, 0, 0], 3);
+        const probe = new THREE.Vector3(0, 1, 0).applyQuaternion(r.quaternion);
+        expect(probe.x).toBeCloseTo(1);
+        expect(probe.y).toBeCloseTo(0);
+        expect(probe.z).toBeCloseTo(0);
+    });
+
+    it('rotates +Y to -Z (straight-down tendon)', () => {
+        const r = tendonTransform([0, 0, 10], [0, 0, 0], 3);
+        const probe = new THREE.Vector3(0, 1, 0).applyQuaternion(r.quaternion);
+        expect(probe.x).toBeCloseTo(0);
+        expect(probe.y).toBeCloseTo(0);
+        expect(probe.z).toBeCloseTo(-1);
+    });
+
+    it('handles zero-length tendon without throwing (degenerate case)', () => {
+        const r = tendonTransform([5, 5, 5], [5, 5, 5], 3);
+        expect(r.lengthMm).toBe(0);
+        expect(r.scale.y).toBe(0);
+        // Midpoint == both endpoints.
+        expect(r.position.x).toBeCloseTo(5);
+    });
+});
+
+describe('applyTransform', () => {
+    it('returns the input point when transform is identity', () => {
+        const identity = [
+            1, 0, 0, 0,
+            0, 1, 0, 0,
+            0, 0, 1, 0,
+            0, 0, 0, 1,
+        ];
+        const w = applyTransform(identity, [3, -7, 11]);
+        expect(w).toEqual([3, -7, 11]);
+    });
+
+    it('applies a pure translation (column-major)', () => {
+        const t = [
+            1, 0, 0, 0,
+            0, 1, 0, 0,
+            0, 0, 1, 0,
+            10, 20, 30, 1,
+        ];
+        const w = applyTransform(t, [1, 2, 3]);
+        expect(w[0]).toBeCloseTo(11);
+        expect(w[1]).toBeCloseTo(22);
+        expect(w[2]).toBeCloseTo(33);
+    });
+
+    it('applies a 90° rotation about Z (column-major)', () => {
+        // Column-major Rz(90°): [cos, sin, 0, 0,  -sin, cos, 0, 0,  0, 0, 1, 0,  0, 0, 0, 1]
+        //                       =   [0,   1,  0, 0,    -1,   0, 0, 0,  0, 0, 1, 0,  0, 0, 0, 1]
+        const rz90 = [
+            0, 1, 0, 0,
+            -1, 0, 0, 0,
+            0, 0, 1, 0,
+            0, 0, 0, 1,
+        ];
+        const w = applyTransform(rz90, [1, 0, 0]);
+        // [1, 0, 0] rotated 90° about +Z → [0, 1, 0].
+        expect(w[0]).toBeCloseTo(0);
+        expect(w[1]).toBeCloseTo(1);
+        expect(w[2]).toBeCloseTo(0);
+    });
+
+    it('composes rotation + translation', () => {
+        const t = [
+            0, 1, 0, 0,
+            -1, 0, 0, 0,
+            0, 0, 1, 0,
+            5, 5, 0, 1,
+        ];
+        const w = applyTransform(t, [1, 0, 0]);
+        // Rotated: (0, 1, 0); translated: (5, 6, 0)
+        expect(w[0]).toBeCloseTo(5);
+        expect(w[1]).toBeCloseTo(6);
+        expect(w[2]).toBeCloseTo(0);
+    });
+});

--- a/src/studio/components/viewer/entities/tendonTransform.ts
+++ b/src/studio/components/viewer/entities/tendonTransform.ts
@@ -1,0 +1,90 @@
+// src/studio/components/viewer/entities/tendonTransform.ts
+//
+// P7 — pure geometry for the Studio tendon renderer. Given two
+// world-frame endpoints, compute the transform that places a unit-tall
+// `CylinderGeometry` (+Y aligned) so it spans from `from` to `to`. The
+// renderer wraps this with a React-three component (`TendonRenderer.tsx`)
+// that reads endpoints from the per-part FK transforms exposed by
+// GeometryContext; this module's interfaces stay framework-agnostic so
+// the unit test below runs without an R3F harness.
+
+import * as THREE from 'three';
+import type { Vec3 } from '../../../../shared/intent/types';
+
+/**
+ * Result of `tendonTransform`. The caller assigns these onto a
+ * `THREE.Mesh` (or React-three's equivalent props) to place a
+ * unit-length +Y cylinder spanning the two endpoints.
+ */
+export interface TendonMeshTransform {
+    /** Cylinder midpoint, world frame. */
+    readonly position: THREE.Vector3;
+    /** Rotation from +Y to (to − from)/‖to − from‖. */
+    readonly quaternion: THREE.Quaternion;
+    /**
+     * Scale the unit cylinder by:
+     *   - x, z: visualDiameter (the radii input is unit; scale stretches it)
+     *   - y:    endpoint-to-endpoint distance
+     */
+    readonly scale: THREE.Vector3;
+    /** Endpoint distance in world units (mm), surfaced for diagnostics. */
+    readonly lengthMm: number;
+}
+
+const Y_AXIS = new THREE.Vector3(0, 1, 0);
+
+/**
+ * Compute the transform for a tendon cylinder spanning `fromWorld` →
+ * `toWorld`. The base geometry is assumed to be `CylinderGeometry(1, 1,
+ * 1, 16)` — a unit-radius, unit-tall cylinder along +Y.
+ *
+ * Degenerate cases:
+ *   - Zero-length tendon (from == to): scale.y = 0; the cylinder
+ *     collapses to a disc. The renderer can choose to skip-render or
+ *     accept the degenerate mesh; we don't throw because tendons are
+ *     visualisation, not semantics.
+ *   - Endpoints colinear with -Y (pointing straight down): the standard
+ *     `setFromUnitVectors` returns a 180° rotation; we use the X axis
+ *     as the rotation pivot.
+ */
+export function tendonTransform(
+    fromWorld: Vec3,
+    toWorld: Vec3,
+    visualDiameterMm: number,
+): TendonMeshTransform {
+    const from = new THREE.Vector3(fromWorld[0], fromWorld[1], fromWorld[2]);
+    const to = new THREE.Vector3(toWorld[0], toWorld[1], toWorld[2]);
+    const delta = new THREE.Vector3().subVectors(to, from);
+    const lengthMm = delta.length();
+    const midpoint = new THREE.Vector3().addVectors(from, to).multiplyScalar(0.5);
+    const quaternion = new THREE.Quaternion();
+    if (lengthMm > 0) {
+        const dir = delta.clone().multiplyScalar(1 / lengthMm);
+        quaternion.setFromUnitVectors(Y_AXIS, dir);
+    }
+    // Cylinder is unit-radius (R=1) on X/Z; scaling by half-diameter
+    // makes it match the requested visual diameter exactly.
+    const radiusScale = visualDiameterMm / 2;
+    const scale = new THREE.Vector3(radiusScale, lengthMm, radiusScale);
+    return { position: midpoint, quaternion, scale, lengthMm };
+}
+
+/**
+ * Apply a per-part world transform (column-major 4×4) to a point in
+ * that part's local frame. Used to map the connector's local-mm origin
+ * to its current world-mm position under FK.
+ *
+ * `transform4x4` is the same shape as `GeometryResult.transform`
+ * (column-major, length 16). Returns a Vec3 in world coordinates (mm).
+ */
+export function applyTransform(transform4x4: readonly number[], local: Vec3): Vec3 {
+    const m = transform4x4;
+    // column-major: m[0..3] = col0, m[4..7] = col1, m[8..11] = col2, m[12..15] = col3.
+    const lx = local[0];
+    const ly = local[1];
+    const lz = local[2];
+    const wx = m[0] * lx + m[4] * ly + m[8] * lz + m[12];
+    const wy = m[1] * lx + m[5] * ly + m[9] * lz + m[13];
+    const wz = m[2] * lx + m[6] * ly + m[10] * lz + m[14];
+    return [wx, wy, wz];
+}


### PR DESCRIPTION
## Summary

Introduces the closed-loop tendon primitive — a 2-anchor element that produces a length-dependent restoring force — as kernel infrastructure. No example uses it yet; this PR is API only.

What ships:

- `assembly.tendon(name, { from, to, restLengthMm, stiffnessNmm, dampingNsmm, visualDiameterMm? })` capture API + `__tendons()` accessor
- MJCF export: each tendon emits `<site>` on each part + `<tendon><spatial>` with the right MuJoCo units (mm → m, N/mm × 1000 → N/m)
- Studio renders tendons as live cylinders that follow the part transforms under joint motion
- Headless CLI render bakes tendon cylinders into the rgb channels of `kernelcad render inspect` (was previously Studio-only)
- Round-trip smoke test: a 1-DoF pendulum with one tendon produces the expected MuJoCo force at simulation start

What's NOT in this PR:

- Luxo lamp tendon usage. The original P7 attempt put tendon anchors at heights tuned for the pre-P9 column / head-neck geometry; P9 substantially reshaped both surfaces. Re-applying tendons to the post-P9 Luxo cleanly is a separate workstream (P10) — needs a new base-side spring connector, posts at both ends of the upper-arm, and physics re-calibration.
- The P6 Luxo drop-test stays skipped (#361 remains open) until P10 lands a proper tendon-anchored lamp.

## Commits

1. `4d3c890b` task 0 — MuJoCo spatial tendon force verified on a 1-DoF pendulum (sanity gate)
2. `b9c1a024` task 1 — `Assembly.tendon(...)` capture API
3. `0d86d362` task 2 — MJCF site + spatial tendon emission
4. `1d0a2d5c` task 3 — Studio Three.js tendon renderer
5. `1712aafc` followup — CLI headless render hook (mesh baking)

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (15 pre-existing warnings in unrelated files)
- Tendon API tests: 31/31 pass (`tendon.test.ts`, `mujocoTendon.test.ts`, `mjcfExport.test.ts`, `tendonTransform.test.ts`)
- Luxo integration unchanged (still passes the criterion-7 joint-mesh-continuity gate from #367)

Closes the API piece of #365; supersedes the now-closed #365.