### PR TITLE
P11 Slice 2 — tendon wrap-geom routing API + criterion 8 (DO NOT MERGE before Slice 3)

### DIFF
--- a/src/modeling/capture/assembly.ts
+++ b/src/modeling/capture/assembly.ts
@@ -26,6 +26,9 @@ import {
   TENDON_DEFAULT_VISUAL_STYLE,
   type TendonOptions,
   type TendonRecord,
+  type TendonWrapRef,
+  type WrapGeomOptions,
+  type WrapGeomRecord,
 } from '../mates/tendon';
 import {
   reviewPoseEnvelope,
@@ -100,6 +103,11 @@ export interface AssemblyPartRef {
    *  is shared with the assembly's stored record and visible to
    *  `Assembly.model()` / `Assembly.solvedModel()`. */
   mateConnectors: Connector[];
+  /** P11 Slice 2 — wrap-geom cylinders registered via `wrapGeom(name, opts)`.
+   *  Mutated in place by the chain method, shared by reference with the
+   *  stored record so the MJCF emitter and criterion 8 see additions made
+   *  after `part(...)` returns. */
+  wrapGeoms: WrapGeomRecord[];
   /** Look up a v0.5 kinematic connector by name (declared via
    *  `assembly.part(..., { connectors })`) — returns an `AssemblyConnectorRef`
    *  for use in `opts.connect`. */
@@ -108,6 +116,11 @@ export interface AssemblyPartRef {
    *  part-ref for chaining. Throws `assembly.connector.duplicate-name` if a
    *  connector with the same name is already registered on this part. */
   connector(name: string, opts: AssemblyConnectorOpts): AssemblyPartRef;
+  /** P11 Slice 2 — declare a named collision-OFF wrap cylinder for tendon
+   *  routing and return the part-ref for chaining. Throws
+   *  `assembly.wrap-geom.duplicate-name` if the name is already used on
+   *  this part, or `feature.invalid-args` on a bad axis / radius. */
+  wrapGeom(name: string, opts: WrapGeomOptions): AssemblyPartRef;
 }
 
 function validateLimitRange(
@@ -484,7 +497,8 @@ export class Assembly {
     // below references the same array via spread (arrays are by-reference),
     // so `makeScene` sees additions made after `part(...)` returns.
     const mateConnectors: Connector[] = [];
-    const part = makePartRef(this.name, record.id, name, at, connectors, mateConnectors);
+    const wrapGeoms: WrapGeomRecord[] = [];
+    const part = makePartRef(this.name, record.id, name, at, connectors, mateConnectors, wrapGeoms);
     const stored: AssemblyPartStored = {
       ...part,
       originalShape: shape,
@@ -945,6 +959,40 @@ export class Assembly {
         `invalid-args.assembly.tendon-invalid-coil-diameter — either increase coilDiameterMm (typical Anglepoise: 5-10 mm) or decrease visualDiameterMm (typical wire: 1.0-1.4 mm).`,
       );
     }
+    // P11 Slice 2 — resolve + validate wrap-geom routing rails. Each entry
+    // must name a part that exists and a `WrapGeomRecord` already declared
+    // on that part via `part.wrapGeom(...)` (declare wrap geoms BEFORE the
+    // tendon, same ordering rule as connectors before mates).
+    const wrapGeoms: TendonWrapRef[] = [];
+    if (opts.wrapGeoms !== undefined) {
+      for (const w of opts.wrapGeoms) {
+        const part = this.parts.find((p) => p.name === w.partName);
+        if (part === undefined) {
+          throw new KernelError(
+            'feature.invalid-args',
+            `assembly.tendon.unknown-wrap-part: tendon '${name}' references wrap geom on part '${w.partName}', which is not declared on assembly '${this.name}'.`,
+            undefined,
+            `invalid-args.assembly.tendon-unknown-wrap-part — the wrap geom's partName must be a part added via arm.part(...). Check for a typo against the declared part names.`,
+          );
+        }
+        const wg = part.wrapGeoms.find((g) => g.name === w.wrapName);
+        if (wg === undefined) {
+          throw new KernelError(
+            'feature.invalid-args',
+            `assembly.tendon.unknown-wrap-geom: tendon '${name}' references wrap geom '${w.wrapName}' on part '${w.partName}', but that part has no such wrap geom. Declared: [${part.wrapGeoms.map((g) => g.name).join(', ') || '(none)'}].`,
+            undefined,
+            `invalid-args.assembly.tendon-unknown-wrap-geom — declare it first with arm.part('${w.partName}', ...).wrapGeom('${w.wrapName}', { axis, radius }), then reference it here.`,
+          );
+        }
+        wrapGeoms.push({
+          partName: w.partName,
+          wrapName: w.wrapName,
+          ...(w.sidesite !== undefined
+            ? { sidesite: [w.sidesite[0], w.sidesite[1], w.sidesite[2]] as const }
+            : {}),
+        });
+      }
+    }
     this.tendons.push({
       name,
       from: opts.from,
@@ -956,6 +1004,7 @@ export class Assembly {
       visualStyle,
       coilTurns,
       coilDiameterMm: coilDiameter,
+      wrapGeoms,
     });
     return this;
   }
@@ -2530,6 +2579,7 @@ function makePartRef(
   at: Vec3Param,
   connectors: Record<string, AssemblyConnectorFrameStored>,
   mateConnectors: Connector[],
+  wrapGeoms: WrapGeomRecord[],
 ): AssemblyPartRef {
   // Overload: `connector(name)` returns the v0.5 kinematic AssemblyConnectorRef;
   // `connector(name, opts)` registers a v0.6 mate-style Connector and returns
@@ -2589,6 +2639,62 @@ function makePartRef(
       ...(frame.axis !== undefined ? { axis: frame.axis } : {}),
     };
   };
+  // P11 Slice 2 — declare a collision-OFF wrap cylinder for tendon
+  // routing. Mirrors the mate-style `connector(name, opts)` chain: validate,
+  // push into the shared `wrapGeoms` array, return `ref`.
+  const wrapGeom = (
+    wrapName: string,
+    opts: WrapGeomOptions,
+  ): AssemblyPartRef => {
+    assertTopoRefSafeName(wrapName, 'wrap-geom-name', id);
+    if (wrapGeoms.some((w) => w.name === wrapName)) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `assembly.wrap-geom.duplicate-name: part '${name}' already has a wrap geom named '${wrapName}'.`,
+        id,
+        `invalid-args.assembly.wrap-geom-duplicate-name — rename one of the wrap geoms on '${name}'.`,
+      );
+    }
+    const axis = opts.axis;
+    const axisLenSq = axis[0] * axis[0] + axis[1] * axis[1] + axis[2] * axis[2];
+    if (
+      !Number.isFinite(axis[0]) || !Number.isFinite(axis[1]) || !Number.isFinite(axis[2]) ||
+      axisLenSq <= 0
+    ) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `assembly.wrap-geom.invalid-axis: wrap geom '${wrapName}' on part '${name}' needs a finite non-zero axis; got [${formatScalarForError(axis[0])}, ${formatScalarForError(axis[1])}, ${formatScalarForError(axis[2])}].`,
+        id,
+        `invalid-args.assembly.wrap-geom-invalid-axis — pass axis: [x, y, z] pointing along the cylinder centerline (the arm's long axis for a balance spring).`,
+      );
+    }
+    if (!Number.isFinite(opts.radius) || opts.radius <= 0) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `assembly.wrap-geom.invalid-radius: wrap geom '${wrapName}' on part '${name}' radius must be a positive finite number; got ${formatScalarForError(opts.radius)}.`,
+        id,
+        `invalid-args.assembly.wrap-geom-invalid-radius — pass radius: <positive mm>. Size it to the arm half-thickness plus the cable standoff so the spring rides clear of the body.`,
+      );
+    }
+    if (opts.halfLengthMm !== undefined && (!Number.isFinite(opts.halfLengthMm) || opts.halfLengthMm <= 0)) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `assembly.wrap-geom.invalid-half-length: wrap geom '${wrapName}' on part '${name}' halfLengthMm must be a positive finite number when provided; got ${formatScalarForError(opts.halfLengthMm)}.`,
+        id,
+        `invalid-args.assembly.wrap-geom-invalid-half-length — pass halfLengthMm: <positive mm>, or omit it for an effectively-infinite routing cylinder.`,
+      );
+    }
+    const origin = opts.origin ?? [0, 0, 0];
+    const rec: WrapGeomRecord = {
+      name: wrapName,
+      axis: [axis[0], axis[1], axis[2]],
+      origin: [origin[0], origin[1], origin[2]],
+      radiusMm: opts.radius,
+      ...(opts.halfLengthMm !== undefined ? { halfLengthMm: opts.halfLengthMm } : {}),
+    };
+    wrapGeoms.push(rec);
+    return ref;
+  };
   const ref: AssemblyPartRef = {
     id,
     name,
@@ -2596,7 +2702,9 @@ function makePartRef(
     at,
     connectors,
     mateConnectors,
+    wrapGeoms,
     connector: connector as AssemblyPartRef['connector'],
+    wrapGeom,
   };
   return ref;
 }

