### PR TITLE
Harden the visual oracle (fidelity gates + VLM judge + funnel reporting)

### DIFF
--- a/eval/lib.test.ts
+++ b/eval/lib.test.ts
@@ -277,3 +277,72 @@ describe('renderTranscript — cookbook_inject', () => {
     expect(out).toMatch(/no match above floor/i);
   });
 });
+
+import type { HarnessResult } from './types';
+
+describe('computeScore — funnel cascade (W2)', () => {
+  const meta = { attempts: 1, tokens_in: 10, tokens_out: 20, time_ms: 100 };
+
+  it('does not change score/gate_pass for an all-pass result (regression)', () => {
+    const result: HarnessResult = {
+      gates: { 'evaluates clean': true, 'non-empty solid': true },
+      scored: { 'silhouette IoU >= 0.45 vs photo': true, 'SSIM >= 0.35 vs photo': false },
+    };
+    const score = computeScore(result, meta);
+    expect(score.gate_pass).toBe(true);
+    expect(score.score).toBe(0.5); // 1 of 2 scored passed — unchanged behavior
+  });
+
+  it('still returns score 0 when a gate fails (regression)', () => {
+    const result: HarnessResult = {
+      gates: { 'evaluates clean': false },
+      scored: { 'silhouette IoU >= 0.45 vs photo': true },
+    };
+    const score = computeScore(result, meta);
+    expect(score.gate_pass).toBe(false);
+    expect(score.score).toBe(0);
+  });
+
+  it('populates the funnel with per-stage pass counts for a partially-failing result', () => {
+    const result: HarnessResult = {
+      gates: {
+        'evaluates clean': true,
+        'non-empty solid': true,
+        'no unintended interferences': false,
+        'eyewear-wide (>= 100 mm in some axis)': true,
+      },
+      scored: {
+        'silhouette IoU >= 0.45 vs photo': true,
+        'SSIM >= 0.35 vs photo': false,
+        'chamfer distance <= 25 mm vs STL': true,
+      },
+    };
+    const score = computeScore(result, meta);
+    expect(score.funnel).toBeDefined();
+    const byStage = Object.fromEntries((score.funnel ?? []).map((s) => [s.stage, s]));
+
+    expect(byStage['code-valid']).toEqual({ stage: 'code-valid', passed: 1, total: 1 });
+    // non-empty solid (pass) + no unintended interferences (fail) = 1/2
+    expect(byStage['watertight/non-overlapping']).toEqual({
+      stage: 'watertight/non-overlapping',
+      passed: 1,
+      total: 2,
+    });
+    // eyewear-wide (pass) = 1/1
+    expect(byStage['mechanism-real']).toEqual({ stage: 'mechanism-real', passed: 1, total: 1 });
+    // silhouette (pass) + ssim (fail) + chamfer (pass) = 2/3
+    expect(byStage['design-intent']).toEqual({ stage: 'design-intent', passed: 2, total: 3 });
+  });
+
+  it('omits a stage that has no matching gate/scored item', () => {
+    const result: HarnessResult = {
+      gates: { 'evaluates clean': true },
+      scored: {},
+    };
+    const score = computeScore(result, meta);
+    const stages = (score.funnel ?? []).map((s) => s.stage);
+    expect(stages).toContain('code-valid');
+    expect(stages).not.toContain('design-intent');
+    expect(stages).not.toContain('watertight/non-overlapping');
+  });
+});

--- a/eval/lib.ts
+++ b/eval/lib.ts
@@ -30,6 +30,37 @@ export function formatDiagnostics(diagnostics: Diagnostic[]): string {
     .join('\n');
 }
 
+// W2 — funnel-gate cascade. Each stage matches gate/scored NAMES by substring
+// (case-insensitive). A stage with zero matches is omitted from the funnel so
+// unrelated tasks don't carry empty stages.
+const FUNNEL_STAGES: { stage: string; matchers: string[] }[] = [
+  { stage: 'code-valid', matchers: ['evaluates clean'] },
+  { stage: 'watertight/non-overlapping', matchers: ['non-empty solid', 'interference', 'watertight'] },
+  { stage: 'mechanism-real', matchers: ['eyewear-wide', 'mechanism', 'joint', 'reachab'] },
+  { stage: 'design-intent', matchers: ['silhouette', 'composite', 'ssim', 'chamfer', 'bbox', 'rubric'] },
+];
+
+function buildFunnel(
+  gates: Record<string, boolean>,
+  scored: Record<string, boolean>,
+): { stage: string; passed: number; total: number }[] {
+  const all: [string, boolean][] = [...Object.entries(gates), ...Object.entries(scored)];
+  const out: { stage: string; passed: number; total: number }[] = [];
+  for (const { stage, matchers } of FUNNEL_STAGES) {
+    let passed = 0;
+    let total = 0;
+    for (const [name, value] of all) {
+      const lower = name.toLowerCase();
+      if (matchers.some((m) => lower.includes(m))) {
+        total++;
+        if (value) passed++;
+      }
+    }
+    if (total > 0) out.push({ stage, passed, total });
+  }
+  return out;
+}
+
 export function computeScore(
   result: HarnessResult,
   meta: { attempts: number; tokens_in: number; tokens_out: number; time_ms: number; firstFailureCode?: string },
@@ -61,6 +92,7 @@ export function computeScore(
     time_ms: meta.time_ms,
   };
   if (meta.firstFailureCode !== undefined) out.firstFailureCode = meta.firstFailureCode;
+  out.funnel = buildFunnel(result.gates, result.scored);
   return out;
 }
 

