### PR TITLE
fix(studio): Wireframe mode draws BREP edge curves, not the triangulation

### DIFF
--- a/src/studio/components/viewer/entities/ShapeGeometry.test.tsx
+++ b/src/studio/components/viewer/entities/ShapeGeometry.test.tsx
@@ -6,7 +6,24 @@ import type { FaceGeometry, GeometryResult } from '../../../../shared/worker/geo
 
 let FaceSelectionOverlay: typeof import('./ShapeGeometry').FaceSelectionOverlay;
 let GhostShape: typeof import('./ShapeGeometry').GhostShape;
+let ConsolidatedShape: typeof import('./ShapeGeometry').ConsolidatedShape;
 let buildShapeMaterial: typeof import('./buildShapeMaterial').buildShapeMaterial;
+
+vi.mock('../../../context/WorkbenchContext', () => ({
+    useWorkbench: () => ({
+        selectedFace: null,
+        setSelectedFace: vi.fn(),
+        setSelectedSketchName: vi.fn(),
+        setSelectedItemId: vi.fn(),
+        toggleSelection: vi.fn(),
+    }),
+}));
+
+vi.mock('../../../context/UIContext', () => ({
+    useUI: () => ({
+        setContextMenu: vi.fn(),
+    }),
+}));
 
 const faceA: FaceGeometry = {
     vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
@@ -65,35 +82,104 @@ describe('ShapeGeometry disposable overlays', () => {
     });
 });
 