--- a/src/modeling/capture/wrapGeom.test.ts
+++ b/src/modeling/capture/wrapGeom.test.ts
@@ -1,0 +1,164 @@
+// src/modeling/capture/wrapGeom.test.ts
+//
+// P11 Slice 2 — capture-side validation for `part.wrapGeom(name, opts)`
+// (collision-OFF tendon routing cylinders) and the `arm.tendon(...)`
+// `wrapGeoms` reference list. Mirrors tendon.test.ts: a wrap geom must
+// have a finite non-zero axis and positive radius, names are unique per
+// part, and a tendon may only reference wrap geoms already declared on a
+// real part.
+
+import { describe, it, expect } from 'vitest';
+import { CaptureSession } from './captureSession';
+import { createApi } from '../api';
+
+function makeArm() {
+  const session = new CaptureSession();
+  const kcad = createApi({ session });
+  const arm = kcad.assembly('test');
+  const a = kcad.box(10, 10, 100);
+  const b = kcad.box(5, 5, 50);
+  arm
+    .part('a', a)
+    .connector('topA', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 10] } });
+  arm
+    .part('b', b)
+    .connector('topB', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 5] } });
+  return { arm };
+}
+
+describe('part.wrapGeom(name, opts) — capture validation', () => {
+  it('a part with no wrap geoms declared exposes an empty array', () => {
+    const { arm } = makeArm();
+    const part = arm.__parts().find((p) => p.name === 'a')!;
+    expect(part.wrapGeoms).toEqual([]);
+  });
+
+  it('records a wrap geom through the builder chain', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('w');
+    const a = kcad.box(10, 10, 100);
+    arm
+      .part('a', a)
+      .wrapGeom('armWrap', { axis: [0, 0, 1], radius: 6, halfLengthMm: 40 });
+    const part = arm.__parts().find((p) => p.name === 'a')!;
+    expect(part.wrapGeoms).toHaveLength(1);
+    expect(part.wrapGeoms[0]).toMatchObject({
+      name: 'armWrap',
+      axis: [0, 0, 1],
+      origin: [0, 0, 0], // default
+      radiusMm: 6,
+      halfLengthMm: 40,
+    });
+  });
+
+  it('omits halfLengthMm when not provided (infinite cylinder)', () => {
+    const session = new CaptureSession();
+    const arm = createApi({ session }).assembly('w');
+    arm.part('a', createApi({ session }).box(10, 10, 100)).wrapGeom('w1', { axis: [1, 0, 0], radius: 4 });
+    const part = arm.__parts()[0];
+    expect(part.wrapGeoms[0].halfLengthMm).toBeUndefined();
+  });
+
+  it('rejects a duplicate wrap-geom name on the same part', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('w');
+    const ref = arm.part('a', kcad.box(10, 10, 100));
+    ref.wrapGeom('dup', { axis: [0, 0, 1], radius: 6 });
+    expect(() => ref.wrapGeom('dup', { axis: [0, 0, 1], radius: 6 })).toThrow(
+      /assembly\.wrap-geom\.duplicate-name/,
+    );
+  });
+
+  it('rejects a zero-length axis', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('w');
+    expect(() =>
+      arm.part('a', kcad.box(10, 10, 100)).wrapGeom('w', { axis: [0, 0, 0], radius: 6 }),
+    ).toThrow(/assembly\.wrap-geom\.invalid-axis/);
+  });
+
+  it('rejects a non-positive radius', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('w');
+    expect(() =>
+      arm.part('a', kcad.box(10, 10, 100)).wrapGeom('w', { axis: [0, 0, 1], radius: 0 }),
+    ).toThrow(/assembly\.wrap-geom\.invalid-radius/);
+  });
+
+  it('rejects a non-positive halfLengthMm when provided', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('w');
+    expect(() =>
+      arm
+        .part('a', kcad.box(10, 10, 100))
+        .wrapGeom('w', { axis: [0, 0, 1], radius: 6, halfLengthMm: -1 }),
+    ).toThrow(/assembly\.wrap-geom\.invalid-half-length/);
+  });
+});
+
+describe('arm.tendon(...).wrapGeoms — routing reference validation', () => {
+  function armWithWrap() {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('t');
+    arm
+      .part('a', kcad.box(10, 10, 100))
+      .connector('topA', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 10] } })
+      .wrapGeom('aWrap', { axis: [0, 0, 1], radius: 6, halfLengthMm: 40 });
+    arm
+      .part('b', kcad.box(5, 5, 50))
+      .connector('topB', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 5] } });
+    return arm;
+  }
+
+  it('records a tendon that routes around a declared wrap geom', () => {
+    const arm = armWithWrap();
+    arm.tendon('spring', {
+      from: 'a.topA',
+      to: 'b.topB',
+      restLengthMm: 30,
+      stiffnessNmm: 0.5,
+      wrapGeoms: [{ partName: 'a', wrapName: 'aWrap' }],
+    });
+    const t = arm.__tendons()[0];
+    expect(t.wrapGeoms).toHaveLength(1);
+    expect(t.wrapGeoms[0]).toMatchObject({ partName: 'a', wrapName: 'aWrap' });
+  });
+
+  it('defaults wrapGeoms to [] when omitted (straight tendon)', () => {
+    const arm = armWithWrap();
+    arm.tendon('s', { from: 'a.topA', to: 'b.topB', restLengthMm: 30, stiffnessNmm: 0.5 });
+    expect(arm.__tendons()[0].wrapGeoms).toEqual([]);
+  });
+
+  it('rejects a wrap geom on an unknown part', () => {
+    const arm = armWithWrap();
+    expect(() =>
+      arm.tendon('s', {
+        from: 'a.topA',
+        to: 'b.topB',
+        restLengthMm: 30,
+        stiffnessNmm: 0.5,
+        wrapGeoms: [{ partName: 'nope', wrapName: 'aWrap' }],
+      }),
+    ).toThrow(/assembly\.tendon\.unknown-wrap-part/);
+  });
+
+  it('rejects a reference to a wrap geom not declared on the part', () => {
+    const arm = armWithWrap();
+    expect(() =>
+      arm.tendon('s', {
+        from: 'a.topA',
+        to: 'b.topB',
+        restLengthMm: 30,
+        stiffnessNmm: 0.5,
+        wrapGeoms: [{ partName: 'a', wrapName: 'ghost' }],
+      }),
+    ).toThrow(/assembly\.tendon\.unknown-wrap-geom/);
+  });
+});

--- a/src/modeling/mates/tendon.ts
+++ b/src/modeling/mates/tendon.ts
@@ -29,6 +29,50 @@
  * only; physically the spring pulls each endpoint toward the other
  * symmetrically.
  */
