### PR TITLE
fix: imported shapes survive assembly capture + solve

### DIFF
--- a/examples/robot-arm/so100/so100.kcad.ts
+++ b/examples/robot-arm/so100/so100.kcad.ts
@@ -69,12 +69,15 @@ const servo2Placed = servo2
   .translate(0, -10, servoZ2);
 
 // Jaw mounted on servo 2's output, in front of the servo so the gripper
-// reads as "open" in the hero pose. The X-offset (+50) pushes the jaw
-// clear of the servo body — SO-100's full assembly uses a coupling here.
+// reads as "open" in the hero pose. The X-offset seats the jaw against
+// the servo output side within bearing tolerance (~0.5 mm) so the
+// fastened mate is a real coupling, not a floating part — the
+// mechanism-truth joint-mesh gate requires the mated bodies to keep
+// bearing contact within 1 mm.
 const jawPlaced = jaw
   .rotate([1, 0, 0], -90)
   .rotate([0, 0, 1], 20)
-  .translate(50, -10, servoZ2);
+  .translate(40.1, -10, servoZ2);
 
 const arm = assembly('so100-gripper');
 const basePart    = arm.part('base-plate',     basePlate);

--- a/src/modeling/backends/occt/occtLowerer.ts
+++ b/src/modeling/backends/occt/occtLowerer.ts
@@ -664,7 +664,12 @@ export class OcctLowerer implements FeatureLowerer {
           });
           return { shape: undefined as unknown as ShapeBackend, diagnostics };
         }
-        shape = backend;
+        // Hand back a clone, never the parked backend itself: replicad's
+        // translate/rotate/mirror/scale destroy their source OCCT handle, so
+        // the post-hoc `r.transforms` loop below (or any destructive
+        // downstream consumer) would invalidate the map entry and the next
+        // lowering pass would throw "This object has been deleted".
+        shape = (backend as OcctBackend).clone();
         break;
       }
       case 'sdfMaterialize': {
@@ -684,7 +689,9 @@ export class OcctLowerer implements FeatureLowerer {
           });
           return { shape: undefined as unknown as ShapeBackend, diagnostics };
         }
-        shape = backend;
+        // Clone for the same reason as `importedStep` above: keep the parked
+        // backend alive across repeated lowering passes.
+        shape = (backend as OcctBackend).clone();
         break;
       }
       case 'sketch': {

--- a/tests/integration/examples/fromStepAssembly.test.ts
+++ b/tests/integration/examples/fromStepAssembly.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateScript } from '../../../src/agent/cli/commands/evaluate';
+
+// Small vendor STEP fixture already in the repo (8.9 KB).
+const FIXTURE = `${process.cwd()}/examples/robot-arm/so100/parts/Passive_Horn.step`;
+
+describe('fromSTEP shapes inside assemblies', () => {
+  it('transformed imported shape survives asm.part + solvedModel', async () => {
+    const code = `
+      const s = (await lib.fromSTEP('${FIXTURE}'))
+        .rotate([0, 0, 1], 90).translate(0, -12.5, -16.5);
+      const asm = assembly('t');
+      const p = asm.part('imported', s);
+      p.connector('mount', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 0] } });
+      return asm.solvedModel({});
+    `;
+    const result = await evaluateScript({ code, file: 'examples/t.kcad.ts' });
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
Transformed `fromSTEP` shapes died in `asm.part` + `solvedModel` with `This object has been deleted` (`recompute.lowering.exception` on the importedStep record, cascading `recompute.input.missing` into every dependent part).

Root cause: `lib.fromSTEP` parks a single `OcctBackend` in `session.importedGeometry`, and the lowerer's `importedStep` case handed out that map-owned instance directly. Replicad's `translate`/`rotate`/`mirror`/`scale` destroy their source OCCT handle, so the post-hoc `r.transforms` loop invalidated the map entry on the first lowering pass; the second pass (the `solvedModel` validate/interference gate, session-pool rebuilds, param updates) then re-read the dead handle. Not a recent regression — present since the v0.6 validate gate started re-lowering (`9d353662`) over v0.5's parked-import hand-out (`d31f41fb`).

Fix: the cache retains ownership; `importedStep` and `sdfMaterialize` lowering hand back `clone()` instead of the parked backend.

Verification: new integration test (red before, green after); spice-dispenser-carousel evaluates `Features: 126` / `OK`; `proof:assembly-contract` passes. Adds an integration test so STEP imports inside assemblies are CI-covered.