### PR TITLE
MJCF: scale nconmax with part count

### DIFF
--- a/src/modeling/runtime/mjcfExport.ts
+++ b/src/modeling/runtime/mjcfExport.ts
@@ -534,16 +534,20 @@ export async function assemblyToMjcf(arm: Assembly): Promise<MjcfExportResult> {
         contactBlockLines.push('  </contact>');
     }
 
-    // P11 Slice 1: `<size nconmax="500"/>` gives MuJoCo headroom for
-    // contact storage. Default is small (~100) and runs out on tight
-    // multi-part assemblies; 500 absorbs the v0.7 corpus without bumping
-    // wasm heap pressure noticeably.
+    // P11: `<size nconmax>` gives MuJoCo headroom for contact storage.
+    // Its default is small (~100) and runs out on tight multi-part
+    // assemblies. Active contacts scale with the number of part pairs, so
+    // budget grows with part count: 500 floor for the small corpus,
+    // +120/part beyond that (a 50-part assembly gets 6000) — well within
+    // wasm heap limits while removing the fixed-cap ceiling that a large
+    // collision-rich assembly could trip over.
+    const nconmax = Math.max(500, parts.length * 120);
     const mjcf = [
         '<?xml version="1.0" ?>',
         `<mujoco model="${escapeXml(arm.name)}">`,
         '  <option gravity="0 0 -9.81"/>',
         '  <compiler angle="radian"/>',
-        '  <size nconmax="500"/>',
+        `  <size nconmax="${nconmax}"/>`,
         ...assetBlockLines,
         '  <worldbody>',
         ...worldbodyBlocks,


### PR DESCRIPTION
Robustness follow-up flagged in P11 Slice 1: `nconmax=500` was hardcoded and 'may be too low for huge assemblies'. Now `max(500, parts*120)` — contacts scale with part pairs, so the budget grows with part count. Small corpus (<=4 parts) stays at the 500 floor (existing assertions unchanged); large assemblies no longer risk overflowing MuJoCo's contact buffer. Tests + tsc -b green.