+describe('ConsolidatedShape scene graph per view mode', () => {
+    beforeAll(async () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        ({ ConsolidatedShape } = await import('./ShapeGeometry'));
+        ({ buildShapeMaterial } = await import('./buildShapeMaterial'));
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    // BREP edge polylines from the kernel payload (two segments).
+    const edges = new Float32Array([
+        0, 0, 0, 1, 0, 0,
+        1, 0, 0, 1, 1, 0,
+    ]);
+
+    const geometryWithEdges: GeometryResult = { faces: [faceA, faceB], edges };
+
+    function renderShape(viewMode3D: 'shaded' | 'wireframe' | 'shadedWithEdges') {
+        return render(
+            <ConsolidatedShape
+                geometry={geometryWithEdges}
+                shapeIndex={0}
+                viewMode3D={viewMode3D}
+                isSelected={false}
+                name="body_1"
+            />,
+        );
+    }
+
+    it('wireframe — edge lines visible, faces ghosted (never the triangulation)', () => {
+        const { container } = renderShape('wireframe');
+
+        // The BREP edge curves are present...
+        expect(container.querySelectorAll('lineSegments')).toHaveLength(1);
+
+        // ...and the face mesh is a barely-visible ghost, not a wireframed
+        // triangulation: transparent, ghost opacity, material.wireframe off.
+        const meshes = container.querySelectorAll('mesh');
+        expect(meshes).toHaveLength(1);
+        const material = buildShapeMaterial(undefined, false, 0xbfc4c8, 'wireframe');
+        expect(material.transparent).toBe(true);
+        expect((material as THREE.MeshBasicMaterial).wireframe).toBe(false);
+    });
+
+    it('shadedWithEdges — edge lines visible over opaque faces', () => {
+        const { container } = renderShape('shadedWithEdges');
+        expect(container.querySelectorAll('lineSegments')).toHaveLength(1);
+        expect(container.querySelectorAll('mesh')).toHaveLength(1);
+    });
+
+    it('shaded — no edge lines', () => {
+        const { container } = renderShape('shaded');
+        expect(container.querySelectorAll('lineSegments')).toHaveLength(0);
+        expect(container.querySelectorAll('mesh')).toHaveLength(1);
+    });
+});
+
 describe('buildShapeMaterial — viewMode3D produces visually-distinct materials', () => {
+    let WIREFRAME_GHOST_OPACITY: number;
+
     beforeAll(async () => {
         ({ buildShapeMaterial } = await import('./buildShapeMaterial'));
+        ({ WIREFRAME_GHOST_OPACITY } = await import('./buildShapeMaterial'));
     });
 
     // Regression test for the toolbar render-mode bug: clicking Wireframe / Shaded /
     // Shaded with Edges flipped the React state but the material never reflected it,
     // so all three modes rendered identically.
 
-    it('shaded — wireframe off, flatShading off (fallback Lambert)', () => {
+    it('shaded — opaque, flatShading off (fallback Lambert)', () => {
         const mat = buildShapeMaterial(undefined, false, 0xc8d2e0, 'shaded');
         expect(mat).toBeInstanceOf(THREE.MeshLambertMaterial);
         expect((mat as THREE.MeshLambertMaterial).wireframe).toBe(false);
         expect((mat as THREE.MeshLambertMaterial).flatShading).toBe(false);
+        expect(mat.transparent).toBe(false);
     });
 
-    it('wireframe — wireframe ON (fallback Lambert)', () => {
+    it('wireframe — faces become a barely-visible ghost, triangulation never shown', () => {
+        // Wireframe mode must NOT set material.wireframe (that draws the
+        // tessellation). Faces are ghosted; the BREP edge lines carry the view.
         const mat = buildShapeMaterial(undefined, false, 0xc8d2e0, 'wireframe');
-        expect((mat as THREE.MeshLambertMaterial).wireframe).toBe(true);
-        expect((mat as THREE.MeshLambertMaterial).flatShading).toBe(false);
+        expect(mat).toBeInstanceOf(THREE.MeshBasicMaterial);
+        expect((mat as THREE.MeshBasicMaterial).wireframe).toBe(false);
+        expect(mat.transparent).toBe(true);
+        expect(mat.opacity).toBe(WIREFRAME_GHOST_OPACITY);
+        expect(mat.depthWrite).toBe(false);
     });
 
-    it('shadedWithEdges — wireframe off, flatShading ON (fallback Lambert)', () => {
+    it('shadedWithEdges — opaque, flatShading ON (fallback Lambert)', () => {
         const mat = buildShapeMaterial(undefined, false, 0xc8d2e0, 'shadedWithEdges');
         expect((mat as THREE.MeshLambertMaterial).wireframe).toBe(false);
         expect((mat as THREE.MeshLambertMaterial).flatShading).toBe(true);
     });
 
-    it('wireframe propagates to PBR MeshPhysicalMaterial', () => {
+    it('wireframe overrides PBR materials with the ghost film', () => {
         const pbr: NonNullable<GeometryResult['material']> = {
             baseColor: '#c8d2e0',
             metalness: 0.1,
@@ -105,20 +191,28 @@ describe('buildShapeMaterial — viewMode3D produces visually-distinct materials
         expect(shaded).toBeInstanceOf(THREE.MeshPhysicalMaterial);
         expect((shaded as THREE.MeshPhysicalMaterial).wireframe).toBe(false);
         expect((shaded as THREE.MeshPhysicalMaterial).flatShading).toBe(false);
-        expect((wire as THREE.MeshPhysicalMaterial).wireframe).toBe(true);
+        expect(wire).toBeInstanceOf(THREE.MeshBasicMaterial);
+        expect((wire as THREE.MeshBasicMaterial).wireframe).toBe(false);
+        expect(wire.transparent).toBe(true);
+        expect(wire.opacity).toBe(WIREFRAME_GHOST_OPACITY);
         expect((edges as THREE.MeshPhysicalMaterial).wireframe).toBe(false);
         expect((edges as THREE.MeshPhysicalMaterial).flatShading).toBe(true);
     });
 
-    it('selected shapes use the selection-colour Lambert regardless of view mode, wireframe still honoured', () => {
+    it('selected shapes in wireframe mode still ghost the faces (selection shows via edge colour)', () => {
         const pbr: NonNullable<GeometryResult['material']> = {
             baseColor: '#aabbcc',
         };
-        // When isSelected=true, the PBR branch is skipped and we fall through to the
-        // Lambert highlight. Wireframe still must propagate so a selected shape in
-        // wireframe mode shows lines, not solid surface.
         const wire = buildShapeMaterial(pbr, true, 0xff0000, 'wireframe');
-        expect(wire).toBeInstanceOf(THREE.MeshLambertMaterial);
-        expect((wire as THREE.MeshLambertMaterial).wireframe).toBe(true);
+        expect(wire).toBeInstanceOf(THREE.MeshBasicMaterial);
+        expect((wire as THREE.MeshBasicMaterial).wireframe).toBe(false);
+        expect(wire.transparent).toBe(true);
+    });
+
+    it('wireframe ghost still honours clipping planes', () => {
+        const plane = new THREE.Plane(new THREE.Vector3(0, 0, -1), 10);
+        const mat = buildShapeMaterial(undefined, false, 0xc8d2e0, 'wireframe', [plane]);
+        expect(mat.clippingPlanes).toHaveLength(1);
+        expect(mat.clippingPlanes![0]).toBe(plane);
     });
 });

--- a/src/studio/components/viewer/entities/ShapeGeometry.tsx
+++ b/src/studio/components/viewer/entities/ShapeGeometry.tsx
@@ -170,9 +170,13 @@ export function ConsolidatedShape({
                 onClick={handleClick}
                 userData={{ type: 'FACE', id: 'consolidated', shapeIndex, faceMap, ownerId: name }}
             />
-            {viewMode3D === 'shadedWithEdges' && edgesGeo && (
+            {viewMode3D !== 'shaded' && edgesGeo && (
+                // BREP edge curves. In shadedWithEdges they overlay the shaded
+                // faces in black; in wireframe mode they ARE the shape (faces
+                // are ghosted by buildShapeMaterial), drawn in the body colour
+                // so they read against the viewport background.
                 <lineSegments geometry={edgesGeo} renderOrder={500}>
-                    <lineBasicMaterial color={0x000000} />
+                    <lineBasicMaterial color={viewMode3D === 'wireframe' ? color : 0x000000} />
                 </lineSegments>
             )}
             {selectedFace?.shapeIndex === shapeIndex && (

--- a/src/studio/components/viewer/entities/buildShapeMaterial.ts
+++ b/src/studio/components/viewer/entities/buildShapeMaterial.ts
@@ -13,10 +13,16 @@ import { buildMaterialFromPBR } from '../../demoPlayer/buildMaterialFromPBR';
  * export non-component values).
  *
  * Three view modes:
- *  - `'shaded'`           — smooth shading, no wireframe, no edge overlay
- *  - `'wireframe'`        — `material.wireframe = true`, surfaces drawn as lines
+ *  - `'shaded'`           — smooth shading, no edge overlay
+ *  - `'wireframe'`        — faces ghosted to a barely-visible depth-tested film;
+ *                           the BREP edge polylines (rendered by ShapeGeometry)
+ *                           carry the visual. The triangulation is never shown.
  *  - `'shadedWithEdges'`  — flat shading + black edge overlay rendered separately
  */
+
+/** Face opacity used by the wireframe-mode ghost film. */
+export const WIREFRAME_GHOST_OPACITY = 0.08;
+
 export function buildShapeMaterial(
     pbr: GeometryResult['material'],
     isSelected: boolean,
@@ -24,7 +30,6 @@ export function buildShapeMaterial(
     viewMode3D: ViewMode3D,
     clippingPlanes: THREE.Plane[] = [],
 ): THREE.Material {
-    const isWireframe = viewMode3D === 'wireframe';
     const flatShading = viewMode3D === 'shadedWithEdges';
     const applyClip = (m: THREE.Material): THREE.Material => {
         // Empty array ⇒ no clipping (three.js no-ops). Non-empty ⇒ GPU clip;
@@ -33,10 +38,22 @@ export function buildShapeMaterial(
         m.clipShadows = true;
         return m;
     };
+    if (viewMode3D === 'wireframe') {
+        // Wireframe mode never shows the triangulation. Faces become a faint
+        // depth-tested ghost so orientation still reads, while the BREP edge
+        // curves (drawn as line segments in ShapeGeometry) define the shape.
+        // depthWrite stays off so the ghost never occludes edge lines.
+        return applyClip(new THREE.MeshBasicMaterial({
+            color,
+            transparent: true,
+            opacity: WIREFRAME_GHOST_OPACITY,
+            depthWrite: false,
+            side: THREE.DoubleSide,
+        }));
+    }
     if (pbr && !isSelected) {
         const pbrMaterial = buildMaterialFromPBR(pbr) as THREE.MeshPhysicalMaterial;
         pbrMaterial.flatShading = flatShading;
-        pbrMaterial.wireframe = isWireframe;
         pbrMaterial.side = THREE.DoubleSide;
         pbrMaterial.depthWrite = (pbr.opacity ?? 1) >= 1;
         return applyClip(pbrMaterial);
@@ -44,6 +61,5 @@ export function buildShapeMaterial(
     return applyClip(new THREE.MeshLambertMaterial({
         color,
         flatShading,
-        wireframe: isWireframe,
     }));
 }


### PR DESCRIPTION
## Problem

The Studio toolbar's Wireframe render mode set `material.wireframe = true`, which renders the mesh tessellation — a dense triangle wireframe. The triangulation is an internal artifact and should never be user-visible; on a donut example the mode was unreadable noise.

## Fix

Wireframe mode now reuses the exact BREP edge polylines that Shaded with Edges already draws (kernel `geometry.edges` payload, with the existing `THREE.EdgesGeometry` fallback). Faces are ghosted to a barely-visible depth-tested film (8% opacity, `depthWrite` off, double-sided) so orientation still reads and face picking keeps working; edge lines render in the body colour so they stand out against the viewport background (black is kept for Shaded with Edges, where edges overlay opaque faces).

- `buildShapeMaterial.ts` — wireframe mode returns a transparent ghost `MeshBasicMaterial` (clipping planes still honoured) instead of flipping `material.wireframe`; exported `WIREFRAME_GHOST_OPACITY`
- `ShapeGeometry.tsx` — edge `lineSegments` now render for both `shadedWithEdges` (black) and `wireframe` (body colour) modes

## Before / after

Verified live on `?script=examples/v0.21/donut.kcad.ts` across all three modes. Before: Wireframe showed thousands of tessellation triangles. After: Wireframe shows smooth feature edges (profile circles, fillet boundaries, counterbore circles, silhouette curves) over a faint ghost — zero triangles. Shaded and Shaded with Edges are pixel-identical to before.

## Tests

- Updated `buildShapeMaterial` mode assertions (ghost material, `wireframe` flag never set, clipping honoured)
- New `ConsolidatedShape` scene-graph tests: wireframe mode has edge lines present and faces ghosted; shaded mode has no edge lines
- `vitest run src/studio`: 65 files, 350 tests, all green; `tsc --noEmit` and `eslint` clean