### PR TITLE
P11 Slice 1 — emit collision geom from BREP into MJCF

### DIFF
--- a/src/modeling/runtime/mjcfExport.test.ts
+++ b/src/modeling/runtime/mjcfExport.test.ts
@@ -115,6 +115,38 @@ describe('assemblyToMjcf', () => {
         const bodyOpenCount = (mjcf.match(/<body /g) ?? []).length;
         expect(bodyOpenCount).toBe(2);
 
+        // P11 Slice 1: every part contributes one `<asset><mesh>` and one
+        // `<geom type="mesh">`. Two parts → two of each.
+        const meshAssetCount = (mjcf.match(/<mesh name="part-/g) ?? []).length;
+        expect(meshAssetCount).toBe(2);
+        const geomMeshCount = (mjcf.match(/<geom type="mesh"/g) ?? []).length;
+        expect(geomMeshCount).toBe(2);
+        // P11 Slice 1: the inline mesh vertex stream is in millimetres,
+        // but the rest of the MJCF (body `pos`, `<inertial>`, gravity) is
+        // in metres. Every `<mesh>` MUST carry `scale="0.001 0.001 0.001"`
+        // so MuJoCo rescales the hull into its metre world — without it
+        // the collision geometry is 1000× oversized and explodes the
+        // drop-test. Guards the unit regression directly.
+        const scaledMeshCount = (
+            mjcf.match(/<mesh name="part-[^"]*" scale="0\.001 0\.001 0\.001"/g) ?? []
+        ).length;
+        expect(scaledMeshCount).toBe(2);
+        // Asset references match their declared assets — `<geom mesh="part-arm">`
+        // and `<geom mesh="part-spring">` are both present.
+        expect(mjcf).toMatch(/<geom type="mesh" mesh="part-arm"/);
+        expect(mjcf).toMatch(/<geom type="mesh" mesh="part-spring"/);
+        // `<size nconmax>` is set so MuJoCo doesn't overflow contact storage
+        // on tighter assemblies than this 2-body fixture.
+        expect(mjcf).toMatch(/<size nconmax="500"\/>/);
+        // P11 Slice 1: every mate emits one `<contact><exclude>` line so
+        // the joint-anchor mesh overlap doesn't generate spurious
+        // contact forces. This fixture has one mate; expect one
+        // exclude. Body-name order matches `parseConnectorRef(mate.a)`
+        // (parent) then `(mate.b)` (child).
+        expect(mjcf).toMatch(/<contact>/);
+        const excludeCount = (mjcf.match(/<exclude /g) ?? []).length;
+        expect(excludeCount).toBe(1);
+
         // Parse — qpos should be empty (no joints).
         const mujoco = (await loadMujocoInNode()) as {
             MjModel: { from_xml_string: (s: string) => unknown };

--- a/src/modeling/runtime/mjcfExport.ts
+++ b/src/modeling/runtime/mjcfExport.ts
@@ -62,6 +62,7 @@ import { resolveConnectorOrigin } from '../mates/connector';
 import type { TendonRecord } from '../mates/tendon';
 import type { OcctBackend } from '../../kernel/backends/occt/occtBackend';
 import type { Vec3 } from '../../shared/intent/types';
+import { stlToMjcfMesh } from './stlToMjcfMesh';
 
 const MM_TO_M = 1e-3;
 const DEG_TO_RAD = Math.PI / 180;
@@ -150,14 +151,24 @@ export async function assemblyToMjcf(arm: Assembly): Promise<MjcfExportResult> {
     // becomes a top-level child of <worldbody>.
     const roots = parts.filter((p) => !parentByChild.has(p.name));
 
-    // Compute per-part inertia + bbox center once. The bbox center is
+    // Compute per-part inertia + collision mesh once. The bbox center is
     // used to position the inertial origin when massProperties is
     // unavailable (e.g. transformed-by-FK shapes). Mass / inertia from
     // OcctBackend.massProperties; the URDF emitter shows the pattern.
+    //
+    // P11 Slice 1: also lower the part to its OCCT backend and pull a
+    // binary-STL tessellation, formatted as an inline `<mesh vertex="...">`
+    // string. Reuses `OcctBackend.exportSTLAsync()` (the same emitter the
+    // URDF writer feeds into per-link STL files) so collision geom and
+    // visual mesh stay byte-identical. Mesh-emission failures fall back
+    // to "inertia only" with no geom — the part stays in the kinematic
+    // tree but can't contact other bodies; criterion 6 will reflect that.
     const inertials = new Map<string, InertiaSpec>();
+    const collisionMeshes = new Map<string, { vertex: string; assetName: string }>();
     for (const p of parts) {
+        let lowered: OcctBackend | undefined;
         try {
-            const lowered = (await p.originalShape.lower()) as OcctBackend;
+            lowered = (await p.originalShape.lower()) as OcctBackend;
             const density = p.density ?? DEFAULT_DENSITY_KG_M3;
             const mp = lowered.massProperties(density);
             // Diagonal inertia in MuJoCo's body frame; for our default
@@ -178,6 +189,20 @@ export async function assemblyToMjcf(arm: Assembly): Promise<MjcfExportResult> {
                 comLocalMm: [0, 0, 0],
                 inertia6: [1e-3, 0, 0, 1e-3, 0, 1e-3],
             });
+        }
+        if (lowered !== undefined) {
+            try {
+                const stl = await lowered.exportSTLAsync();
+                const mesh = stlToMjcfMesh(stl);
+                collisionMeshes.set(p.name, {
+                    vertex: mesh.vertex,
+                    assetName: mjcfMeshAssetName(p.name),
+                });
+            } catch {
+                // STL export or parse failed (degenerate shape, empty
+                // tessellation, etc.). Skip the `<asset><mesh>` for this
+                // part — the body still emits inertia but won't contact.
+            }
         }
     }
 
@@ -325,11 +350,21 @@ export async function assemblyToMjcf(arm: Assembly): Promise<MjcfExportResult> {
             );
         }
 
-        // Geometry — we don't emit visual meshes; the physics gate only
-        // needs inertia + joint topology. Adding meshes would require
-        // exporting STL per-part on every validate call (heavy). MuJoCo
-        // is fine with bodies that have only <inertial> (no <geom>):
-        // they participate in joint dynamics, just don't collide.
+        // P11 Slice 1: collision geom from the part's tessellated BREP.
+        // Without `<geom>`, MuJoCo treats every body as a point-mass with
+        // joint constraints — drop-tests "pass" on geometry that
+        // physically interpenetrates. We register one mesh under
+        // `<asset>` per part (above) and reference it here with
+        // `contype="1" conaffinity="1"` so part-pair contacts are active.
+        // Friction triple matches MuJoCo's default for general body
+        // contacts (sliding, torsional, rolling) — sufficient for
+        // static-equilibrium and drop-test scoring.
+        const collision = collisionMeshes.get(partName);
+        if (collision !== undefined) {
+            lines.push(
+                `${indent}  <geom type="mesh" mesh="${escapeXml(collision.assetName)}" contype="1" conaffinity="1" group="1" friction="1.0 0.005 0.0001"/>`,
+            );
+        }
 
         // Children — recurse.
         for (const childEntry of childrenByParent.get(partName) ?? []) {
@@ -371,15 +406,75 @@ export async function assemblyToMjcf(arm: Assembly): Promise<MjcfExportResult> {
         tendonBlockLines.push('  </tendon>');
     }
 
+    // P11 Slice 1: emit the `<asset>` block before `<worldbody>`. MJCF
+    // requires asset definitions ahead of every body that references
+    // them. One `<mesh>` per part that successfully exported STL;
+    // bodies whose mesh emission failed simply skip both the asset and
+    // the `<geom>` (they remain valid MuJoCo bodies, just inertia-only
+    // — the criterion 6 drop-test still observes their joint dynamics).
+    const assetBlockLines: string[] = [];
+    if (collisionMeshes.size > 0) {
+        assetBlockLines.push('  <asset>');
+        // Preserve part-declaration order so the snapshot is deterministic.
+        for (const p of parts) {
+            const m = collisionMeshes.get(p.name);
+            if (m === undefined) continue;
+            // `scale` converts the mm vertex stream to MuJoCo's metre
+            // world. The rest of the MJCF (body `pos`, `<inertial>`,
+            // gravity, the drop-test drift thresholds) is in metres via
+            // MM_TO_M; the inline mesh vertices are the one payload still
+            // in millimetres, so MuJoCo must rescale them at compile time.
+            // Without this the collision hull is 1000× oversized and every
+            // part interpenetrates the origin, exploding the drop-test.
+            assetBlockLines.push(
+                `    <mesh name="${escapeXml(m.assetName)}" scale="${MM_TO_M} ${MM_TO_M} ${MM_TO_M}" vertex="${m.vertex}"/>`,
+            );
+        }
+        assetBlockLines.push('  </asset>');
+    }
+
+    // P11 Slice 1: emit a `<contact><exclude>` block for every mate's
+    // parent-child pair. A clevis fork-and-tongue pair (and every other
+    // joint primitive that nests one body inside another) is
+    // intentionally interpenetrating at the joint anchor — the
+    // constraint comes from the joint, not from contact. Without the
+    // exclude, MuJoCo treats the BREP overlap at every clevis as a deep
+    // penetration and applies enormous repulsive forces that kick the
+    // chain apart on the first integration step. The standard MJCF
+    // robotics idiom (see mujoco_menagerie + every Anglepoise/cable
+    // demo) is one `<exclude>` per kinematic-tree edge. Non-adjacent
+    // body pairs keep their default contact, so the genuine "free
+    // body falls onto another" failure modes Slice 1 was built to
+    // catch are still detectable.
+    const contactBlockLines: string[] = [];
+    if (mates.length > 0) {
+        contactBlockLines.push('  <contact>');
+        for (const m of mates) {
+            const aName = parseConnectorRef(m.a).partName;
+            const bName = parseConnectorRef(m.b).partName;
+            contactBlockLines.push(
+                `    <exclude body1="${escapeXml(aName)}" body2="${escapeXml(bName)}"/>`,
+            );
+        }
+        contactBlockLines.push('  </contact>');
+    }
+
+    // P11 Slice 1: `<size nconmax="500"/>` gives MuJoCo headroom for
+    // contact storage. Default is small (~100) and runs out on tight
+    // multi-part assemblies; 500 absorbs the v0.7 corpus without bumping
+    // wasm heap pressure noticeably.
     const mjcf = [
         '<?xml version="1.0" ?>',
         `<mujoco model="${escapeXml(arm.name)}">`,
         '  <option gravity="0 0 -9.81"/>',
         '  <compiler angle="radian"/>',
+        '  <size nconmax="500"/>',
+        ...assetBlockLines,
         '  <worldbody>',
         ...worldbodyBlocks,
         '  </worldbody>',
         ...tendonBlockLines,
+        ...contactBlockLines,
         '</mujoco>',
         '',
     ].join('\n');
@@ -480,6 +575,21 @@ function sanitizeJointName(s: string): string {
     // is to keep names matching the kernelCAD mate name verbatim. No
     // sanitisation needed beyond XML escaping.
     return s;
+}
+
+/**
+ * Slugified per-part mesh asset name. MJCF mesh names must be unique
+ * inside `<asset>`; we slug the kernelCAD part name into a stable
+ * `part-<slug>` form so `<geom mesh="...">` references stay readable
+ * in diagnostic output. Run-collapses non-alphanumeric chars to single
+ * '-' separators; leading/trailing separators are trimmed.
+ */
+function mjcfMeshAssetName(partName: string): string {
+    const slug = partName
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+    return `part-${slug.length > 0 ? slug : 'unnamed'}`;
 }
 
 function fmtNum(n: number): string {

--- a/src/modeling/runtime/mjcfPhysicsContacts.test.ts
+++ b/src/modeling/runtime/mjcfPhysicsContacts.test.ts
@@ -1,0 +1,168 @@
+// src/modeling/runtime/mjcfPhysicsContacts.test.ts
+//
+// P11 Slice 1 proof-of-life test: two interpenetrating cubes, hinged so
+// MuJoCo treats them as a single connected tree, must produce `ncon > 0`
+// contacts at rest pose. Before Slice 1, MJCF emitted `<inertial>` only
+// and MuJoCo reported `ncon === 0` regardless of overlap — drop-tests
+// "passed" on geometry that physically intersected. This test fails the
+// moment collision-mesh emission regresses.
+//
+// Spec:  docs/specs/2026-06-03-physics-loop-P11-collision-aware-mujoco.md
+// Plan:  docs/plans/2026-06-03-physics-loop-P11-slice-1-collision-geom-emission.md
+
+import { describe, expect, it } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { CaptureSession } from '../capture/captureSession';
+import { createApi } from '../api';
+import { initOcct } from '../../kernel/backends/occt/occtBackend';
+import { assemblyToMjcf } from './mjcfExport';
+
+const require_ = createRequire(import.meta.url);
+
+async function loadMujocoInNode(): Promise<unknown> {
+    const pkgEntry = require_.resolve('@mujoco/mujoco');
+    const pkgDir = dirname(pkgEntry);
+    const wasmBinary = await readFile(join(pkgDir, 'mujoco.wasm'));
+    const loadMujoco = (await import('@mujoco/mujoco')).default;
+    return await loadMujoco({
+        wasmBinary,
+        locateFile: (path: string) => join(pkgDir, path),
+        print: () => undefined,
+        printErr: () => undefined,
+    });
+}
+
+describe('P11 Slice 1 — MuJoCo sees collision contacts on non-adjacent interpenetrating bodies', () => {
+    it('three-body chain with A↔C overlap reports ncon > 0; joint-adjacent A↔B and B↔C excluded', async () => {
+        // Build a three-cube chain A — hinge — B — hinge — C where:
+        //   - A and B are joint-adjacent (one revolute mate)
+        //   - B and C are joint-adjacent (one revolute mate)
+        //   - A and C are NOT directly mated. C is folded back so its
+        //     mesh overlaps A — the genuine "two unconnected bodies
+        //     interpenetrate" case that Slice 1's collision emission
+        //     must detect.
+        //
+        // Adjacent-pair contact (A↔B, B↔C) is excluded via the
+        // `<contact><exclude>` block — that's the standard MJCF
+        // robotics idiom for kinematic chains, without which clevis
+        // fork-tongue overlaps generate enormous spurious contact
+        // forces and kick the simulation apart on the first integrator
+        // step. The interpenetration we DO want flagged is A↔C, which
+        // stays in MuJoCo's contact set and produces `ncon > 0`.
+        await initOcct();
+        const session = new CaptureSession();
+        const kcad = createApi({ session });
+        const arm = kcad.assembly('three-cube-chain');
+
+        // Three 40 mm cubes. Hinges chain them along +X; the second
+        // hinge's pose folds C back toward A so the two cubes
+        // physically share a slab of geometry.
+        const cubeA = kcad.box(40, 40, 40, true);
+        const cubeB = kcad.box(40, 40, 40, true);
+        const cubeC = kcad.box(40, 40, 40, true);
+        const jAB = kcad.joint.clevis({
+            parentBody: cubeA,
+            childBody: cubeB,
+            axis: 'Y',
+            pivotParent: [20, 0, 0],
+            pivotChild: [-20, 0, 0],
+            limitsDeg: [-180, 180],
+        });
+        const jBC = kcad.joint.clevis({
+            parentBody: jAB.childGeometry,
+            childBody: cubeC,
+            axis: 'Y',
+            pivotParent: [20, 0, 0],
+            pivotChild: [-20, 0, 0],
+            limitsDeg: [-180, 180],
+        });
+        arm.part('a', jAB.parentGeometry).connector('hingeAB', {
+            type: 'axis',
+            origin: { kind: 'vec3', value: jAB.parentConnector.origin },
+            axis: jAB.parentConnector.axis,
+        });
+        arm.part('b', jBC.parentGeometry)
+            .connector('hingeAB', {
+                type: 'axis',
+                origin: { kind: 'vec3', value: jAB.childConnector.origin },
+                axis: jAB.childConnector.axis,
+            })
+            .connector('hingeBC', {
+                type: 'axis',
+                origin: { kind: 'vec3', value: jBC.parentConnector.origin },
+                axis: jBC.parentConnector.axis,
+            });
+        arm.part('c', jBC.childGeometry).connector('hingeBC', {
+            type: 'axis',
+            origin: { kind: 'vec3', value: jBC.childConnector.origin },
+            axis: jBC.childConnector.axis,
+        });
+        // Pose: AB hinge straight (0°), BC hinge folded back 180°.
+        // Result in world frame: A at x≈0, B at x≈40, C folded back to
+        // x≈0 — A and C cubes overlap deeply.
+        arm.mate('hingeAB', 'a.hingeAB', 'b.hingeAB', 'revolute', {
+            pose: 0,
+            limitsDeg: [-180, 180],
+        });
+        arm.mate('hingeBC', 'b.hingeBC', 'c.hingeBC', 'revolute', {
+            pose: 180,
+            limitsDeg: [-180, 180],
+        });
+
+        const { mjcf } = await assemblyToMjcf(arm);
+
+        // Sanity-check the MJCF carries the collision surface and the
+        // canonical robotics-MJCF `<contact><exclude>` block.
+        expect(mjcf).toMatch(/<asset>/);
+        expect(mjcf).toMatch(/<mesh name="part-a"/);
+        expect(mjcf).toMatch(/<mesh name="part-b"/);
+        expect(mjcf).toMatch(/<mesh name="part-c"/);
+        expect(mjcf).toMatch(/<geom type="mesh" mesh="part-a"/);
+        expect(mjcf).toMatch(/<geom type="mesh" mesh="part-b"/);
+        expect(mjcf).toMatch(/<geom type="mesh" mesh="part-c"/);
+        expect(mjcf).toMatch(/<contact>/);
+        expect(mjcf).toMatch(/<exclude body1="a" body2="b"\/>/);
+        expect(mjcf).toMatch(/<exclude body1="b" body2="c"\/>/);
+        // A↔C must NOT be excluded — that's the pair we want flagged.
+        expect(mjcf).not.toMatch(/<exclude body1="a" body2="c"\/>/);
+
+        // The mesh vertex stream is in millimetres; the emitter tags
+        // every `<mesh>` with `scale="0.001 0.001 0.001"` so MuJoCo
+        // rescales it into its metre world. Assert the scale is present —
+        // without it the collision hull is 1000× oversized.
+        expect(mjcf).toMatch(/<mesh name="part-a" scale="0\.001 0\.001 0\.001"/);
+
+        // Parse through MuJoCo and check contact count at rest pose.
+        const mujoco = (await loadMujocoInNode()) as {
+            MjModel: { from_xml_string: (s: string) => unknown };
+            MjData: new (m: unknown) => unknown;
+            mj_forward: (m: unknown, d: unknown) => void;
+        };
+        const model = mujoco.MjModel.from_xml_string(mjcf);
+        const data = new mujoco.MjData(model);
+        try {
+            mujoco.mj_forward(model, data);
+            const ncon = Number((data as { ncon: number }).ncon);
+            expect(ncon).toBeGreaterThan(0);
+
+            // Penetration-depth sanity: the two 40 mm cubes overlap by at
+            // most their own ~0.04 m extent, so every contact distance must
+            // be physically bounded. A mm/metre unit slip would make the
+            // hull 1000× oversized and report penetrations of tens of
+            // METRES — this bound catches that regression even though
+            // `ncon > 0` alone does not (the oversized cubes overlap too).
+            const contacts = (data as {
+                contact: { get: (i: number) => { dist: number } };
+            }).contact;
+            for (let i = 0; i < ncon; i++) {
+                expect(Math.abs(contacts.get(i).dist)).toBeLessThan(0.1);
+            }
+        } finally {
+            (data as { delete: () => void }).delete();
+            (model as { delete: () => void }).delete();
+        }
+    }, 60000);
+
+});

--- a/src/modeling/runtime/stlToMjcfMesh.test.ts
+++ b/src/modeling/runtime/stlToMjcfMesh.test.ts
@@ -1,0 +1,89 @@
+// src/modeling/runtime/stlToMjcfMesh.test.ts
+//
+// Unit tests for the binary-STL → MJCF vertex-string formatter. Round-
+// trips known geometry: two-triangle quad → exact vertex string;
+// cube STL (12 triangles) → 8 unique vertices.
+//
+// Spec:  docs/specs/2026-06-03-physics-loop-P11-collision-aware-mujoco.md
+// Plan:  docs/plans/2026-06-03-physics-loop-P11-slice-1-collision-geom-emission.md
+
+import { describe, expect, it } from 'vitest';
+import { encodeBinaryStl } from '../../kernel/backends/occt/exportStlBinary';
+import { stlToMjcfMesh } from './stlToMjcfMesh';
+
+describe('stlToMjcfMesh', () => {
+    it('parses two known triangles into the expected vertex string', () => {
+        // Two triangles sharing an edge — forms a unit square on z=0.
+        //   v0 = (0,0,0)  v1 = (1,0,0)  v2 = (0,1,0)  v3 = (1,1,0)
+        // Triangles: (v0,v1,v2), (v1,v3,v2). Shared verts after dedup: 4.
+        const vertices = [0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0];
+        const triangles = [0, 1, 2, 1, 3, 2];
+        const stl = encodeBinaryStl({ vertices, triangles });
+        const { vertex, triangleCount, vertexCount } = stlToMjcfMesh(
+            Uint8Array.from(stl),
+        );
+        expect(triangleCount).toBe(2);
+        expect(vertexCount).toBe(4);
+        // The 4 unique vertices, in first-seen order from the triangle stream:
+        //   (0,0,0), (1,0,0), (0,1,0), (1,1,0).
+        expect(vertex).toBe(
+            '0.0000 0.0000 0.0000 1.0000 0.0000 0.0000 0.0000 1.0000 0.0000 1.0000 1.0000 0.0000',
+        );
+    });
+
+    it('dedups a cube STL (12 triangles, 36 raw verts) to 8 unique vertices', () => {
+        // Hand-built unit cube vertex / index list (size 2 along each axis,
+        // centred at origin so coordinates are ±1).
+        const cubeVertices = [
+            -1, -1, -1, // 0
+             1, -1, -1, // 1
+             1,  1, -1, // 2
+            -1,  1, -1, // 3
+            -1, -1,  1, // 4
+             1, -1,  1, // 5
+             1,  1,  1, // 6
+            -1,  1,  1, // 7
+        ];
+        // 12 triangles, 2 per face.
+        const cubeTriangles = [
+            // -Z bottom
+            0, 2, 1,  0, 3, 2,
+            // +Z top
+            4, 5, 6,  4, 6, 7,
+            // -Y front
+            0, 1, 5,  0, 5, 4,
+            // +Y back
+            2, 3, 7,  2, 7, 6,
+            // -X left
+            0, 4, 7,  0, 7, 3,
+            // +X right
+            1, 2, 6,  1, 6, 5,
+        ];
+        const stl = encodeBinaryStl({
+            vertices: cubeVertices,
+            triangles: cubeTriangles,
+        });
+        const { triangleCount, vertexCount } = stlToMjcfMesh(Uint8Array.from(stl));
+        expect(triangleCount).toBe(12);
+        expect(vertexCount).toBe(8); // cube has exactly 8 unique corners
+    });
+
+    it('throws on zero-triangle STL (a part with no collision geometry can\'t contact)', () => {
+        const empty = encodeBinaryStl({ vertices: [], triangles: [] });
+        expect(() => stlToMjcfMesh(Uint8Array.from(empty))).toThrow(/zero triangles/);
+    });
+
+    it('throws on truncated input (below the 84-byte header threshold)', () => {
+        const tiny = new Uint8Array(40);
+        expect(() => stlToMjcfMesh(tiny)).toThrow(/too short/);
+    });
+
+    it('throws when declared triangle count would overrun the buffer', () => {
+        const buf = new Uint8Array(HEADER_PLUS_COUNT);
+        // Write triangleCount = 1000 but provide no triangle records.
+        new DataView(buf.buffer).setUint32(80, 1000, true);
+        expect(() => stlToMjcfMesh(buf)).toThrow(/would require/);
+    });
+});
+
+const HEADER_PLUS_COUNT = 84;

--- a/src/modeling/runtime/stlToMjcfMesh.ts
+++ b/src/modeling/runtime/stlToMjcfMesh.ts
@@ -1,0 +1,118 @@
+// src/modeling/runtime/stlToMjcfMesh.ts
+//
+// Binary STL → MJCF `<mesh vertex="...">` formatter for the P11 collision-
+// aware MuJoCo gate. Parses the binary STL record stream that
+// `OcctBackend.exportSTLAsync()` produces, deduplicates vertices, and
+// emits the space-separated `x y z x y z ...` string MJCF accepts inline
+// inside `<asset><mesh vertex="..."/>`.
+//
+// Why inline rather than FS-mounted STL files: MuJoCo's wasm runtime can
+// read meshes off Emscripten's virtual FS, but it adds a sync FS-write
+// step on every `validate` invocation. Kinematic-part meshes are small
+// (the Luxo lamp tops out at ~1k triangles per part); a 7-part assembly
+// inlines to ~150 KB of XML — fine for the gate, no temp-file lifecycle
+// to manage.
+//
+// Spec:  docs/specs/2026-06-03-physics-loop-P11-collision-aware-mujoco.md
+// Plan:  docs/plans/2026-06-03-physics-loop-P11-slice-1-collision-geom-emission.md
+
+const HEADER_SIZE = 80;
+const TRIANGLE_COUNT_SIZE = 4;
+const TRIANGLE_RECORD_SIZE = 50; // 12 (normal) + 36 (3 vertices) + 2 (attribute)
+
+export interface MjcfMeshData {
+    /** Space-separated triplets, mm. Order: `v1x v1y v1z v2x v2y v2z ...`. */
+    readonly vertex: string;
+    /** Triangle count (matches the binary-STL header field). */
+    readonly triangleCount: number;
+    /** Unique vertex count after dedup. */
+    readonly vertexCount: number;
+}
+
+/**
+ * Parse a binary STL byte array into a deduplicated vertex list and
+ * format it as MJCF's `<mesh vertex="...">` attribute string.
+ *
+ * - Normals are skipped; MuJoCo recomputes them per face at compile time.
+ * - Vertices are deduplicated via a quantised-key map so a watertight
+ *   cube (12 triangles, 36 raw vertex records) collapses to 8 unique
+ *   `<mesh>` vertices. Dedup cuts XML size ~3× on typical OCCT export
+ *   tessellations.
+ * - Coordinate values stay in millimetres. `mjcfExport.ts` emits the
+ *   `<mesh>` with `scale="0.001 0.001 0.001"` so MuJoCo rescales the
+ *   vertex stream into its metre world at compile time — matching the
+ *   mm→m conversion already applied to body `pos` / `<inertial>`.
+ *
+ * Throws if the input is shorter than the binary-STL header or if the
+ * declared triangle count would overrun the buffer — both are
+ * serializer bugs upstream, not user-visible errors. Empty meshes
+ * (`triangleCount === 0`) also throw: a part with no collision geometry
+ * cannot participate in MuJoCo contact resolution.
+ */
+export function stlToMjcfMesh(stlBytes: Uint8Array): MjcfMeshData {
+    if (stlBytes.byteLength < HEADER_SIZE + TRIANGLE_COUNT_SIZE) {
+        throw new Error(
+            `stlToMjcfMesh: input too short (${stlBytes.byteLength} bytes) — expected at least ${HEADER_SIZE + TRIANGLE_COUNT_SIZE} for the binary-STL header.`,
+        );
+    }
+    const view = new DataView(
+        stlBytes.buffer,
+        stlBytes.byteOffset,
+        stlBytes.byteLength,
+    );
+    const triangleCount = view.getUint32(HEADER_SIZE, true);
+    const expectedSize =
+        HEADER_SIZE + TRIANGLE_COUNT_SIZE + triangleCount * TRIANGLE_RECORD_SIZE;
+    if (stlBytes.byteLength < expectedSize) {
+        throw new Error(
+            `stlToMjcfMesh: declared triangle count ${triangleCount} would require ${expectedSize} bytes, but input is only ${stlBytes.byteLength}.`,
+        );
+    }
+    if (triangleCount === 0) {
+        throw new Error(
+            'stlToMjcfMesh: STL has zero triangles — a part with no collision geometry cannot participate in MuJoCo contact resolution.',
+        );
+    }
+
+    // Dedup vertices via a quantised key. OCCT's binary STL records each
+    // triangle's three vertices independently, so a watertight mesh has
+    // 3× duplication. The quantisation (1e-4 mm) is well below
+    // export-STL tessellation noise but tight enough to keep adjacent
+    // faces sharing one vertex.
+    const uniqueCoords: number[] = []; // flat x,y,z,x,y,z,...
+    const indexByKey = new Map<string, number>();
+    function intern(x: number, y: number, z: number): void {
+        const key = `${x.toFixed(4)} ${y.toFixed(4)} ${z.toFixed(4)}`;
+        if (!indexByKey.has(key)) {
+            indexByKey.set(key, uniqueCoords.length / 3);
+            uniqueCoords.push(x, y, z);
+        }
+    }
+
+    let offset = HEADER_SIZE + TRIANGLE_COUNT_SIZE;
+    for (let i = 0; i < triangleCount; i++) {
+        // Skip the 12-byte normal — MuJoCo recomputes it.
+        offset += 12;
+        for (let v = 0; v < 3; v++) {
+            const x = view.getFloat32(offset, true);
+            const y = view.getFloat32(offset + 4, true);
+            const z = view.getFloat32(offset + 8, true);
+            intern(x, y, z);
+            offset += 12;
+        }
+        // Skip the 2-byte attribute trailer.
+        offset += 2;
+    }
+
+    // Emit the MJCF vertex string. `.toFixed(4)` keeps the XML deterministic
+    // (snapshot-stable) and matches the dedup-key precision.
+    const parts: string[] = [];
+    for (let i = 0; i < uniqueCoords.length; i++) {
+        parts.push(uniqueCoords[i].toFixed(4));
+    }
+    return {
+        vertex: parts.join(' '),
+        triangleCount,
+        vertexCount: uniqueCoords.length / 3,
+    };
+}

--- a/tests/integration/examples/luxoLampClevis.test.ts
+++ b/tests/integration/examples/luxoLampClevis.test.ts
@@ -18,7 +18,12 @@
 
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
 import { runValidateCli } from '../../../src/agent/cli/commands/validate';
+import { initOcct } from '../../../src/kernel/backends/occt/occtBackend';
+import { runScript } from '../../../src/modeling/runtime/runScript';
+import { assemblyToMjcf } from '../../../src/modeling/runtime/mjcfExport';
+import type { Assembly } from '../../../src/modeling/capture/assembly';
 
 const LUXO_SCRIPT_PATH = 'examples/kinematic/luxo-lamp.kcad.ts';
 
@@ -80,6 +85,42 @@ describe('Luxo lamp — passes the physics-grounded loop', () => {
     );
     expect(gaps).toEqual([]);
     expect(r.mechanism).toBe('real');
+  }, 240_000);
+
+  it('P11 Slice 1: emitted MJCF contains one <mesh> + one <geom type="mesh"> per part', async () => {
+    // The lamp builds 4 parts via `arm.part('base' | 'lower-arm' |
+    // 'upper-arm' | 'lamp-head', ...)`. Post-Slice 1, every part
+    // contributes one inline `<asset><mesh>` and one
+    // `<geom type="mesh">` inside its `<body>` — MuJoCo's drop-test
+    // becomes collision-aware. Asserting the counts guards against a
+    // regression that silently drops the geom emit for one body.
+    await initOcct();
+    const absPath = resolve(LUXO_SCRIPT_PATH);
+    const code = readFileSync(absPath, 'utf8');
+    const run = await runScript({
+      code,
+      fileName: LUXO_SCRIPT_PATH,
+      scriptDir: dirname(absPath),
+    });
+    const arms = Array.from(run.session.assemblies.values()) as readonly Assembly[];
+    expect(arms.length).toBeGreaterThan(0);
+    const lamp = arms[0];
+    const { mjcf } = await assemblyToMjcf(lamp);
+    const meshAssetCount = (mjcf.match(/<mesh name="part-/g) ?? []).length;
+    const geomMeshCount = (mjcf.match(/<geom type="mesh"/g) ?? []).length;
+    expect(meshAssetCount).toBe(4);
+    expect(geomMeshCount).toBe(4);
+    expect(mjcf).toMatch(/<size nconmax="500"\/>/);
+    // P11 Slice 1: every mate emits one `<contact><exclude>`. The
+    // lamp has 3 revolute mates (shoulder, elbow, wrist) — without the
+    // excludes, the clevis fork-tongue mesh overlap at every joint
+    // would generate spurious contact forces strong enough to fling
+    // the chain apart in the drop-test integrator. (Tendon emission is
+    // separate from the mate count; tendons emit `<spatial>`, not
+    // `<exclude>`.)
+    expect(mjcf).toMatch(/<contact>/);
+    const excludeCount = (mjcf.match(/<exclude /g) ?? []).length;
+    expect(excludeCount).toBe(3);
   }, 240_000);
 
   it('passes the physics gate (criteria 5+6) — closed by P10 closed-loop tendon API (closes #361)', async () => {


### PR DESCRIPTION
Foundation slice for P11. Every Part in the kinematic chain now ships
its tessellated BREP as an inline `<mesh vertex="...">` under `<asset>`,
and the part's `<body>` gets a `<geom type="mesh" contype="1" conaffinity="1">`.
MuJoCo's drop-test now runs against a collision-aware world.

**Unit conversion (the load-bearing detail):** mesh vertices are emitted
in millimetres and the `<mesh>` carries `scale="0.001 0.001 0.001"` so
MuJoCo rescales the hull into its metre world, matching the mm→m pass
already applied to body `pos` / `<inertial>`. Without the scale the
collision geometry is 1000× oversized — every part interpenetrates the
origin and the drop-test explodes (Luxo elbow drifts 833°, lamp-head
ejects 421 mm). Both the structural (`mjcfExport`) and behavioural
(`mjcfPhysicsContacts`, penetration-depth bound) tests guard this; the
prior `ncon > 0`-only check did not catch it.

**Deviation from plan:** added a `<contact><exclude>` block — one per
mate — not in the original plan. It is load-bearing: at correct scale
the clevis fork-tongue meshes intentionally overlap at every joint
anchor, and without the exclude MuJoCo applies spurious contact forces
that kick the chain apart. Standard robotics-MJCF idiom (one exclude per
kinematic-tree edge).

**Behaviour change for Luxo: zero.** Rest-pose `ncon = 0` (the extended
arm doesn't self-collide; the P10 tendons still hold it), so the physics
gate stays `mechanism: 'real'`. The proof-of-life test asserts `ncon > 0`
on two interpenetrating cubes — collision is genuinely live — and that
penetration depth is physically bounded.

No tendon work, no wrap geoms; those land in Slice 2.