### PR TITLE
P11 Slice 3 — route Luxo springs over wrap rails + routed coil render (closes the train)

### DIFF
--- a/examples/kinematic/luxo-lamp.kcad.ts
+++ b/examples/kinematic/luxo-lamp.kcad.ts
@@ -102,6 +102,18 @@ const SPRING_POST_R = 1.0;                   // 1 mm wire-thin
 const SPRING_MOUNT_DZ = 5;                   // 5 mm clearance between beam top and anchor centerline
 const SPRING_POST_H = SPRING_MOUNT_DZ + 1;   // 1 mm of overlap with the beam top
 
+// P11 Slice 2/3 — tendon wrap-routing rails. Each balance spring rode as
+// a straight <spatial> line between its two anchors, which (with the
+// arms folded at every joint) cut straight through the arm bodies it
+// spans — criterion 8 (mechanism.tendon-body-intersect) flags this. A
+// thin collision-OFF cylinder running along each beam at the spring-
+// anchor height gives the cable a rail to wrap over, so it rides above
+// the beam instead of through it. Centerline at the anchor height
+// (ARM_T/2 + SPRING_MOUNT_DZ) so the routed path stays clear of the beam
+// solid (top at ARM_T/2).
+const RAIL_R = 4;                            // rail radius (cable standoff over the beam)
+const RAIL_Z = ARM_T / 2 + SPRING_MOUNT_DZ;  // 14 mm — same height as the spring anchors
+
 // ---- assembly handle -----------------------------------------------------
 const arm = assembly('luxo-lamp');
 
@@ -399,6 +411,15 @@ const lowerArmPart = arm
   .connector('elbowSpringAnchorLower', {
     type: 'frame',
     origin: { kind: 'vec3', value: LOWER_ELBOW_ANCHOR },
+  })
+  // P11 Slice 3 — wrap rail along the lower-arm beam at the spring-anchor
+  // height. The shoulder + elbow springs route over it so neither cable
+  // cuts through the lower-arm body.
+  .wrapGeom('lowerRail', {
+    axis: [1, 0, 0],
+    origin: [LOWER_BEAM_MID, 0, RAIL_Z],
+    radius: RAIL_R,
+    halfLengthMm: LOWER_BEAM_LEN / 2,
   });
 
 const upperArmPart = arm
@@ -420,6 +441,14 @@ const upperArmPart = arm
   .connector('wristSpringAnchorUpper', {
     type: 'frame',
     origin: { kind: 'vec3', value: UPPER_WRIST_ANCHOR },
+  })
+  // P11 Slice 3 — wrap rail along the upper-arm beam; the elbow spring
+  // routes over it so the cable rides above the upper-arm body.
+  .wrapGeom('upperRail', {
+    axis: [1, 0, 0],
+    origin: [UPPER_BEAM_MID, 0, RAIL_Z],
+    radius: RAIL_R,
+    halfLengthMm: UPPER_BEAM_LEN / 2,
   });
 
 const headPart = arm
@@ -432,6 +461,15 @@ const headPart = arm
   .connector('wristSpringAnchorHead', {
     type: 'frame',
     origin: { kind: 'vec3', value: HEAD_WRIST_ANCHOR },
+  })
+  // P11 Slice 3 — short wrap rail over the head neck at the wrist-spring
+  // anchor height; the wrist spring routes over it so the cable clears
+  // the lamp-head body.
+  .wrapGeom('headRail', {
+    axis: [1, 0, 0],
+    origin: [HEAD_WRIST_ANCHOR_X, 0, HEAD_NECK_TOP_Z + SPRING_MOUNT_DZ],
+    radius: RAIL_R,
+    halfLengthMm: 15,
   });
 
 void basePart;
@@ -489,6 +527,8 @@ arm.tendon('shoulder-spring', {
   coilTurns: 12,
   coilDiameterMm: 8,
   visualDiameterMm: 1.4,
+  // P11 Slice 3 — route over the lower-arm rail so the cable clears the beam.
+  wrapGeoms: [{ partName: 'lower-arm', wrapName: 'lowerRail' }],
 });
 
 // Elbow spring: spans from the lower-arm rear-end post (140 mm forward
