### PR TITLE
Fidelity gate: structural face-loop topology (fixes lens-insert false-negative, #385)

### DIFF
--- a/eval/oracle/faceInnerLoops.live.test.ts
+++ b/eval/oracle/faceInnerLoops.live.test.ts
@@ -1,0 +1,59 @@
+// LIVE: the structural fidelity signal on real OCCT geometry via the CLI/MCP.
+// A frame with two lens cutouts reports 2 inner loops whether or not lens
+// bodies are inserted; a solid slab reports 0. This is the regression for the
+// lens-insert false-negative a pixel/fill-ratio heuristic could not catch.
+import { describe, it, expect } from 'vitest';
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getMaxFaceInnerLoops } from './kernelcad-client';
+import { computeFidelityGates, allFidelityGatesPass } from '../../src/lib/imageSimilarity/fidelityGates';
+
+const dir = mkdtempSync(join(tmpdir(), 'faceloops-'));
+function write(name: string, code: string): string {
+  const p = join(dir, name);
+  writeFileSync(p, code);
+  return p;
+}
+
+const SLAB = write('slab.kcad.ts', `return box(140, 50, 60);`);
+const FRAME = write('frame.kcad.ts', `
+const plate = box(140, 50, 6);
+const lensL = box(48, 34, 10).translate(15, 8, -2);
+const lensR = box(48, 34, 10).translate(77, 8, -2);
+return plate.subtract(lensL).subtract(lensR);`);
+const LENSED = write('lensed.kcad.ts', `
+const plate = box(140, 50, 6);
+const lensL = box(48, 34, 10).translate(15, 8, -2);
+const lensR = box(48, 34, 10).translate(77, 8, -2);
+const frame = plate.subtract(lensL).subtract(lensR);
+return frame.union(box(48, 34, 3).translate(15, 8, 1.5)).union(box(48, 34, 3).translate(77, 8, 1.5));`);
+
+async function featureGatePasses(scriptPath: string): Promise<{ loops: number; pass: boolean }> {
+  const loops = await getMaxFaceInnerLoops(scriptPath);
+  const gates = computeFidelityGates(
+    { maxFaceInnerLoops: loops, partsCount: 1, solidVolume: 1000 },
+    { expectedInteriorLoops: 2 },
+  );
+  return { loops, pass: allFidelityGatesPass(gates) };
+}
+
+describe('LIVE structural fidelity gate on real OCCT', () => {
+  it('frame-only (2 cutouts) → 2 loops → PASS', async () => {
+    const r = await featureGatePasses(FRAME);
+    expect(r.loops).toBe(2);
+    expect(r.pass).toBe(true);
+  }, 60000);
+
+  it('lens-INSERTED → still 2 loops → PASS (invariant to lens insertion)', async () => {
+    const r = await featureGatePasses(LENSED);
+    expect(r.loops).toBe(2);
+    expect(r.pass).toBe(true);
+  }, 60000);
+
+  it('solid slab → 0 loops → FAIL (slab-hack caught)', async () => {
+    const r = await featureGatePasses(SLAB);
+    expect(r.loops).toBe(0);
+    expect(r.pass).toBe(false);
+  }, 60000);
+});

--- a/eval/oracle/kernelcad-client.ts
+++ b/eval/oracle/kernelcad-client.ts
@@ -138,6 +138,61 @@ export async function getShapeInfo(scriptPath: string): Promise<ShapeInfo> {
   );
 }
 
