### PR TITLE
Close the generation loop (shared closed-loop + eval gates on interference)

### DIFF
--- a/eval/loop/webGateRunner.test.ts
+++ b/eval/loop/webGateRunner.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../oracle/kernelcad-client.js', () => ({ evaluateScript: vi.fn() }));
+vi.mock('../oracle/interference.js', () => ({ runInterference: vi.fn() }));
+
+import { evaluateScript } from '../oracle/kernelcad-client.js';
+import { runInterference } from '../oracle/interference.js';
+import { createWebGateRunner } from './webGateRunner.js';
+
+const mockEval = vi.mocked(evaluateScript);
+const mockInterf = vi.mocked(runInterference);
+
+describe('createWebGateRunner', () => {
+  it('reports ok when evaluate ok and no interference pairs', async () => {
+    mockEval.mockResolvedValue({ ok: true, diagnostics: [], featureCount: 3 });
+    mockInterf.mockResolvedValue({ ok: true, noSceneToCheck: false, partCount: 2, comparisonCount: 1, epsilonMm3: 0.01, pairs: [], diagnostics: [] });
+    const report = await createWebGateRunner().run('/tmp/x.kcad.ts');
+    expect(report.ok).toBe(true);
+    expect(report.verdicts.find((v) => v.gate === 'evaluate')?.ok).toBe(true);
+    expect(report.verdicts.find((v) => v.gate === 'interference')?.ok).toBe(true);
+  });
+
+  it('maps evaluate diagnostics to failing evaluate verdicts', async () => {
+    mockEval.mockResolvedValue({ ok: false, diagnostics: [{ code: 'mechanism.interpenetration', message: 'parts overlap', hint: 'reduce length' }] });
+    mockInterf.mockResolvedValue({ ok: true, noSceneToCheck: false, partCount: 0, comparisonCount: 0, epsilonMm3: 0.01, pairs: [], diagnostics: [] });
+    const report = await createWebGateRunner().run('/tmp/x.kcad.ts');
+    expect(report.ok).toBe(false);
+    const evalVerdict = report.verdicts.find((v) => v.code === 'mechanism.interpenetration');
+    expect(evalVerdict).toBeDefined();
+    expect(evalVerdict?.gate).toBe('evaluate');
+    expect(evalVerdict?.ok).toBe(false);
+    expect(evalVerdict?.hint).toBe('reduce length');
+  });
+
+  it('maps interference pairs to verdicts with locus and margin', async () => {
+    mockEval.mockResolvedValue({ ok: true, diagnostics: [] });
+    mockInterf.mockResolvedValue({ ok: false, noSceneToCheck: false, partCount: 2, comparisonCount: 1, epsilonMm3: 0.01, pairs: [{ partA: 'arm', partB: 'base', volumeMm3: 12.5 }], diagnostics: [{ code: 'interference.overlap', message: 'arm overlaps base' }] });
+    const report = await createWebGateRunner().run('/tmp/x.kcad.ts');
+    expect(report.ok).toBe(false);
+    const interfVerdict = report.verdicts.find((v) => v.gate === 'interference' && !v.ok);
+    expect(interfVerdict).toBeDefined();
+    expect(interfVerdict?.locus).toBe('arm∩base');
+    expect(interfVerdict?.margin).toBe(12.5);
+  });
+});