+import type { Vec3 } from '../../shared/intent/types';
+
+/**
+ * P11 Slice 2 — a named collision-OFF cylinder declared on a Part for
+ * tendon cable routing. Emitted as `<geom type="cylinder" contype="0"
+ * conaffinity="0">` so it never generates body-body contacts; it serves
+ * only as a wrap rail the solver routes a `<spatial>` tendon around, so a
+ * balance spring physically rides over the arm instead of cutting
+ * through it. Axis / origin are part-local; converted mm→m at emit.
+ */
+export interface WrapGeomRecord {
+    /** Unique within its owning part. Surfaced in the MJCF geom name. */
+    readonly name: string;
+    /** Part-local cylinder axis direction (need not be unit length). */
+    readonly axis: Vec3;
+    /** Part-local cylinder centre. */
+    readonly origin: Vec3;
+    /** Cylinder radius (mm). > 0. */
+    readonly radiusMm: number;
+    /** Half-length (mm) along `axis`. Undefined = MuJoCo-infinite cylinder;
+     *  the emitter substitutes a large finite half-length for `fromto`. */
+    readonly halfLengthMm?: number;
+}
+
+/** Agent-facing options for `part.wrapGeom(name, opts)`. */
+export interface WrapGeomOptions {
+    readonly axis: readonly [number, number, number];
+    readonly origin?: readonly [number, number, number];
+    readonly radius: number;
+    readonly halfLengthMm?: number;
+}
+
+/**
+ * One wrap-geom reference inside a tendon's `wrapGeoms` array. `partName`
+ * + `wrapName` name a `WrapGeomRecord` the cable routes around, in array
+ * order between the two endpoints. `sidesite` (part-local) forces which
+ * side of the cylinder the cable passes; omit to let MuJoCo pick.
+ */
+export interface TendonWrapRef {
+    readonly partName: string;
+    readonly wrapName: string;
+    readonly sidesite?: readonly [number, number, number];
+}
+
 export interface TendonRecord {
     /** Unique tendon name. Surfaced in diagnostics + MJCF site / spatial
      *  identifiers. */
@@ -66,6 +110,10 @@ export interface TendonRecord {
      *  satisfy `coilDiameterMm > 2 * visualDiameterMm` (i.e. the wire
      *  fits inside the coil). Defaults to 7. */
     readonly coilDiameterMm: number;
+    /** P11 Slice 2 — ordered wrap-geom rails the cable routes around
+     *  between its two endpoints. Empty for a straight `<spatial>` tendon
+     *  (the pre-Slice-2 behavior). */
+    readonly wrapGeoms: readonly TendonWrapRef[];
 }
 
 /**
@@ -84,6 +132,14 @@ export interface TendonOptions {
     readonly visualStyle?: 'line' | 'coil';
     readonly coilTurns?: number;
     readonly coilDiameterMm?: number;
+    /** P11 Slice 2 — wrap-geom rails (in routing order) the cable passes.
+     *  Each entry names a `WrapGeomRecord` declared via `part.wrapGeom(...)`
+     *  on a part the tendon passes. Omit for a straight tendon. */
+    readonly wrapGeoms?: ReadonlyArray<{
+        readonly partName: string;
+        readonly wrapName: string;
+        readonly sidesite?: readonly [number, number, number];
+    }>;
 }
 
 /** Default visual diameter (mm) used when the agent doesn't pass one. */