--- a/eval/tasks/eyewear-wayfarer-front/harness.test.ts
+++ b/eval/tasks/eyewear-wayfarer-front/harness.test.ts
@@ -1,0 +1,82 @@
+// eval/tasks/eyewear-wayfarer-front/harness.test.ts
+//
+// W2 — verifies the harness ANDs fidelity gates BEFORE visual scoring so a
+// high silhouette/SSIM can never rescue a wrong object (the "slab hack").
+
+import { describe, it, expect } from 'vitest';
+import { decideScored } from './harness';
+
+describe('eyewear harness — fidelity gates AND before visual score', () => {
+  it('forces all visual scored items false when a fidelity gate fails (R5 slab)', () => {
+    const scored = decideScored({
+      fidelityGates: [
+        { name: 'expectedFeatureVisibleAtPose', pass: false, reason: 'no interior opening' },
+        { name: 'nonDegenerateSolid', pass: true, reason: 'ok' },
+      ],
+      rendered: true,
+      silhouetteIoU: 0.95, // would normally pass the 0.45 floor
+      composite: 0.9,
+      ssim: 0.9,
+      geomScored: false,
+      chamferMm: 0,
+      bboxIoU: 0,
+      judgeScore: undefined,
+    });
+    expect(scored['silhouette IoU >= 0.45 vs photo']).toBe(false);
+    expect(scored['composite >= 0.30 vs photo']).toBe(false);
+    expect(scored['SSIM >= 0.35 vs photo']).toBe(false);
+    expect(scored['fidelity gates pass']).toBe(false);
+  });
+
+  it('lets visual scored items reflect their floors when all fidelity gates pass', () => {
+    const scored = decideScored({
+      fidelityGates: [
+        { name: 'expectedFeatureVisibleAtPose', pass: true, reason: 'ok' },
+        { name: 'nonDegenerateSolid', pass: true, reason: 'ok' },
+      ],
+      rendered: true,
+      silhouetteIoU: 0.5,
+      composite: 0.4,
+      ssim: 0.2, // below the 0.35 floor → false
+      geomScored: false,
+      chamferMm: 0,
+      bboxIoU: 0,
+      judgeScore: undefined,
+    });
+    expect(scored['fidelity gates pass']).toBe(true);
+    expect(scored['silhouette IoU >= 0.45 vs photo']).toBe(true);
+    expect(scored['composite >= 0.30 vs photo']).toBe(true);
+    expect(scored['SSIM >= 0.35 vs photo']).toBe(false);
+  });
+
+  it('emits a VLM-judge scored item when a judge score is present and no STL oracle', () => {
+    const scored = decideScored({
+      fidelityGates: [{ name: 'nonDegenerateSolid', pass: true, reason: 'ok' }],
+      rendered: true,
+      silhouetteIoU: 0.5,
+      composite: 0.4,
+      ssim: 0.4,
+      geomScored: false,
+      chamferMm: 0,
+      bboxIoU: 0,
+      judgeScore: 0.7, // above the 0.5 judge floor
+    });
+    expect(scored['VLM rubric judge >= 0.50']).toBe(true);
+  });
+
+  it('keeps the 3D geometry oracle as the primary signal when present', () => {
+    const scored = decideScored({
+      fidelityGates: [{ name: 'nonDegenerateSolid', pass: true, reason: 'ok' }],
+      rendered: true,
+      silhouetteIoU: 0.5,
+      composite: 0.4,
+      ssim: 0.4,
+      geomScored: true,
+      chamferMm: 18, // <= 25 → pass
+      bboxIoU: 0.1, // >= 0.05 → pass
+      judgeScore: undefined,
+    });
+    expect(scored['chamfer distance <= 25 mm vs STL']).toBe(true);
+    expect(scored['bbox IoU >= 0.05 vs STL']).toBe(true);
+  });
+});

--- a/eval/tasks/eyewear-wayfarer-front/harness.ts
+++ b/eval/tasks/eyewear-wayfarer-front/harness.ts
@@ -7,6 +7,7 @@ import { renderScript } from '../../oracle/render';
 import { scoreAgainstReference } from '../../oracle/scoreReference';
 import { scoreMesh } from '../../oracle/scoreMesh';
 import type { HarnessCtx, HarnessResult } from '../../types';
+import { computeFidelityGates, allFidelityGatesPass, type FidelityGate, type FidelityBundle } from '../../../src/lib/imageSimilarity/fidelityGates';
 
 // Reference photo: front-right product shot from approximately az=30°, el=15°.
 // See ../../docs/specs/2026-05-15-from-prompt-to-object-eval-loop-roadmap.md
@@ -36,6 +37,11 @@ const CHAMFER_CEIL_MM = 25;     // Pass if chamfer ≤ 25mm (R5's 32mm fails;
                                 //   expert's 19mm passes; R14's 12mm passes)
 const BBOX_IOU_FLOOR = 0.05;    // Pass if bbox IoU ≥ 0.05 (R5's 0.056 borderline)
 
+// W2 — VLM rubric judge floor. Used only when no reference.stl exists (the
+// deterministic 3D oracle is primary when it does). SSIM/silhouette below are
+// informational selectors only — never the iterative reward target.
+const JUDGE_FLOOR = 0.5;
+
 async function exportToStl(scriptPath: string, outPath: string): Promise<boolean> {
   // Shell out to `kernelcad export stl <script> -o <outPath>`. Doesn't need
   // a running dev server — STL export is BREP→mesh in-process.
@@ -47,6 +53,69 @@ async function exportToStl(scriptPath: string, outPath: string): Promise<boolean
     child.on('close', (code) => resolve(code === 0 && existsSync(outPath)));
     child.on('error', () => resolve(false));
   });
