### PR TITLE
feat(loop): export typed buildRepairPrompt for the hosted server (W3 close)

### DIFF
--- a/src/agent/mcp/toolRegistry.publicContract.test.ts
+++ b/src/agent/mcp/toolRegistry.publicContract.test.ts
@@ -4,6 +4,9 @@ import {
   TOOLS,
   callMcpTool,
   getToolDefinition,
+  runClosedLoop,
+  buildRepairPrompt,
+  defaultBuildRepairPrompt,
   type McpToolDefinition,
 } from './toolRegistry';
 
@@ -48,5 +51,33 @@ describe('toolRegistry public contract', () => {
     // Assignment compiles only if McpToolDefinition matches the returned shape.
     const def: McpToolDefinition | undefined = getToolDefinition('list_api');
     expect(def).toBeDefined();
+  });
+
+  it('exposes the closed-loop seam the hosted server consumes', () => {
+    // The kernelCAD-server orchestrator imports these from this public entry.
+    // Keep them exported so the hosted generation loop can repair with the
+    // typed, root-cause-first prompt instead of the generic fallback.
+    expect(typeof runClosedLoop).toBe('function');
+    expect(typeof buildRepairPrompt).toBe('function');
+    expect(typeof defaultBuildRepairPrompt).toBe('function');
+  });
+
+  it('the rich buildRepairPrompt differs from the generic fallback for a typed verdict', () => {
+    const verdicts = [
+      {
+        gate: 'interference',
+        ok: false,
+        code: 'mechanism.interpenetration',
+        message: 'Parts overlap.',
+        margin: 42,
+        locus: 'shade∩beam',
+      },
+    ];
+    const rich = buildRepairPrompt(verdicts);
+    const generic = defaultBuildRepairPrompt(verdicts);
+    expect(rich).not.toBe(generic);
+    // Rich prompt carries the numeric margin + topological locus as evidence.
+    expect(rich).toContain('42');
+    expect(rich).toContain('shade∩beam');
   });
 });

--- a/src/agent/mcp/toolRegistry.ts
+++ b/src/agent/mcp/toolRegistry.ts
@@ -61,6 +61,7 @@ import { checkReachableTool } from './tools/checkReachable';
 import { checkMountingHoleConsistencyTool } from './tools/checkMountingHoleConsistency';
 import { checkLoadCapacityTool } from './tools/checkLoadCapacity';
 export { runClosedLoop } from '../loop/closedLoop.js';
+export { buildRepairPrompt } from '../loop/repairPrompt.js';
 export * from '../loop/types.js';
 
 export interface McpToolDefinition {


### PR DESCRIPTION
## What

Closes the last open piece of **generation-loop W3 — typed requirement-level feedback**: the hosted generation path.

W3's eval half already landed on develop (`repairPrompt.ts`, `verdictsFromOracles.ts`, `webGateRunner` wiring, ceiling constant, `eval/runner.ts` passing the rich builder). But the **hosted server orchestrator** (`kernelCAD-server`) still repairs with the weak generic `defaultBuildRepairPrompt`, because the rich `buildRepairPrompt` was never exported from the package's public entry that the server vendors.

This PR re-exports `buildRepairPrompt` from `src/agent/mcp/toolRegistry.ts` — the public entry the `kernelCAD-server` orchestrator imports via its `vendor/kernelcad` submodule — so the hosted closed loop can repair with typed, root-cause-first prompts (numeric margin + topological locus) instead of the generic join.

## Changes

- `src/agent/mcp/toolRegistry.ts` — `export { buildRepairPrompt } from '../loop/repairPrompt.js'`.
- `src/agent/mcp/toolRegistry.publicContract.test.ts` — assert the closed-loop seam (`runClosedLoop`, `buildRepairPrompt`, `defaultBuildRepairPrompt`) stays exported, and that the rich builder differs from the fallback (carries margin + locus).

## Verification

- `npm test -- src/agent/mcp/toolRegistry.publicContract.test.ts` → 8 passing
- `npm test -- src/agent/loop/repairPrompt.test.ts eval/loop/verdictsFromOracles.test.ts src/agent/loop/closedLoop.ceiling.test.ts` → 8 passing
- `npm run typecheck` → clean

## Follow-up (after merge)

Cut `v0.11.3`, then `kernelCAD-server`: bump `vendor/kernelcad` submodule, declare the export in `vendor-shims.d.ts`, thread `buildRepairPrompt` through `verifyArtifact`.