--- a/eval/loop/webGateRunner.ts
+++ b/eval/loop/webGateRunner.ts
@@ -1,0 +1,45 @@
+import type { GateReport, GateRunner, GateVerdict } from '../../src/agent/loop/types.js';
+import { evaluateScript } from '../oracle/kernelcad-client.js';
+import { runInterference } from '../oracle/interference.js';
+
+/**
+ * Web (CLI-oracle) GateRunner. Runs the build-blocking suite on a written script:
+ *  - evaluate_script via evaluateScript() (mechanism.* failures surface here as diagnostics)
+ *  - interference via runInterference()
+ * Maps both into the shared GateVerdict[] contract. ok = evaluate.ok && interference.ok.
+ */
+export function createWebGateRunner(epsilonMm3 = 0.01): GateRunner {
+  return {
+    async run(scriptPath: string): Promise<GateReport> {
+      const verdicts: GateVerdict[] = [];
+
+      const evaluate = await evaluateScript(scriptPath);
+      if (evaluate.ok) {
+        verdicts.push({ gate: 'evaluate', ok: true, message: 'evaluate passed' });
+      } else if (evaluate.diagnostics.length === 0) {
+        verdicts.push({ gate: 'evaluate', ok: false, message: 'evaluate failed' });
+      } else {
+        for (const d of evaluate.diagnostics) {
+          verdicts.push({ gate: 'evaluate', ok: false, code: d.code, message: d.message, hint: d.hint, locus: d.featureId });
+        }
+      }
+
+      const interference = await runInterference(scriptPath, epsilonMm3);
+      if (interference.ok) {
+        verdicts.push({ gate: 'interference', ok: true, message: 'no interferences' });
+      } else {
+        for (const pair of interference.pairs) {
+          verdicts.push({ gate: 'interference', ok: false, code: 'interference.overlap', message: `${pair.partA} overlaps ${pair.partB} by ${pair.volumeMm3} mm³`, locus: `${pair.partA}∩${pair.partB}`, margin: pair.volumeMm3 });
+        }
+        if (interference.pairs.length === 0) {
+          for (const d of interference.diagnostics) {
+            verdicts.push({ gate: 'interference', ok: false, code: d.code, message: d.message, hint: d.hint });
+          }
+        }
+      }
+
+      const ok = evaluate.ok && interference.ok;
+      return { ok, verdicts };
+    },
+  };
+}