+}
+
+// W2 — derive a coarse foreground mask from a rendered PNG for the fidelity
+// gates. Mirrors the scorer's corner-background convention. Returns a
+// size×size Uint8Array (1 = foreground).
+async function maskFromPng(pngPath: string, size = 64): Promise<Uint8Array> {
+  const sharp = (await import('sharp')).default;
+  const { data } = await sharp(pngPath)
+    .resize(size, size, { fit: 'contain' })
+    .grayscale()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  const corners = [data[0], data[size - 1], data[(size - 1) * size], data[size * size - 1]];
+  const bg = corners.reduce((a, b) => a + b, 0) / corners.length;
+  const mask = new Uint8Array(size * size);
+  for (let i = 0; i < size * size; i++) mask[i] = Math.abs(data[i] - bg) > 18 ? 1 : 0;
+  return mask;
+}
+
+/**
+ * Pure scoring-decision: given the fidelity gates and the raw visual metrics,
+ * produce the `scored` map. The KEY RULE: if ANY fidelity gate fails, every
+ * visual scored item is forced false — a high SSIM/silhouette can never rescue
+ * a wrong object. SSIM/silhouette are informational selectors only; the VLM
+ * rubric judge (when no STL oracle) and the 3D geometry oracle (when an STL
+ * exists) are the qualitative signals.
+ *
+ * Exported for unit testing (no render/network needed).
+ */
+export function decideScored(args: {
+  fidelityGates: FidelityGate[];
+  rendered: boolean;
+  silhouetteIoU: number;
+  composite: number;
+  ssim: number;
+  geomScored: boolean;
+  chamferMm: number;
+  bboxIoU: number;
+  judgeScore: number | undefined;
+}): Record<string, boolean> {
+  const fidelityPass = allFidelityGatesPass(args.fidelityGates);
+  const visualOk = args.rendered && fidelityPass;
+
+  const scored: Record<string, boolean> = {
+    'fidelity gates pass': fidelityPass,
+    'rendered against reference': args.rendered,
+    'silhouette IoU >= 0.45 vs photo': visualOk && args.silhouetteIoU >= SILHOUETTE_FLOOR,
+    'composite >= 0.30 vs photo': visualOk && args.composite >= COMPOSITE_FLOOR,
+    'SSIM >= 0.35 vs photo': visualOk && args.ssim >= SSIM_FLOOR,
+  };
+
+  // VLM rubric judge — only when no deterministic 3D oracle is available.
+  if (!args.geomScored && args.judgeScore !== undefined) {
+    scored[`VLM rubric judge >= ${JUDGE_FLOOR.toFixed(2)}`] = visualOk && args.judgeScore >= JUDGE_FLOOR;
+  }
+
+  // 3D geometry oracle — primary signal when reference.stl exists.
+  if (args.geomScored) {
+    scored[`chamfer distance <= ${CHAMFER_CEIL_MM} mm vs STL`] = visualOk && args.chamferMm <= CHAMFER_CEIL_MM;
+    scored[`bbox IoU >= ${BBOX_IOU_FLOOR.toFixed(2)} vs STL`] = visualOk && args.bboxIoU >= BBOX_IOU_FLOOR;
+  }
+
+  return scored;
 }
 
 export default async function harness(scriptPath: string, ctx?: HarnessCtx): Promise<HarnessResult> {
@@ -74,6 +143,7 @@ export default async function harness(scriptPath: string, ctx?: HarnessCtx): Pro
   let composite = 0;
   let ssim = 0;
   let rendered = false;
+  let renderedPosePath: string | undefined;
   if (ctx) {
     const referencePath = join(ctx.taskDir, 'reference.jpg');
     const renderStem = join(ctx.runDir, 'render.png');
@@ -82,7 +152,8 @@ export default async function harness(scriptPath: string, ctx?: HarnessCtx): Pro
       poses: [REFERENCE_POSE],
     });
     if (r.ok && r.paths.poses[REFERENCE_POSE]) {
-      const score = await scoreAgainstReference(r.paths.poses[REFERENCE_POSE], referencePath);
+      renderedPosePath = r.paths.poses[REFERENCE_POSE];
+      const score = await scoreAgainstReference(renderedPosePath, referencePath);
       silhouetteIoU = score.perGate.silhouetteIoU;
       composite = score.composite;
       ssim = score.perGate.ssim;
@@ -116,6 +187,36 @@ export default async function harness(scriptPath: string, ctx?: HarnessCtx): Pro
     }
   }
 
+  // W2 — fidelity gates computed from the render-inspect-equivalent mask, ANDed
+  // before any visual score. Eyewear requires at least one interior opening
+  // (lens openings) visible at the pose; a single-frame part is expected.
+  let fidelityGates: FidelityGate[] = [];
+  if (rendered && renderedPosePath) {
+    const mask = await maskFromPng(renderedPosePath, 64);
+    const bundle: FidelityBundle = {
+      size: 64,
+      mask,
+      partsCount: 1,
+      solidVolume: shape.volume,
+    };
+    fidelityGates = computeFidelityGates(bundle, {
+      requireInteriorOpenings: true,
+      expectedPartsCount: 1,
+    });
+  }
+
+  const scored = decideScored({
+    fidelityGates,
+    rendered,
+    silhouetteIoU,
+    composite,
+    ssim,
+    geomScored,
+    chamferMm,
+    bboxIoU,
+    judgeScore: undefined, // no judge wired in the deterministic harness path
+  });
+
   return {
     gates: {
       'evaluates clean': true,
@@ -126,17 +227,6 @@ export default async function harness(scriptPath: string, ctx?: HarnessCtx): Pro
       'eyewear-wide (>= 100 mm in some axis)': dims[0] >= 100,
       'no unintended interferences': interferenceClean,
     },
-    scored: {
-      'rendered against reference': rendered,
-      'silhouette IoU >= 0.45 vs photo': rendered && silhouetteIoU >= SILHOUETTE_FLOOR,
-      'composite >= 0.30 vs photo': rendered && composite >= COMPOSITE_FLOOR,
-      'SSIM >= 0.35 vs photo': rendered && ssim >= SSIM_FLOOR,
-      // 3D-geometric gates (only present when reference.stl is shipped).
-      // Order in object literal preserved → reads naturally in harness output.
-      ...(geomScored ? {
-        [`chamfer distance <= ${CHAMFER_CEIL_MM} mm vs STL`]: chamferMm <= CHAMFER_CEIL_MM,
-        [`bbox IoU >= ${BBOX_IOU_FLOOR.toFixed(2)} vs STL`]: bboxIoU >= BBOX_IOU_FLOOR,
-      } : {}),
-    },
+    scored,
   };
 }