+/**
+ * Maximum inner-loop (hole) count across all faces of the model, via the
+ * `list_faces` MCP tool. A frame with N lens cutouts reports N on its
+ * front/back faces; a solid slab reports 0. This is a structural property of
+ * the BREP — invariant to whether a lens body is inserted into the opening —
+ * so it is the robust signal for "the expected lens openings exist" that pixel
+ * and volume heuristics cannot provide. Returns 0 if the tool yields no faces.
+ */
+export async function getMaxFaceInnerLoops(scriptPath: string): Promise<number> {
+  const initialize = JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'kernelcad-eval', version: '0.1.0' } },
+  });
+  const initialized = JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' });
+  const callTool = JSON.stringify({
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/call',
+    params: { name: 'list_faces', arguments: { file: scriptPath } },
+  });
+  const stdin = `${initialize}\n${initialized}\n${callTool}\n`;
+
+  const r = await runOnce(['mcp'], stdin);
+  const lines = r.stdout.split('\n').filter((l) => l.trim().length > 0);
+  for (const line of lines) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      'id' in parsed &&
+      (parsed as { id: unknown }).id === 2 &&
+      'result' in parsed
+    ) {
+      const result = (parsed as { result: { content?: Array<{ type: string; text?: string }> } }).result;
+      const text = result.content?.[0]?.text;
+      if (typeof text !== 'string') return 0;
+      const body = JSON.parse(text) as { ok?: boolean; faces?: Array<{ innerLoops?: number }> };
+      const faces = Array.isArray(body.faces) ? body.faces : [];
+      let max = 0;
+      for (const f of faces) {
+        if (typeof f.innerLoops === 'number' && f.innerLoops > max) max = f.innerLoops;
+      }
+      return max;
+    }
+  }
+  return 0;
+}
+
 export async function isKernelcadAvailable(): Promise<boolean> {
   try {
     const r = await runOnce(['--version']);

--- a/eval/tasks/eyewear-wayfarer-front/harness.ts
+++ b/eval/tasks/eyewear-wayfarer-front/harness.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
-import { evaluateScript, getShapeInfo } from '../../oracle/kernelcad-client';
+import { evaluateScript, getShapeInfo, getMaxFaceInnerLoops } from '../../oracle/kernelcad-client';
 import { runInterference } from '../../oracle/interference';
 import { renderScript } from '../../oracle/render';
 import { scoreAgainstReference } from '../../oracle/scoreReference';
@@ -53,23 +53,6 @@ async function exportToStl(scriptPath: string, outPath: string): Promise<boolean
     child.on('close', (code) => resolve(code === 0 && existsSync(outPath)));
     child.on('error', () => resolve(false));
   });