--- a/src/modeling/runtime/jointMeshContinuity.ts
+++ b/src/modeling/runtime/jointMeshContinuity.ts
@@ -206,7 +206,7 @@ export function checkJointMeshContinuity(
  * Returns `undefined` when the OCCT pipeline throws on the inputs
  * (degenerate body, missing wasm handle). Caller skips the row.
  */
-function measureGapToBody(
+export function measureGapToBody(
   localShape: OcctBackend,
   worldTransform: Transform,
   pointWorld: readonly [number, number, number],

--- a/src/modeling/runtime/mechanismTruth.ts
+++ b/src/modeling/runtime/mechanismTruth.ts
@@ -66,6 +66,10 @@ import {
   checkJointMeshContinuity,
   JOINT_MESH_GAP_TOLERANCE_MM,
 } from './jointMeshContinuity';
+import {
+  checkTendonBodyIntersectAtPose,
+  TENDON_BODY_CLEARANCE_MM,
+} from './tendonBodyIntersect';
 
 /**
  * Number of pose samples per articulated mate. Currently 3 (min, mid, max
@@ -257,6 +261,13 @@ export async function checkMechanismTruth(
   // physics are constraints on abstract rigid bodies, not assertions
   // about material continuity in the rendered geometry).
   failures.push(...(await checkJointMeshContinuityCriterion(arm, solved)));
+
+  // Criterion 8 (mechanism.tendon-body-intersect) — a balance tendon's
+  // routed path must not cut through a non-anchor body at any sampled
+  // pose. The static authoring backstop for "the spring goes through the
+  // arm"; MuJoCo wrap routing (Slice 2 MJCF) is the runtime side, this is
+  // the design-time gate. No-op for assemblies with no tendons.
+  failures.push(...(await checkTendonBodyIntersectCriterion(arm, solved)));
 
   // Criteria 5 + 6 (physics) — gated on `opts.physicsCheck`. The MuJoCo
   // session is shared between the two passes so the ~9 MB WASM module
@@ -702,6 +713,47 @@ async function checkJointMeshContinuityCriterion(
 }
 
 // ─────────────────────────────────────────────────────────────────────────
+// Criterion 8 — mechanism.tendon-body-intersect
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * For every tendon, at every sampled pose, the routed cable polyline must
+ * not pass through the solid interior of any part other than its anchor
+ * parts and the wrap-geom parts it rides on. Reuses the per-sample lowered
+ * scene (criteria 2/3/7) — no extra lower for poses already evaluated.
+ *
+ * No-op when the assembly declares no tendons.
+ */
+async function checkTendonBodyIntersectCriterion(
+  arm: Assembly,
+  solved: SolvedSample[],
+): Promise<CompilerDiagnostic[]> {
+  if (arm.__tendons().length === 0) return [];
+  const out: CompilerDiagnostic[] = [];
+  const seen = new Set<string>(); // dedupe (tendon, part) across poses
+  for (const s of solved) {
+    const scene = await lowerSceneForSample(arm, s);
+    if (scene === undefined) continue;
+    const results = checkTendonBodyIntersectAtPose(arm, { transforms: s.transforms, scene });
+    for (const r of results) {
+      const key = `${r.tendonName}|${r.partName}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(makeFailure(
+        'mechanism.tendon-body-intersect',
+        `Tendon '${r.tendonName}' routes through part '${r.partName}' ` +
+        `(${r.gapMm <= 0 ? 'inside the solid' : `${r.gapMm.toFixed(2)}mm clearance`}, ` +
+        `tolerance ${TENDON_BODY_CLEARANCE_MM.toFixed(1)}mm) at pose '${s.sample.name}'. ` +
+        `The cable cuts through a body it is not anchored to or routing around — ` +
+        `add a wrap geom on '${r.partName}' to the tendon's wrapGeoms so the cable rides ` +
+        `over it, or relocate the anchors so the line stays clear at every pose.`,
+      ));
+    }
+  }
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
 // Pose sampling
 // ─────────────────────────────────────────────────────────────────────────
 
@@ -1101,7 +1153,8 @@ function makeFailure(
     | 'mechanism.orphan-part'
     | 'mechanism.unstable-under-gravity'
     | 'mechanism.drops-on-release'
-    | 'mechanism.joint-mesh-gap',
+    | 'mechanism.joint-mesh-gap'
+    | 'mechanism.tendon-body-intersect',
   message: string,
 ): CompilerDiagnostic {
   return {

--- a/src/modeling/runtime/mjcfExport.ts
+++ b/src/modeling/runtime/mjcfExport.ts
@@ -275,6 +275,47 @@ export async function assemblyToMjcf(arm: Assembly): Promise<MjcfExportResult> {
         }
     }
 
+    // P11 Slice 2 — build the routed `<spatial>` child sequence for every
+    // tendon that declares wrapGeoms: `<site from>` → (wrap geom, with any
+    // sidesite / separator sites) → `<site to>`. MuJoCo requires a `<site>`
+    // between two consecutive wrap `<geom>`s, so a separator site is
+    // injected at each subsequent wrap's origin. Sidesite + separator sites
+    // are registered into `sitesByPart` here so `emitBody` (which runs
+    // after this pass) materialises them inside the owning body.
+    const addExtraSite = (partName: string, siteName: string, localPosMm: Vec3): void => {
+        const list = sitesByPart.get(partName) ?? [];
+        list.push({ partName, siteName, localPosMm });
+        sitesByPart.set(partName, list);
+    };
+    const spatialChildrenByTendon = new Map<string, string[]>();
+    for (const rt of resolvedTendons) {
+        const t = rt.record;
+        if (t.wrapGeoms.length === 0) continue;
+        const [fromE, toE] = rt.endpoints;
+        const children: string[] = [`      <site site="${escapeXml(fromE.siteName)}"/>`];
+        t.wrapGeoms.forEach((w, i) => {
+            const ownerPart = partByName.get(w.partName);
+            const wg = ownerPart?.wrapGeoms.find((g) => g.name === w.wrapName);
+            if (ownerPart === undefined || wg === undefined) return; // capture-validated
+            if (i > 0) {
+                const sepName = `${t.name}__wrap${i}_sep`;
+                addExtraSite(w.partName, sepName, wg.origin);
+                children.push(`      <site site="${escapeXml(sepName)}"/>`);
+            }
+            let sidesiteAttr = '';
+            if (w.sidesite !== undefined) {
+                const sideName = `${t.name}__wrap${i}_side`;
+                addExtraSite(w.partName, sideName, [w.sidesite[0], w.sidesite[1], w.sidesite[2]]);
+                sidesiteAttr = ` sidesite="${escapeXml(sideName)}"`;
+            }
+            children.push(
+                `      <geom geom="${escapeXml(mjcfWrapGeomName(w.partName, w.wrapName))}"${sidesiteAttr}/>`,
+            );
+        });
+        children.push(`      <site site="${escapeXml(toE.siteName)}"/>`);
+        spatialChildrenByTendon.set(t.name, children);
+    }
+
     // Emit MJCF by recursive body-tree walk.
     const jointOrder: { mjcfName: string; mateName: string }[] = [];
     const bodyOrder: string[] = [];
@@ -366,6 +407,32 @@ export async function assemblyToMjcf(arm: Assembly): Promise<MjcfExportResult> {
             );
         }
 
+        // P11 Slice 2 — collision-OFF wrap cylinders for tendon routing.
+        // `contype="0" conaffinity="0"` so they never generate body-body
+        // contacts; a `<spatial>` tendon references them by name and the
+        // solver routes the cable tangent to the cylinder surface, so a
+        // balance spring rides over the arm instead of cutting through it.
+        // `fromto` endpoints are origin ± (unit axis)·halfLength, mm→m.
+        for (const wg of part.wrapGeoms) {
+            const ax = wg.axis;
+            const len = Math.hypot(ax[0], ax[1], ax[2]) || 1;
+            const u: Vec3 = [ax[0] / len, ax[1] / len, ax[2] / len];
+            const halfMm = wg.halfLengthMm ?? WRAP_GEOM_INFINITE_HALF_LEN_MM;
+            const p1 = [
+                (wg.origin[0] - u[0] * halfMm) * MM_TO_M,
+                (wg.origin[1] - u[1] * halfMm) * MM_TO_M,
+                (wg.origin[2] - u[2] * halfMm) * MM_TO_M,
+            ];
+            const p2 = [
+                (wg.origin[0] + u[0] * halfMm) * MM_TO_M,
+                (wg.origin[1] + u[1] * halfMm) * MM_TO_M,
+                (wg.origin[2] + u[2] * halfMm) * MM_TO_M,
+            ];
+            lines.push(
+                `${indent}  <geom name="${escapeXml(mjcfWrapGeomName(partName, wg.name))}" type="cylinder" contype="0" conaffinity="0" group="3" fromto="${[...p1, ...p2].map(fmtNum).join(' ')}" size="${fmtNum(wg.radiusMm * MM_TO_M)}"/>`,
+            );
+        }
+
         // Children — recurse.
         for (const childEntry of childrenByParent.get(partName) ?? []) {
             lines.push(emitBody(childEntry.childName, childEntry.mate, indent + '  '));
@@ -398,8 +465,16 @@ export async function assemblyToMjcf(arm: Assembly): Promise<MjcfExportResult> {
             tendonBlockLines.push(
                 `    <spatial name="${escapeXml(t.name)}" springlength="${fmtNum(springLenM)}" stiffness="${fmtNum(stiffnessNm)}"${dampingAttr}>`,
             );
-            for (const ep of rt.endpoints) {
-                tendonBlockLines.push(`      <site site="${escapeXml(ep.siteName)}"/>`);
+            // P11 Slice 2: emit the routed child sequence (sites + wrap
+            // geoms) when this tendon declares wrapGeoms; otherwise the
+            // straight two-site spatial (pre-Slice-2 behavior).
+            const routed = spatialChildrenByTendon.get(t.name);
+            if (routed !== undefined) {
+                for (const c of routed) tendonBlockLines.push(c);
+            } else {
+                for (const ep of rt.endpoints) {
+                    tendonBlockLines.push(`      <site site="${escapeXml(ep.siteName)}"/>`);
+                }
             }
             tendonBlockLines.push('    </spatial>');
         }
@@ -591,6 +666,31 @@ function mjcfMeshAssetName(partName: string): string {
         .replace(/^-|-$/g, '');
     return `part-${slug.length > 0 ? slug : 'unnamed'}`;
 }
+
+function mjcfSlug(s: string): string {
+    const slug = s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    return slug.length > 0 ? slug : 'unnamed';
+}
+
+/**
+ * Globally-unique MJCF geom name for a part's wrap cylinder. MuJoCo geom
+ * names must be unique model-wide and a `<spatial><geom geom="...">`
+ * routing child references this exact string, so it folds in both the
+ * owning part and the wrap-geom name.
+ */
+function mjcfWrapGeomName(partName: string, wrapName: string): string {
+    return `wrap-${mjcfSlug(partName)}-${mjcfSlug(wrapName)}`;
+}
+
+/**
+ * Substitute half-length (mm) for a wrap geom declared with no explicit
+ * `halfLengthMm` (MuJoCo's true-infinite cylinder). `<geom fromto>`
+ * requires finite endpoints; 1 m half-length covers any realistic
+ * kinematic arm while the cylinder stays contact-disabled, so the
+ * over-length is invisible to the solver and only ever serves as a
+ * tendon-wrap rail.
+ */
+const WRAP_GEOM_INFINITE_HALF_LEN_MM = 1000;
 
 function fmtNum(n: number): string {
     // 6-decimal fixed for readability; scientific notation for

--- a/src/modeling/runtime/mjcfWrapGeom.test.ts
+++ b/src/modeling/runtime/mjcfWrapGeom.test.ts
@@ -1,0 +1,149 @@
+// src/modeling/runtime/mjcfWrapGeom.test.ts
+//
+// P11 Slice 2 — MJCF emit for tendon wrap-geom routing. A part with a
+// declared wrap geom emits a collision-OFF `<geom type="cylinder">`, and a
+// tendon that references it emits a `<geom geom="...">` routing child
+// between its two `<site>` endpoints inside the `<spatial>`. The whole
+// thing must round-trip through MuJoCo's `MjModel.from_xml_string`.
+
+import { describe, it, expect } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { CaptureSession } from '../capture/captureSession';
+import { createApi } from '../api';
+import { initOcct } from '../../kernel/backends/occt/occtBackend';
+import { assemblyToMjcf } from './mjcfExport';
+
+const require_ = createRequire(import.meta.url);
+
+async function loadMujocoInNode(): Promise<unknown> {
+    const pkgEntry = require_.resolve('@mujoco/mujoco');
+    const pkgDir = dirname(pkgEntry);
+    const wasmBinary = await readFile(join(pkgDir, 'mujoco.wasm'));
+    const loadMujoco = (await import('@mujoco/mujoco')).default;
+    return await loadMujoco({
+        wasmBinary,
+        locateFile: (path: string) => join(pkgDir, path),
+        print: () => undefined,
+        printErr: () => undefined,
+    });
+}
+
+async function buildWrappedHinge() {
+    await initOcct();
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('wrapped-hinge');
+
+    const baseBody = kcad.box(40, 40, 30, true).translate(0, 0, -15);
+    const armBody = kcad.box(120, 20, 20, true).translate(70, 0, 0);
+    const j = kcad.joint.clevis({
+        parentBody: baseBody,
+        childBody: armBody,
+        axis: 'Y',
+        pivotParent: [0, 0, 15],
+        pivotChild: [0, 0, 0],
+        limitsDeg: [-45, 45],
+    });
+    arm
+        .part('base', j.parentGeometry)
+        .connector('hinge', {
+            type: 'axis',
+            origin: { kind: 'vec3', value: j.parentConnector.origin },
+            axis: j.parentConnector.axis,
+        })
+        .connector('springBase', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 20] } });
+    arm
+        .part('lower-arm', j.childGeometry)
+        .connector('hinge', {
+            type: 'axis',
+            origin: { kind: 'vec3', value: j.childConnector.origin },
+            axis: j.childConnector.axis,
+        })
+        .connector('springArm', { type: 'frame', origin: { kind: 'vec3', value: [120, 0, 12] } })
+        // A wrap rail collinear with the arm's long (X) axis.
+        .wrapGeom('armRail', { axis: [1, 0, 0], origin: [60, 0, 12], radius: 12, halfLengthMm: 60 });
+    arm.mate('elbow', 'base.hinge', 'lower-arm.hinge', 'revolute', { limitsDeg: [-45, 45] });
+    arm.tendon('balance', {
+        from: 'base.springBase',
+        to: 'lower-arm.springArm',
+        restLengthMm: 40,
+        stiffnessNmm: 0.6,
+        wrapGeoms: [{ partName: 'lower-arm', wrapName: 'armRail' }],
+    });
+    return arm;
+}
+
+describe('assemblyToMjcf — wrap-geom routing (P11 Slice 2)', () => {
+    it('emits a contact-OFF wrap cylinder + spatial routing child, round-trips through MuJoCo', async () => {
+        const arm = await buildWrappedHinge();
+        const { mjcf } = await assemblyToMjcf(arm);
+
+        // Collision-OFF cylinder on the owning body.
+        expect(mjcf).toMatch(
+            /<geom name="wrap-lower-arm-armrail" type="cylinder" contype="0" conaffinity="0" group="3" fromto="[^"]+" size="0\.012000"\/>/,
+        );
+        // Routing child inside the spatial, flanked by the two endpoint sites.
+        const spatial = mjcf.slice(mjcf.indexOf('<spatial'), mjcf.indexOf('</spatial>'));
+        expect(spatial).toMatch(/<site site="balance__from"\/>/);
+        expect(spatial).toMatch(/<geom geom="wrap-lower-arm-armrail"\/>/);
+        expect(spatial).toMatch(/<site site="balance__to"\/>/);
+        // Order: from-site, then wrap geom, then to-site.
+        const iFrom = spatial.indexOf('balance__from');
+        const iGeom = spatial.indexOf('wrap-lower-arm-armrail');
+        const iTo = spatial.indexOf('balance__to');
+        expect(iFrom).toBeLessThan(iGeom);
+        expect(iGeom).toBeLessThan(iTo);
+
+        // MuJoCo accepts the routed model.
+        const mujoco = (await loadMujocoInNode()) as {
+            MjModel: { from_xml_string: (s: string) => unknown };
+            MjData: new (m: unknown) => unknown;
+            mj_forward: (m: unknown, d: unknown) => void;
+        };
+        const model = mujoco.MjModel.from_xml_string(mjcf);
+        const data = new mujoco.MjData(model);
+        try {
+            mujoco.mj_forward(model, data);
+            const qpos = (data as { qpos: number[] }).qpos;
+            expect(qpos.length).toBe(1);
+        } finally {
+            (data as { delete: () => void }).delete();
+            (model as { delete: () => void }).delete();
+        }
+    }, 60000);
+
+    it('leaves straight tendons (no wrapGeoms) as plain two-site spatials', async () => {
+        await initOcct();
+        const session = new CaptureSession();
+        const kcad = createApi({ session });
+        const arm = kcad.assembly('straight');
+        const baseBody = kcad.box(40, 40, 30, true).translate(0, 0, -15);
+        const armBody = kcad.box(120, 20, 20, true).translate(70, 0, 0);
+        const j = kcad.joint.clevis({
+            parentBody: baseBody,
+            childBody: armBody,
+            axis: 'Y',
+            pivotParent: [0, 0, 15],
+            pivotChild: [0, 0, 0],
+            limitsDeg: [-45, 45],
+        });
+        arm
+            .part('base', j.parentGeometry)
+            .connector('hinge', { type: 'axis', origin: { kind: 'vec3', value: j.parentConnector.origin }, axis: j.parentConnector.axis })
+            .connector('sb', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 20] } });
+        arm
+            .part('lower-arm', j.childGeometry)
+            .connector('hinge', { type: 'axis', origin: { kind: 'vec3', value: j.childConnector.origin }, axis: j.childConnector.axis })
+            .connector('sa', { type: 'frame', origin: { kind: 'vec3', value: [120, 0, 12] } });
+        arm.mate('elbow', 'base.hinge', 'lower-arm.hinge', 'revolute', { limitsDeg: [-45, 45] });
+        arm.tendon('balance', { from: 'base.sb', to: 'lower-arm.sa', restLengthMm: 40, stiffnessNmm: 0.6 });
+
+        const { mjcf } = await assemblyToMjcf(arm);
+        expect(mjcf).not.toMatch(/type="cylinder"/);
+        const spatial = mjcf.slice(mjcf.indexOf('<spatial'), mjcf.indexOf('</spatial>'));
+        expect(spatial).not.toMatch(/<geom /);
+        expect((spatial.match(/<site /g) ?? []).length).toBe(2);
+    }, 60000);
+});