--- a/eval/types.ts
+++ b/eval/types.ts
@@ -45,6 +45,13 @@ export interface Score {
    * synthetic `eval.no-script-extracted` fallbacks).
    */
   firstFailureCode?: string;
+  /**
+   * W2 — funnel-gate cascade. Per-stage pass-rates derived from the gates /
+   * scored maps via a documented stage→name substring mapping (see
+   * computeScore in eval/lib.ts). Optional and additive: omitted stages had
+   * no matching gate/scored item. Existing `score`/`gate_pass` are unaffected.
+   */
+  funnel?: { stage: string; passed: number; total: number }[];
 }
 
 // Transcript events — captured during a run, rendered to markdown afterward.

--- a/src/agent/skills/kernelcad-from-reference/image-replicator/SKILL.md
+++ b/src/agent/skills/kernelcad-from-reference/image-replicator/SKILL.md
@@ -106,10 +106,40 @@ Stop and report when:
 - Or the hard iteration cap (8 passes) is reached — report which gates remain
   below threshold and stop; do not restart the counter silently.
 
+## Policy: SSIM and silhouette are selectors, not reward targets
+
+SSIM and silhouette IoU are **selectors and gates only** — use them to pick the
+better of two candidates and to gate "is this even the right object," never as a
+quantity to iteratively maximize. They are gameable: a past run inflated body
+depth into a featureless slab and scored top on silhouette IoU while producing
+an object with **no lens openings at all** — geometrically not eyewear. Pixel
+similarity decoupled from the real goal.
+
+Therefore:
+
+- **Fidelity gates AND before any visual score.** Before the silhouette/SSIM
+  numbers count, the build must pass boolean fidelity gates (the expected
+  distinctive feature is visible at the pose — e.g. lens openings; the parts
+  count matches; the solid is non-degenerate). If any fidelity gate fails, the
+  visual scored items are forced to fail regardless of how high the pixel
+  similarity is.
+- **When a reference 3D model (`reference.stl`) exists, the deterministic 3D
+  geometry oracle is the primary signal** (chamfer distance, bbox IoU). SSIM and
+  silhouette are supplementary only.
+- **When there is no reference 3D model, a VLM rubric judge is the qualitative
+  signal** — scored against an explicit per-criterion rubric of the distinctive
+  features, at temperature 0 for repeatability. SSIM/silhouette remain selectors.
+- **Never iterate to climb SSIM or silhouette for its own sake.** If those
+  numbers rise while the distinctive features regress, you are gaming the metric.
+  Chase the feature, not the score.
+
 ## Iteration discipline
 
 - **Never edit a gate to loosen the threshold.** If the threshold seems wrong,
   stop and surface the evidence to the user.
+- **SSIM/silhouette are selectors, not reward targets** (see the policy section
+  above). Fidelity gates AND before any visual score; never iterate to climb a
+  pixel-similarity number while distinctive features regress.
 - **Commit per score, not per change.** Evaluate and score after every geometry
   change; never accumulate multiple changes and score once.
 - **Read PNGs back.** The render command writes a file; the file is not evidence

