### PR TITLE
Typed requirement-level repair feedback (W3, stacked on #381)

### DIFF
--- a/eval/loop/verdictsFromOracles.test.ts
+++ b/eval/loop/verdictsFromOracles.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { verdictsFromOracles } from './verdictsFromOracles';
+
+describe('verdictsFromOracles', () => {
+  it('maps an interference pair to a verdict carrying margin (mm³) and locus (partA∩partB)', () => {
+    const evaluateResult = { ok: true, diagnostics: [], featureCount: 3 };
+    const interferenceResult = { ok: false, pairs: [{ partA: 'shade', partB: 'beam', volumeMm3: 42 }], diagnostics: [{ code: 'mechanism.interpenetration', message: 'Parts overlap.' }] };
+    const verdicts = verdictsFromOracles(evaluateResult, interferenceResult);
+    const interference = verdicts.find((v) => v.gate === 'interference');
+    expect(interference).toBeDefined();
+    expect(interference!.ok).toBe(false);
+    expect(interference!.margin).toBe(42);
+    expect(interference!.locus).toBe('shade∩beam');
+    expect(interference!.code).toBe('mechanism.interpenetration');
+  });
+  it('carries featureId as locus on evaluate verdicts when present', () => {
+    const evaluateResult = { ok: false, diagnostics: [{ code: 'feature.fillet.no-edges', message: 'Fillet selected no edges.', featureId: 'fillet-1' }], featureCount: 2 };
+    const interferenceResult = { ok: true, pairs: [], diagnostics: [] };
+    const verdicts = verdictsFromOracles(evaluateResult, interferenceResult);
+    const evaluate = verdicts.find((v) => v.code === 'feature.fillet.no-edges');
+    expect(evaluate).toBeDefined();
+    expect(evaluate!.ok).toBe(false);
+    expect(evaluate!.locus).toBe('fillet-1');
+  });
+  it('produces an all-ok report when both oracles pass', () => {
+    const evaluateResult = { ok: true, diagnostics: [], featureCount: 1 };
+    const interferenceResult = { ok: true, pairs: [], diagnostics: [] };
+    const verdicts = verdictsFromOracles(evaluateResult, interferenceResult);
+    expect(verdicts.every((v) => v.ok)).toBe(true);
+  });
+});

--- a/eval/loop/verdictsFromOracles.ts
+++ b/eval/loop/verdictsFromOracles.ts
@@ -1,0 +1,39 @@
+import type { GateVerdict } from '../../src/agent/loop/types';
+
+interface EvaluateLike {
+  ok: boolean;
+  diagnostics: Array<{ code: string; message: string; hint?: string; featureId?: string }>;
+  featureCount?: number;
+}
+interface InterferenceLike {
+  ok: boolean;
+  pairs: Array<{ partA: string; partB: string; volumeMm3: number }>;
+  diagnostics: Array<{ code: string; message: string; hint?: string }>;
+}
+
+/**
+ * Pure mapping from oracle results to typed gate verdicts.
+ * - Interference verdicts get margin = volumeMm3 and locus = `${partA}∩${partB}`,
+ *   pairing each diagnostic with the overlap pair at the same index when available.
+ * - Evaluate verdicts get locus = diagnostic.featureId when present.
+ * Extracted as a pure function so margin/locus population is unit-testable without the CLI.
+ */
+export function verdictsFromOracles(evaluateResult: EvaluateLike, interferenceResult: InterferenceLike): GateVerdict[] {
+  const verdicts: GateVerdict[] = [];
+  if (evaluateResult.diagnostics.length === 0) {
+    verdicts.push({ gate: 'evaluate', ok: evaluateResult.ok, message: evaluateResult.ok ? 'Script evaluated cleanly.' : 'Script evaluation failed.' });
+  } else {
+    for (const diag of evaluateResult.diagnostics) {
+      verdicts.push({ gate: 'evaluate', ok: false, code: diag.code, message: diag.message, hint: diag.hint, locus: diag.featureId });
+    }
+  }
+  if (interferenceResult.diagnostics.length === 0) {
+    verdicts.push({ gate: 'interference', ok: interferenceResult.ok, message: interferenceResult.ok ? 'No part interferences detected.' : 'Interference detected.' });
+  } else {
+    interferenceResult.diagnostics.forEach((diag, index) => {
+      const pair = interferenceResult.pairs[index];
+      verdicts.push({ gate: 'interference', ok: false, code: diag.code, message: diag.message, hint: diag.hint, margin: pair?.volumeMm3, locus: pair ? `${pair.partA}∩${pair.partB}` : undefined });
+    });
+  }
+  return verdicts;
+}

--- a/eval/loop/webGateRunner.ts
+++ b/eval/loop/webGateRunner.ts
@@ -1,6 +1,7 @@
-import type { GateReport, GateRunner, GateVerdict } from '../../src/agent/loop/types.js';
+import type { GateReport, GateRunner } from '../../src/agent/loop/types.js';
 import { evaluateScript } from '../oracle/kernelcad-client.js';
 import { runInterference } from '../oracle/interference.js';
+import { verdictsFromOracles } from './verdictsFromOracles';
 
 /**
  * Web (CLI-oracle) GateRunner. Runs the build-blocking suite on a written script:
@@ -11,35 +12,10 @@ import { runInterference } from '../oracle/interference.js';
 export function createWebGateRunner(epsilonMm3 = 0.01): GateRunner {
   return {
     async run(scriptPath: string): Promise<GateReport> {
-      const verdicts: GateVerdict[] = [];
-
       const evaluate = await evaluateScript(scriptPath);
-      if (evaluate.ok) {
-        verdicts.push({ gate: 'evaluate', ok: true, message: 'evaluate passed' });
-      } else if (evaluate.diagnostics.length === 0) {
-        verdicts.push({ gate: 'evaluate', ok: false, message: 'evaluate failed' });
-      } else {
-        for (const d of evaluate.diagnostics) {
-          verdicts.push({ gate: 'evaluate', ok: false, code: d.code, message: d.message, hint: d.hint, locus: d.featureId });
-        }
-      }
-
       const interference = await runInterference(scriptPath, epsilonMm3);
-      if (interference.ok) {
-        verdicts.push({ gate: 'interference', ok: true, message: 'no interferences' });
-      } else {
-        for (const pair of interference.pairs) {
-          verdicts.push({ gate: 'interference', ok: false, code: 'interference.overlap', message: `${pair.partA} overlaps ${pair.partB} by ${pair.volumeMm3} mm³`, locus: `${pair.partA}∩${pair.partB}`, margin: pair.volumeMm3 });
-        }
-        if (interference.pairs.length === 0) {
-          for (const d of interference.diagnostics) {
-            verdicts.push({ gate: 'interference', ok: false, code: d.code, message: d.message, hint: d.hint });
-          }
-        }
-      }
-
-      const ok = evaluate.ok && interference.ok;
-      return { ok, verdicts };
+      const verdicts = verdictsFromOracles(evaluate, interference);
+      return { ok: verdicts.every((v) => v.ok), verdicts };
     },
   };
 }

--- a/eval/runner.ts
+++ b/eval/runner.ts
@@ -5,6 +5,7 @@ import { extractScript, computeScore, renderTranscript } from './lib';
 import { evaluateScript } from './oracle/kernelcad-client';
 import { runClosedLoop, type LoopMessage } from '../src/agent/loop/closedLoop.js';
 import { createWebGateRunner } from './loop/webGateRunner.js';
+import { buildRepairPrompt } from '../src/agent/loop/repairPrompt';
 import type { CookbookInjection } from './cookbook-injector';
 
 const MAX_ATTEMPTS = 3;
@@ -63,6 +64,7 @@ export async function runTask(args: RunTaskArgs): Promise<TaskResult> {
     prompt,
     gateRunner: createWebGateRunner(),
     extractScript,
+    buildRepairPrompt,
     maxAttempts: MAX_ATTEMPTS,
     writeScript: async (code: string) => {
       writeFileSync(outputScriptPath, code);

--- a/src/agent/loop/closedLoop.ceiling.test.ts
+++ b/src/agent/loop/closedLoop.ceiling.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { MAX_REPAIR_ATTEMPTS_CEILING } from './closedLoop';
+
+describe('MAX_REPAIR_ATTEMPTS_CEILING', () => {
+  it('is documented at 10 (default maxAttempts intentionally stays lower until W5)', () => {
+    expect(MAX_REPAIR_ATTEMPTS_CEILING).toBe(10);
+  });
+});

--- a/src/agent/loop/closedLoop.ts
+++ b/src/agent/loop/closedLoop.ts
@@ -6,6 +6,13 @@ import {
 } from './types.js';
 
 /**
+ * Hard upper bound a caller may configure for repair attempts.
+ * The DEFAULT stays 3. Only safe to raise toward this ceiling once the W5
+ * convergence guard ships — without it a higher cap risks repair doom-loops.
+ */
+export const MAX_REPAIR_ATTEMPTS_CEILING = 10;
+
+/**
  * Host-agnostic generate→gate→repair loop. Imports nothing from fs/CLI/oracle so it
  * bundles cleanly for the server. The host injects generate(), gateRunner, extractScript,
  * and writeScript.

--- a/src/agent/loop/repairPrompt.test.ts
+++ b/src/agent/loop/repairPrompt.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { buildRepairPrompt } from './repairPrompt';
+import type { GateVerdict } from './types';
+
+describe('buildRepairPrompt', () => {
+  it('(a) names the root cause first with margin, locus, and the keep-unchanged instruction', () => {
+    const verdicts: GateVerdict[] = [
+      { gate: 'evaluate', ok: false, code: 'feature.fillet.no-edges', message: 'Fillet selected no edges.', hint: 'Widen the edge query or reduce the radius.' },
+      { gate: 'interference', ok: false, code: 'mechanism.interpenetration', message: 'Parts overlap.', hint: 'Move one part out of the other.', margin: 42, locus: 'shade∩beam' },
+    ];
+    const prompt = buildRepairPrompt(verdicts);
+    const rootIdx = prompt.indexOf('mechanism.interpenetration');
+    const otherIdx = prompt.indexOf('feature.fillet.no-edges');
+    expect(rootIdx).toBeGreaterThanOrEqual(0);
+    expect(otherIdx).toBeGreaterThanOrEqual(0);
+    expect(rootIdx).toBeLessThan(otherIdx);
+    expect(prompt).toContain('42');
+    expect(prompt).toContain('shade∩beam');
+    expect(prompt.toLowerCase()).toContain('keep the rest of the model unchanged');
+    expect(prompt.toLowerCase()).toContain('return the full corrected script');
+  });
+  it('(b) is short and contains no prior-attempt transcript', () => {
+    const verdicts: GateVerdict[] = [
+      { gate: 'interference', ok: false, code: 'mechanism.interpenetration', message: 'Parts overlap.', margin: 42, locus: 'shade∩beam' },
+      { gate: 'evaluate', ok: false, code: 'feature.fillet.no-edges', message: 'Fillet selected no edges.' },
+    ];
+    const prompt = buildRepairPrompt(verdicts);
+    expect(prompt.length).toBeLessThan(1200);
+    expect(prompt.toLowerCase()).not.toContain('attempt 1');
+    expect(prompt.toLowerCase()).not.toContain('transcript');
+  });
+  it('(c) returns empty string when all verdicts pass', () => {
+    const verdicts: GateVerdict[] = [{ gate: 'evaluate', ok: true, message: 'ok' }, { gate: 'interference', ok: true, message: 'ok' }];
+    expect(buildRepairPrompt(verdicts)).toBe('');
+  });
+});

--- a/src/agent/loop/repairPrompt.ts
+++ b/src/agent/loop/repairPrompt.ts
@@ -1,0 +1,47 @@
+import type { GateVerdict } from './types';
+
+function severityRank(verdict: GateVerdict): number {
+  const code = verdict.code ?? '';
+  if (code.startsWith('mechanism.')) return 0;
+  if (verdict.gate === 'interference' || code.startsWith('interference')) return 1;
+  if (code.startsWith('feature.') || verdict.gate === 'evaluate') return 2;
+  return 3;
+}
+
+function renderRootCause(verdict: GateVerdict): string {
+  const parts: string[] = [];
+  parts.push(`ROOT CAUSE — ${verdict.code ?? verdict.gate}: ${verdict.message}`);
+  if (verdict.locus) parts.push(`  locus: ${verdict.locus}`);
+  if (typeof verdict.margin === 'number') parts.push(`  margin: ${verdict.margin}`);
+  if (verdict.hint) parts.push(`  fix: ${verdict.hint}`);
+  return parts.join('\n');
+}
+
+function renderSecondary(verdict: GateVerdict): string {
+  const tag = verdict.code ?? verdict.gate;
+  const locus = verdict.locus ? ` (${verdict.locus})` : '';
+  return `- ${tag}${locus}: ${verdict.message}`;
+}
+
+/**
+ * Build a typed, root-cause-first repair prompt from gate verdicts.
+ * Picks the highest-severity failing verdict as the root cause (rendered first
+ * with code, locus, margin, hint); lists the rest compactly. No transcript replay.
+ * Returns '' when nothing failed.
+ */
+export function buildRepairPrompt(verdicts: GateVerdict[]): string {
+  const failing = verdicts.filter((v) => !v.ok);
+  if (failing.length === 0) return '';
+  const ranked = [...failing].sort((a, b) => severityRank(a) - severityRank(b));
+  const [root, ...rest] = ranked;
+  const lines: string[] = [];
+  lines.push(renderRootCause(root));
+  if (rest.length > 0) {
+    lines.push('');
+    lines.push('Other gate failures (likely downstream of the root cause):');
+    for (const verdict of rest) lines.push(renderSecondary(verdict));
+  }
+  lines.push('');
+  lines.push('Fix the root cause; keep the rest of the model unchanged. Return the full corrected script.');
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary

Phase 0 / W3 — stacks on #381 (W1). Turns repair feedback from a generic error dump into typed, **root-cause-first** prompts carrying a numeric margin + topological locus per failing gate, so the agent fixes the actual cause with minimal context.

- `src/agent/loop/repairPrompt.ts` — `buildRepairPrompt`: ranks failing verdicts (mechanism > interference > feature/evaluate), renders the root cause first with code/locus/margin/hint, lists the rest compactly, says "keep the rest of the model unchanged". No transcript replay (stays short).
- `eval/loop/verdictsFromOracles.ts` — pure oracle→verdict mapper populating `margin = volumeMm³` and `locus = partA∩partB` (interference) / `featureId` (evaluate). Unit-testable without the CLI.
- `eval/loop/webGateRunner.ts` — now delegates to the pure mapper.
- `eval/runner.ts` — the eval closed loop now uses the typed prompt.
- `src/agent/loop/closedLoop.ts` — adds documented `MAX_REPAIR_ATTEMPTS_CEILING = 10` (default stays 3 until the W5 convergence guard ships).

No new diagnostic codes — the catalogue sentinel stays green.

## Test Plan

- [x] 7 new unit tests (repair prompt ranking/brevity/empty; mapper margin/locus/all-ok)
- [x] Existing webGateRunner + closedLoop tests stay green (mapper is shape-compatible)
- [x] eval runner loop test green; diagnostics sentinel green
- [x] `tsc -b` clean

## Note

Wiring the typed prompt into the **server** orchestrator is part of the deferred server slice (the `vendor/kernelcad` submodule bump), tracked with W1's server tasks.