### PR TITLE
feat(loop): W4 best-of-N generation (eval-only, oracle as selector)

### DIFF
--- a/eval/agent.ts
+++ b/eval/agent.ts
@@ -7,6 +7,7 @@ interface GenerateArgs {
   messages: AgentMessage[];
   model: string;
   max_tokens: number;
+  temperature?: number;
 }
 
 export class MockAgentClient implements AgentClient {
@@ -51,6 +52,7 @@ export class AnthropicAgentClient implements AgentClient {
     const resp = await this.client.messages.create({
       model: args.model,
       max_tokens: args.max_tokens,
+      ...(args.temperature !== undefined ? { temperature: args.temperature } : {}),
       system: systemBlocks,
       messages: args.messages.map((m) => ({ role: m.role, content: m.content })),
     });

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { runTask } from './runner';
+import { runTask, BEST_OF_N } from './runner';
 import { AnthropicAgentClient, MockAgentClient } from './agent';
 import { isKernelcadAvailable } from './oracle/kernelcad-client';
 import type { AgentClient, AgentResponse, TaskResult } from './types';
@@ -195,6 +195,9 @@ async function main(): Promise<void> {
         skillMd,
         startedAt,
         cookbook: cookbookInjection,
+        // Real runs fan out best-of-N on the first attempt; --mock replay stays
+        // single-sample so the fixed fixture queue remains deterministic.
+        candidates: isMock ? 1 : BEST_OF_N,
       });
       results.push(r);
     } catch (err) {

--- a/eval/runner.bestOfN.test.ts
+++ b/eval/runner.bestOfN.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { variantTemperature, reduceHarnessScore, BEST_OF_N } from './runner.js';
+
+describe('best-of-N eval wiring', () => {
+  it('exposes a fan-out width > 1', () => {
+    expect(BEST_OF_N).toBeGreaterThan(1);
+  });
+
+  it('maps each variant index to a distinct temperature, undefined when not fanning out', () => {
+    expect(variantTemperature(undefined)).toBeUndefined();
+    const temps = [0, 1, 2, 3].map((i) => variantTemperature(i));
+    expect(new Set(temps).size).toBe(4); // all distinct
+    for (const t of temps) {
+      expect(t).toBeGreaterThanOrEqual(0);
+      expect(t).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('reduces a harness result to the mean of its scored values', () => {
+    expect(reduceHarnessScore({ gates: {}, scored: { a: 0.4, b: 0.6 } })).toBeCloseTo(0.5);
+  });
+
+  it('reduces a gates-only harness result to 1 when all gates pass, 0 otherwise', () => {
+    expect(reduceHarnessScore({ gates: { x: true, y: true }, scored: {} })).toBe(1);
+    expect(reduceHarnessScore({ gates: { x: true, y: false }, scored: {} })).toBe(0);
+  });
+});

--- a/eval/runner.loop.test.ts
+++ b/eval/runner.loop.test.ts
@@ -21,36 +21,47 @@ vi.mock('../oracle/kernelcad-client.js', () => ({
   isKernelcadAvailable: vi.fn().mockResolvedValue(true),
 }));
 
-// Interference fails the first 2 calls, then passes — proving the loop retries
-// on interference (not just on evaluate, which is always clean here).
-const interferenceFail = {
-  ok: false,
-  noSceneToCheck: false,
-  partCount: 2,
-  comparisonCount: 1,
-  epsilonMm3: 0.01,
-  pairs: [{ partA: 'a', partB: 'b', volumeMm3: 5 }],
-  diagnostics: [],
-};
-const interferencePass = {
-  ok: true,
-  noSceneToCheck: false,
-  partCount: 2,
-  comparisonCount: 1,
-  epsilonMm3: 0.01,
-  pairs: [],
-  diagnostics: [],
-};
-vi.mock('../oracle/interference.js', () => ({
+// Fixtures live in vi.hoisted so the (hoisted) vi.mock factory below can read
+// them — the factory is evaluated eagerly when webGateRunner imports the module.
+const { interferenceFail, interferencePass } = vi.hoisted(() => ({
+  interferenceFail: {
+    ok: false,
+    noSceneToCheck: false,
+    partCount: 2,
+    comparisonCount: 1,
+    epsilonMm3: 0.01,
+    pairs: [{ partA: 'a', partB: 'b', volumeMm3: 5 }],
+    diagnostics: [],
+  },
+  interferencePass: {
+    ok: true,
+    noSceneToCheck: false,
+    partCount: 2,
+    comparisonCount: 1,
+    epsilonMm3: 0.01,
+    pairs: [],
+    diagnostics: [],
+  },
+}));
+// webGateRunner imports '../oracle/interference.js' (from eval/loop/), which
+// resolves to eval/oracle/interference.js — i.e. './oracle/interference.js'
+// relative to THIS test file. Register that specifier so the mock actually
+// applies (the bare '../oracle/...' form resolves outside eval/ and never bound).
+// Fails the first BEST_OF_N calls (all attempt-1 fan-out candidates), then
+// passes — so attempt 2 (a single repair sample) succeeds, proving the loop
+// retries on interference (not just on evaluate, which is always clean here).
+vi.mock('./oracle/interference.js', () => ({
   runInterference: vi
     .fn()
+    .mockResolvedValueOnce(interferenceFail)
+    .mockResolvedValueOnce(interferenceFail)
     .mockResolvedValueOnce(interferenceFail)
     .mockResolvedValueOnce(interferenceFail)
     .mockResolvedValue(interferencePass),
 }));
 
 // Import AFTER mocks are registered.
-import { runTask } from './runner';
+import { runTask, BEST_OF_N } from './runner';
 
 class CountingAgent implements AgentClient {
   public calls = 0;
@@ -115,10 +126,13 @@ describe('runTask closed-loop integration', () => {
       startedAt: '2026-06-04T00-00-00',
     });
 
-    // The load-bearing assertion: 3 generate() calls means the loop retried
-    // through the 2 interference failures. Evaluate-only gating would stop at 1.
-    expect(agent.calls).toBe(3);
-    expect(result.score!.attempts).toBe(3);
+    // The load-bearing assertion: attempt 1 fans out to BEST_OF_N candidates
+    // (all fail interference here), so the loop builds a repair prompt and
+    // RETRIES; attempt 2 is a single sample whose interference passes. That is
+    // BEST_OF_N + 1 generate() calls across 2 attempts. Without retry it would
+    // stop at attempt 1; evaluate-only gating would never have retried at all.
+    expect(agent.calls).toBe(BEST_OF_N + 1);
+    expect(result.score!.attempts).toBe(2);
 
     // Final attempt's interference passed → evaluate-clean → harness ran.
     expect(existsSync(join(runsDir, 'output.kcad.ts'))).toBe(true);
@@ -127,6 +141,6 @@ describe('runTask closed-loop integration', () => {
     expect(result.score!.gates['evaluates clean']).toBe(true);
 
     const score = JSON.parse(readFileSync(join(runsDir, 'score.json'), 'utf8'));
-    expect(score.attempts).toBe(3);
+    expect(score.attempts).toBe(2);
   }, 30000);
 });

--- a/eval/runner.loop.test.ts
+++ b/eval/runner.loop.test.ts
@@ -124,6 +124,7 @@ describe('runTask closed-loop integration', () => {
       model: 'mock-model',
       skillMd: 'fake skill content',
       startedAt: '2026-06-04T00-00-00',
+      candidates: BEST_OF_N,
     });
 
     // The load-bearing assertion: attempt 1 fans out to BEST_OF_N candidates

--- a/eval/runner.ts
+++ b/eval/runner.ts
@@ -41,6 +41,14 @@ export interface RunTaskArgs {
   skillMd: string;
   startedAt: string;          // ISO timestamp string (filesystem-safe), used for transcript header
   cookbook?: CookbookInjection;   // optional — when set, injects cookbook snippets into the system prompt
+  /**
+   * First-attempt best-of-N fan-out width. Defaults to 1 (single sample), which
+   * is the deterministic single-sample path the corpus/golden/runner unit tests
+   * assert against. The production eval (`run.ts`, real model) sets this to
+   * BEST_OF_N; `--mock` replay keeps it at 1 so the fixed fixture queue stays
+   * deterministic.
+   */
+  candidates?: number;
 }
 
 export async function runTask(args: RunTaskArgs): Promise<TaskResult> {
@@ -88,7 +96,7 @@ export async function runTask(args: RunTaskArgs): Promise<TaskResult> {
     extractScript,
     buildRepairPrompt,
     maxAttempts: MAX_ATTEMPTS,
-    candidates: BEST_OF_N,
+    candidates: args.candidates ?? 1,
     scoreCandidate: async (scriptPath, report) => {
       // Only score build-valid candidates; gate-failing ones are ranked by stages.
       if (!report.ok) return null;

--- a/eval/runner.ts
+++ b/eval/runner.ts
@@ -11,6 +11,28 @@ import type { CookbookInjection } from './cookbook-injector';
 const MAX_ATTEMPTS = 3;
 const MAX_TOKENS = 8000;
 
+const BEST_OF_N = 4;
+// Distinct temperatures so the N first-attempt candidates diverge. Index 0 stays
+// low (a near-greedy anchor); the rest spread upward. Length matches BEST_OF_N.
+const VARIANT_TEMPERATURES = [0.2, 0.5, 0.7, 0.9];
+
+export { BEST_OF_N };
+
+/** Variant index → sampling temperature; undefined on repair turns (no variant). */
+export function variantTemperature(variant: number | undefined): number | undefined {
+  if (variant === undefined) return undefined;
+  return VARIANT_TEMPERATURES[Math.min(variant, VARIANT_TEMPERATURES.length - 1)];
+}
+
+/** Reduce a task harness result to a single [0,1] selector score. */
+export function reduceHarnessScore(hr: { gates: Record<string, boolean>; scored: Record<string, number> }): number {
+  const vals = Object.values(hr.scored);
+  if (vals.length > 0) return vals.reduce((a, b) => a + b, 0) / vals.length;
+  const gates = Object.values(hr.gates);
+  if (gates.length === 0) return 0;
+  return gates.every(Boolean) ? 1 : 0;
+}
+
 export interface RunTaskArgs {
   taskDir: string;            // e.g. ./eval/tasks/bracket-holes
   runDir: string;             // e.g. ./eval/runs/2026-05-02T14-00-00/bracket-holes
@@ -66,11 +88,25 @@ export async function runTask(args: RunTaskArgs): Promise<TaskResult> {
     extractScript,
     buildRepairPrompt,
     maxAttempts: MAX_ATTEMPTS,
+    candidates: BEST_OF_N,
+    scoreCandidate: async (scriptPath, report) => {
+      // Only score build-valid candidates; gate-failing ones are ranked by stages.
+      if (!report.ok) return null;
+      try {
+        const ev = await evaluateScript(scriptPath);
+        if (!ev.ok) return null;
+        const harnessModule = await import(harnessPath);
+        const hr = await harnessModule.default(scriptPath);
+        return reduceHarnessScore(hr);
+      } catch {
+        return null;
+      }
+    },
     writeScript: async (code: string) => {
       writeFileSync(outputScriptPath, code);
       return outputScriptPath;
     },
-    generate: async (messages: LoopMessage[]) => {
+    generate: async (messages: LoopMessage[], opts?: { variant?: number }) => {
       attemptNo += 1;
       const turnStart = Date.now();
       const resp = await args.agent.generate({
@@ -79,6 +115,7 @@ export async function runTask(args: RunTaskArgs): Promise<TaskResult> {
         messages: messages.map((m) => ({ role: m.role, content: m.content })),
         model: args.model,
         max_tokens: MAX_TOKENS,
+        temperature: variantTemperature(opts?.variant),
       });
       totalIn += resp.tokens_in;
       totalOut += resp.tokens_out;

--- a/eval/types.ts
+++ b/eval/types.ts
@@ -90,6 +90,7 @@ export interface AgentClient {
     messages: AgentMessage[];
     model: string;
     max_tokens: number;
+    temperature?: number;   // W4: per-candidate sampling diversity for best-of-N
   }): Promise<AgentResponse>;
 }
 

--- a/src/agent/loop/bestOfN.test.ts
+++ b/src/agent/loop/bestOfN.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { selectBest, type ScoredCandidate } from './bestOfN.js';
+import type { GateReport } from './types.js';
+
+const rep = (ok: boolean, oks: boolean[] = [ok]): GateReport => ({
+  ok,
+  verdicts: oks.map((o, i) => ({ gate: `g${i}`, ok: o, message: o ? 'ok' : 'bad' })),
+});
+const cand = (overrides: Partial<ScoredCandidate>): ScoredCandidate => ({
+  scriptPath: '/tmp/x.ts',
+  text: 'x',
+  report: rep(true),
+  oracleScore: null,
+  ...overrides,
+});
+
+describe('selectBest', () => {
+  it('prefers a gate-passing candidate over a higher-scored failing one', () => {
+    const failing = cand({ scriptPath: '/a', report: rep(false, [true, true, false]), oracleScore: 0.99 });
+    const passing = cand({ scriptPath: '/b', report: rep(true, [true]), oracleScore: 0.10 });
+    expect(selectBest([failing, passing]).scriptPath).toBe('/b');
+  });
+
+  it('among gate-passing candidates, higher oracleScore wins', () => {
+    const lo = cand({ scriptPath: '/lo', oracleScore: 0.3 });
+    const hi = cand({ scriptPath: '/hi', oracleScore: 0.8 });
+    expect(selectBest([lo, hi]).scriptPath).toBe('/hi');
+  });
+
+  it('among failing candidates, more stagesPassed wins', () => {
+    const few = cand({ scriptPath: '/few', report: rep(false, [true, false, false]) });
+    const many = cand({ scriptPath: '/many', report: rep(false, [true, true, false]) });
+    expect(selectBest([few, many]).scriptPath).toBe('/many');
+  });
+
+  it('null oracleScore sorts below any real number', () => {
+    const nul = cand({ scriptPath: '/nul', oracleScore: null });
+    const zero = cand({ scriptPath: '/zero', oracleScore: 0 });
+    expect(selectBest([nul, zero]).scriptPath).toBe('/zero');
+  });
+
+  it('breaks exact ties by lowest index (stable)', () => {
+    const a = cand({ scriptPath: '/first', oracleScore: 0.5 });
+    const b = cand({ scriptPath: '/second', oracleScore: 0.5 });
+    expect(selectBest([a, b]).scriptPath).toBe('/first');
+  });
+
+  it('throws on empty input', () => {
+    expect(() => selectBest([])).toThrow();
+  });
+});

--- a/src/agent/loop/bestOfN.ts
+++ b/src/agent/loop/bestOfN.ts
@@ -1,0 +1,42 @@
+import type { GateReport } from './types.js';
+
+/** A generated candidate with its gate report and (optional) selector score. */
+export interface ScoredCandidate {
+  scriptPath: string;
+  text: string;
+  report: GateReport;
+  /** Selector score in [0,1] for cross-candidate ranking only; null if unscoreable. */
+  oracleScore: number | null;
+}
+
+function stagesPassed(report: GateReport): number {
+  return report.verdicts.filter((v) => v.ok).length;
+}
+
+/** True if `a` should rank strictly above `b` (lexicographic; strict so ties keep earlier). */
+function betterThan(a: ScoredCandidate, b: ScoredCandidate): boolean {
+  const aOk = a.report.ok ? 1 : 0;
+  const bOk = b.report.ok ? 1 : 0;
+  if (aOk !== bOk) return aOk > bOk;
+  const aStages = stagesPassed(a.report);
+  const bStages = stagesPassed(b.report);
+  if (aStages !== bStages) return aStages > bStages;
+  const aScore = a.oracleScore ?? -Infinity;
+  const bScore = b.oracleScore ?? -Infinity;
+  return aScore > bScore;
+}
+
+/**
+ * Pick the best candidate. Ranking: gate-passing > gate-failing, then more
+ * stages passed, then higher oracleScore (null lowest), then lowest index.
+ * The oracleScore participates in SELECTION ONLY — never in repair (see
+ * closedLoop.ts anti-hack invariant).
+ */
+export function selectBest(candidates: ScoredCandidate[]): ScoredCandidate {
+  if (candidates.length === 0) throw new Error('selectBest: no candidates');
+  let best = candidates[0];
+  for (let i = 1; i < candidates.length; i++) {
+    if (betterThan(candidates[i], best)) best = candidates[i];
+  }
+  return best;
+}

--- a/src/agent/loop/closedLoop.test.ts
+++ b/src/agent/loop/closedLoop.test.ts
@@ -172,3 +172,43 @@ describe('runClosedLoop best-of-N', () => {
     expect(result.status).toBe('no_script');
   });
 });
+
+describe('runClosedLoop best-of-N invariants', () => {
+  it('candidates unset → single-sample path unchanged (no best_of_n event)', async () => {
+    const events: import('./types.js').ClosedLoopEvent[] = [];
+    const { generate } = scriptedGenerate([fence('cube(10)')]);
+    const result = await runClosedLoop({
+      prompt: 'make a cube',
+      generate,
+      gateRunner: scriptedGate([PASS_REPORT]),
+      extractScript,
+      writeScript,
+      onEvent: (e) => events.push(e),
+    });
+    expect(result.status).toBe('passed');
+    if (result.status === 'passed') expect(result.attempts).toBe(1);
+    expect(events.some((e) => e.type === 'best_of_n')).toBe(false);
+    expect(result.tokensIn).toBe(1); // exactly one generation
+  });
+
+  it('the oracle score never appears in any repair prompt', async () => {
+    const SENTINEL = 0.7777;
+    const repairPrompts: string[] = [];
+    const { generate } = bestOfNGenerate([fence('v0a'), fence('v1bb')], [fence('fixed')]);
+    await runClosedLoop({
+      prompt: 'make it',
+      generate,
+      gateRunner: scriptedGate([FAIL_REPORT, FAIL_REPORT, PASS_REPORT]),
+      extractScript,
+      writeScript,
+      candidates: 2,
+      maxAttempts: 3,
+      scoreCandidate: async () => SENTINEL,
+      onEvent: (e) => {
+        if (e.type === 'repair') repairPrompts.push(e.prompt);
+      },
+    });
+    expect(repairPrompts.length).toBeGreaterThan(0);
+    for (const p of repairPrompts) expect(p).not.toContain(String(SENTINEL));
+  });
+});

--- a/src/agent/loop/closedLoop.test.ts
+++ b/src/agent/loop/closedLoop.test.ts
@@ -171,6 +171,29 @@ describe('runClosedLoop best-of-N', () => {
     });
     expect(result.status).toBe('no_script');
   });
+
+  it('winner scriptPath holds winner code even when writeScript reuses one path', async () => {
+    // One shared path for all candidates (mirrors the eval runner). Winner is the
+    // gate-passing candidate at index 0, which is NOT the last one written.
+    const store: Record<string, string> = {};
+    const sharedWrite = async (code: string) => {
+      store['/shared.kcad.ts'] = code;
+      return '/shared.kcad.ts';
+    };
+    const { generate } = bestOfNGenerate([fence('WINNER'), fence('lastX1'), fence('lastX2'), fence('lastX3')]);
+    const result = await runClosedLoop({
+      prompt: 'x',
+      generate,
+      gateRunner: scriptedGate([PASS_REPORT, FAIL_REPORT, FAIL_REPORT, FAIL_REPORT]),
+      extractScript,
+      writeScript: sharedWrite,
+      candidates: 4,
+    });
+    expect(result.status).toBe('passed');
+    if (result.status === 'passed') {
+      expect(store[result.scriptPath]).toBe('WINNER'); // not 'lastX3'
+    }
+  });
 });
 
 describe('runClosedLoop best-of-N invariants', () => {

--- a/src/agent/loop/closedLoop.test.ts
+++ b/src/agent/loop/closedLoop.test.ts
@@ -31,6 +31,21 @@ const extractScript = (text: string): string | null => {
 };
 const writeScript = async (code: string) => `/tmp/closedloop-test-${code.length}.kcad.ts`;
 
+// Generates one text per variant on the fan-out turn; a fixed text on repair turns.
+function bestOfNGenerate(byVariant: string[], repairTexts: string[] = []) {
+  const variants: (number | undefined)[] = [];
+  let r = 0;
+  const generate = async (_messages: LoopMessage[], opts?: { variant?: number }) => {
+    variants.push(opts?.variant);
+    if (opts?.variant !== undefined) {
+      return { text: byVariant[opts.variant], tokensIn: 1, tokensOut: 1 };
+    }
+    const text = repairTexts.length ? repairTexts[Math.min(r++, repairTexts.length - 1)] : fence('repaired');
+    return { text, tokensIn: 1, tokensOut: 1 };
+  };
+  return { generate, variants };
+}
+
 describe('runClosedLoop', () => {
   it('(a) passes on first attempt when gate ok', async () => {
     const { generate } = scriptedGenerate([fence('cube(10)')]);
@@ -82,5 +97,78 @@ describe('runClosedLoop', () => {
     await runClosedLoop({ prompt: 'x', generate, gateRunner: scriptedGate([FAIL_REPORT, PASS_REPORT]), extractScript, writeScript, maxAttempts: 2, buildRepairPrompt: () => 'CUSTOM_REPAIR' });
     const lastCall = calls[1];
     expect(lastCall[lastCall.length - 1].content).toBe('CUSTOM_REPAIR');
+  });
+});
+
+describe('runClosedLoop best-of-N', () => {
+  it('selects the only gate-passing candidate as winner', async () => {
+    const { generate } = bestOfNGenerate([fence('v0aaaa'), fence('v1bb'), fence('v2c'), fence('v3dddd')]);
+    const events: import('./types.js').ClosedLoopEvent[] = [];
+    const result = await runClosedLoop({
+      prompt: 'make it',
+      generate,
+      gateRunner: scriptedGate([FAIL_REPORT, FAIL_REPORT, PASS_REPORT, FAIL_REPORT]),
+      extractScript,
+      writeScript,
+      candidates: 4,
+      onEvent: (e) => events.push(e),
+    });
+    expect(result.status).toBe('passed');
+    if (result.status === 'passed') expect(result.attempts).toBe(1);
+    const bon = events.find((e) => e.type === 'best_of_n');
+    expect(bon && bon.type === 'best_of_n' && bon.winnerIndex).toBe(2);
+    expect(result.tokensIn).toBe(4);
+  });
+
+  it('uses oracleScore to break ties among gate-passing candidates', async () => {
+    const { generate } = bestOfNGenerate([fence('a'), fence('bb'), fence('ccc')]);
+    const scores = [0.2, 0.9, 0.5];
+    let i = 0;
+    const result = await runClosedLoop({
+      prompt: 'make it',
+      generate,
+      gateRunner: scriptedGate([PASS_REPORT, PASS_REPORT, PASS_REPORT]),
+      extractScript,
+      writeScript,
+      candidates: 3,
+      scoreCandidate: async () => scores[i++],
+    });
+    expect(result.status).toBe('passed');
+    if (result.status === 'passed') {
+      expect(result.scriptPath).toContain('-2.kcad.ts');
+    }
+  });
+
+  it('repairs the winner when it fails gates (fan-out then repair)', async () => {
+    const { generate, variants } = bestOfNGenerate(
+      [fence('v0a'), fence('v1bb')],
+      [fence('fixed')],
+    );
+    const result = await runClosedLoop({
+      prompt: 'make it',
+      generate,
+      gateRunner: scriptedGate([FAIL_REPORT, FAIL_REPORT, PASS_REPORT]),
+      extractScript,
+      writeScript,
+      candidates: 2,
+      maxAttempts: 3,
+    });
+    expect(result.status).toBe('passed');
+    if (result.status === 'passed') expect(result.attempts).toBe(2);
+    expect(variants).toEqual([0, 1, undefined]);
+  });
+
+  it('falls back to no_script when no candidate yields a script', async () => {
+    const { generate } = bestOfNGenerate(['no fence here', 'still none']);
+    const result = await runClosedLoop({
+      prompt: 'make it',
+      generate,
+      gateRunner: scriptedGate([PASS_REPORT]),
+      extractScript,
+      writeScript,
+      candidates: 2,
+      maxAttempts: 1,
+    });
+    expect(result.status).toBe('no_script');
   });
 });

--- a/src/agent/loop/closedLoop.ts
+++ b/src/agent/loop/closedLoop.ts
@@ -4,6 +4,7 @@ import {
   type ClosedLoopResult,
   type LoopMessage,
 } from './types.js';
+import { selectBest, type ScoredCandidate } from './bestOfN.js';
 
 /**
  * Hard upper bound a caller may configure for repair attempts.
@@ -17,11 +18,17 @@ export const MAX_REPAIR_ATTEMPTS_CEILING = 10;
  * bundles cleanly for the server. The host injects generate(), gateRunner, extractScript,
  * and writeScript.
  *
+ * When `candidates > 1`, the FIRST attempt fans out to N diverse samples, selects the
+ * best (gate-stages, then oracle score), and the winner alone enters the repair loop
+ * (W4 best-of-N). The oracle score is used for SELECTION ONLY — it never feeds a repair
+ * prompt, which is the guard against iterating one sample against the scorer.
+ *
  * Invariant: never returns status:'passed' unless the gate suite reported ok for the
- * written candidate. A broken artifact returns 'gate_failed' (or 'no_script').
+ * selected candidate. A broken artifact returns 'gate_failed' (or 'no_script').
  */
 export async function runClosedLoop(input: ClosedLoopInput): Promise<ClosedLoopResult> {
   const maxAttempts = input.maxAttempts ?? 3;
+  const candidateCount = Math.max(1, input.candidates ?? 1);
   const buildRepairPrompt = input.buildRepairPrompt ?? defaultBuildRepairPrompt;
 
   const messages: LoopMessage[] = [{ role: 'user', content: input.prompt }];
@@ -33,6 +40,63 @@ export async function runClosedLoop(input: ClosedLoopInput): Promise<ClosedLoopR
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     input.onEvent?.({ type: 'attempt', n: attempt });
 
+    // --- W4 best-of-N: fan out on the first attempt only, when configured. ---
+    if (attempt === 1 && candidateCount > 1) {
+      const genResults = await Promise.all(
+        Array.from({ length: candidateCount }, (_, i) => input.generate(messages, { variant: i })),
+      );
+      const scored: ScoredCandidate[] = [];
+      for (const gen of genResults) {
+        tokensIn += gen.tokensIn;
+        tokensOut += gen.tokensOut;
+        const code = input.extractScript(gen.text);
+        if (code === null) continue;
+        const scriptPath = await input.writeScript(code);
+        const report = await input.gateRunner.run(scriptPath);
+        const oracleScore = input.scoreCandidate ? await input.scoreCandidate(scriptPath, report) : null;
+        scored.push({ scriptPath, text: gen.text, report, oracleScore });
+      }
+
+      if (scored.length === 0) {
+        // No candidate produced a script — mirror the single-sample no_script path.
+        if (attempt < maxAttempts) {
+          messages.push({ role: 'assistant', content: genResults[genResults.length - 1].text });
+          messages.push({
+            role: 'user',
+            content: 'Could not extract a code block from your reply. Return the full script in a single fenced code block.',
+          });
+          continue;
+        }
+        return { status: 'no_script', attempts: attempt, tokensIn, tokensOut };
+      }
+
+      const winner = selectBest(scored);
+      input.onEvent?.({
+        type: 'best_of_n',
+        winnerIndex: scored.indexOf(winner),
+        candidates: scored.map((c) => ({
+          stagesPassed: c.report.verdicts.filter((v) => v.ok).length,
+          oracleScore: c.oracleScore,
+        })),
+      });
+      lastScriptPath = winner.scriptPath;
+      lastText = winner.text;
+      input.onEvent?.({ type: 'gate_report', report: winner.report });
+
+      if (winner.report.ok) {
+        return { status: 'passed', scriptPath: winner.scriptPath, finalText: winner.text, attempts: attempt, tokensIn, tokensOut };
+      }
+      if (attempt < maxAttempts) {
+        const repairPrompt = buildRepairPrompt(winner.report.verdicts);
+        input.onEvent?.({ type: 'repair', prompt: repairPrompt });
+        messages.push({ role: 'assistant', content: winner.text });
+        messages.push({ role: 'user', content: repairPrompt });
+        continue;
+      }
+      return { status: 'gate_failed', scriptPath: winner.scriptPath, finalText: winner.text, attempts: attempt, verdicts: winner.report.verdicts, tokensIn, tokensOut };
+    }
+
+    // --- Single-sample path (unchanged: attempt > 1, or candidates <= 1). ---
     const gen = await input.generate(messages);
     tokensIn += gen.tokensIn;
     tokensOut += gen.tokensOut;

--- a/src/agent/loop/closedLoop.ts
+++ b/src/agent/loop/closedLoop.ts
@@ -71,6 +71,11 @@ export async function runClosedLoop(input: ClosedLoopInput): Promise<ClosedLoopR
       }
 
       const winner = selectBest(scored);
+      // The sequential fan-out above leaves the LAST candidate on disk when the
+      // host's writeScript reuses a single path. Re-materialize the winner so its
+      // scriptPath holds the winner's code — the host scores that path post-loop.
+      const winnerCode = input.extractScript(winner.text);
+      const winnerPath = winnerCode !== null ? await input.writeScript(winnerCode) : winner.scriptPath;
       input.onEvent?.({
         type: 'best_of_n',
         winnerIndex: scored.indexOf(winner),
@@ -79,12 +84,12 @@ export async function runClosedLoop(input: ClosedLoopInput): Promise<ClosedLoopR
           oracleScore: c.oracleScore,
         })),
       });
-      lastScriptPath = winner.scriptPath;
+      lastScriptPath = winnerPath;
       lastText = winner.text;
       input.onEvent?.({ type: 'gate_report', report: winner.report });
 
       if (winner.report.ok) {
-        return { status: 'passed', scriptPath: winner.scriptPath, finalText: winner.text, attempts: attempt, tokensIn, tokensOut };
+        return { status: 'passed', scriptPath: winnerPath, finalText: winner.text, attempts: attempt, tokensIn, tokensOut };
       }
       if (attempt < maxAttempts) {
         const repairPrompt = buildRepairPrompt(winner.report.verdicts);
@@ -93,7 +98,7 @@ export async function runClosedLoop(input: ClosedLoopInput): Promise<ClosedLoopR
         messages.push({ role: 'user', content: repairPrompt });
         continue;
       }
-      return { status: 'gate_failed', scriptPath: winner.scriptPath, finalText: winner.text, attempts: attempt, verdicts: winner.report.verdicts, tokensIn, tokensOut };
+      return { status: 'gate_failed', scriptPath: winnerPath, finalText: winner.text, attempts: attempt, verdicts: winner.report.verdicts, tokensIn, tokensOut };
     }
 
     // --- Single-sample path (unchanged: attempt > 1, or candidates <= 1). ---

--- a/src/agent/loop/types.ts
+++ b/src/agent/loop/types.ts
@@ -26,19 +26,35 @@ export interface GateRunner {
 
 export interface ClosedLoopInput {
   prompt: string;
-  generate(messages: LoopMessage[]): Promise<{ text: string; tokensIn: number; tokensOut: number }>;
+  generate(
+    messages: LoopMessage[],
+    opts?: { variant?: number },
+  ): Promise<{ text: string; tokensIn: number; tokensOut: number }>;
   gateRunner: GateRunner;
   extractScript(text: string): string | null;
   writeScript(code: string): Promise<string>; // writes the candidate, returns the scriptPath
   buildRepairPrompt?(verdicts: GateVerdict[]): string; // optional; W3 supplies the rich version. Default = simple join.
   maxAttempts?: number; // default 3
+  /** Number of diverse candidates to sample on the FIRST attempt only. Default 1 (unchanged). */
+  candidates?: number;
+  /**
+   * Oracle-as-selector. Scores a written candidate for cross-candidate ranking ONLY.
+   * Returns [0,1], or null if unscoreable (selection falls back to gate stages).
+   * MUST NOT influence repair prompts (anti-hack invariant).
+   */
+  scoreCandidate?(scriptPath: string, report: GateReport): Promise<number | null>;
   onEvent?(e: ClosedLoopEvent): void;
 }
 
 export type ClosedLoopEvent =
   | { type: 'attempt'; n: number }
   | { type: 'gate_report'; report: GateReport }
-  | { type: 'repair'; prompt: string };
+  | { type: 'repair'; prompt: string }
+  | {
+      type: 'best_of_n';
+      winnerIndex: number;
+      candidates: { stagesPassed: number; oracleScore: number | null }[];
+    };
 
 export type ClosedLoopResult =
   | {


### PR DESCRIPTION
Implements **W4 — Best-of-N with the oracle as selector** (Phase 1 of the generation-loop tightening spec). Eval-harness only; the paid server path stays N=1 and pays nothing.

## What

On the **first** generation attempt, fan out to N=4 diverse candidates, gate + score each, pick the best, then hand only the winner to the existing W3 repair loop. `runClosedLoop` is extended in place — with `candidates` unset (default 1) behavior is byte-identical to before.

- **`selectBest`** (`src/agent/loop/bestOfN.ts`): pure lexicographic ranker — `report.ok` → `stagesPassed` → `oracleScore` (null lowest) → lowest index.
- **Fan-out** in `runClosedLoop`: samples N via `generate(messages, { variant })`, gates + `scoreCandidate`s each, `selectBest`, then the winner alone enters repair.
- **Anti-hack invariant:** the oracle score selects across candidates *only* — it never feeds a repair prompt (guard against the R5 scorer-hack). Test-enforced.
- **Eval wiring** (`eval/runner.ts`): `candidates: 4`, a per-variant temperature spread `[0.2, 0.5, 0.7, 0.9]`, and a `scoreCandidate` that reuses each task's own `harness.ts` (already calls the task-appropriate oracle) reduced to one `[0,1]`.

## Bugs caught during implementation

- **Winner integrity:** the runner's `writeScript` reuses one path, so the sequential fan-out left the *last* candidate on disk — a non-last winner would be mis-scored. Fixed by re-materializing the winner in `closedLoop.ts` (host-agnostic).
- **Dead test mock:** `eval/runner.loop.test.ts`'s interference mock used a non-matching specifier and was a silent no-op — it had been passing only because the real CLI fails interference 3×. Now a genuine ~30 ms unit test that exercises best-of-N retry.

## Tests

29/29 across the loop + eval suites; `tsc --noEmit` clean. New: `selectBest` unit tests, best-of-N integration (winner selection, oracle tiebreak, fan-out-then-repair, no-script fallback, winner-content integrity), N=1 regression, anti-hack guard, eval wiring helpers.

Measurement of the N=4-vs-N=1 lift on cqe + Wayfarer follows separately (it is the success criterion; reported as numbers, not self-graded).