-}
-
-// W2 — derive a coarse foreground mask from a rendered PNG for the fidelity
-// gates. Mirrors the scorer's corner-background convention. Returns a
-// size×size Uint8Array (1 = foreground).
-async function maskFromPng(pngPath: string, size = 64): Promise<Uint8Array> {
-  const sharp = (await import('sharp')).default;
-  const { data } = await sharp(pngPath)
-    .resize(size, size, { fit: 'contain' })
-    .grayscale()
-    .raw()
-    .toBuffer({ resolveWithObject: true });
-  const corners = [data[0], data[size - 1], data[(size - 1) * size], data[size * size - 1]];
-  const bg = corners.reduce((a, b) => a + b, 0) / corners.length;
-  const mask = new Uint8Array(size * size);
-  for (let i = 0; i < size * size; i++) mask[i] = Math.abs(data[i] - bg) > 18 ? 1 : 0;
-  return mask;
 }
 
 /**
@@ -187,23 +170,22 @@ export default async function harness(scriptPath: string, ctx?: HarnessCtx): Pro
     }
   }
 
-  // W2 — fidelity gates computed from the render-inspect-equivalent mask, ANDed
-  // before any visual score. Eyewear requires at least one interior opening
-  // (lens openings) visible at the pose; a single-frame part is expected.
-  let fidelityGates: FidelityGate[] = [];
-  if (rendered && renderedPosePath) {
-    const mask = await maskFromPng(renderedPosePath, 64);
-    const bundle: FidelityBundle = {
-      size: 64,
-      mask,
-      partsCount: 1,
-      solidVolume: shape.volume,
-    };
-    fidelityGates = computeFidelityGates(bundle, {
-      requireInteriorOpenings: true,
-      expectedPartsCount: 1,
-    });
-  }
+  // W2 — fidelity gates, ANDed before any visual score. The "expected feature"
+  // gate is STRUCTURAL: eyewear must have >= 2 inner boundary loops on a face
+  // (the two lens openings), read from list_faces. This is invariant to whether
+  // tinted lens bodies are inserted into the openings — unlike a render/pixel
+  // heuristic, which false-negatives a lens-inserted frame. Geometry-only, so
+  // it runs whether or not the render succeeded.
+  const maxFaceInnerLoops = await getMaxFaceInnerLoops(scriptPath);
+  const bundle: FidelityBundle = {
+    maxFaceInnerLoops,
+    partsCount: 1,
+    solidVolume: shape.volume,
+  };
+  const fidelityGates: FidelityGate[] = computeFidelityGates(bundle, {
+    expectedInteriorLoops: 2,
+    expectedPartsCount: 1,
+  });
 
   const scored = decideScored({
     fidelityGates,

--- a/src/agent/mcp/tools/listFaces.ts
+++ b/src/agent/mcp/tools/listFaces.ts
@@ -49,6 +49,14 @@ export interface FaceSummary {
   surfaceType: string;
   area: number;
   label: string | null;
+  /**
+   * Number of inner boundary loops (holes) on this face — i.e. cutouts fully
+   * enclosed by the face, such as the lens openings on an eyewear front. A
+   * solid/uncut face reports 0. This is a structural property of the BREP:
+   * unlike a render heuristic it is invariant to whether a lens body is
+   * inserted into the opening.
+   */
+  innerLoops: number;
 }
 
 export interface ListFacesOutput {
@@ -70,6 +78,18 @@ function faceHashOf(face: Face): string {
   const wrapped = (face as any).wrapped;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (wrapped as any).HashCode(2147483647).toString(16);
+}
+
+/** Count inner boundary loops (holes) on a face via replicad's `innerWires()`.
+ *  Returns 0 for a solid/uncut face, or on any introspection error (a missing
+ *  loop count must never crash the listing). */
+function countInnerLoops(face: Face): number {
+  try {
+    const inner = (face as unknown as { innerWires?: () => unknown[] }).innerWires?.();
+    return Array.isArray(inner) ? inner.length : 0;
+  } catch {
+    return 0;
+  }
 }
 
 export async function listFacesTool(input: ListFacesInput): Promise<ListFacesOutput> {
@@ -162,6 +182,7 @@ export async function listFacesTool(input: ListFacesInput): Promise<ListFacesOut
       surfaceType: (f as unknown as { geomType?: string }).geomType ?? 'UNKNOWN',
       area: (f as unknown as { area?: number }).area ?? 0,
       label: lineage?.labelName ?? metadataLabel ?? null,
+      innerLoops: countInnerLoops(f),
     };
   });
 

--- a/src/lib/imageSimilarity/fidelityGates.test.ts
+++ b/src/lib/imageSimilarity/fidelityGates.test.ts
@@ -1,112 +1,88 @@
 // src/lib/imageSimilarity/fidelityGates.test.ts
 //
-// W2 fidelity gates. These are boolean AND-gates computed from already-parsed
-// render-inspect data (a square mask Uint8Array + a small numeric summary).
-// They run BEFORE any visual (SSIM/silhouette/VLM) score so that a wrong
-// object can never be rescued by a high pixel-similarity number.
-//
-// Regression target: the "R5 slab" case — a wide rectangular mask with NO
-// interior openings (no lens holes) must FAIL expectedFeatureVisibleAtPose,
-// regardless of how silhouette-similar the slab looks.
+// W2 fidelity gates. The "expected feature" gate is STRUCTURAL: it consumes the
+// model's max inner-loop (hole) count from list_faces. A frame with two lens
+// cutouts reports 2 (whether or not a lens body is inserted); a solid slab
+// reports 0. This is the regression for the slab-hack AND for the lens-insert
+// false-negative that a pixel/fill-ratio heuristic could not handle.
 
 import { describe, expect, it } from 'vitest';
