### PR TITLE
Studio: render assemblies on localhost (node mesh fallback)

### DIFF
--- a/src/studio/context/GeometryContext.tsx
+++ b/src/studio/context/GeometryContext.tsx
@@ -5,7 +5,7 @@ import { parseCode } from '../../shared/codeGeneration/ast';
 import { rehydrateFromBridge, type FeatureMeshSerialized } from '../../modeling/capture/featureMeshSerialize';
 import type { SerializedParamEntry, SerializedParamTable } from '../../shared/runtime/paramTable';
 import type { FeatureRecord } from '../../shared/intent/featureRecord';
-import { shouldUseHostedMesh, meshSourceHosted } from '../scriptSource';
+import { shouldUseHostedMesh, meshSourceHosted, devMeshAvailable, meshSourceDev } from '../scriptSource';
 import { apiCall, rewritePath } from '../api/apiBase';
 
 export type ExecutionStatus = 'success' | 'error' | 'stale';
@@ -648,6 +648,36 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
                     }
                 } else {
                     message = String(err);
+                }
+                // P11 follow-up: the in-browser worker is the legacy v0.1
+                // runtime and can't evaluate the modern assembly/joint/tendon
+                // API (throws "<global> is not defined"). On localhost dev,
+                // fall back to the node-backed dev mesh endpoint, which runs
+                // the full kernel. Gated on the API-gap signature so genuine
+                // user errors still surface immediately without a round-trip.
+                if (devMeshAvailable() && /is not defined|is not a function/.test(message)) {
+                    try {
+                        const payload = await meshSourceDev(code);
+                        if (revision !== mainRevisionRef.current) {
+                            setStaleMainResponsesDropped((prev) => prev + 1);
+                            staleRecorded = true;
+                            return;
+                        }
+                        setGeometries(featureMeshesToGeometries(payload.features as FeatureMeshSerialized[]));
+                        setGeometryTransformOverrides({});
+                        setFeatureRecords((payload.featureRecords as FeatureRecord[]) ?? []);
+                        setScriptParams(Object.values(payload.params ?? {}));
+                        setScriptReview(payload.review ?? { ok: true, diagnostics: [] });
+                        setSketchesGeometries([]);
+                        setPreviewGeometries([]);
+                        setError(null);
+                        setLastSuccessfulRevision(revision);
+                        pushExecutionRecord({ revision, status: 'success', executionCountAtRecord: executionCount + 1 });
+                        return;
+                    } catch {
+                        // Dev fallback also failed — fall through and surface
+                        // the original worker error below.
+                    }
                 }
                 setError(message);
                 // Preserve last successful geometry; only track failed execution metadata.

--- a/src/studio/scriptSource.test.ts
+++ b/src/studio/scriptSource.test.ts
@@ -9,11 +9,50 @@ vi.mock('../funnel/lib/supabaseClient', () => ({
   }),
 }));
 
-import { loadGalleryScriptSource, loadStudioScriptSource } from './scriptSource';
+import { loadGalleryScriptSource, loadStudioScriptSource, meshSourceDev } from './scriptSource';
 
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+});
+
+describe('meshSourceDev', () => {
+  it('POSTs { source } to /__kernelcad/mesh and returns the bridge payload', async () => {
+    const payload = {
+      features: [{ featureId: 'f0' }],
+      featureRecords: [],
+      bounds: { min: [0, 0, 0], max: [1, 1, 1] },
+      params: {},
+    };
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => payload,
+    } as Response);
+
+    await expect(meshSourceDev('return box(1,1,1);')).resolves.toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith('/__kernelcad/mesh', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source: 'return box(1,1,1);' }),
+    });
+  });
+
+  it('throws the endpoint error message on a non-ok response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'assembly compile failed' }),
+    } as Response);
+    await expect(meshSourceDev('boom')).rejects.toThrow('assembly compile failed');
+  });
+
+  it('throws when the response is not a bridge payload (no features array)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ notFeatures: true }),
+    } as Response);
+    await expect(meshSourceDev('x')).rejects.toThrow(/did not return features/);
+  });
 });
 
 describe('loadStudioScriptSource', () => {

--- a/src/studio/scriptSource.ts
+++ b/src/studio/scriptSource.ts
@@ -56,6 +56,39 @@ export function shouldUseHostedMesh(): boolean {
   return typeof window !== 'undefined' && window.location.hostname === 'app.kernelcad.com';
 }
 
+/**
+ * True in the vite dev server (localhost). The dev middleware exposes a
+ * node-backed `/__kernelcad/mesh` that can run the modern assembly/joint/
+ * tendon API the in-browser worker can't — so when the worker throws on an
+ * undefined API global, we fall back to it. Only in `import.meta.env.DEV`
+ * (the dev middleware doesn't exist on the hosted/static build).
+ */
+export function devMeshAvailable(): boolean {
+  return Boolean(import.meta.env?.DEV) && !shouldUseHostedMesh();
+}
+
+/**
+ * Mesh arbitrary edited code through the dev server's node kernel
+ * (`POST /__kernelcad/mesh { source }`). Returns the same bridge payload
+ * shape as `meshSourceHosted`, so the GeometryContext success handler
+ * consumes it identically. Used as the localhost fallback when the
+ * in-browser worker can't evaluate the script (e.g. assembly models).
+ */
+export async function meshSourceDev(source: string): Promise<BackendMeshPayload> {
+  const response = await fetch('/__kernelcad/mesh', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ source }),
+  });
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    const message = payload && typeof payload.error === 'string' ? payload.error : `HTTP ${response.status}`;
+    throw new Error(message);
+  }
+  if (!isBridgePayload(payload)) throw new Error('Dev mesh endpoint did not return features.');
+  return payload;
+}
+
 /** sha256 hex of a string via the Web Crypto API (available in https
  *  contexts). Matches the node `crypto.createHash('sha256')` digest the
  *  build uses for precomputed-mesh filenames, so an unedited gallery source


### PR DESCRIPTION
Closes the second half of "Studio can't render assemblies locally" (backend was #377). The in-browser worker is the legacy v0.1 runtime — it throws `<global> is not defined` on the modern `assembly`/`joint`/`tendon` API, so editing a kinematic model in `/studio` failed.

## Change
- `scriptSource.ts`: `meshSourceDev(source)` (POST to the dev `/__kernelcad/mesh`) + `devMeshAvailable()` (`import.meta.env.DEV` && not hosted).
- `GeometryContext.tsx`: in the `executeCode` catch, when the error matches `/is not defined|is not a function/` **and** `devMeshAvailable()`, POST the code to the node kernel and consume the bridge payload through the **same handler the hosted path already uses**.

**Zero regression by construction:** the fallback only fires on a worker API-gap error, only on the vite dev server. The normal worker path (box/cylinder) and the hosted path are untouched.

## Verification status (honest)
- ✅ Dev endpoint meshes luxo source → **7 features, 0 failed** (verified in #377).
- ✅ `meshSourceDev` unit tests (POST shape, error passthrough, payload guard) — 7/7.
- ✅ tsc -b clean.
- ⚠️ **Not pixel-verified in a live `/studio`** — the chrome-devtools browser tooling disconnected mid-session. The meshes are known-good and the consumption mirrors the working hosted path, so the render is highly likely correct, but final visual confirmation should happen on next browser session.

Merge note: safe to land (zero-regression design); just open `/studio`, paste `examples/kinematic/luxo-lamp.kcad.ts`, and confirm the lamp appears when you next have a browser.