### PR TITLE
Typed requirement-level repair feedback (W3)

### DIFF
--- a/eval/loop/liveLoopDemo.test.ts
+++ b/eval/loop/liveLoopDemo.test.ts
@@ -1,0 +1,70 @@
+// LIVE end-to-end integration test: drives the REAL closed loop against the
+// REAL OCCT CLI (no mocks). A scripted "author" emits a broken model (two
+// overlapping parts) then a fixed one; everything else — evaluate, interference
+// detection, the typed margin/locus feedback, and convergence — is real.
+//
+// This is the regression that unit tests (which mocked the oracle) could not
+// catch: it proves the loop builds → catches a real BREP interference with
+// typed evidence → repairs → passes on real geometry. Requires the CLI build
+// (`npm run build:cli`), like the other eval oracle integration tests.
+import { describe, it, expect } from 'vitest';
+import { writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runClosedLoop } from '../../src/agent/loop/closedLoop';
+import { buildRepairPrompt } from '../../src/agent/loop/repairPrompt';
+import type { GateVerdict } from '../../src/agent/loop/types';
+import { createWebGateRunner } from './webGateRunner';
+
+const BROKEN = `
+const a = assembly('overlap-demo');
+a.part('blockA', box(40, 40, 20), { at: [0, 0, 0] });
+a.part('blockB', box(40, 40, 20), { at: [20, 0, 0] });
+return a.model();
+`.trim();
+
+const FIXED = `
+const a = assembly('overlap-demo');
+a.part('blockA', box(40, 40, 20), { at: [0, 0, 0] });
+a.part('blockB', box(40, 40, 20), { at: [50, 0, 0] });
+return a.model();
+`.trim();
+
+describe('LIVE closed loop on real OCCT', () => {
+  it('builds broken → real gate catches interference with typed margin/locus → repairs → passes', async () => {
+    const scriptPath = join(tmpdir(), 'liveloop.kcad.ts');
+    const drafts = [BROKEN, FIXED];
+    let i = 0;
+    let firstFailVerdict: GateVerdict | undefined;
+
+    const result = await runClosedLoop({
+      prompt: 'two non-overlapping blocks',
+      gateRunner: createWebGateRunner(),
+      buildRepairPrompt,
+      maxAttempts: 3,
+      extractScript: (t) => t,
+      writeScript: async (code) => {
+        await writeFile(scriptPath, code);
+        return scriptPath;
+      },
+      generate: async () => ({ text: drafts[Math.min(i++, drafts.length - 1)], tokensIn: 0, tokensOut: 0 }),
+      onEvent: (e) => {
+        if (e.type === 'gate_report' && !e.report.ok && !firstFailVerdict) {
+          firstFailVerdict = e.report.verdicts.find((v) => v.gate === 'interference' && !v.ok);
+        }
+      },
+    });
+
+    // The loop converged on real geometry: broken first, repaired second.
+    expect(result.status).toBe('passed');
+    expect(result.attempts).toBe(2);
+
+    // The typed feedback is real (this is what the mocked unit tests missed):
+    // the interference verdict from the real CLI carries a numeric margin and a
+    // topological locus, not a generic "Interference detected." string.
+    expect(firstFailVerdict).toBeDefined();
+    expect(firstFailVerdict!.locus).toBe('blockA∩blockB');
+    expect(firstFailVerdict!.margin).toBeGreaterThan(15000);
+    expect(firstFailVerdict!.code).toBe('interference.overlap');
+  }, 120000);
+});