--- a/src/modeling/runtime/tendonBodyIntersect.test.ts
+++ b/src/modeling/runtime/tendonBodyIntersect.test.ts
@@ -1,0 +1,133 @@
+// src/modeling/runtime/tendonBodyIntersect.test.ts
+//
+// P11 Slice 2 — criterion 8 (mechanism.tendon-body-intersect), tested at
+// the helper level with a hand-built scene so every body position is
+// deterministic (the mate solver + clevis geometry make end-to-end
+// fixtures unreliable for precise pierce/clear assertions). The realistic
+// end-to-end RED case is asserted on the Luxo lamp in
+// tests/integration/examples/luxoLampClevis.test.ts.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { CaptureSession } from '../capture/captureSession';
+import { createApi } from '../api';
+import { initOcct } from '../../kernel/backends/occt/occtBackend';
+import type { OcctBackend } from '../../kernel/backends/occt/occtBackend';
+import type { SceneBackend } from '../../kernel/backends/sceneBackend';
+import { Transform } from '../../shared/runtime/se3';
+import { checkTendonBodyIntersectAtPose } from './tendonBodyIntersect';
+import type { Assembly } from '../capture/assembly';
+
+// A tendon from base.sb (world origin) to arm.sa (world (100,0,0)); the
+// straight cable runs along +X at z=0. Bodies are placed by hand so we
+// know exactly what the cable does or does not pass through.
+async function buildArm(opts: { wrapObstacle?: boolean } = {}): Promise<{
+  arm: Assembly;
+  boxes: Record<string, OcctBackend>;
+}> {
+  const session = new CaptureSession();
+  const kcad = createApi({ session });
+  const arm = kcad.assembly('det');
+
+  const baseBox = kcad.box(20, 20, 20, true);
+  const armBox = kcad.box(120, 20, 20, true);
+  const obsBox = kcad.box(20, 20, 20, true);
+
+  arm.part('base', baseBox).connector('sb', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 0] } });
+  const obs = arm.part('obstacle', obsBox);
+  if (opts.wrapObstacle) {
+    obs.wrapGeom('rail', { axis: [0, 1, 0], origin: [0, 0, 0], radius: 6, halfLengthMm: 30 });
+  }
+  arm.part('arm', armBox).connector('sa', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 0] } });
+
+  arm.tendon('balance', {
+    from: 'base.sb',
+    to: 'arm.sa',
+    restLengthMm: 90,
+    stiffnessNmm: 0.6,
+    ...(opts.wrapObstacle ? { wrapGeoms: [{ partName: 'obstacle', wrapName: 'rail' }] } : {}),
+  });
+
+  const boxes: Record<string, OcctBackend> = {
+    base: (await baseBox.lower()) as OcctBackend,
+    arm: (await armBox.lower()) as OcctBackend,
+    obstacle: (await obsBox.lower()) as OcctBackend,
+  };
+  return { arm, boxes };
+}
+
+// Build a duck-typed scene + transforms map at chosen world placements.
+function makeSample(
+  boxes: Record<string, OcctBackend>,
+  placements: Record<string, Transform>,
+) {
+  const parts = Object.keys(placements).map((name) => ({
+    name,
+    shape: boxes[name],
+    worldTransform: placements[name],
+  }));
+  return {
+    scene: { parts } as unknown as SceneBackend,
+    transforms: new Map(Object.entries(placements)),
+  };
+}
+
+function fired(results: { partName: string }[], part: string): boolean {
+  return results.some((r) => r.partName === part);
+}
+
+describe('checkTendonBodyIntersectAtPose — criterion 8 helper', () => {
+  beforeAll(async () => {
+    await initOcct();
+  });
+
+  it('fires on a NON-anchor body the cable cuts through', async () => {
+    const { arm, boxes } = await buildArm();
+    // base at origin, arm anchor at (100,0,0); obstacle (±10) centred at
+    // (50,0,0) sits squarely on the z=0 cable line.
+    const sample = makeSample(boxes, {
+      base: Transform.identity(),
+      arm: Transform.translation(100, 0, 0),
+      obstacle: Transform.translation(50, 0, 0),
+    });
+    const results = checkTendonBodyIntersectAtPose(arm, sample);
+    expect(fired(results, 'obstacle')).toBe(true);
+  });
+
+  it('fires on an ANCHOR body when the cable dives through its interior', async () => {
+    const { arm, boxes } = await buildArm();
+    // The 120 mm arm spans x∈[40,160] at z=0; the cable from origin to the
+    // arm anchor at (100,0,0) runs through the arm interior for x∈[40,95]
+    // (beyond the 5 mm anchor margin). Anchor parts are checked.
+    const sample = makeSample(boxes, {
+      base: Transform.identity(),
+      arm: Transform.translation(100, 0, 0),
+      obstacle: Transform.translation(50, 0, 200), // far away, clear
+    });
+    const results = checkTendonBodyIntersectAtPose(arm, sample);
+    expect(fired(results, 'arm')).toBe(true);
+  });
+
+  it('is GREEN when the obstacle is moved clear of the cable', async () => {
+    const { arm, boxes } = await buildArm();
+    const sample = makeSample(boxes, {
+      base: Transform.identity(),
+      arm: Transform.translation(100, 0, 0),
+      obstacle: Transform.translation(50, 0, 200), // lifted off the line
+    });
+    const results = checkTendonBodyIntersectAtPose(arm, sample);
+    expect(fired(results, 'obstacle')).toBe(false);
+  });
+
+  it('is GREEN on the obstacle when the tendon routes around it via a wrap geom', async () => {
+    const { arm, boxes } = await buildArm({ wrapObstacle: true });
+    // Obstacle still on the line, but the tendon declares a wrap rail on
+    // it — the cable rides on the rail, so the wrap owner is excluded.
+    const sample = makeSample(boxes, {
+      base: Transform.identity(),
+      arm: Transform.translation(100, 0, 0),
+      obstacle: Transform.translation(50, 0, 0),
+    });
+    const results = checkTendonBodyIntersectAtPose(arm, sample);
+    expect(fired(results, 'obstacle')).toBe(false);
+  });
+});