@@ -506,6 +546,12 @@ arm.tendon('elbow-spring', {
   coilTurns: 10,
   coilDiameterMm: 7,
   visualDiameterMm: 1.2,
+  // P11 Slice 3 — route over both arm rails so the cable spans the elbow
+  // above the two beams instead of through them.
+  wrapGeoms: [
+    { partName: 'lower-arm', wrapName: 'lowerRail' },
+    { partName: 'upper-arm', wrapName: 'upperRail' },
+  ],
 });
 
 // Wrist spring: spans from the upper-arm rear-end post to the head
@@ -521,6 +567,12 @@ arm.tendon('wrist-spring', {
   coilTurns: 8,
   coilDiameterMm: 6,
   visualDiameterMm: 1.0,
+  // P11 Slice 3 — route over the upper-arm rail then the head-neck rail
+  // so the cable clears both bodies on its way to the head anchor.
+  wrapGeoms: [
+    { partName: 'upper-arm', wrapName: 'upperRail' },
+    { partName: 'lamp-head', wrapName: 'headRail' },
+  ],
 });
 
 return arm.solvedModel({});

--- a/src/modeling/capture/featureMeshing.ts
+++ b/src/modeling/capture/featureMeshing.ts
@@ -17,7 +17,7 @@ import { transformFeatureMesh } from './transformMesh';
 import { resolveFaceLabelToFace } from '../../kernel/backends/occt/edgeSelection';
 import { faceHashOf } from '../../kernel/backends/occt/createdRefs';
 import { generatePlanarUVs } from './planarUv';
-import { helixPolyline } from '../mates/helixPolyline';
+import { helixPolylineRouted } from '../mates/helixPolyline';
 
 /** Attach bbox-planar UVs to every face in-place (idempotent — pre-existing
  *  uv arrays are preserved). Called after meshing so any consumer of
@@ -243,6 +243,11 @@ interface AssemblyLikeForTendons {
     readonly visualStyle?: 'line' | 'coil';
     readonly coilTurns?: number;
     readonly coilDiameterMm?: number;
+    /** P11 Slice 3: ordered wrap-geom rails the coil routes over. */
+    readonly wrapGeoms?: readonly {
+      readonly partName: string;
+      readonly wrapName: string;
+    }[];
   }[];
   __parts(): readonly {
     readonly name: string;
@@ -251,6 +256,11 @@ interface AssemblyLikeForTendons {
       readonly origin:
         | { kind: 'vec3'; value: Vec3 }
         | { kind: 'topology'; query: unknown };
+    }[];
+    /** P11 Slice 3: wrap-geom rails declared on this part. */
+    readonly wrapGeoms?: readonly {
+      readonly name: string;
+      readonly origin: Vec3;
     }[];
   }[];
 }