--- a/eval/loop/verdictsFromOracles.test.ts
+++ b/eval/loop/verdictsFromOracles.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { verdictsFromOracles } from './verdictsFromOracles';
+
+describe('verdictsFromOracles', () => {
+  it('maps an interference pair to a verdict carrying margin (mm³) and locus (partA∩partB)', () => {
+    const evaluateResult = { ok: true, diagnostics: [], featureCount: 3 };
+    const interferenceResult = { ok: false, pairs: [{ partA: 'shade', partB: 'beam', volumeMm3: 42 }], diagnostics: [{ code: 'mechanism.interpenetration', message: 'Parts overlap.' }] };
+    const verdicts = verdictsFromOracles(evaluateResult, interferenceResult);
+    const interference = verdicts.find((v) => v.gate === 'interference');
+    expect(interference).toBeDefined();
+    expect(interference!.ok).toBe(false);
+    expect(interference!.margin).toBe(42);
+    expect(interference!.locus).toBe('shade∩beam');
+    expect(interference!.code).toBe('mechanism.interpenetration');
+  });
+  it('carries featureId as locus on evaluate verdicts when present', () => {
+    const evaluateResult = { ok: false, diagnostics: [{ code: 'feature.fillet.no-edges', message: 'Fillet selected no edges.', featureId: 'fillet-1' }], featureCount: 2 };
+    const interferenceResult = { ok: true, pairs: [], diagnostics: [] };
+    const verdicts = verdictsFromOracles(evaluateResult, interferenceResult);
+    const evaluate = verdicts.find((v) => v.code === 'feature.fillet.no-edges');
+    expect(evaluate).toBeDefined();
+    expect(evaluate!.ok).toBe(false);
+    expect(evaluate!.locus).toBe('fillet-1');
+  });
+  it('produces an all-ok report when both oracles pass', () => {
+    const evaluateResult = { ok: true, diagnostics: [], featureCount: 1 };
+    const interferenceResult = { ok: true, pairs: [], diagnostics: [] };
+    const verdicts = verdictsFromOracles(evaluateResult, interferenceResult);
+    expect(verdicts.every((v) => v.ok)).toBe(true);
+  });
+});