--- a/src/modeling/runtime/tendonBodyIntersect.ts
+++ b/src/modeling/runtime/tendonBodyIntersect.ts
@@ -1,0 +1,147 @@
+// src/modeling/runtime/tendonBodyIntersect.ts
+//
+// P11 Slice 2 — criterion 8 helper (`mechanism.tendon-body-intersect`).
+// A balance tendon's routed path must not pass through the solid interior
+// of any part that is not one of its two anchor parts (or a part it
+// explicitly routes around via a wrap geom). This is the static authoring
+// backstop that runs in `kernelcad validate` BEFORE MuJoCo spins up — it
+// red-flags "the spring cuts through the arm" at author time.
+//
+// The cable polyline is approximated as straight segments through the
+// endpoint anchors and each wrap-geom origin (a conservative centerline
+// proxy; the tangent-accurate wrap path is a follow-up).
+//
+// Exclusion model (DEVIATES from the spec's "non-anchor parts only", on
+// purpose — see plan note): the spec's literal rule would skip the two
+// anchor parts entirely, but on the Luxo lamp every balance spring spans
+// two ADJACENT arms, so the straight cable cuts through its OWN anchor
+// arm — exactly the reported "spring goes through the structure" bug, yet
+// invisible to a non-anchor-only check. So we instead exclude only the
+// parts the cable physically routes AROUND (the wrap-geom owners; the
+// centerline proxy runs through their interior by construction) and skip
+// samples within `ANCHOR_MARGIN_MM` of an anchor attachment point (the
+// cable legitimately touches the body surface there). Every other body —
+// anchor or not — must stay clear.
+//
+// Spec:  docs/specs/2026-06-03-physics-loop-P11-collision-aware-mujoco.md
+// Plan:  docs/plans/2026-06-03-physics-loop-P11-slice-2-wrap-geom-routing.md
+
+import type { Assembly } from '../capture/assembly';
+import type { SceneBackend } from '../../kernel/backends/sceneBackend';
+import type { OcctBackend } from '../../kernel/backends/occt/occtBackend';
+import type { Transform } from '../../shared/runtime/se3';
+import { parseConnectorRef } from '../mates/mate';
+import { measureGapToBody } from './jointMeshContinuity';
+
+/** Polyline sampling pitch (mm) along each tendon segment. */
+export const TENDON_SAMPLE_MM = 5;
+/**
+ * Clearance floor (mm). A sample point whose surface gap to a non-anchor
+ * body is below this — including 0, the "inside the solid" value
+ * `measureGapToBody` returns — counts as a pierce. Tighter than criterion
+ * 7's 1.0 mm because tendon clearance is a "must not touch" condition;
+ * 0.5 mm absorbs OCCT boolean noise without admitting visible piercing.
+ */
+export const TENDON_BODY_CLEARANCE_MM = 0.5;
+/**
+ * Radius (mm) around each anchor attachment point within which samples are
+ * ignored — the cable legitimately meets the body surface at its anchor,
+ * so a small neighbourhood must not count as a pierce.
+ */
+export const ANCHOR_MARGIN_MM = 5;
+
+export interface TendonBodyIntersectSample {
+  readonly transforms: ReadonlyMap<string, Transform>;
+  readonly scene: SceneBackend;
+}
+
+export interface TendonBodyIntersectResult {
+  readonly tendonName: string;
+  readonly partName: string;
+  readonly pointWorld: readonly [number, number, number];
+  /** Surface gap (mm) at the offending sample; 0 means inside the solid. */
+  readonly gapMm: number;
+}
+
+type V3 = readonly [number, number, number];
+
+function dist(a: V3, b: V3): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+function lerp(a: V3, b: V3, u: number): V3 {
+  return [a[0] + (b[0] - a[0]) * u, a[1] + (b[1] - a[1]) * u, a[2] + (b[2] - a[2]) * u];
+}
+
+/**
+ * Evaluate criterion 8 at a single solved pose. Returns one result per
+ * (tendon, pierced-part) pair — the first offending sample for that pair.
+ * The caller maps each into a `mechanism.tendon-body-intersect` diagnostic.
+ */
+export function checkTendonBodyIntersectAtPose(
+  arm: Assembly,
+  sample: TendonBodyIntersectSample,
+): TendonBodyIntersectResult[] {
+  const out: TendonBodyIntersectResult[] = [];
+  const partByName = new Map<string, ReturnType<Assembly['__parts']>[number]>();
+  for (const p of arm.__parts()) partByName.set(p.name, p);
+
+  // Resolve a tendon endpoint ("part.connector") to a world point at this
+  // pose. Returns undefined for topology-query origins (not resolved here,
+  // same as criterion 7) or a missing transform.
+  const endpointWorld = (ref: string): { partName: string; world: V3 } | undefined => {
+    let parsed: { partName: string; connectorName: string };
+    try {
+      parsed = parseConnectorRef(ref);
+    } catch {
+      return undefined;
+    }
+    const part = partByName.get(parsed.partName);
+    const conn = part?.mateConnectors.find((c) => c.name === parsed.connectorName);
+    if (conn === undefined || conn.origin.kind !== 'vec3') return undefined;
+    const T = sample.transforms.get(parsed.partName);
+    if (T === undefined) return undefined;
+    return { partName: parsed.partName, world: T.point(conn.origin.value) as V3 };
+  };
+
+  for (const t of arm.__tendons()) {
+    const a = endpointWorld(t.from);
+    const b = endpointWorld(t.to);
+    if (a === undefined || b === undefined) continue;
+
+    // Only the parts the cable routes AROUND are excluded (the centerline
+    // proxy runs through their interior by construction). Anchor parts are
+    // checked — the anchor-point margin below admits the legitimate surface
+    // attachment without admitting a cable that dives through the body.
+    const excluded = new Set<string>();
+    const waypoints: V3[] = [a.world];
+    for (const w of t.wrapGeoms) {
+      excluded.add(w.partName);
+      const owner = partByName.get(w.partName);
+      const wg = owner?.wrapGeoms.find((g) => g.name === w.wrapName);
+      const T = sample.transforms.get(w.partName);
+      if (wg !== undefined && T !== undefined) waypoints.push(T.point(wg.origin) as V3);
+    }
+    waypoints.push(b.world);
+
+    const fired = new Set<string>(); // one diagnostic per (tendon, part)
+    for (let seg = 0; seg < waypoints.length - 1; seg++) {
+      const p0 = waypoints[seg];
+      const p1 = waypoints[seg + 1];
+      const n = Math.max(1, Math.ceil(dist(p0, p1) / TENDON_SAMPLE_MM));
+      for (let k = 0; k <= n; k++) {
+        const pt = lerp(p0, p1, k / n);
+        // Skip the legitimate attachment neighbourhood around each anchor.
+        if (dist(pt, a.world) < ANCHOR_MARGIN_MM || dist(pt, b.world) < ANCHOR_MARGIN_MM) continue;
+        for (const sp of sample.scene.parts) {
+          if (excluded.has(sp.name) || fired.has(sp.name)) continue;
+          const gap = measureGapToBody(sp.shape as OcctBackend, sp.worldTransform, pt);
+          if (gap !== undefined && gap < TENDON_BODY_CLEARANCE_MM) {
+            out.push({ tendonName: t.name, partName: sp.name, pointWorld: pt, gapMm: gap });
+            fired.add(sp.name);
+          }
+        }
+      }
+    }
+  }
+  return out;
+}