@@ -379,15 +389,17 @@ function buildCylinderFaceWorld(
  * `wireDiameterMm` is the WIRE diameter (the tube sweep radius is half).
  */
 function buildHelixTubeMesh(
-  fromWorld: Vec3,
-  toWorld: Vec3,
+  centerline: readonly Vec3[],
   coilTurns: number,
   coilDiameterMm: number,
   wireDiameterMm: number,
   radialSegments = 8,
 ): FaceGeometry | null {
   if (wireDiameterMm <= 0 || coilDiameterMm <= 0 || coilTurns < 1) return null;
-  const polyline = helixPolyline(fromWorld, toWorld, coilTurns, coilDiameterMm);
+  // P11 Slice 3: spiral along the wrap-routed centerline (`[from, …wraps,
+  // to]`). A 2-point centerline is byte-identical to the old straight
+  // helixPolyline(from, to, …).
+  const polyline = helixPolylineRouted(centerline, coilTurns, coilDiameterMm);
   if (polyline.length < 2) return null;
   const ringCount = polyline.length;
   const tubeR = wireDiameterMm * 0.5;
@@ -523,11 +535,16 @@ function collectTendonMeshes(
 
   // (partName.connectorName) → vec3 origin lookup.
   const originByRef = new Map<string, Vec3>();
+  // (partName, wrapName) → part-local wrap origin lookup (P11 Slice 3).
+  const wrapOriginByRef = new Map<string, Vec3>();
   for (const part of arm.__parts()) {
     for (const conn of part.mateConnectors) {
       if (conn.origin.kind === 'vec3') {
         originByRef.set(`${part.name}.${conn.name}`, conn.origin.value);
       }
+    }
+    for (const wg of part.wrapGeoms ?? []) {
+      wrapOriginByRef.set(`${part.name}.${wg.name}`, wg.origin);
     }
   }
 
@@ -556,6 +573,19 @@ function collectTendonMeshes(
     if (fromT === undefined || toT === undefined) continue;
     const fromWorld = applyMat4ToPoint(fromT, fromOrigin);
     const toWorld = applyMat4ToPoint(toT, toOrigin);
+    // P11 Slice 3: routed centerline — from-anchor, each wrap-geom origin
+    // in world coords (skip ones whose part/origin can't be resolved), then
+    // the to-anchor. With no wrapGeoms this is just [from, to], so straight
+    // tendons render identically to the pre-Slice-3 path.
+    const centerline: Vec3[] = [fromWorld];
+    for (const w of t.wrapGeoms ?? []) {
+      const wLocal = wrapOriginByRef.get(`${w.partName}.${w.wrapName}`);
+      const wT = transformByPart.get(w.partName);
+      if (wLocal !== undefined && wT !== undefined) {
+        centerline.push(applyMat4ToPoint(wT, wLocal));
+      }
+    }
+    centerline.push(toWorld);
     // P10: coil tendons sweep an 8-facet tube along the helix polyline;
     // line tendons fall through to the existing PR #368 cylinder path.
     const style = t.visualStyle ?? 'line';
@@ -563,7 +593,7 @@ function collectTendonMeshes(
     if (style === 'coil') {
       const turns = t.coilTurns ?? 10;
       const coilDiameter = t.coilDiameterMm ?? 7;
-      face = buildHelixTubeMesh(fromWorld, toWorld, turns, coilDiameter, t.visualDiameterMm);
+      face = buildHelixTubeMesh(centerline, turns, coilDiameter, t.visualDiameterMm);
     } else {
       face = buildCylinderFaceWorld(fromWorld, toWorld, t.visualDiameterMm);
     }

--- a/src/modeling/mates/helixPolyline.test.ts
+++ b/src/modeling/mates/helixPolyline.test.ts
@@ -1,0 +1,61 @@
+// src/modeling/mates/helixPolyline.test.ts
+//
+// P11 Slice 3 — helixPolylineRouted spirals a coil along a wrap-routed
+// centerline. A 2-point centerline must reproduce the straight
+// helixPolyline exactly (back-compat); a multi-waypoint centerline must
+// bend through its waypoints with endpoints landing exactly on the ends.
+
+import { describe, it, expect } from 'vitest';
+import { helixPolyline, helixPolylineRouted } from './helixPolyline';
+
+const dist = (a: readonly number[], b: readonly number[]) =>
+  Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+
+describe('helixPolylineRouted', () => {
+  it('reduces to the straight helix for a 2-point centerline', () => {
+    const a: [number, number, number] = [0, 0, 0];
+    const b: [number, number, number] = [100, 0, 0];
+    const straight = helixPolyline(a, b, 6, 8);
+    const routed = helixPolylineRouted([a, b], 6, 8);
+    expect(routed.length).toBe(straight.length);
+    for (let i = 0; i < straight.length; i++) {
+      expect(dist(routed[i], straight[i])).toBeLessThan(1e-9);
+    }
+  });
+
+  it('bends through an interior waypoint (routed path hugs the kink)', () => {
+    const a: [number, number, number] = [0, 0, 0];
+    const w: [number, number, number] = [50, 0, 40]; // lifted waypoint
+    const b: [number, number, number] = [100, 0, 0];
+    const routed = helixPolylineRouted([a, w, b], 6, 8);
+    // Some sample near the middle of the coil must sit near the waypoint
+    // height (the straight a→b chord stays at z≈0, so z≈40 proves routing).
+    const maxZ = Math.max(...routed.map((p) => p[2]));
+    expect(maxZ).toBeGreaterThan(30);
+    // The straight helix would never reach that height.
+    const straightMaxZ = Math.max(...helixPolyline(a, b, 6, 8).map((p) => p[2]));
+    expect(straightMaxZ).toBeLessThan(10);
+  });
+
+  it('lands exactly on the first and last centerline points', () => {
+    const a: [number, number, number] = [3, -2, 1];
+    const w: [number, number, number] = [40, 5, 30];
+    const b: [number, number, number] = [90, 0, 2];
+    const routed = helixPolylineRouted([a, w, b], 8, 7);
+    expect(dist(routed[0], a)).toBeLessThan(1e-9);
+    expect(dist(routed[routed.length - 1], b)).toBeLessThan(1e-9);
+    // No NaN anywhere.
+    for (const p of routed) {
+      expect(Number.isFinite(p[0]) && Number.isFinite(p[1]) && Number.isFinite(p[2])).toBe(true);
+    }
+  });
+
+  it('drops duplicate consecutive waypoints without throwing', () => {
+    const a: [number, number, number] = [0, 0, 0];
+    const b: [number, number, number] = [100, 0, 0];
+    const routed = helixPolylineRouted([a, a, [50, 0, 0], b, b], 5, 6);
+    expect(routed.length).toBeGreaterThan(2);
+    expect(dist(routed[0], a)).toBeLessThan(1e-9);
+    expect(dist(routed[routed.length - 1], b)).toBeLessThan(1e-9);
+  });
+});

--- a/src/modeling/mates/helixPolyline.ts
+++ b/src/modeling/mates/helixPolyline.ts
@@ -114,3 +114,126 @@ export function helixPolyline(
     out[sampleCount - 1] = [bx, by, bz];
     return out;
 }
+
+function unitFrame(t: Vec3): [Vec3, Vec3] {
+    // u = worldZ × t (fallback worldX × t when t ∥ worldZ); v = t × u.
+    let ux = -t[1], uy = t[0], uz = 0;
+    let uLen = Math.sqrt(ux * ux + uy * uy + uz * uz);
+    if (uLen < 1e-6) {
+        ux = 0; uy = -t[2]; uz = t[1];
+        uLen = Math.sqrt(ux * ux + uy * uy + uz * uz) || 1;
+    }
+    ux /= uLen; uy /= uLen; uz /= uLen;
+    const v: Vec3 = [
+        t[1] * uz - t[2] * uy,
+        t[2] * ux - t[0] * uz,
+        t[0] * uy - t[1] * ux,
+    ];
+    return [[ux, uy, uz], v];
+}
+
+// Rotate vector `w` from tangent `t0` to tangent `t1` (Rodrigues about the
+// t0×t1 axis) so a twist frame parallel-transports across a waypoint kink
+// without flipping. Returns `w` unchanged when the tangents are colinear.
+function transport(w: Vec3, t0: Vec3, t1: Vec3): Vec3 {
+    const ax = t0[1] * t1[2] - t0[2] * t1[1];
+    const ay = t0[2] * t1[0] - t0[0] * t1[2];
+    const az = t0[0] * t1[1] - t0[1] * t1[0];
+    const sin = Math.sqrt(ax * ax + ay * ay + az * az);
+    const cos = t0[0] * t1[0] + t0[1] * t1[1] + t0[2] * t1[2];
+    if (sin < 1e-9) return w; // colinear (same or opposite — leave as-is)
+    const kx = ax / sin, ky = ay / sin, kz = az / sin;
+    const dot = kx * w[0] + ky * w[1] + kz * w[2];
+    const cx = ky * w[2] - kz * w[1];
+    const cy = kz * w[0] - kx * w[2];
+    const cz = kx * w[1] - ky * w[0];
+    return [
+        w[0] * cos + cx * sin + kx * dot * (1 - cos),
+        w[1] * cos + cy * sin + ky * dot * (1 - cos),
+        w[2] * cos + cz * sin + kz * dot * (1 - cos),
+    ];
+}
+
+/**
+ * P11 Slice 3 — spiral a helix along an arbitrary piecewise-linear
+ * centerline `[a, w1, w2, …, b]` (the tendon's wrap-routed path) instead
+ * of a straight A→B segment. Winding phase advances by cumulative arc
+ * length so the coil reads continuously across waypoint kinks; the twist
+ * frame parallel-transports between segments to avoid flips. Endpoints
+ * land exactly on the first/last centerline point.
+ *
+ * A 2-point centerline reduces to `helixPolyline(a, b, …)` exactly, so
+ * straight (wrap-free) tendons are byte-identical to the pre-Slice-3 path.
+ */
+export function helixPolylineRouted(
+    centerline: readonly Vec3[],
+    turns: number,
+    coilDiameterMm: number,
+): Vec3[] {
+    // Drop consecutive duplicate waypoints (a collapsed wrap origin etc.).
+    const c: Vec3[] = [];
+    for (const p of centerline) {
+        const last = c[c.length - 1];
+        if (last === undefined || Math.hypot(p[0] - last[0], p[1] - last[1], p[2] - last[2]) > 1e-9) {
+            c.push([p[0], p[1], p[2]]);
+        }
+    }
+    if (c.length === 0) return helixPolyline([0, 0, 0], [0, 0, 0], turns, coilDiameterMm);
+    if (c.length === 1) return helixPolyline(c[0], c[0], turns, coilDiameterMm);
+    if (c.length === 2) return helixPolyline(c[0], c[1], turns, coilDiameterMm);
+
+    // Segment directions, lengths, cumulative arc length.
+    const dirs: Vec3[] = [];
+    const lens: number[] = [];
+    const cum: number[] = [0];
+    let L = 0;
+    for (let i = 0; i < c.length - 1; i++) {
+        const dx = c[i + 1][0] - c[i][0];
+        const dy = c[i + 1][1] - c[i][1];
+        const dz = c[i + 1][2] - c[i][2];
+        const l = Math.sqrt(dx * dx + dy * dy + dz * dz) || 1;
+        dirs.push([dx / l, dy / l, dz / l]);
+        lens.push(l);
+        L += l;
+        cum.push(L);
+    }
+
+    // Parallel-transported twist frame per segment.
+    const us: Vec3[] = [];
+    const vs: Vec3[] = [];
+    let [u, v] = unitFrame(dirs[0]);
+    us.push(u); vs.push(v);
+    for (let i = 1; i < dirs.length; i++) {
+        u = transport(u, dirs[i - 1], dirs[i]);
+        v = transport(v, dirs[i - 1], dirs[i]);
+        us.push(u); vs.push(v);
+    }
+
+    const safeTurns = Math.max(1, turns);
+    const sampleCount = Math.max(2, Math.floor(safeTurns * HELIX_SAMPLES_PER_TURN) + 1);
+    const coilR = coilDiameterMm * 0.5;
+    const twoPi = Math.PI * 2;
+    const out: Vec3[] = new Array(sampleCount);
+    for (let i = 0; i < sampleCount; i++) {
+        const t = i / (sampleCount - 1);
+        const s = t * L;
+        let k = 0;
+        while (k < lens.length - 1 && s > cum[k + 1]) k++;
+        const local = lens[k] > 1e-12 ? (s - cum[k]) / lens[k] : 0;
+        const bx = c[k][0] + dirs[k][0] * local * lens[k];
+        const by = c[k][1] + dirs[k][1] * local * lens[k];
+        const bz = c[k][2] + dirs[k][2] * local * lens[k];
+        const theta = t * safeTurns * twoPi;
+        const cosT = Math.cos(theta), sinT = Math.sin(theta);
+        const r = coilR * 4 * t * (1 - t);
+        const uu = us[k], vv = vs[k];
+        out[i] = [
+            bx + (uu[0] * cosT + vv[0] * sinT) * r,
+            by + (uu[1] * cosT + vv[1] * sinT) * r,
+            bz + (uu[2] * cosT + vv[2] * sinT) * r,
+        ];
+    }
+    out[0] = [c[0][0], c[0][1], c[0][2]];
+    out[sampleCount - 1] = [c[c.length - 1][0], c[c.length - 1][1], c[c.length - 1][2]];
+    return out;
+}

--- a/tests/integration/examples/luxoLampClevis.test.ts
+++ b/tests/integration/examples/luxoLampClevis.test.ts
@@ -49,17 +49,13 @@ describe('Luxo lamp — passes the physics-grounded loop', () => {
     expect(revoluteMates.length).toBeGreaterThanOrEqual(3);
   });
 
-  it('P11 Slice 2: criterion 8 flags the straight springs piercing the arms (RED by design until Slice 3 wrap re-author)', async () => {
-    // P9 made the lamp pass the kinematic loop (criteria 1-4 + 7) with
-    // `mechanism: real`. P11 Slice 2 adds criterion 8
-    // (mechanism.tendon-body-intersect): the three balance springs are
-    // still authored as straight `<spatial>` lines, so each cable cuts
-    // through the arm body it spans — exactly the "spring goes through
-    // the structure" bug. The gate is therefore RED here BY DESIGN; Slice
-    // 3 re-authors the springs with wrap geoms and restores `real`. The
-    // assertion below pins the intermediate state AND proves the only new
-    // breakage is criterion 8 — the kinematic criteria (1-4, 7) remain
-    // clean, so the soundness P9 established is intact.
+  it('passes the kinematic-only mechanism-truth loop incl. criterion 8: mechanism: real (P11 Slice 3 wrap re-author)', async () => {
+    // P9 made the lamp pass criteria 1-4 + 7. P11 Slice 2 added criterion
+    // 8 (tendon-body-intersect), which flagged the straight springs
+    // cutting through the arms. P11 Slice 3 routes each spring over a wrap
+    // rail on the beam it spans, so no cable pierces a body — the lamp is
+    // back to `mechanism: real` with the spring-through-structure bug
+    // closed.
     const r = await runValidateCli({
       file: LUXO_SCRIPT_PATH,
       epsilon: 0.01,
@@ -68,13 +64,8 @@ describe('Luxo lamp — passes the physics-grounded loop', () => {
       json: true,
       includePhysics: false,
     });
-    expect(r.mechanism).toBe('broken');
-    const failures = r.mechanismFailures ?? [];
-    const tendonHits = failures.filter((f) => f.code === 'mechanism.tendon-body-intersect');
-    // At least one spring pierces an arm.
-    expect(tendonHits.length).toBeGreaterThan(0);
-    // EVERY failure is criterion 8 — no kinematic criterion regressed.
-    expect(failures.every((f) => f.code === 'mechanism.tendon-body-intersect')).toBe(true);
+    expect(r.mechanism).toBe('real');
+    expect(r.mechanismFailures ?? []).toEqual([]);
   }, 240_000);
 
   it('P8 joint-mesh-continuity gate sees NO joint-mesh-gap diagnostics on the post-P9 Luxo (GREEN after P9)', async () => {
@@ -94,11 +85,7 @@ describe('Luxo lamp — passes the physics-grounded loop', () => {
       (f) => f.code === 'mechanism.joint-mesh-gap',
     );
     expect(gaps).toEqual([]);
-    // NOTE: the overall verdict is `broken` in Slice 2 because criterion 8
-    // (tendon-body-intersect) flags the straight springs — see the
-    // dedicated test above. This test's contract is ONLY that criterion 7
-    // (joint-mesh-gap) stays clean, which it does. Slice 3's wrap
-    // re-author restores `mechanism: real`.
+    expect(r.mechanism).toBe('real');
   }, 240_000);
 
   it('P11 Slice 1: emitted MJCF contains one <mesh> + one <geom type="mesh"> per part', async () => {
@@ -137,18 +124,14 @@ describe('Luxo lamp — passes the physics-grounded loop', () => {
     expect(excludeCount).toBe(3);
   }, 240_000);
 
-  it('still passes the physics gate (criteria 5+6) — only criterion 8 breaks the overall verdict in Slice 2', async () => {
+  it('passes the full physics gate (criteria 1-8 incl. 5+6) — wrap-routed springs hold the lamp (closes #361)', async () => {
     // P10 (2026-06-03): the lamp's three balance springs are closed-loop
     // `arm.tendon(...)` calls; MuJoCo's <spatial> tendon holds the lamp at
     // qpos=0 against gravity, so the drop-test (criterion 6) and static
-    // equilibrium (criterion 5) stay clean.
-    //
-    // P11 Slice 2: criterion 8 now also runs and is RED (straight springs
-    // pierce the arms), so the OVERALL verdict is `broken`. But the
-    // PHYSICS criteria themselves are unaffected — this test pins that no
-    // `drops-on-release` / `unstable-under-gravity` diagnostic fires, i.e.
-    // P10's #361 closure still holds. Slice 3's wrap re-author clears
-    // criterion 8 and the overall verdict returns to `real`.
+    // equilibrium (criterion 5) stay clean. P11 Slice 3 routes those
+    // springs over wrap rails, clearing criterion 8 without disturbing the
+    // physics calibration — the lamp passes every criterion with
+    // `mechanism: real`.
     const r = await runValidateCli({
       file: LUXO_SCRIPT_PATH,
       epsilon: 0.01,
@@ -157,12 +140,7 @@ describe('Luxo lamp — passes the physics-grounded loop', () => {
       json: true,
       includePhysics: true,
     });
-    const failures = r.mechanismFailures ?? [];
-    const physicsHits = failures.filter(
-      (f) => f.code === 'mechanism.drops-on-release' || f.code === 'mechanism.unstable-under-gravity',
-    );
-    expect(physicsHits).toEqual([]);
-    // The only thing keeping the lamp from `real` is criterion 8.
-    expect(failures.every((f) => f.code === 'mechanism.tendon-body-intersect')).toBe(true);
+    expect(r.mechanism).toBe('real');
+    expect(r.mechanismFailures ?? []).toEqual([]);
   }, 240_000);
 });


### PR DESCRIPTION
**Stacked on #371 (Slice 2).** Closes the P11 train: the Luxo balance springs no longer cut through the arms — geometrically, in MuJoCo, AND in the render. Restores `mechanism: real`.

## What ships
1. **Luxo re-author** — each arm gets a thin collision-OFF wrap rail at the spring-anchor height; the three springs declare `wrapGeoms` over the rails they span. `kernelcad validate --include-physics` → `mechanism: real`, zero failures (criteria 1-8 all green). No spring re-tuning needed — the P10 calibration still holds the lamp at qpos=0.
2. **Routed coil geometry** — `helixPolylineRouted()` spirals a coil along an arbitrary piecewise-linear centerline (phase by arc length, parallel-transported twist frame). `featureMeshing` feeds it the wrap-routed centerline, so the baked render draws each spring riding OVER the beams. 2-point centerline reproduces the old straight helix exactly → wrap-free tendons unchanged.

## Visual verification (the actual point)
`render inspect` of the lamp at the folded pose: all three coils arc over the arm beams (shoulder spring along the lower arm, elbow spring over the elbow joint, wrist spring to the head) instead of cutting straight chords through the bodies. The "spring goes through the structure" complaint is resolved. Criterion 8 additionally confirms clearance at every sampled pose (rest + joint limits), not just the rendered one.

## Tests
Luxo integration restored to `mechanism: real` (6 tests). New `helixPolylineRouted` unit tests (back-compat, waypoint bending, exact endpoints, dup-waypoint). featureMeshing (11) green. tsc clean.

## Follow-up (flagged, not in this PR)
The Studio INTERACTIVE renderer (`TendonRenderer.tsx`) still draws straight live coils during FK drag — routing the live path needs the wrap world-points plumbed through the Studio scene recompute loop. The baked/static render (hero + demo artifacts) is fixed here.

## Merge order
#370 (Slice 1) → #371 (Slice 2) → this. Once the train lands on `develop`, `mechanism: real` holds with the spring-through-structure bug closed across the gate, physics, and render.