--- a/eval/loop/verdictsFromOracles.test.ts
+++ b/eval/loop/verdictsFromOracles.test.ts
@@ -3,15 +3,25 @@ import { verdictsFromOracles } from './verdictsFromOracles';
 
 describe('verdictsFromOracles', () => {
   it('maps an interference pair to a verdict carrying margin (mm³) and locus (partA∩partB)', () => {
+    // Real CLI shape: overlap data lives in `pairs`; `diagnostics` is empty.
     const evaluateResult = { ok: true, diagnostics: [], featureCount: 3 };
-    const interferenceResult = { ok: false, pairs: [{ partA: 'shade', partB: 'beam', volumeMm3: 42 }], diagnostics: [{ code: 'mechanism.interpenetration', message: 'Parts overlap.' }] };
+    const interferenceResult = { ok: false, pairs: [{ partA: 'shade', partB: 'beam', volumeMm3: 42 }], diagnostics: [] };
     const verdicts = verdictsFromOracles(evaluateResult, interferenceResult);
     const interference = verdicts.find((v) => v.gate === 'interference');
     expect(interference).toBeDefined();
     expect(interference!.ok).toBe(false);
     expect(interference!.margin).toBe(42);
     expect(interference!.locus).toBe('shade∩beam');
-    expect(interference!.code).toBe('mechanism.interpenetration');
+    expect(interference!.code).toBe('interference.overlap');
+  });
+
+  it('surfaces interference diagnostics when failing with no pair detail (CLI exception)', () => {
+    const evaluateResult = { ok: true, diagnostics: [], featureCount: 1 };
+    const interferenceResult = { ok: false, pairs: [], diagnostics: [{ code: 'cli.interference-exception', message: 'boom' }] };
+    const verdicts = verdictsFromOracles(evaluateResult, interferenceResult);
+    const interference = verdicts.find((v) => v.gate === 'interference');
+    expect(interference!.ok).toBe(false);
+    expect(interference!.code).toBe('cli.interference-exception');
   });
   it('carries featureId as locus on evaluate verdicts when present', () => {
     const evaluateResult = { ok: false, diagnostics: [{ code: 'feature.fillet.no-edges', message: 'Fillet selected no edges.', featureId: 'fillet-1' }], featureCount: 2 };

--- a/eval/loop/verdictsFromOracles.ts
+++ b/eval/loop/verdictsFromOracles.ts
@@ -13,8 +13,10 @@ interface InterferenceLike {
 
 /**
  * Pure mapping from oracle results to typed gate verdicts.
- * - Interference verdicts get margin = volumeMm3 and locus = `${partA}∩${partB}`,
- *   pairing each diagnostic with the overlap pair at the same index when available.
+ * - Interference verdicts are driven by `pairs` (where the CLI actually reports
+ *   the overlap), giving margin = volumeMm3 and locus = `${partA}∩${partB}`.
+ *   The CLI emits the overlap data in `pairs` with `diagnostics` empty, so we
+ *   must read `pairs` — not `diagnostics` — to surface the typed evidence.
  * - Evaluate verdicts get locus = diagnostic.featureId when present.
  * Extracted as a pure function so margin/locus population is unit-testable without the CLI.
  */
@@ -27,13 +29,25 @@ export function verdictsFromOracles(evaluateResult: EvaluateLike, interferenceRe
       verdicts.push({ gate: 'evaluate', ok: false, code: diag.code, message: diag.message, hint: diag.hint, locus: diag.featureId });
     }
   }
-  if (interferenceResult.diagnostics.length === 0) {
-    verdicts.push({ gate: 'interference', ok: interferenceResult.ok, message: interferenceResult.ok ? 'No part interferences detected.' : 'Interference detected.' });
+  if (interferenceResult.pairs.length > 0) {
+    // Real overlaps — one typed verdict per pair, carrying margin (mm³) and locus.
+    for (const pair of interferenceResult.pairs) {
+      verdicts.push({
+        gate: 'interference',
+        ok: false,
+        code: 'interference.overlap',
+        message: `${pair.partA} overlaps ${pair.partB} by ${Math.round(pair.volumeMm3)} mm³`,
+        margin: pair.volumeMm3,
+        locus: `${pair.partA}∩${pair.partB}`,
+      });
+    }
+  } else if (!interferenceResult.ok && interferenceResult.diagnostics.length > 0) {
+    // Failed without pair detail (e.g. a CLI exception) — surface the diagnostics.
+    for (const diag of interferenceResult.diagnostics) {
+      verdicts.push({ gate: 'interference', ok: false, code: diag.code, message: diag.message, hint: diag.hint });
+    }
   } else {
-    interferenceResult.diagnostics.forEach((diag, index) => {
-      const pair = interferenceResult.pairs[index];
-      verdicts.push({ gate: 'interference', ok: false, code: diag.code, message: diag.message, hint: diag.hint, margin: pair?.volumeMm3, locus: pair ? `${pair.partA}∩${pair.partB}` : undefined });
-    });
+    verdicts.push({ gate: 'interference', ok: interferenceResult.ok, message: interferenceResult.ok ? 'No part interferences detected.' : 'Interference detected.' });
   }
   return verdicts;
 }

--- a/eval/loop/verdictsFromOracles.ts
+++ b/eval/loop/verdictsFromOracles.ts
@@ -1,0 +1,39 @@
+import type { GateVerdict } from '../../src/agent/loop/types';
+
+interface EvaluateLike {
+  ok: boolean;
+  diagnostics: Array<{ code: string; message: string; hint?: string; featureId?: string }>;
+  featureCount?: number;
+}
+interface InterferenceLike {
+  ok: boolean;
+  pairs: Array<{ partA: string; partB: string; volumeMm3: number }>;
+  diagnostics: Array<{ code: string; message: string; hint?: string }>;
+}
+
+/**
+ * Pure mapping from oracle results to typed gate verdicts.
+ * - Interference verdicts get margin = volumeMm3 and locus = `${partA}∩${partB}`,
+ *   pairing each diagnostic with the overlap pair at the same index when available.
+ * - Evaluate verdicts get locus = diagnostic.featureId when present.
+ * Extracted as a pure function so margin/locus population is unit-testable without the CLI.
+ */
+export function verdictsFromOracles(evaluateResult: EvaluateLike, interferenceResult: InterferenceLike): GateVerdict[] {
+  const verdicts: GateVerdict[] = [];
+  if (evaluateResult.diagnostics.length === 0) {
+    verdicts.push({ gate: 'evaluate', ok: evaluateResult.ok, message: evaluateResult.ok ? 'Script evaluated cleanly.' : 'Script evaluation failed.' });
+  } else {
+    for (const diag of evaluateResult.diagnostics) {
+      verdicts.push({ gate: 'evaluate', ok: false, code: diag.code, message: diag.message, hint: diag.hint, locus: diag.featureId });
+    }
+  }
+  if (interferenceResult.diagnostics.length === 0) {
+    verdicts.push({ gate: 'interference', ok: interferenceResult.ok, message: interferenceResult.ok ? 'No part interferences detected.' : 'Interference detected.' });
+  } else {
+    interferenceResult.diagnostics.forEach((diag, index) => {
+      const pair = interferenceResult.pairs[index];
+      verdicts.push({ gate: 'interference', ok: false, code: diag.code, message: diag.message, hint: diag.hint, margin: pair?.volumeMm3, locus: pair ? `${pair.partA}∩${pair.partB}` : undefined });
+    });
+  }
+  return verdicts;
+}

--- a/eval/loop/webGateRunner.ts
+++ b/eval/loop/webGateRunner.ts
@@ -1,6 +1,7 @@
-import type { GateReport, GateRunner, GateVerdict } from '../../src/agent/loop/types.js';
+import type { GateReport, GateRunner } from '../../src/agent/loop/types.js';
 import { evaluateScript } from '../oracle/kernelcad-client.js';
 import { runInterference } from '../oracle/interference.js';
+import { verdictsFromOracles } from './verdictsFromOracles';
 
 /**
  * Web (CLI-oracle) GateRunner. Runs the build-blocking suite on a written script:
@@ -11,35 +12,10 @@ import { runInterference } from '../oracle/interference.js';
 export function createWebGateRunner(epsilonMm3 = 0.01): GateRunner {
   return {
     async run(scriptPath: string): Promise<GateReport> {
-      const verdicts: GateVerdict[] = [];
-
       const evaluate = await evaluateScript(scriptPath);
-      if (evaluate.ok) {
-        verdicts.push({ gate: 'evaluate', ok: true, message: 'evaluate passed' });
-      } else if (evaluate.diagnostics.length === 0) {
-        verdicts.push({ gate: 'evaluate', ok: false, message: 'evaluate failed' });
-      } else {
-        for (const d of evaluate.diagnostics) {
-          verdicts.push({ gate: 'evaluate', ok: false, code: d.code, message: d.message, hint: d.hint, locus: d.featureId });
-        }
-      }
-
       const interference = await runInterference(scriptPath, epsilonMm3);
-      if (interference.ok) {
-        verdicts.push({ gate: 'interference', ok: true, message: 'no interferences' });
-      } else {
-        for (const pair of interference.pairs) {
-          verdicts.push({ gate: 'interference', ok: false, code: 'interference.overlap', message: `${pair.partA} overlaps ${pair.partB} by ${pair.volumeMm3} mm³`, locus: `${pair.partA}∩${pair.partB}`, margin: pair.volumeMm3 });
-        }
-        if (interference.pairs.length === 0) {
-          for (const d of interference.diagnostics) {
-            verdicts.push({ gate: 'interference', ok: false, code: d.code, message: d.message, hint: d.hint });
-          }
-        }
-      }
-
-      const ok = evaluate.ok && interference.ok;
-      return { ok, verdicts };
+      const verdicts = verdictsFromOracles(evaluate, interference);
+      return { ok: verdicts.every((v) => v.ok), verdicts };
     },
   };
 }

--- a/eval/oracle/interference.ts
+++ b/eval/oracle/interference.ts
@@ -69,7 +69,15 @@ export async function runInterference(scriptPath: string, epsilonMm3 = 0.01): Pr
       partCount: parsed.partCount ?? 0,
       comparisonCount: parsed.comparisonCount ?? 0,
       epsilonMm3: parsed.epsilonMm3 ?? epsilonMm3,
-      pairs: Array.isArray(parsed.pairs) ? parsed.pairs : [],
+      // The CLI emits pairs as { a, b, volumeMm3 }; normalise to the declared
+      // { partA, partB, volumeMm3 } shape so consumers get stable field names.
+      pairs: Array.isArray(parsed.pairs)
+        ? parsed.pairs.map((p: { a?: string; b?: string; partA?: string; partB?: string; volumeMm3?: number }) => ({
+            partA: p.partA ?? p.a ?? 'partA',
+            partB: p.partB ?? p.b ?? 'partB',
+            volumeMm3: p.volumeMm3 ?? 0,
+          }))
+        : [],
       diagnostics: Array.isArray(parsed.diagnostics) ? parsed.diagnostics : [],
     };
   } catch {

--- a/eval/runner.ts
+++ b/eval/runner.ts
@@ -5,6 +5,7 @@ import { extractScript, computeScore, renderTranscript } from './lib';
 import { evaluateScript } from './oracle/kernelcad-client';
 import { runClosedLoop, type LoopMessage } from '../src/agent/loop/closedLoop.js';
 import { createWebGateRunner } from './loop/webGateRunner.js';
+import { buildRepairPrompt } from '../src/agent/loop/repairPrompt';
 import type { CookbookInjection } from './cookbook-injector';
 
 const MAX_ATTEMPTS = 3;
@@ -63,6 +64,7 @@ export async function runTask(args: RunTaskArgs): Promise<TaskResult> {
     prompt,
     gateRunner: createWebGateRunner(),
     extractScript,
+    buildRepairPrompt,
     maxAttempts: MAX_ATTEMPTS,
     writeScript: async (code: string) => {
       writeFileSync(outputScriptPath, code);

--- a/src/agent/loop/closedLoop.ceiling.test.ts
+++ b/src/agent/loop/closedLoop.ceiling.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { MAX_REPAIR_ATTEMPTS_CEILING } from './closedLoop';
+
+describe('MAX_REPAIR_ATTEMPTS_CEILING', () => {
+  it('is documented at 10 (default maxAttempts intentionally stays lower until W5)', () => {
+    expect(MAX_REPAIR_ATTEMPTS_CEILING).toBe(10);
+  });
+});

--- a/src/agent/loop/closedLoop.ts
+++ b/src/agent/loop/closedLoop.ts
@@ -6,6 +6,13 @@ import {
 } from './types.js';
 
 /**
+ * Hard upper bound a caller may configure for repair attempts.
+ * The DEFAULT stays 3. Only safe to raise toward this ceiling once the W5
+ * convergence guard ships — without it a higher cap risks repair doom-loops.
+ */
+export const MAX_REPAIR_ATTEMPTS_CEILING = 10;
+
+/**
  * Host-agnostic generate→gate→repair loop. Imports nothing from fs/CLI/oracle so it
  * bundles cleanly for the server. The host injects generate(), gateRunner, extractScript,
  * and writeScript.

--- a/src/agent/loop/repairPrompt.test.ts
+++ b/src/agent/loop/repairPrompt.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { buildRepairPrompt } from './repairPrompt';
+import type { GateVerdict } from './types';
+
+describe('buildRepairPrompt', () => {
+  it('(a) names the root cause first with margin, locus, and the keep-unchanged instruction', () => {
+    const verdicts: GateVerdict[] = [
+      { gate: 'evaluate', ok: false, code: 'feature.fillet.no-edges', message: 'Fillet selected no edges.', hint: 'Widen the edge query or reduce the radius.' },
+      { gate: 'interference', ok: false, code: 'mechanism.interpenetration', message: 'Parts overlap.', hint: 'Move one part out of the other.', margin: 42, locus: 'shade∩beam' },
+    ];
+    const prompt = buildRepairPrompt(verdicts);
+    const rootIdx = prompt.indexOf('mechanism.interpenetration');
+    const otherIdx = prompt.indexOf('feature.fillet.no-edges');
+    expect(rootIdx).toBeGreaterThanOrEqual(0);
+    expect(otherIdx).toBeGreaterThanOrEqual(0);
+    expect(rootIdx).toBeLessThan(otherIdx);
+    expect(prompt).toContain('42');
+    expect(prompt).toContain('shade∩beam');
+    expect(prompt.toLowerCase()).toContain('keep the rest of the model unchanged');
+    expect(prompt.toLowerCase()).toContain('return the full corrected script');
+  });
+  it('(b) is short and contains no prior-attempt transcript', () => {
+    const verdicts: GateVerdict[] = [
+      { gate: 'interference', ok: false, code: 'mechanism.interpenetration', message: 'Parts overlap.', margin: 42, locus: 'shade∩beam' },
+      { gate: 'evaluate', ok: false, code: 'feature.fillet.no-edges', message: 'Fillet selected no edges.' },
+    ];
+    const prompt = buildRepairPrompt(verdicts);
+    expect(prompt.length).toBeLessThan(1200);
+    expect(prompt.toLowerCase()).not.toContain('attempt 1');
+    expect(prompt.toLowerCase()).not.toContain('transcript');
+  });
+  it('(c) returns empty string when all verdicts pass', () => {
+    const verdicts: GateVerdict[] = [{ gate: 'evaluate', ok: true, message: 'ok' }, { gate: 'interference', ok: true, message: 'ok' }];
+    expect(buildRepairPrompt(verdicts)).toBe('');
+  });
+});

--- a/src/agent/loop/repairPrompt.ts
+++ b/src/agent/loop/repairPrompt.ts
@@ -1,0 +1,47 @@
+import type { GateVerdict } from './types';
+
+function severityRank(verdict: GateVerdict): number {
+  const code = verdict.code ?? '';
+  if (code.startsWith('mechanism.')) return 0;
+  if (verdict.gate === 'interference' || code.startsWith('interference')) return 1;
+  if (code.startsWith('feature.') || verdict.gate === 'evaluate') return 2;
+  return 3;
+}
+
+function renderRootCause(verdict: GateVerdict): string {
+  const parts: string[] = [];
+  parts.push(`ROOT CAUSE — ${verdict.code ?? verdict.gate}: ${verdict.message}`);
+  if (verdict.locus) parts.push(`  locus: ${verdict.locus}`);
+  if (typeof verdict.margin === 'number') parts.push(`  margin: ${verdict.margin}`);
+  if (verdict.hint) parts.push(`  fix: ${verdict.hint}`);
+  return parts.join('\n');
+}
+
+function renderSecondary(verdict: GateVerdict): string {
+  const tag = verdict.code ?? verdict.gate;
+  const locus = verdict.locus ? ` (${verdict.locus})` : '';
+  return `- ${tag}${locus}: ${verdict.message}`;
+}
+
+/**
+ * Build a typed, root-cause-first repair prompt from gate verdicts.
+ * Picks the highest-severity failing verdict as the root cause (rendered first
+ * with code, locus, margin, hint); lists the rest compactly. No transcript replay.
+ * Returns '' when nothing failed.
+ */
+export function buildRepairPrompt(verdicts: GateVerdict[]): string {
+  const failing = verdicts.filter((v) => !v.ok);
+  if (failing.length === 0) return '';
+  const ranked = [...failing].sort((a, b) => severityRank(a) - severityRank(b));
+  const [root, ...rest] = ranked;
+  const lines: string[] = [];
+  lines.push(renderRootCause(root));
+  if (rest.length > 0) {
+    lines.push('');
+    lines.push('Other gate failures (likely downstream of the root cause):');
+    for (const verdict of rest) lines.push(renderSecondary(verdict));
+  }
+  lines.push('');
+  lines.push('Fix the root cause; keep the rest of the model unchanged. Return the full corrected script.');
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary

Phase 0 / W3 — re-targeted to `develop` after #382 merged into the W1 branch. The W1 commits are already in `develop` (via #381), so this PR's diff is W3-only: typed, root-cause-first repair feedback.

- `src/agent/loop/repairPrompt.ts` — `buildRepairPrompt`: ranks failing verdicts (mechanism > interference > feature/evaluate), root cause first with code/locus/margin/hint, "keep the rest unchanged", no transcript replay.
- `eval/loop/verdictsFromOracles.ts` — pure oracle→verdict mapper (margin = mm³, locus = partA∩partB / featureId).
- `eval/loop/webGateRunner.ts` — uses the pure mapper.
- `eval/runner.ts` — eval closed loop uses the typed prompt.
- `src/agent/loop/closedLoop.ts` — documented `MAX_REPAIR_ATTEMPTS_CEILING = 10` (default stays 3 until W5).

No new diagnostic codes; catalogue sentinel stays green.

## Test Plan

- [x] 7 new unit tests; existing webGateRunner + closedLoop tests stay green; eval loop test + diagnostics sentinel green; `tsc -b` clean.