--- a/src/lib/imageSimilarity/fidelityGates.test.ts
+++ b/src/lib/imageSimilarity/fidelityGates.test.ts
@@ -1,0 +1,112 @@
+// src/lib/imageSimilarity/fidelityGates.test.ts
+//
+// W2 fidelity gates. These are boolean AND-gates computed from already-parsed
+// render-inspect data (a square mask Uint8Array + a small numeric summary).
+// They run BEFORE any visual (SSIM/silhouette/VLM) score so that a wrong
+// object can never be rescued by a high pixel-similarity number.
+//
+// Regression target: the "R5 slab" case — a wide rectangular mask with NO
+// interior openings (no lens holes) must FAIL expectedFeatureVisibleAtPose,
+// regardless of how silhouette-similar the slab looks.
+
+import { describe, expect, it } from 'vitest';
+import { computeFidelityGates } from './fidelityGates';
+import type { FidelityBundle } from './fidelityGates';
+
+/** Build a size×size mask that is a solid filled rectangle (no holes). */
+function solidRectMask(size: number, x0: number, y0: number, x1: number, y1: number): Uint8Array {
+  const m = new Uint8Array(size * size);
+  for (let y = y0; y < y1; y++) {
+    for (let x = x0; x < x1; x++) {
+      m[y * size + x] = 1;
+    }
+  }
+  return m;
+}
+
+/** Punch a rectangular background hole into an existing mask (sets pixels to 0). */
+function punchHole(mask: Uint8Array, size: number, x0: number, y0: number, x1: number, y1: number): void {
+  for (let y = y0; y < y1; y++) {
+    for (let x = x0; x < x1; x++) {
+      mask[y * size + x] = 0;
+    }
+  }
+}
+
+describe('computeFidelityGates', () => {
+  const SIZE = 64;
+
+  it('fails expectedFeatureVisibleAtPose for a solid slab with no interior openings (R5 case)', () => {
+    // Wide solid slab, foreground from x=4..60, y=24..40 — no holes.
+    const mask = solidRectMask(SIZE, 4, 24, 60, 40);
+    const bundle: FidelityBundle = {
+      size: SIZE,
+      mask,
+      partsCount: 1,
+      solidVolume: 12000,
+    };
+    const gates = computeFidelityGates(bundle, {
+      requireInteriorOpenings: true,
+      expectedPartsCount: 1,
+    });
+    const feat = gates.find((g) => g.name === 'expectedFeatureVisibleAtPose');
+    expect(feat).toBeDefined();
+    expect(feat!.pass).toBe(false);
+    expect(feat!.reason).toMatch(/no interior opening/i);
+  });
+
+  it('passes expectedFeatureVisibleAtPose for an eyewear-like mask with two lens openings', () => {
+    // Frame band y=24..40, x=4..60. Punch two background lens openings.
+    const mask = solidRectMask(SIZE, 4, 24, 60, 40);
+    punchHole(mask, SIZE, 12, 28, 26, 38); // left lens
+    punchHole(mask, SIZE, 38, 28, 52, 38); // right lens
+    const bundle: FidelityBundle = {
+      size: SIZE,
+      mask,
+      partsCount: 1,
+      solidVolume: 9000,
+    };
+    const gates = computeFidelityGates(bundle, {
+      requireInteriorOpenings: true,
+      expectedPartsCount: 1,
+    });
+    const feat = gates.find((g) => g.name === 'expectedFeatureVisibleAtPose');
+    expect(feat!.pass).toBe(true);
+  });
+
+  it('fails partsCountMatches when the count differs from expected', () => {
+    const mask = solidRectMask(SIZE, 4, 24, 60, 40);
+    punchHole(mask, SIZE, 12, 28, 26, 38);
+    punchHole(mask, SIZE, 38, 28, 52, 38);
+    const bundle: FidelityBundle = { size: SIZE, mask, partsCount: 3, solidVolume: 9000 };
+    const gates = computeFidelityGates(bundle, {
+      requireInteriorOpenings: true,
+      expectedPartsCount: 1,
+    });
+    const parts = gates.find((g) => g.name === 'partsCountMatches');
+    expect(parts!.pass).toBe(false);
+    expect(parts!.reason).toMatch(/expected 1.*got 3/i);
+  });
+
+  it('fails nonDegenerateSolid for zero/near-zero volume', () => {
+    const mask = solidRectMask(SIZE, 4, 24, 60, 40);
+    const bundle: FidelityBundle = { size: SIZE, mask, partsCount: 1, solidVolume: 0 };
+    const gates = computeFidelityGates(bundle, { requireInteriorOpenings: false });
+    const nd = gates.find((g) => g.name === 'nonDegenerateSolid');
+    expect(nd!.pass).toBe(false);
+  });
+
+  it('skips the interior-openings gate when requireInteriorOpenings is false', () => {
+    const mask = solidRectMask(SIZE, 4, 24, 60, 40);
+    const bundle: FidelityBundle = { size: SIZE, mask, partsCount: 1, solidVolume: 100 };
+    const gates = computeFidelityGates(bundle, { requireInteriorOpenings: false });
+    expect(gates.find((g) => g.name === 'expectedFeatureVisibleAtPose')).toBeUndefined();
+  });
+
+  it('skips partsCountMatches when expectedPartsCount is undefined', () => {
+    const mask = solidRectMask(SIZE, 4, 24, 60, 40);
+    const bundle: FidelityBundle = { size: SIZE, mask, partsCount: 5, solidVolume: 100 };
+    const gates = computeFidelityGates(bundle, { requireInteriorOpenings: false });
+    expect(gates.find((g) => g.name === 'partsCountMatches')).toBeUndefined();
+  });
+});