--- a/eval/runner.loop.test.ts
+++ b/eval/runner.loop.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { AgentClient, AgentMessage, AgentResponse } from './types';
+
+// Evaluate is ALWAYS clean. We mock BOTH specifier forms — the runner imports
+// './oracle/kernelcad-client' (no .js) while webGateRunner imports
+// '../oracle/kernelcad-client.js'. vitest resolves both to the same module, so
+// one mock factory per module suffices, but we register the exact specifiers
+// each importer uses to be safe across resolver quirks.
+vi.mock('./oracle/kernelcad-client', () => ({
+  evaluateScript: vi.fn().mockResolvedValue({ ok: true, diagnostics: [] }),
+  // getShapeInfo / isKernelcadAvailable unused on this path; provide stubs.
+  getShapeInfo: vi.fn(),
+  isKernelcadAvailable: vi.fn().mockResolvedValue(true),
+}));
+vi.mock('../oracle/kernelcad-client.js', () => ({
+  evaluateScript: vi.fn().mockResolvedValue({ ok: true, diagnostics: [] }),
+  getShapeInfo: vi.fn(),
+  isKernelcadAvailable: vi.fn().mockResolvedValue(true),
+}));
+
+// Interference fails the first 2 calls, then passes — proving the loop retries
+// on interference (not just on evaluate, which is always clean here).
+const interferenceFail = {
+  ok: false,
+  noSceneToCheck: false,
+  partCount: 2,
+  comparisonCount: 1,
+  epsilonMm3: 0.01,
+  pairs: [{ partA: 'a', partB: 'b', volumeMm3: 5 }],
+  diagnostics: [],
+};
+const interferencePass = {
+  ok: true,
+  noSceneToCheck: false,
+  partCount: 2,
+  comparisonCount: 1,
+  epsilonMm3: 0.01,
+  pairs: [],
+  diagnostics: [],
+};
+vi.mock('../oracle/interference.js', () => ({
+  runInterference: vi
+    .fn()
+    .mockResolvedValueOnce(interferenceFail)
+    .mockResolvedValueOnce(interferenceFail)
+    .mockResolvedValue(interferencePass),
+}));
+
+// Import AFTER mocks are registered.
+import { runTask } from './runner';
+
+class CountingAgent implements AgentClient {
+  public calls = 0;
+  constructor(private readonly script: string) {}
+  async generate(_args: {
+    system: string;
+    systemAddendum?: string;
+    messages: AgentMessage[];
+    model: string;
+    max_tokens: number;
+  }): Promise<AgentResponse> {
+    this.calls += 1;
+    return {
+      text: '```typescript\n' + this.script + '\n```',
+      tokens_in: 100,
+      tokens_out: 20,
+    };
+  }
+}
+
+// The harness is dynamically imported by absolute path and its relative
+// imports ('../../oracle/...') resolve from the harness file's location — so
+// the fixture MUST live inside eval/tasks/ for those to resolve. We create a
+// throwaway sibling dir and clean it up afterward.
+function makeTaskDir(): string {
+  const taskDir = mkdtempSync(join(process.cwd(), 'eval', 'tasks', '.loop-fixture-'));
+  writeFileSync(join(taskDir, 'prompt.md'), 'Build a two-part assembly.');
+  // Trivial harness that always passes its (mocked-clean) evaluate gate. The
+  // harness only runs when the final evaluate is clean.
+  const harness = `import { evaluateScript } from '../../oracle/kernelcad-client';
+import type { HarnessResult } from '../../types';
+export default async function harness(scriptPath: string): Promise<HarnessResult> {
+  const ev = await evaluateScript(scriptPath);
+  return { gates: { 'evaluates clean': ev.ok }, scored: {} };
+}
+`;
+  writeFileSync(join(taskDir, 'harness.ts'), harness);
+  return taskDir;
+}
+
+let runsDir: string;
+let taskDir: string | undefined;
+beforeEach(() => {
+  runsDir = mkdtempSync(join(tmpdir(), 'eval-loop-run-'));
+});
+afterEach(() => {
+  if (taskDir && existsSync(taskDir)) rmSync(taskDir, { recursive: true, force: true });
+  taskDir = undefined;
+});
+
+describe('runTask closed-loop integration', () => {
+  it('retries on interference failures (not just evaluate failures)', async () => {
+    taskDir = makeTaskDir();
+    const agent = new CountingAgent('return cube(10);');
+
+    const result = await runTask({
+      taskDir,
+      runDir: runsDir,
+      agent,
+      model: 'mock-model',
+      skillMd: 'fake skill content',
+      startedAt: '2026-06-04T00-00-00',
+    });
+
+    // The load-bearing assertion: 3 generate() calls means the loop retried
+    // through the 2 interference failures. Evaluate-only gating would stop at 1.
+    expect(agent.calls).toBe(3);
+    expect(result.score!.attempts).toBe(3);
+
+    // Final attempt's interference passed → evaluate-clean → harness ran.
+    expect(existsSync(join(runsDir, 'output.kcad.ts'))).toBe(true);
+    expect(existsSync(join(runsDir, 'transcript.md'))).toBe(true);
+    expect(existsSync(join(runsDir, 'score.json'))).toBe(true);
+    expect(result.score!.gates['evaluates clean']).toBe(true);
+
+    const score = JSON.parse(readFileSync(join(runsDir, 'score.json'), 'utf8'));
+    expect(score.attempts).toBe(3);
+  }, 30000);
+});

--- a/eval/runner.ts
+++ b/eval/runner.ts
@@ -1,8 +1,10 @@
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import type { AgentClient, AgentMessage, TranscriptEvent, TaskResult, HarnessResult } from './types';
-import { extractScript, formatDiagnostics, computeScore, renderTranscript } from './lib';
+import type { AgentClient, TranscriptEvent, TaskResult, HarnessResult } from './types';
+import { extractScript, computeScore, renderTranscript } from './lib';
 import { evaluateScript } from './oracle/kernelcad-client';
+import { runClosedLoop, type LoopMessage } from '../src/agent/loop/closedLoop.js';
+import { createWebGateRunner } from './loop/webGateRunner.js';
 import type { CookbookInjection } from './cookbook-injector';
 
 const MAX_ATTEMPTS = 3;
@@ -42,12 +44,11 @@ export async function runTask(args: RunTaskArgs): Promise<TaskResult> {
     });
   }
 
-  const messages: AgentMessage[] = [{ role: 'user', content: prompt }];
-  let attempts = 0;
+  // Per-turn bookkeeping. `attemptNo` mirrors the closed loop's attempt index
+  // so the existing `'turn'`/`'evaluate'` transcript events keep their numbers.
+  let attemptNo = 0;
   let totalIn = 0;
   let totalOut = 0;