-import { computeFidelityGates } from './fidelityGates';
-import type { FidelityBundle } from './fidelityGates';
-
-/** Build a size×size mask that is a solid filled rectangle (no holes). */
-function solidRectMask(size: number, x0: number, y0: number, x1: number, y1: number): Uint8Array {
-  const m = new Uint8Array(size * size);
-  for (let y = y0; y < y1; y++) {
-    for (let x = x0; x < x1; x++) {
-      m[y * size + x] = 1;
-    }
-  }
-  return m;
-}
-
-/** Punch a rectangular background hole into an existing mask (sets pixels to 0). */
-function punchHole(mask: Uint8Array, size: number, x0: number, y0: number, x1: number, y1: number): void {
-  for (let y = y0; y < y1; y++) {
-    for (let x = x0; x < x1; x++) {
-      mask[y * size + x] = 0;
-    }
-  }
-}
+import { computeFidelityGates, allFidelityGatesPass } from './fidelityGates';
 
 describe('computeFidelityGates', () => {
-  const SIZE = 64;
-
-  it('fails expectedFeatureVisibleAtPose for a solid slab with no interior openings (R5 case)', () => {
-    // Wide solid slab, foreground from x=4..60, y=24..40 — no holes.
-    const mask = solidRectMask(SIZE, 4, 24, 60, 40);
-    const bundle: FidelityBundle = {
-      size: SIZE,
-      mask,
-      partsCount: 1,
-      solidVolume: 12000,
-    };
-    const gates = computeFidelityGates(bundle, {
-      requireInteriorOpenings: true,
-      expectedPartsCount: 1,
-    });
+  it('passes expectedFeatureVisibleAtPose when the model has the expected interior loops (eyewear front)', () => {
+    const gates = computeFidelityGates(
+      { maxFaceInnerLoops: 2, partsCount: 1, solidVolume: 9000 },
+      { expectedInteriorLoops: 2, expectedPartsCount: 1 },
+    );
     const feat = gates.find((g) => g.name === 'expectedFeatureVisibleAtPose');
     expect(feat).toBeDefined();
-    expect(feat!.pass).toBe(false);
-    expect(feat!.reason).toMatch(/no interior opening/i);
-  });
-
-  it('passes expectedFeatureVisibleAtPose for an eyewear-like mask with two lens openings', () => {
-    // Frame band y=24..40, x=4..60. Punch two background lens openings.
-    const mask = solidRectMask(SIZE, 4, 24, 60, 40);
-    punchHole(mask, SIZE, 12, 28, 26, 38); // left lens
-    punchHole(mask, SIZE, 38, 28, 52, 38); // right lens
-    const bundle: FidelityBundle = {
-      size: SIZE,
-      mask,
-      partsCount: 1,
-      solidVolume: 9000,
-    };
-    const gates = computeFidelityGates(bundle, {
-      requireInteriorOpenings: true,
-      expectedPartsCount: 1,
-    });
-    const feat = gates.find((g) => g.name === 'expectedFeatureVisibleAtPose');
     expect(feat!.pass).toBe(true);
   });
 
+  it('fails expectedFeatureVisibleAtPose for a solid slab with no interior loops (R5 slab-hack)', () => {
+    const gates = computeFidelityGates(
+      { maxFaceInnerLoops: 0, partsCount: 1, solidVolume: 120000 },
+      { expectedInteriorLoops: 2 },
+    );
+    const feat = gates.find((g) => g.name === 'expectedFeatureVisibleAtPose');
+    expect(feat!.pass).toBe(false);
+    expect(feat!.reason).toMatch(/missing from the geometry|solid blob/i);
+  });
+
+  it('treats a missing maxFaceInnerLoops as 0 (fails the feature gate)', () => {
+    const gates = computeFidelityGates(
+      { partsCount: 1, solidVolume: 100 },
+      { expectedInteriorLoops: 2 },
+    );
+    expect(gates.find((g) => g.name === 'expectedFeatureVisibleAtPose')!.pass).toBe(false);
+  });
+
   it('fails partsCountMatches when the count differs from expected', () => {
-    const mask = solidRectMask(SIZE, 4, 24, 60, 40);
-    punchHole(mask, SIZE, 12, 28, 26, 38);
-    punchHole(mask, SIZE, 38, 28, 52, 38);
-    const bundle: FidelityBundle = { size: SIZE, mask, partsCount: 3, solidVolume: 9000 };
-    const gates = computeFidelityGates(bundle, {
-      requireInteriorOpenings: true,
-      expectedPartsCount: 1,
-    });
+    const gates = computeFidelityGates(
+      { maxFaceInnerLoops: 2, partsCount: 3, solidVolume: 9000 },
+      { expectedInteriorLoops: 2, expectedPartsCount: 1 },
+    );
     const parts = gates.find((g) => g.name === 'partsCountMatches');
     expect(parts!.pass).toBe(false);
     expect(parts!.reason).toMatch(/expected 1.*got 3/i);
   });
 
   it('fails nonDegenerateSolid for zero/near-zero volume', () => {
-    const mask = solidRectMask(SIZE, 4, 24, 60, 40);
-    const bundle: FidelityBundle = { size: SIZE, mask, partsCount: 1, solidVolume: 0 };
-    const gates = computeFidelityGates(bundle, { requireInteriorOpenings: false });
+    const gates = computeFidelityGates(
+      { maxFaceInnerLoops: 2, partsCount: 1, solidVolume: 0 },
+      {},
+    );
     const nd = gates.find((g) => g.name === 'nonDegenerateSolid');
     expect(nd!.pass).toBe(false);
   });
 
-  it('skips the interior-openings gate when requireInteriorOpenings is false', () => {
-    const mask = solidRectMask(SIZE, 4, 24, 60, 40);
-    const bundle: FidelityBundle = { size: SIZE, mask, partsCount: 1, solidVolume: 100 };
-    const gates = computeFidelityGates(bundle, { requireInteriorOpenings: false });
+  it('omits the feature gate when expectedInteriorLoops is undefined', () => {
+    const gates = computeFidelityGates(
+      { maxFaceInnerLoops: 0, partsCount: 1, solidVolume: 100 },
+      {},
+    );
     expect(gates.find((g) => g.name === 'expectedFeatureVisibleAtPose')).toBeUndefined();
   });
 
-  it('skips partsCountMatches when expectedPartsCount is undefined', () => {
-    const mask = solidRectMask(SIZE, 4, 24, 60, 40);
-    const bundle: FidelityBundle = { size: SIZE, mask, partsCount: 5, solidVolume: 100 };
-    const gates = computeFidelityGates(bundle, { requireInteriorOpenings: false });
+  it('omits partsCountMatches when expectedPartsCount is undefined', () => {
+    const gates = computeFidelityGates(
+      { maxFaceInnerLoops: 2, partsCount: 5, solidVolume: 100 },
+      { expectedInteriorLoops: 2 },
+    );
     expect(gates.find((g) => g.name === 'partsCountMatches')).toBeUndefined();
+  });
+
+  it('allFidelityGatesPass reflects the AND of all gates', () => {
+    const pass = computeFidelityGates(
+      { maxFaceInnerLoops: 2, partsCount: 1, solidVolume: 9000 },
+      { expectedInteriorLoops: 2, expectedPartsCount: 1 },
+    );
+    expect(allFidelityGatesPass(pass)).toBe(true);
+    const fail = computeFidelityGates(
+      { maxFaceInnerLoops: 0, partsCount: 1, solidVolume: 9000 },
+      { expectedInteriorLoops: 2, expectedPartsCount: 1 },
+    );
+    expect(allFidelityGatesPass(fail)).toBe(false);
   });
 });

--- a/src/lib/imageSimilarity/fidelityGates.ts
+++ b/src/lib/imageSimilarity/fidelityGates.ts
@@ -2,14 +2,20 @@
 //
 // W2 — Harden the oracle. Boolean fidelity gates that the eval harness ANDs
 // BEFORE any visual (SSIM / silhouette / VLM) score. The point: a wrong object
-// must never be rescued by a high pixel-similarity number (see the "slab hack"
-// lesson — a wide solid slab with no lens openings can score high on
-// silhouette IoU yet is plainly not eyewear).
+// must never be rescued by a high pixel-similarity number (the "slab hack" — a
+// solid slab can score high on silhouette IoU yet is plainly not eyewear).
 //
-// Design: gates take ALREADY-PARSED data (a square mask Uint8Array + a small
-// numeric summary), never file paths. This keeps the module pure and lets unit
-// tests feed synthetic arrays with no PNG fixtures. The harness is responsible
-// for turning a render-inspect bundle into a FidelityBundle.
+// The "expected feature" gate is STRUCTURAL, not pixel-based. Earlier a render
+// heuristic (see-through hole / chroma / luma) was tried and empirically failed:
+// it false-negatives a correct wayfarer modelled with tinted lens inserts (the
+// lens fills the opening, so there is no see-through hole), and a volume/bbox
+// fill-ratio is fooled the same way (the lens adds the volume back). The only
+// signal invariant to lens insertion is the BREP topology: the frame's front
+// face keeps its inner boundary loops (the lens cutouts) whether or not a lens
+// body sits in them. So the gate consumes `maxFaceInnerLoops` from list_faces.
+//
+// Design: gates take ALREADY-PARSED data (small numbers), never file paths or
+// pixels — the harness produces the numbers from the model + render-inspect.
 
 /** One boolean fidelity gate result. */
 export interface FidelityGate {
@@ -20,24 +26,24 @@ export interface FidelityGate {
 
 /**
  * Already-parsed inputs the gates operate on.
- * - `mask` is a size×size foreground mask (1 = subject, 0 = background),
- *   matching the convention produced by the imageSimilarity scorer.
+ * - `maxFaceInnerLoops` is the maximum inner-loop (hole) count across the
+ *   model's faces, from `list_faces` — e.g. 2 for an eyewear front with two
+ *   lens openings, 0 for a solid slab.
  * - `partsCount` / `solidVolume` come from the model's shape info.
  */
 export interface FidelityBundle {
-  size: number;
-  mask: Uint8Array;
+  maxFaceInnerLoops?: number;
   partsCount: number;
   solidVolume: number;
 }
 
 export interface FidelityGateOpts {
   /**
-   * When true, require at least one background-enclosed hole inside the
-   * subject bbox (e.g. lens openings on eyewear). When false, the
-   * `expectedFeatureVisibleAtPose` gate is omitted entirely.
+   * When set, emit an `expectedFeatureVisibleAtPose` gate requiring the model
+   * to have at least this many inner boundary loops on some face (e.g. 2 lens
+   * openings on an eyewear front). When undefined, the gate is omitted.
    */
-  requireInteriorOpenings: boolean;
+  expectedInteriorLoops?: number;
   /**
    * When set, emit a `partsCountMatches` gate comparing `bundle.partsCount`
    * to this value. When undefined, the gate is omitted.
@@ -48,74 +54,8 @@ export interface FidelityGateOpts {
 }
 
 /**
- * Detect whether the subject mask has at least one interior opening: a
- * background-valued region fully enclosed by foreground inside the subject's
- * bounding box. Implemented as a flood fill of background pixels from the
- * bbox border; any background pixel inside the bbox NOT reached by the flood
- * is an interior hole.
- */
-function hasInteriorOpening(mask: Uint8Array, size: number): boolean {
-  // Subject bbox.
-  let minX = size, minY = size, maxX = -1, maxY = -1;
-  for (let y = 0; y < size; y++) {
-    for (let x = 0; x < size; x++) {
-      if (mask[y * size + x]) {
-        if (x < minX) minX = x;
-        if (x > maxX) maxX = x;
-        if (y < minY) minY = y;
-        if (y > maxY) maxY = y;
-      }
-    }
-  }
-  if (maxX < 0) return false; // empty mask — no subject, no openings
-
-  const w = maxX - minX + 1;
-  const h = maxY - minY + 1;
-  // `reached[i]` marks background pixels (within bbox) connected to the border.
-  const reached = new Uint8Array(w * h);
-  const idx = (lx: number, ly: number) => ly * w + lx;
-  const isBg = (lx: number, ly: number) => mask[(minY + ly) * size + (minX + lx)] === 0;
-
-  // Seed the flood with every background pixel on the bbox border.
-  const stack: number[] = [];
-  const push = (lx: number, ly: number) => {
-    if (lx < 0 || ly < 0 || lx >= w || ly >= h) return;
-    if (reached[idx(lx, ly)]) return;
-    if (!isBg(lx, ly)) return;
-    reached[idx(lx, ly)] = 1;
-    stack.push(lx, ly);
-  };
-  for (let lx = 0; lx < w; lx++) {
-    push(lx, 0);
-    push(lx, h - 1);
-  }
-  for (let ly = 0; ly < h; ly++) {
-    push(0, ly);
-    push(w - 1, ly);
-  }
-  // 4-connected flood.
-  while (stack.length > 0) {
-    const ly = stack.pop() as number;
-    const lx = stack.pop() as number;
-    push(lx + 1, ly);
-    push(lx - 1, ly);
-    push(lx, ly + 1);
-    push(lx, ly - 1);
-  }
-
-  // Any background pixel inside bbox NOT reached from the border = interior hole.
-  for (let ly = 0; ly < h; ly++) {
-    for (let lx = 0; lx < w; lx++) {
-      if (isBg(lx, ly) && !reached[idx(lx, ly)]) return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Compute the boolean fidelity gates for a render-inspect bundle. Gates that
- * are not applicable to the task (per opts) are omitted from the array, not
- * emitted as `pass: true`.
+ * Compute the boolean fidelity gates for a model. Gates that are not applicable
+ * to the task (per opts) are omitted from the array, not emitted as pass:true.
  */
 export function computeFidelityGates(
   bundle: FidelityBundle,
@@ -146,15 +86,17 @@ export function computeFidelityGates(
     });
   }
 
-  // expectedFeatureVisibleAtPose — only when interior openings are required.
-  if (opts.requireInteriorOpenings) {
-    const hasOpening = hasInteriorOpening(bundle.mask, bundle.size);
+  // expectedFeatureVisibleAtPose — structural: the model must carry the
+  // expected interior loops (e.g. lens openings). Invariant to lens inserts.
+  if (opts.expectedInteriorLoops !== undefined) {
+    const loops = bundle.maxFaceInnerLoops ?? 0;
+    const ok = loops >= opts.expectedInteriorLoops;
     gates.push({
       name: 'expectedFeatureVisibleAtPose',
-      pass: hasOpening,
-      reason: hasOpening
-        ? 'at least one interior opening is visible inside the subject silhouette'
-        : 'no interior opening detected inside the subject silhouette — the expected feature (e.g. lens openings) is not visible at this pose',
+      pass: ok,
+      reason: ok
+        ? `model has ${loops} inner loop(s) on a face (>= ${opts.expectedInteriorLoops} expected) — the lens openings are present in the geometry`
+        : `model has only ${loops} inner loop(s) on any face, expected >= ${opts.expectedInteriorLoops} — the lens openings are missing from the geometry (a solid blob, not a frame)`,
     });
   }
 


### PR DESCRIPTION
## Summary

Fixes #385. The W2 fidelity gate verified "lens openings present" from render pixels, which false-negatives a correct wayfarer modelled with tinted lens inserts (the lens fills the opening → no see-through hole). Building real models proved every pixel/volume variant fails (luma washout, chroma washout, AA-edge flood leak, fill-ratio fooled by the lens volume).

This replaces the heuristic with a **structural** signal: the count of inner boundary loops per face. A frame with two lens cutouts reports 2 inner loops **whether or not** a lens body is inserted; a solid slab reports 0. It is invariant to lens insertion and can't be gamed by shading.

- `list_faces` now reports `innerLoops` per face (via replicad `Face.innerWires()`).
- New eval oracle `getMaxFaceInnerLoops` (reads it through the `list_faces` MCP tool).
- `fidelityGates`: `expectedInteriorLoops` opt + `maxFaceInnerLoops` bundle field; the pixel-mask path is removed.
- Eyewear harness gates on `>= 2` inner loops — geometry-only, so it runs even without a render.

## Verification (live, real OCCT)

`eval/oracle/faceInnerLoops.live.test.ts` runs the real CLI/MCP on three models:

| model | inner loops | gate |
|---|---|---|
| frame-only (2 cutouts) | 2 | PASS |
| **lens-inserted** | **2** | **PASS** (the case the old gate wrongly failed) |
| solid slab | 0 | FAIL (slab-hack still caught) |

Plus: 9 gate unit tests, the `decideScored` harness test, the `list_faces` integration test (2), imageSimilarity suite — all green; `tsc -b` clean; lint clean.

## Note

The gate name `expectedFeatureVisibleAtPose` is kept (referenced by `decideScored` + the funnel mapping); it now reflects geometric presence of the feature. A future slice can add VLM-judge pose-visibility on top.