--- a/src/lib/imageSimilarity/fidelityGates.ts
+++ b/src/lib/imageSimilarity/fidelityGates.ts
@@ -1,0 +1,167 @@
+// src/lib/imageSimilarity/fidelityGates.ts
+//
+// W2 — Harden the oracle. Boolean fidelity gates that the eval harness ANDs
+// BEFORE any visual (SSIM / silhouette / VLM) score. The point: a wrong object
+// must never be rescued by a high pixel-similarity number (see the "slab hack"
+// lesson — a wide solid slab with no lens openings can score high on
+// silhouette IoU yet is plainly not eyewear).
+//
+// Design: gates take ALREADY-PARSED data (a square mask Uint8Array + a small
+// numeric summary), never file paths. This keeps the module pure and lets unit
+// tests feed synthetic arrays with no PNG fixtures. The harness is responsible
+// for turning a render-inspect bundle into a FidelityBundle.
+
+/** One boolean fidelity gate result. */
+export interface FidelityGate {
+  name: string;
+  pass: boolean;
+  reason: string;
+}
+
+/**
+ * Already-parsed inputs the gates operate on.
+ * - `mask` is a size×size foreground mask (1 = subject, 0 = background),
+ *   matching the convention produced by the imageSimilarity scorer.
+ * - `partsCount` / `solidVolume` come from the model's shape info.
+ */
+export interface FidelityBundle {
+  size: number;
+  mask: Uint8Array;
+  partsCount: number;
+  solidVolume: number;
+}
+
+export interface FidelityGateOpts {
+  /**
+   * When true, require at least one background-enclosed hole inside the
+   * subject bbox (e.g. lens openings on eyewear). When false, the
+   * `expectedFeatureVisibleAtPose` gate is omitted entirely.
+   */
+  requireInteriorOpenings: boolean;
+  /**
+   * When set, emit a `partsCountMatches` gate comparing `bundle.partsCount`
+   * to this value. When undefined, the gate is omitted.
+   */
+  expectedPartsCount?: number;
+  /** Minimum solid volume to count as non-degenerate. Default: > 0. */
+  minSolidVolume?: number;
+}
+
+/**
+ * Detect whether the subject mask has at least one interior opening: a
+ * background-valued region fully enclosed by foreground inside the subject's
+ * bounding box. Implemented as a flood fill of background pixels from the
+ * bbox border; any background pixel inside the bbox NOT reached by the flood
+ * is an interior hole.
+ */
+function hasInteriorOpening(mask: Uint8Array, size: number): boolean {
+  // Subject bbox.
+  let minX = size, minY = size, maxX = -1, maxY = -1;
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      if (mask[y * size + x]) {
+        if (x < minX) minX = x;
+        if (x > maxX) maxX = x;
+        if (y < minY) minY = y;
+        if (y > maxY) maxY = y;
+      }
+    }
+  }
+  if (maxX < 0) return false; // empty mask — no subject, no openings
+
+  const w = maxX - minX + 1;
+  const h = maxY - minY + 1;
+  // `reached[i]` marks background pixels (within bbox) connected to the border.
+  const reached = new Uint8Array(w * h);
+  const idx = (lx: number, ly: number) => ly * w + lx;
+  const isBg = (lx: number, ly: number) => mask[(minY + ly) * size + (minX + lx)] === 0;
+
+  // Seed the flood with every background pixel on the bbox border.
+  const stack: number[] = [];
+  const push = (lx: number, ly: number) => {
+    if (lx < 0 || ly < 0 || lx >= w || ly >= h) return;
+    if (reached[idx(lx, ly)]) return;
+    if (!isBg(lx, ly)) return;
+    reached[idx(lx, ly)] = 1;
+    stack.push(lx, ly);
+  };
+  for (let lx = 0; lx < w; lx++) {
+    push(lx, 0);
+    push(lx, h - 1);
+  }
+  for (let ly = 0; ly < h; ly++) {
+    push(0, ly);
+    push(w - 1, ly);
+  }
+  // 4-connected flood.
+  while (stack.length > 0) {
+    const ly = stack.pop() as number;
+    const lx = stack.pop() as number;
+    push(lx + 1, ly);
+    push(lx - 1, ly);
+    push(lx, ly + 1);
+    push(lx, ly - 1);
+  }
+
+  // Any background pixel inside bbox NOT reached from the border = interior hole.
+  for (let ly = 0; ly < h; ly++) {
+    for (let lx = 0; lx < w; lx++) {
+      if (isBg(lx, ly) && !reached[idx(lx, ly)]) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Compute the boolean fidelity gates for a render-inspect bundle. Gates that
+ * are not applicable to the task (per opts) are omitted from the array, not
+ * emitted as `pass: true`.
+ */
+export function computeFidelityGates(
+  bundle: FidelityBundle,
+  opts: FidelityGateOpts,
+): FidelityGate[] {
+  const gates: FidelityGate[] = [];
+  const minVol = opts.minSolidVolume ?? 0;
+
+  // nonDegenerateSolid — always emitted.
+  gates.push({
+    name: 'nonDegenerateSolid',
+    pass: bundle.solidVolume > minVol,
+    reason:
+      bundle.solidVolume > minVol
+        ? `solid volume ${bundle.solidVolume} > ${minVol}`
+        : `solid volume ${bundle.solidVolume} is not greater than ${minVol} — degenerate or empty solid`,
+  });
+
+  // partsCountMatches — only when expectedPartsCount is set.
+  if (opts.expectedPartsCount !== undefined) {
+    const ok = bundle.partsCount === opts.expectedPartsCount;
+    gates.push({
+      name: 'partsCountMatches',
+      pass: ok,
+      reason: ok
+        ? `parts count ${bundle.partsCount} matches expected ${opts.expectedPartsCount}`
+        : `expected ${opts.expectedPartsCount} part(s) but got ${bundle.partsCount}`,
+    });
+  }
+
+  // expectedFeatureVisibleAtPose — only when interior openings are required.
+  if (opts.requireInteriorOpenings) {
+    const hasOpening = hasInteriorOpening(bundle.mask, bundle.size);
+    gates.push({
+      name: 'expectedFeatureVisibleAtPose',
+      pass: hasOpening,
+      reason: hasOpening
+        ? 'at least one interior opening is visible inside the subject silhouette'
+        : 'no interior opening detected inside the subject silhouette — the expected feature (e.g. lens openings) is not visible at this pose',
+    });
+  }
+
+  return gates;
+}
+
+/** True iff every gate passes. Convenience for the harness AND-step. */
+export function allFidelityGatesPass(gates: FidelityGate[]): boolean {
+  return gates.every((g) => g.pass);
+}

--- a/src/lib/imageSimilarity/judge.test.ts
+++ b/src/lib/imageSimilarity/judge.test.ts
@@ -1,0 +1,108 @@
+// src/lib/imageSimilarity/judge.test.ts
+//
+// W2 — VisualJudge. Verifies:
+//  1. MockVisualJudge returns its canned score (no API key, no network).
+//  2. VlmRubricJudge caches by sha256(render+reference+rubric): a repeated
+//     identical request returns the same result WITHOUT a second client call.
+//  3. VlmRubricJudge parses the JSON rubric response and pins temperature 0.
+
+import { describe, expect, it } from 'vitest';
+import {
+  MockVisualJudge,
+  VlmRubricJudge,
+  type JudgeLlmClient,
+  type JudgeLlmRequest,
+} from './judge';
+
+/** Fake SDK-shaped client that counts calls and returns a canned JSON body. */
+class CountingJudgeClient implements JudgeLlmClient {
+  public calls: JudgeLlmRequest[] = [];
+  constructor(private readonly body: string) {}
+  async create(req: JudgeLlmRequest): Promise<{ text: string }> {
+    this.calls.push(req);
+    return { text: this.body };
+  }
+}
+
+describe('MockVisualJudge', () => {
+  it('returns the canned score and per-criterion map', async () => {
+    const judge = new MockVisualJudge({
+      score: 0.42,
+      perCriterion: { 'lens openings present': 0.5, 'frame proportion': 0.34 },
+      reason: 'canned',
+    });
+    const out = await judge.judge({
+      renderPng: Buffer.from('render'),
+      referencePng: Buffer.from('ref'),
+      rubric: ['lens openings present', 'frame proportion'],
+    });
+    expect(out.score).toBe(0.42);
+    expect(out.perCriterion['lens openings present']).toBe(0.5);
+    expect(out.reason).toBe('canned');
+  });
+});
+
+describe('VlmRubricJudge', () => {
+  const validBody = JSON.stringify({
+    perCriterion: { 'lens openings present': 0.8, 'frame proportion': 0.6 },
+    reason: 'lenses visible; proportion slightly tall',
+  });
+
+  it('parses the JSON rubric response and averages per-criterion into score', async () => {
+    const client = new CountingJudgeClient(validBody);
+    const judge = new VlmRubricJudge(client);
+    const out = await judge.judge({
+      renderPng: Buffer.from('render-bytes'),
+      referencePng: Buffer.from('ref-bytes'),
+      rubric: ['lens openings present', 'frame proportion'],
+    });
+    expect(out.perCriterion['lens openings present']).toBe(0.8);
+    expect(out.perCriterion['frame proportion']).toBe(0.6);
+    expect(out.score).toBeCloseTo(0.7, 5); // (0.8 + 0.6) / 2
+    expect(client.calls.length).toBe(1);
+  });
+
+  it('pins temperature 0 and a fixed model in the request', async () => {
+    const client = new CountingJudgeClient(validBody);
+    const judge = new VlmRubricJudge(client);
+    await judge.judge({
+      renderPng: Buffer.from('r'),
+      referencePng: Buffer.from('f'),
+      rubric: ['lens openings present', 'frame proportion'],
+    });
+    expect(client.calls[0].temperature).toBe(0);
+    expect(client.calls[0].model.length).toBeGreaterThan(0);
+  });
+
+  it('caches by sha256(render+reference+rubric): identical input → no second call', async () => {
+    const client = new CountingJudgeClient(validBody);
+    const judge = new VlmRubricJudge(client);
+    const args = {
+      renderPng: Buffer.from('same-render'),
+      referencePng: Buffer.from('same-ref'),
+      rubric: ['lens openings present', 'frame proportion'],
+    };
+    const first = await judge.judge(args);
+    const second = await judge.judge(args);
+    expect(second).toEqual(first);
+    expect(client.calls.length).toBe(1); // cache hit, no second call
+  });
+
+  it('makes a fresh call when the render bytes differ', async () => {
+    const client = new CountingJudgeClient(validBody);
+    const judge = new VlmRubricJudge(client);
+    const rubric = ['lens openings present', 'frame proportion'];
+    await judge.judge({ renderPng: Buffer.from('a'), referencePng: Buffer.from('f'), rubric });
+    await judge.judge({ renderPng: Buffer.from('b'), referencePng: Buffer.from('f'), rubric });
+    expect(client.calls.length).toBe(2);
+  });
+
+  it('retries once on malformed JSON then throws', async () => {
+    const bad = new CountingJudgeClient('not json at all');
+    const judge = new VlmRubricJudge(bad);
+    await expect(
+      judge.judge({ renderPng: Buffer.from('r'), referencePng: Buffer.from('f'), rubric: ['x'] }),
+    ).rejects.toThrow(/malformed JSON after retry/);
+    expect(bad.calls.length).toBe(2);
+  });
+});

--- a/src/lib/imageSimilarity/judge.ts
+++ b/src/lib/imageSimilarity/judge.ts
@@ -1,0 +1,182 @@
+// src/lib/imageSimilarity/judge.ts
+//
+// W2 — Harden the oracle. A pluggable VisualJudge.
+//
+// Policy context (see image-replicator/SKILL.md): SSIM and silhouette IoU are
+// SELECTORS/GATES ONLY — never an iterative reward target, because they are
+// gameable (a wide solid slab with no lens openings can score high). The VLM
+// rubric judge is the qualitative signal used WHEN there is no deterministic
+// 3D geometry oracle (no reference.stl). When a reference.stl exists, the
+// deterministic 3D oracle stays primary and this judge is supplementary.
+//
+// VlmRubricJudge reuses the visionLlmBackend pattern: a tiny injected client
+// seam (so tests need no API key), one retry on malformed JSON, code-fence
+// stripping before JSON.parse, model + temperature pinned, and a sha256 cache
+// keyed on the render + reference bytes + rubric (deterministic re-scoring).
+
+import { createHash } from 'node:crypto';
+
+/** Output of any visual judge. `score` is the headline in [0, 1]. */
+export interface VisualJudgeResult {
+  score: number;
+  perCriterion: Record<string, number>;
+  reason: string;
+}
+
+export interface VisualJudgeArgs {
+  renderPng: Buffer;
+  referencePng?: Buffer;
+  rubric: string[];
+}
+
+/** Pluggable judge. Implemented by VlmRubricJudge (prod) and MockVisualJudge (tests). */
+export interface VisualJudge {
+  judge(args: VisualJudgeArgs): Promise<VisualJudgeResult>;
+}
+
+// ─── Mock (tests / CI without an API key) ────────────────────────────────────
+
+export class MockVisualJudge implements VisualJudge {
+  private readonly canned: VisualJudgeResult;
+  constructor(canned: VisualJudgeResult) {
+    this.canned = canned;
+  }
+  async judge(_args: VisualJudgeArgs): Promise<VisualJudgeResult> {
+    return this.canned;
+  }
+}
+
+// ─── Injected client seam (mirrors visionLlmBackend's VisionLlmClient) ───────
+
+export interface JudgeLlmRequest {
+  model: string;
+  temperature: number;
+  prompt: string;
+  renderPng: Buffer;
+  referencePng?: Buffer;
+}
+
+/** Minimal client surface — accepts the production client or a test counter. */
+export interface JudgeLlmClient {
+  create(req: JudgeLlmRequest): Promise<{ text: string }>;
+}
+
+// Pinned for determinism. Temperature 0 → repeatable judgments.
+const JUDGE_MODEL = 'claude-sonnet-4-6';
+const JUDGE_TEMPERATURE = 0;
+
+function buildRubricPrompt(rubric: string[]): string {
+  const lines = rubric.map((c, i) => `  ${i + 1}. ${c}`);
+  return [
+    'You are a strict visual-fidelity judge. Compare the RENDER to the REFERENCE',
+    '(when provided) and score how well the render satisfies each criterion.',
+    '',
+    `Criteria (${rubric.length}):`,
+    ...lines,
+    '',
+    'Score each criterion in the closed interval [0, 1]: 1 = fully satisfied,',
+    '0 = absent or wrong. Be conservative — a plausible-looking shape that is',
+    'missing the requested distinctive feature scores low on that criterion.',
+    '',
+    'Return ONLY a single JSON object (no prose, no markdown fence) of this shape:',
+    '{',
+    '  "perCriterion": { "<criterion text>": 0.0, ... },',
+    '  "reason": "<one-sentence justification>"',
+    '}',
+  ].join('\n');
+}
+
+function stripCodeFences(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('```')) {
+    const firstNewline = trimmed.indexOf('\n');
+    if (firstNewline >= 0) {
+      const body = trimmed.slice(firstNewline + 1);
+      const closeIdx = body.lastIndexOf('```');
+      return (closeIdx >= 0 ? body.slice(0, closeIdx) : body).trim();
+    }
+  }
+  return trimmed;
+}
+
+function parseRubricResponse(text: string, rubric: string[]): VisualJudgeResult {
+  const parsed = JSON.parse(stripCodeFences(text)) as unknown;
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    typeof (parsed as { perCriterion?: unknown }).perCriterion !== 'object' ||
+    (parsed as { perCriterion?: unknown }).perCriterion === null
+  ) {
+    throw new Error('judge: response JSON missing "perCriterion" object');
+  }
+  const rawPer = (parsed as { perCriterion: Record<string, unknown> }).perCriterion;
+  const reason =
+    typeof (parsed as { reason?: unknown }).reason === 'string'
+      ? (parsed as { reason: string }).reason
+      : '';
+
+  const perCriterion: Record<string, number> = {};
+  for (const c of rubric) {
+    const v = rawPer[c];
+    const n = typeof v === 'number' && Number.isFinite(v) ? Math.max(0, Math.min(1, v)) : 0;
+    perCriterion[c] = n;
+  }
+  const values = Object.values(perCriterion);
+  const score = values.length === 0 ? 0 : values.reduce((a, b) => a + b, 0) / values.length;
+  return { score, perCriterion, reason };
+}
+
+export class VlmRubricJudge implements VisualJudge {
+  private cache = new Map<string, VisualJudgeResult>();
+  private readonly client: JudgeLlmClient;
+  private readonly model: string;
+  private readonly temperature: number;
+
+  constructor(
+    client: JudgeLlmClient,
+    model: string = JUDGE_MODEL,
+    temperature: number = JUDGE_TEMPERATURE,
+  ) {
+    this.client = client;
+    this.model = model;
+    this.temperature = temperature;
+  }
+
+  private cacheKey(args: VisualJudgeArgs): string {
+    const h = createHash('sha256');
+    h.update(args.renderPng);
+    if (args.referencePng) h.update(args.referencePng);
+    h.update(JSON.stringify(args.rubric));
+    h.update(this.model);
+    h.update(String(this.temperature));
+    return h.digest('hex');
+  }
+
+  async judge(args: VisualJudgeArgs): Promise<VisualJudgeResult> {
+    const key = this.cacheKey(args);
+    const cached = this.cache.get(key);
+    if (cached) return cached;
+
+    const prompt = buildRubricPrompt(args.rubric);
+    const req: JudgeLlmRequest = {
+      model: this.model,
+      temperature: this.temperature,
+      prompt,
+      renderPng: args.renderPng,
+      referencePng: args.referencePng,
+    };
+
+    let lastErr: Error | null = null;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const resp = await this.client.create(req);
+      try {
+        const result = parseRubricResponse(resp.text, args.rubric);
+        this.cache.set(key, result);
+        return result;
+      } catch (err) {
+        lastErr = err instanceof Error ? err : new Error(String(err));
+      }
+    }
+    throw new Error(`judge: malformed JSON after retry (${lastErr?.message ?? 'unknown'})`);
+  }
+}