-  let lastEvaluateOk = false;
-  let finalScript: string | null = null;
   // First non-OK diagnostic code observed across the loop. Set once, never
   // overwritten — downstream classifiers (portfolio attempt logger) use this
   // to tag a failed run with the diagnostic that surfaced first.
@@ -55,79 +56,85 @@ export async function runTask(args: RunTaskArgs): Promise<TaskResult> {
 
   const start = Date.now();
 
-  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-    attempts = attempt;
-    const turnStart = Date.now();
-    const resp = await args.agent.generate({
-      system: args.skillMd,
-      systemAddendum: args.cookbook?.systemPromptAddendum,
-      messages,
-      model: args.model,
-      max_tokens: MAX_TOKENS,
-    });
-    const turnMs = Date.now() - turnStart;
-    totalIn += resp.tokens_in;
-    totalOut += resp.tokens_out;
-    const script = extractScript(resp.text);
-
-    events.push({
-      kind: 'turn',
-      attempt,
-      assistant_text: resp.text,
-      script_extracted: script,
-      tokens_in: resp.tokens_in,
-      tokens_out: resp.tokens_out,
-      ms: turnMs,
-    });
-
-    if (!script) {
-      // Couldn't extract a script — append a guidance message and retry.
+  // Drive the generate→gate→repair loop through the shared closed loop. The
+  // web gate runner gates on evaluate AND interference, so the loop now retries
+  // on interference failures too — not just on evaluate failures.
+  const loopResult = await runClosedLoop({
+    prompt,
+    gateRunner: createWebGateRunner(),
+    extractScript,
+    maxAttempts: MAX_ATTEMPTS,
+    writeScript: async (code: string) => {
+      writeFileSync(outputScriptPath, code);
+      return outputScriptPath;
+    },
+    generate: async (messages: LoopMessage[]) => {
+      attemptNo += 1;
+      const turnStart = Date.now();
+      const resp = await args.agent.generate({
+        system: args.skillMd,
+        systemAddendum: args.cookbook?.systemPromptAddendum,
+        messages: messages.map((m) => ({ role: m.role, content: m.content })),
+        model: args.model,
+        max_tokens: MAX_TOKENS,
+      });
+      totalIn += resp.tokens_in;
+      totalOut += resp.tokens_out;
       events.push({
-        kind: 'evaluate',
-        attempt,
-        ok: false,
-        diagnostics: [
-          { code: 'eval.no-script-extracted', message: 'No script extracted from model response.' },
-        ],
+        kind: 'turn',
+        attempt: attemptNo,
+        assistant_text: resp.text,
+        script_extracted: extractScript(resp.text),
+        tokens_in: resp.tokens_in,
+        tokens_out: resp.tokens_out,
+        ms: Date.now() - turnStart,
       });
-      messages.push({ role: 'assistant', content: resp.text });
-      messages.push({
-        role: 'user',
-        content: 'I could not extract a script from your response. Please return the full script in a single ```typescript code block.',
-      });
-      continue;
-    }
+      return { text: resp.text, tokensIn: resp.tokens_in, tokensOut: resp.tokens_out };
+    },
+    onEvent: (e) => {
+      if (e.type === 'gate_report') {
+        const failing = e.report.verdicts.filter((v) => !v.ok);
+        events.push({
+          kind: 'evaluate',
+          attempt: attemptNo,
+          ok: e.report.ok,
+          diagnostics: failing.map((v) => ({
+            code: v.code ?? v.gate,
+            message: v.message,
+            hint: v.hint,
+            featureId: v.locus,
+          })),
+        });
+        if (firstFailureCode === undefined && failing.length > 0) {
+          firstFailureCode = failing[0].code ?? failing[0].gate;
+        }
+      }
+    },
+  });
 
-    writeFileSync(outputScriptPath, script);
-    finalScript = script;
-
-    const ev = await evaluateScript(outputScriptPath);
-    events.push({ kind: 'evaluate', attempt, ok: ev.ok, diagnostics: ev.diagnostics });
-
-    if (!ev.ok && firstFailureCode === undefined && ev.diagnostics.length > 0) {
-      firstFailureCode = ev.diagnostics[0].code;
-    }
-
-    if (ev.ok) {
-      lastEvaluateOk = true;
-      break;
-    }
-
-    // Feed diagnostics back and retry (unless this was the last attempt).
-    if (attempt < MAX_ATTEMPTS) {
-      messages.push({ role: 'assistant', content: resp.text });
-      messages.push({
-        role: 'user',
-        content: `Diagnostics:\n${formatDiagnostics(ev.diagnostics)}\nFix and return the full corrected script.`,
-      });
-    }
-  }
-
-  // If we never got a clean evaluate, finalScript may still be the last broken attempt or null.
-  // Write whatever we have so the human can read it; harness will mark gate-fail.
-  if (!finalScript) {
+  // If we never extracted a script, write a placeholder so the human can read
+  // the run; the harness will be skipped and gate-fail recorded below.
+  if (loopResult.status === 'no_script') {
     writeFileSync(outputScriptPath, '// (no script extracted from any attempt)');
   }
+
+  // Re-run evaluate on the final written script to preserve the EXACT prior
+  // clean-decision + firstFailureCode semantics: the harness must still run
+  // when the script evaluates clean, even though the loop may have stopped on
+  // interference (which the harness does not itself gate on).
+  const finalEvaluate =
+    loopResult.status === 'no_script'
+      ? {
+          ok: false,
+          diagnostics: [
+            { code: 'eval.no-script-extracted', message: 'No script extracted from any attempt.' },
+          ],
+        }
+      : await evaluateScript(outputScriptPath);
+  if (firstFailureCode === undefined && !finalEvaluate.ok && finalEvaluate.diagnostics.length > 0) {
+    firstFailureCode = finalEvaluate.diagnostics[0].code;
+  }
+  const lastEvaluateOk = finalEvaluate.ok;
 
   // Run the task's harness against the final output.
   let harnessResult: HarnessResult;
@@ -145,7 +152,7 @@ export async function runTask(args: RunTaskArgs): Promise<TaskResult> {
   });
 
   const score = computeScore(harnessResult, {
-    attempts,
+    attempts: loopResult.attempts,
     tokens_in: totalIn,
     tokens_out: totalOut,
     time_ms: Date.now() - start,

--- a/src/agent/loop/closedLoop.test.ts
+++ b/src/agent/loop/closedLoop.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { runClosedLoop } from './closedLoop.js';
+import type { GateReport, GateRunner, LoopMessage } from './types.js';
+
+const PASS_REPORT: GateReport = { ok: true, verdicts: [{ gate: 'evaluate', ok: true, message: 'ok' }] };
+const FAIL_REPORT: GateReport = {
+  ok: false,
+  verdicts: [{ gate: 'evaluate', ok: false, code: 'evaluate.broken', message: 'broken' }],
+};
+
+function scriptedGate(reports: GateReport[]): GateRunner {
+  let i = 0;
+  return { run: async () => reports[Math.min(i++, reports.length - 1)] };
+}
+
+function scriptedGenerate(texts: string[]) {
+  const calls: LoopMessage[][] = [];
+  let i = 0;
+  const generate = async (messages: LoopMessage[]) => {
+    calls.push(messages.map((m) => ({ ...m })));
+    const text = texts[Math.min(i++, texts.length - 1)];
+    return { text, tokensIn: 1, tokensOut: 2 };
+  };
+  return { generate, calls };
+}
+
+const fence = (body: string) => '```ts\n' + body + '\n```';
+const extractScript = (text: string): string | null => {
+  const m = text.match(/```[a-zA-Z]*\n([\s\S]*?)```/);
+  return m ? m[1].trimEnd() : null;
+};
+const writeScript = async (code: string) => `/tmp/closedloop-test-${code.length}.kcad.ts`;
+
+describe('runClosedLoop', () => {
+  it('(a) passes on first attempt when gate ok', async () => {
+    const { generate } = scriptedGenerate([fence('cube(10)')]);
+    const result = await runClosedLoop({ prompt: 'make a cube', generate, gateRunner: scriptedGate([PASS_REPORT]), extractScript, writeScript });
+    expect(result.status).toBe('passed');
+    if (result.status === 'passed') {
+      expect(result.attempts).toBe(1);
+      expect(result.scriptPath).toContain('.kcad.ts');
+      expect(result.tokensIn).toBe(1);
+      expect(result.tokensOut).toBe(2);
+    }
+  });
+
+  it('(b) fails twice then passes at attempt 3, sending a repair prompt between attempts', async () => {
+    const { generate, calls } = scriptedGenerate([fence('bad1'), fence('bad2'), fence('good')]);
+    const result = await runClosedLoop({ prompt: 'make it', generate, gateRunner: scriptedGate([FAIL_REPORT, FAIL_REPORT, PASS_REPORT]), extractScript, writeScript, maxAttempts: 3 });
+    expect(result.status).toBe('passed');
+    if (result.status === 'passed') expect(result.attempts).toBe(3);
+    expect(calls.length).toBe(3);
+    const lastCall = calls[2];
+    const repairMsg = lastCall[lastCall.length - 1];
+    expect(repairMsg.role).toBe('user');
+    expect(repairMsg.content).toContain('evaluate.broken');
+    expect(repairMsg.content).toContain('Fix and return the full corrected script.');
+    expect(result.tokensIn).toBe(3);
+    expect(result.tokensOut).toBe(6);
+  });
+
+  it('(c) always-broken gate returns gate_failed after maxAttempts with verdicts', async () => {
+    const { generate } = scriptedGenerate([fence('bad')]);
+    const result = await runClosedLoop({ prompt: 'x', generate, gateRunner: scriptedGate([FAIL_REPORT]), extractScript, writeScript, maxAttempts: 2 });
+    expect(result.status).toBe('gate_failed');
+    if (result.status === 'gate_failed') {
+      expect(result.attempts).toBe(2);
+      expect(result.verdicts[0].code).toBe('evaluate.broken');
+      expect(result.scriptPath).toContain('.kcad.ts');
+    }
+  });
+
+  it('(d) no code fence returns no_script', async () => {
+    const { generate } = scriptedGenerate(['sorry, here is some prose with no code']);
+    const result = await runClosedLoop({ prompt: 'x', generate, gateRunner: scriptedGate([PASS_REPORT]), extractScript, writeScript, maxAttempts: 2 });
+    expect(result.status).toBe('no_script');
+    if (result.status === 'no_script') expect(result.attempts).toBe(2);
+  });
+
+  it('uses an injected buildRepairPrompt when provided', async () => {
+    const { generate, calls } = scriptedGenerate([fence('bad'), fence('good')]);
+    await runClosedLoop({ prompt: 'x', generate, gateRunner: scriptedGate([FAIL_REPORT, PASS_REPORT]), extractScript, writeScript, maxAttempts: 2, buildRepairPrompt: () => 'CUSTOM_REPAIR' });
+    const lastCall = calls[1];
+    expect(lastCall[lastCall.length - 1].content).toBe('CUSTOM_REPAIR');
+  });
+});

--- a/src/agent/loop/closedLoop.ts
+++ b/src/agent/loop/closedLoop.ts
@@ -1,0 +1,68 @@
+import {
+  defaultBuildRepairPrompt,
+  type ClosedLoopInput,
+  type ClosedLoopResult,
+  type LoopMessage,
+} from './types.js';
+
+/**
+ * Host-agnostic generate→gate→repair loop. Imports nothing from fs/CLI/oracle so it
+ * bundles cleanly for the server. The host injects generate(), gateRunner, extractScript,
+ * and writeScript.
+ *
+ * Invariant: never returns status:'passed' unless the gate suite reported ok for the
+ * written candidate. A broken artifact returns 'gate_failed' (or 'no_script').
+ */
+export async function runClosedLoop(input: ClosedLoopInput): Promise<ClosedLoopResult> {
+  const maxAttempts = input.maxAttempts ?? 3;
+  const buildRepairPrompt = input.buildRepairPrompt ?? defaultBuildRepairPrompt;
+
+  const messages: LoopMessage[] = [{ role: 'user', content: input.prompt }];
+  let tokensIn = 0;
+  let tokensOut = 0;
+  let lastScriptPath = '';
+  let lastText = '';
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    input.onEvent?.({ type: 'attempt', n: attempt });
+
+    const gen = await input.generate(messages);
+    tokensIn += gen.tokensIn;
+    tokensOut += gen.tokensOut;
+    lastText = gen.text;
+
+    const code = input.extractScript(gen.text);
+    if (code === null) {
+      if (attempt < maxAttempts) {
+        messages.push({ role: 'assistant', content: gen.text });
+        messages.push({
+          role: 'user',
+          content: 'Could not extract a code block from your reply. Return the full script in a single fenced code block.',
+        });
+        continue;
+      }
+      return { status: 'no_script', attempts: attempt, tokensIn, tokensOut };
+    }
+
+    lastScriptPath = await input.writeScript(code);
+    const report = await input.gateRunner.run(lastScriptPath);
+    input.onEvent?.({ type: 'gate_report', report });
+
+    if (report.ok) {
+      return { status: 'passed', scriptPath: lastScriptPath, finalText: lastText, attempts: attempt, tokensIn, tokensOut };
+    }
+
+    if (attempt < maxAttempts) {
+      const repairPrompt = buildRepairPrompt(report.verdicts);
+      input.onEvent?.({ type: 'repair', prompt: repairPrompt });
+      messages.push({ role: 'assistant', content: gen.text });
+      messages.push({ role: 'user', content: repairPrompt });
+      continue;
+    }
+
+    return { status: 'gate_failed', scriptPath: lastScriptPath, finalText: lastText, attempts: attempt, verdicts: report.verdicts, tokensIn, tokensOut };
+  }
+
+  // Unreachable given maxAttempts >= 1, but the type checker needs a terminal return.
+  return { status: 'no_script', attempts: maxAttempts, tokensIn, tokensOut };
+}

--- a/src/agent/loop/types.test.ts
+++ b/src/agent/loop/types.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { defaultBuildRepairPrompt, type GateVerdict } from './types.js';
+
+describe('defaultBuildRepairPrompt', () => {
+  it('lists only failing verdicts with code/message/hint', () => {
+    const verdicts: GateVerdict[] = [
+      { gate: 'evaluate', ok: true, message: 'all good' },
+      { gate: 'mechanism', ok: false, code: 'mechanism.interpenetration', message: 'parts overlap' },
+      { gate: 'interference', ok: false, code: 'interference.overlap', message: 'A∩B', hint: 'move A by 2mm' },
+    ];
+    const prompt = defaultBuildRepairPrompt(verdicts);
+    expect(prompt).toBe(
+      'Diagnostics:\n' +
+        '- mechanism.interpenetration: parts overlap\n' +
+        '- interference.overlap: A∩B (hint: move A by 2mm)\n' +
+        'Fix and return the full corrected script.',
+    );
+  });
+
+  it('falls back to gate name when code is absent', () => {
+    const verdicts: GateVerdict[] = [{ gate: 'evaluate', ok: false, message: 'boom' }];
+    expect(defaultBuildRepairPrompt(verdicts)).toBe(
+      'Diagnostics:\n- evaluate: boom\nFix and return the full corrected script.',
+    );
+  });
+});

--- a/src/agent/loop/types.ts
+++ b/src/agent/loop/types.ts
@@ -1,0 +1,73 @@
+export interface LoopMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+/** One gate's verdict. Typed so repair prompts can carry concrete evidence (W3 enriches margin/locus). */
+export interface GateVerdict {
+  gate: string; // 'evaluate' | 'interference' | 'mechanism' | ...
+  ok: boolean;
+  code?: string; // diagnostic code when failed, e.g. 'mechanism.interpenetration'
+  message: string;
+  hint?: string;
+  margin?: number; // numeric distance-from-pass (e.g. mm³ over budget) — populated by W3
+  locus?: string; // topological locus, e.g. 'partA∩partB' or a featureId — populated by W3
+}
+
+export interface GateReport {
+  ok: boolean;
+  verdicts: GateVerdict[];
+}
+
+/** Host-injected: runs the build-blocking gate suite on a written script file. */
+export interface GateRunner {
+  run(scriptPath: string): Promise<GateReport>;
+}
+
+export interface ClosedLoopInput {
+  prompt: string;
+  generate(messages: LoopMessage[]): Promise<{ text: string; tokensIn: number; tokensOut: number }>;
+  gateRunner: GateRunner;
+  extractScript(text: string): string | null;
+  writeScript(code: string): Promise<string>; // writes the candidate, returns the scriptPath
+  buildRepairPrompt?(verdicts: GateVerdict[]): string; // optional; W3 supplies the rich version. Default = simple join.
+  maxAttempts?: number; // default 3
+  onEvent?(e: ClosedLoopEvent): void;
+}
+
+export type ClosedLoopEvent =
+  | { type: 'attempt'; n: number }
+  | { type: 'gate_report'; report: GateReport }
+  | { type: 'repair'; prompt: string };
+
+export type ClosedLoopResult =
+  | {
+      status: 'passed';
+      scriptPath: string;
+      finalText: string;
+      attempts: number;
+      tokensIn: number;
+      tokensOut: number;
+    }
+  | {
+      status: 'gate_failed';
+      scriptPath: string;
+      finalText: string;
+      attempts: number;
+      verdicts: GateVerdict[];
+      tokensIn: number;
+      tokensOut: number;
+    }
+  | { status: 'no_script'; attempts: number; tokensIn: number; tokensOut: number };
+
+/** Default repair-prompt builder used when ClosedLoopInput.buildRepairPrompt is not supplied. */
+export function defaultBuildRepairPrompt(verdicts: GateVerdict[]): string {
+  return (
+    'Diagnostics:\n' +
+    verdicts
+      .filter((v) => !v.ok)
+      .map((v) => `- ${v.code ?? v.gate}: ${v.message}${v.hint ? ' (hint: ' + v.hint + ')' : ''}`)
+      .join('\n') +
+    '\nFix and return the full corrected script.'
+  );
+}

--- a/src/agent/mcp/toolRegistry.ts
+++ b/src/agent/mcp/toolRegistry.ts
@@ -60,6 +60,8 @@ import { checkSweptCollisionTool } from './tools/checkSweptCollision';
 import { checkReachableTool } from './tools/checkReachable';
 import { checkMountingHoleConsistencyTool } from './tools/checkMountingHoleConsistency';
 import { checkLoadCapacityTool } from './tools/checkLoadCapacity';
+export { runClosedLoop } from '../loop/closedLoop.js';
+export * from '../loop/types.js';
 
 export interface McpToolDefinition {
   name: string;


### PR DESCRIPTION
## Summary

Phase 0 / W1 of the generation-loop tightening workstream: a host-agnostic, build-blocking **closed loop** that the eval harness (and, in a later slice, the hosted/MCP generation path) drives. Generation now runs generate → gate → repair against the real oracle instead of accepting the first artifact.

- `src/agent/loop/types.ts` — locked shared contract (`GateVerdict`/`GateRunner`/`ClosedLoop*`) + `defaultBuildRepairPrompt`. Pure module.
- `src/agent/loop/closedLoop.ts` — `runClosedLoop`: generate→gate→repair with an injected `GateRunner`. Invariant: never returns `passed` unless the gate reported ok (broken → `gate_failed`, no fence → `no_script`).
- `eval/loop/webGateRunner.ts` — web gate runner mapping `evaluateScript` + `runInterference` to typed verdicts (with locus/margin).
- `src/agent/mcp/toolRegistry.ts` — re-exports the loop so the server vendor bundle can consume it (no build-script change).
- `eval/runner.ts` — delegates its retry loop to the shared loop. **Net effect: the eval harness now retries on interference failures, not just `evaluate.ok`.**

## Test Plan

- [x] 10 unit tests for the contract + orchestrator (incl. the never-`passed`-unless-ok invariant) and the web gate runner
- [x] New `eval/runner.loop.test.ts` proves retry-on-interference (evaluate clean, interference fails twice then passes → 3 generate calls)
- [x] Full eval suite: 74 passed (16 files), no regressions
- [x] `tsc -b` clean

## Notes

- Server-side wiring (orchestrator → `gate_failed` SSE) is deferred to its own slice because the `vendor/kernelcad` submodule is pinned to v0.8.0 and needs a separate bump.