--- a/src/shared/diagnostics/registry.ts
+++ b/src/shared/diagnostics/registry.ts
@@ -1081,6 +1081,20 @@ export const DIAGNOSTIC_REGISTRY = {
     group: 'mechanism',
     description: 'Starting from REST, the mechanism does not hold its declared pose under gravity: at least one joint drifts > 5° or one body translates > 50 mm in a 0.5 s passive simulation. Means the mechanism would visibly collapse on a desk without an actuator or closed-loop spring.',
   },
+  // Physics-loop P11 Slice 2 — static tendon-routing backstop. Emitted by
+  // `mechanismTruth.ts` criterion 8 when a balance tendon's routed path
+  // cuts through a body it is neither anchored to nor routing around. The
+  // runtime counterpart is MuJoCo wrap-geom routing; this code is the
+  // design-time gate that red-flags "the spring goes through the arm"
+  // before MuJoCo is asked to spin up.
+  'mechanism.tendon-body-intersect': {
+    hintTemplate:
+      "A tendon's routed path passes through (or within 0.5 mm of) a part it is not anchored to and does not route around. Declare a wrap geom on the offending part via part.wrapGeom(name, { axis, radius }) and add it to the tendon's wrapGeoms so the cable rides over the body, or relocate the tendon anchors so the straight line stays clear at every sampled pose.",
+    nextAction: { kind: 'rewrite-feature', guidance: 'route the tendon around the body with a wrap geom, or relocate its anchors so the cable stays clear of non-anchor parts at every pose' },
+    defaultSeverity: 'error',
+    group: 'mechanism',
+    description: 'A balance tendon\'s routed polyline passes through the solid interior of a part that is neither one of its anchor parts nor a wrap-geom rail it routes around, at some sampled pose. Means the spring would visibly cut through structure.',
+  },
   // Assembly visual-review gating (3)
   'assembly.visual.review-check-failed': {
     hintTemplate:

--- a/tests/integration/examples/luxoLampClevis.test.ts
+++ b/tests/integration/examples/luxoLampClevis.test.ts
@@ -49,12 +49,17 @@ describe('Luxo lamp — passes the physics-grounded loop', () => {
     expect(revoluteMates.length).toBeGreaterThanOrEqual(3);
   });
 
-  it('passes the kinematic-only mechanism-truth loop: mechanism: real with empty failures (re-enabled by P9 Luxo geometry fix)', async () => {
-    // P9 (2026-06-02): with the column extended to COLUMN_TOP_Z, the
-    // head-neck pulled back to cover the wrist pivot, and small
-    // spring-mounting posts added to each arm, the lamp now passes
-    // the full kinematic-only mechanism-truth loop (criteria 1-4 +
-    // P8 joint-mesh-continuity criterion 7).
+  it('P11 Slice 2: criterion 8 flags the straight springs piercing the arms (RED by design until Slice 3 wrap re-author)', async () => {
+    // P9 made the lamp pass the kinematic loop (criteria 1-4 + 7) with
+    // `mechanism: real`. P11 Slice 2 adds criterion 8
+    // (mechanism.tendon-body-intersect): the three balance springs are
+    // still authored as straight `<spatial>` lines, so each cable cuts
+    // through the arm body it spans — exactly the "spring goes through
+    // the structure" bug. The gate is therefore RED here BY DESIGN; Slice
+    // 3 re-authors the springs with wrap geoms and restores `real`. The
+    // assertion below pins the intermediate state AND proves the only new
+    // breakage is criterion 8 — the kinematic criteria (1-4, 7) remain
+    // clean, so the soundness P9 established is intact.
     const r = await runValidateCli({
       file: LUXO_SCRIPT_PATH,
       epsilon: 0.01,
@@ -63,8 +68,13 @@ describe('Luxo lamp — passes the physics-grounded loop', () => {
       json: true,
       includePhysics: false,
     });
-    expect(r.mechanism).toBe('real');
-    expect(r.mechanismFailures ?? []).toEqual([]);
+    expect(r.mechanism).toBe('broken');
+    const failures = r.mechanismFailures ?? [];
+    const tendonHits = failures.filter((f) => f.code === 'mechanism.tendon-body-intersect');
+    // At least one spring pierces an arm.
+    expect(tendonHits.length).toBeGreaterThan(0);
+    // EVERY failure is criterion 8 — no kinematic criterion regressed.
+    expect(failures.every((f) => f.code === 'mechanism.tendon-body-intersect')).toBe(true);
   }, 240_000);
 
   it('P8 joint-mesh-continuity gate sees NO joint-mesh-gap diagnostics on the post-P9 Luxo (GREEN after P9)', async () => {
@@ -84,7 +94,11 @@ describe('Luxo lamp — passes the physics-grounded loop', () => {
       (f) => f.code === 'mechanism.joint-mesh-gap',
     );
     expect(gaps).toEqual([]);
-    expect(r.mechanism).toBe('real');
+    // NOTE: the overall verdict is `broken` in Slice 2 because criterion 8
+    // (tendon-body-intersect) flags the straight springs — see the
+    // dedicated test above. This test's contract is ONLY that criterion 7
+    // (joint-mesh-gap) stays clean, which it does. Slice 3's wrap
+    // re-author restores `mechanism: real`.
   }, 240_000);
 
   it('P11 Slice 1: emitted MJCF contains one <mesh> + one <geom type="mesh"> per part', async () => {
@@ -123,13 +137,18 @@ describe('Luxo lamp — passes the physics-grounded loop', () => {
     expect(excludeCount).toBe(3);
   }, 240_000);
 
-  it('passes the physics gate (criteria 5+6) — closed by P10 closed-loop tendon API (closes #361)', async () => {
-    // P10 (2026-06-03): the lamp's three balance springs are now
-    // closed-loop `arm.tendon(...)` calls. MuJoCo's <spatial> tendon
-    // applies the restoring moment that holds the lamp at qpos=0
-    // against gravity; the drop-test reports `mechanism: 'real'` with
-    // no `mechanism.drops-on-release` diagnostic. Issue #361 closes
-    // with this commit.
+  it('still passes the physics gate (criteria 5+6) — only criterion 8 breaks the overall verdict in Slice 2', async () => {
+    // P10 (2026-06-03): the lamp's three balance springs are closed-loop
+    // `arm.tendon(...)` calls; MuJoCo's <spatial> tendon holds the lamp at
+    // qpos=0 against gravity, so the drop-test (criterion 6) and static
+    // equilibrium (criterion 5) stay clean.
+    //
+    // P11 Slice 2: criterion 8 now also runs and is RED (straight springs
+    // pierce the arms), so the OVERALL verdict is `broken`. But the
+    // PHYSICS criteria themselves are unaffected — this test pins that no
+    // `drops-on-release` / `unstable-under-gravity` diagnostic fires, i.e.
+    // P10's #361 closure still holds. Slice 3's wrap re-author clears
+    // criterion 8 and the overall verdict returns to `real`.
     const r = await runValidateCli({
       file: LUXO_SCRIPT_PATH,
       epsilon: 0.01,
@@ -138,7 +157,12 @@ describe('Luxo lamp — passes the physics-grounded loop', () => {
       json: true,
       includePhysics: true,
     });
-    expect(r.mechanism).toBe('real');
-    expect(r.mechanismFailures ?? []).toEqual([]);
+    const failures = r.mechanismFailures ?? [];
+    const physicsHits = failures.filter(
+      (f) => f.code === 'mechanism.drops-on-release' || f.code === 'mechanism.unstable-under-gravity',
+    );
+    expect(physicsHits).toEqual([]);
+    // The only thing keeping the lamp from `real` is criterion 8.
+    expect(failures.every((f) => f.code === 'mechanism.tendon-body-intersect')).toBe(true);
   }, 240_000);
 });

--- a/tests/unit/diagnostics/codes.test.ts
+++ b/tests/unit/diagnostics/codes.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { DIAGNOSTIC_CODES, HINT_TEMPLATES } from '../../../src/shared/diagnostics/registry';
 
 describe('diagnostic catalogue invariants', () => {
-  it('emits exactly 203 codes', () => {
-    // 165 baseline + 10 NURBS analytics (V merged) + 10 Query DSL (Q merged) + 9 K1-K9 kinematic + 1 v0.7 Gate 4 (assembly.joint.not-visible) + 1 G2 Gate 6 (assembly.mate.not-physically-realized) + 4 P0 mechanism-truth codes (mechanism.disconnect / interpenetration / dof-mismatch / orphan-part) + 2 P6 physics codes (mechanism.unstable-under-gravity / mechanism.drops-on-release) + 1 P8 joint-mesh-continuity gate (mechanism.joint-mesh-gap).
-    expect(DIAGNOSTIC_CODES).toHaveLength(203);
-    expect(new Set(DIAGNOSTIC_CODES).size).toBe(203);
+  it('emits exactly 204 codes', () => {
+    // 165 baseline + 10 NURBS analytics (V merged) + 10 Query DSL (Q merged) + 9 K1-K9 kinematic + 1 v0.7 Gate 4 (assembly.joint.not-visible) + 1 G2 Gate 6 (assembly.mate.not-physically-realized) + 4 P0 mechanism-truth codes (mechanism.disconnect / interpenetration / dof-mismatch / orphan-part) + 2 P6 physics codes (mechanism.unstable-under-gravity / mechanism.drops-on-release) + 1 P8 joint-mesh-continuity gate (mechanism.joint-mesh-gap) + 1 P11 Slice 2 tendon-routing gate (mechanism.tendon-body-intersect).
+    expect(DIAGNOSTIC_CODES).toHaveLength(204);
+    expect(new Set(DIAGNOSTIC_CODES).size).toBe(204);
   });
 
   it('every code has a non-empty hint template', () => {

--- a/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
+++ b/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
@@ -120,8 +120,9 @@ describe('every diagnostic code emitted in src/ is in the catalogue', () => {
     //  + 2 P6 physics-grounded loop: mechanism.unstable-under-gravity,
     //       mechanism.drops-on-release.
     //  + 1 P8 joint-mesh-continuity gate (this slice): mechanism.joint-mesh-gap.
-    // Final = 157 - 3 + 11 + 1 + 5 + 2 + 2 + 7 + 1 + 1 + 1 + 9 + 1 + 1 + 4 + 2 + 1 = 203.
-    expect(catalogue.size).toBe(203);
+    //  + 1 P11 Slice 2 tendon-routing gate: mechanism.tendon-body-intersect.
+    // Final = 157 - 3 + 11 + 1 + 5 + 2 + 2 + 7 + 1 + 1 + 1 + 9 + 1 + 1 + 4 + 2 + 1 + 1 = 204.
+    expect(catalogue.size).toBe(204);
   });
 
   it('no emit site uses a code outside the catalogue', () => {


### PR DESCRIPTION
**Stacked on #370 (Slice 1). DO NOT MERGE until Slice 3 re-authors Luxo green** — criterion 8 is RED on Luxo by design here (see below); merging alone turns `develop` red.

Routes balance tendons around bodies so the cable stops cutting through structure (the bug the user reported on the P10 Luxo: "springs go through the arms").

## What ships
- **Capture API** — `part.wrapGeom(name, { axis, origin?, radius, halfLengthMm? })` declares a collision-OFF routing cylinder; `tendon({ ..., wrapGeoms: [{ partName, wrapName, sidesite? }] })` routes the cable around them. Full capture-time validation.
- **MJCF emit** — one `<geom type="cylinder" contype="0" conaffinity="0">` per wrap geom; tendons with wrapGeoms emit a routed `<spatial>` child sequence (`<site from>` → `<geom geom=…>` with sidesite + auto separator sites → `<site to>`). Round-trips through `MjModel.from_xml_string`.
- **Criterion 8 `mechanism.tendon-body-intersect`** — static authoring gate: samples each tendon's routed polyline every 5 mm at every solved pose and flags any body it pierces (0.5 mm clearance). Reuses `measureGapToBody`. Registry 203 → 204.

## Deviation from plan (flagged)
The spec said criterion 8 should check "non-anchor parts only". Built it that way, ran it on Luxo → **`mechanism: real`, gate silent.** Every Luxo spring spans two *adjacent* arms, so the cable pierces its *own anchor arm* — the actual bug, which a non-anchor check misses. Corrected to: exclude only the parts the cable **routes around** (wrap-geom owners) + a 5 mm margin around each anchor point; all other bodies (anchor or not) must stay clear. Re-ran → Luxo RED with 4 actionable diagnostics. The spec's "RED on Luxo" intent holds, now for the right reason.

## Luxo is RED by design
Criterion 8 flags all three straight springs piercing the arms. The Luxo tests were updated (not deleted) to pin this intermediate state and prove **only** criterion 8 breaks the verdict — kinematic criteria 1-4,7 and physics criteria 5+6 are all still clean. Slice 3's wrap re-author clears criterion 8 and restores `mechanism: real`.

## Tests
- Capture validation (11), MJCF wrap round-trip (2), criterion-8 helper RED/GREEN — non-anchor pierce, anchor-interior pierce, moved-clear, wrap-routed-clear (4, deterministic hand-built scene), diagnostics count (204), Luxo integration (6, intermediate state). tsc clean.