--- a/src/lib/imageSimilarity/judge.ts
+++ b/src/lib/imageSimilarity/judge.ts
@@ -41,7 +41,7 @@ export class MockVisualJudge implements VisualJudge {
   constructor(canned: VisualJudgeResult) {
     this.canned = canned;
   }
-  async judge(_args: VisualJudgeArgs): Promise<VisualJudgeResult> {
+  async judge(): Promise<VisualJudgeResult> {
     return this.canned;
   }
 }


### PR DESCRIPTION
## Summary

Phase 0 / W2 — stops the visual scorer from being gameable. Independent of W1/W3 (nothing under `src/agent/loop/*` touched).

- `src/lib/imageSimilarity/fidelityGates.ts` — boolean fidelity gates computed from already-parsed render data (pure; unit-testable with synthetic masks). `expectedFeatureVisibleAtPose` (interior-opening flood-fill), `partsCountMatches`, `nonDegenerateSolid`. The harness **ANDs these before any visual score**, so a high SSIM/silhouette can never rescue the wrong object (the slab-with-no-lens-openings case fails by construction).
- `src/lib/imageSimilarity/judge.ts` — pluggable `VisualJudge`: `VlmRubricJudge` (injected client seam, pinned model + temperature 0, sha256 render-hash cache, one-retry JSON parse) + `MockVisualJudge`. Runs in CI with no API key.
- `eval/types.ts` / `eval/lib.ts` — additive `Score.funnel`: per-stage pass-rates (code-valid → watertight/non-overlapping → mechanism-real → design-intent). Existing `score`/`gate_pass` unchanged (regression-tested).
- `eval/tasks/eyewear-wayfarer-front/harness.ts` — demonstrates the AND-before-visual-score policy; 3D geometry oracle stays primary when `reference.stl` exists, VLM judge is the qualitative signal otherwise, SSIM/silhouette demoted to selectors.
- `image-replicator/SKILL.md` — documents the selectors-not-reward-targets rule.

## Test Plan

- [x] 42 tests across fidelity gates (6), judge (6), funnel + regressions (eval/lib), and the harness AND-policy (4)
- [x] Additive `Score` change — regression tests confirm `score`/`gate_pass` unchanged
- [x] Judge suite runs with no API key (injected fake client)
- [x] `tsc -b` clean; `src/agent/loop/*` untouched