### PR TITLE
fix(ci): grant id-token:write for npm publish --provenance

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write # required for `npm publish --provenance`
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The publish-npm workflow grants only `contents: read`, but `npm publish --provenance` requires `id-token: write` to mint the provenance attestation. v0.11.3's publish failed with `EUSAGE: Provenance generation in GitHub Actions requires "write" access to the "id-token" permission`. This one-line permission addition unblocks it and all future tag-triggered releases.

After merge, re-publish v0.11.3 via `workflow_dispatch` with the fixed workflow.