### PR TITLE
fix: print-prep paper cuts — returned-shape probes, exact bbox, render framing, base-url, script-relative export paths

### DIFF
--- a/src/agent/cli/commands/export.ts
+++ b/src/agent/cli/commands/export.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { readFile, writeFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
+import { resolve, dirname } from 'node:path';
 import { initOcct } from '../../../kernel/backends/occt/occtBackend';
 import { runAndExport, type ExportFormat } from '../../script-runtime/export';
 import { formatHuman } from '../../../shared/diagnostics/formatter';
@@ -38,7 +38,12 @@ export async function exportScript(input: ExportInput): Promise<ExportCliResult>
   }
   let result;
   try {
-    result = await runAndExport({ code, fileName: filePath, format: input.format });
+    result = await runAndExport({
+      code,
+      fileName: filePath,
+      format: input.format,
+      scriptDir: dirname(filePath),
+    });
   } catch (e) {
     const diag = kernelErrorToDiagnostic(e, 'cli.export-exception');
     return {

--- a/src/agent/cli/commands/render.ts
+++ b/src/agent/cli/commands/render.ts
@@ -6,7 +6,7 @@
 // script. Use `--separate` to emit four individual files.
 //
 // Requires a studio dev server reachable at the configured base URL
-// (default http://127.0.0.1:5173). For development run `npm run dev` first;
+// (see --base-url; default DEFAULT_RENDER_BASE_URL). For development run `npm run dev` first;
 // a bundled-static-dist mode is on the v2 list.
 
 import { Command } from 'commander';
@@ -17,6 +17,7 @@ import {
   headlessRender,
   composite2x2,
   ALL_VIEWS,
+  DEFAULT_RENDER_BASE_URL,
   type HeadlessObjectFilter,
   type HeadlessInspectionChannel,
 } from '../../render/headlessRender';
@@ -483,7 +484,7 @@ export function renderCommand(): Command {
     .option(
       '--base-url <url>',
       'studio dev server URL (run `npm run dev` first)',
-      'http://localhost:5173',
+      DEFAULT_RENDER_BASE_URL,
     )
     .option('--hide-reference-images', 'hide referenceImage() overlays in rendered output (default false)', false)
     .option(
@@ -535,7 +536,7 @@ export function renderCommand(): Command {
     .option(
       '--base-url <url>',
       'studio dev server URL (run `npm run dev` first)',
-      'http://localhost:5173',
+      DEFAULT_RENDER_BASE_URL,
     )
     .option('--hide-reference-images', 'hide referenceImage() overlays in rendered output (default false)', false)
     .option(

--- a/src/agent/mcp/activeSession.ts
+++ b/src/agent/mcp/activeSession.ts
@@ -11,6 +11,12 @@ export interface ActiveMcpSession {
   session: CaptureSession;
   tailId?: string;
   tailShape?: ShapeBackend;
+  /** Feature id of the script's `return` value (Shape or Scene); falls
+   *  back to the tail when the script returned nothing lowerable. */
+  rootId?: string;
+  /** Lowered shape of the script's `return` value. Prefer this over
+   *  `tailShape` in probe / measurement consumers. */
+  rootShape?: ShapeBackend;
 }
 
 let activeSession: ActiveMcpSession | undefined;
@@ -35,6 +41,8 @@ export async function establishActiveMcpSession(input: ScriptSourceInput): Promi
     session: model.session,
     tailId: model.tailId,
     tailShape: model.tailShape,
+    rootId: model.rootId,
+    rootShape: model.rootShape,
   };
   return activeSession;
 }

--- a/src/agent/mcp/runMcpScript.ts
+++ b/src/agent/mcp/runMcpScript.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { initOcct } from '../../kernel/backends/occt/occtBackend';
 import { kernelErrorToDiagnostic } from '../script-runtime/kernelErrorToDiagnostic';
 import { runScript, type RunScriptResult } from '../../modeling/runtime/runScript';
@@ -30,9 +30,7 @@ export async function runMcpScript(input: McpScriptInput): Promise<RunMcpScriptR
   try {
     // When source came from a file, pass the script's directory so
     // `lib.fromSTEP('parts/foo.step')` resolves relative to the script.
-    const scriptDir = input.file !== undefined
-      ? resolve(input.file).replace(/[\\/][^\\/]*$/, '')
-      : undefined;
+    const scriptDir = input.file !== undefined ? dirname(resolve(input.file)) : undefined;
     return {
       ok: true,
       fileName: source.fileName,

--- a/src/agent/mcp/toolRegistry.ts
+++ b/src/agent/mcp/toolRegistry.ts
@@ -193,7 +193,7 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
     definition: {
       name: 'get_shape_info',
       description:
-        'Run + recompute a script, return volume/surfaceArea/bbox for one feature (default: last). ' +
+        "Run + recompute a script, return volume/surfaceArea/bbox for one feature (default: the script's returned shape). " +
         'Pass { file?, code?, feature_id? }.',
       inputSchema: {
         type: 'object',
@@ -202,7 +202,7 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
           code: { type: 'string', description: 'Inline kernelCAD script source.' },
           feature_id: {
             type: 'string',
-            description: 'Feature id to inspect. Defaults to the last captured feature.',
+            description: "Feature id to inspect. Defaults to the script's returned shape (falls back to the last captured feature when nothing lowerable is returned).",
           },
         },
       },

--- a/src/agent/mcp/tools/evaluateScript.ts
+++ b/src/agent/mcp/tools/evaluateScript.ts
@@ -32,6 +32,8 @@ export async function evaluateScriptTool(
       session: model!.session,
       tailId: model!.tailId,
       tailShape: model!.tailShape,
+      rootId: model!.rootId,
+      rootShape: model!.rootShape,
     });
   } else {
     clearActiveMcpSession();

--- a/src/agent/mcp/tools/exportModel.ts
+++ b/src/agent/mcp/tools/exportModel.ts
@@ -9,7 +9,7 @@
 // `export.<format>.not-implemented` until a follow-up slice fills them in.
 
 import { writeFile, mkdir } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { initOcct } from '../../../kernel/backends/occt/occtBackend';
 import {
   runAndExport,
@@ -79,6 +79,7 @@ export async function exportModelTool(input: ExportModelInput): Promise<ExportMo
       format,
       feature_id,
       options,
+      scriptDir: input.file !== undefined ? dirname(resolve(input.file)) : undefined,
     });
   } catch (e) {
     return {

--- a/src/agent/mcp/tools/getShapeInfo.ts
+++ b/src/agent/mcp/tools/getShapeInfo.ts
@@ -2,6 +2,7 @@
 import { RecomputeEngine } from '../../../modeling/compute/recomputeEngine';
 import { createOcctLowerer } from '../../../modeling/backends/occt/occtLowerer';
 import type { FeatureKind } from '../../../shared/intent/types';
+import { resolveRootId } from '../../../modeling/buildModel';
 import { runMcpScript } from '../runMcpScript';
 
 export interface GetShapeInfoInput {
@@ -41,7 +42,8 @@ export async function getShapeInfoTool(
     return { ok: false, error: 'Script produced no features.' };
   }
 
-  const targetId = input.feature_id ?? run.records[run.records.length - 1].id;
+  const tailId = run.records[run.records.length - 1].id;
+  const targetId = input.feature_id ?? resolveRootId(run.returnValue, tailId)!;
   const targetRecord = run.records.find(r => r.id === targetId);
   if (!targetRecord) {
     return { ok: false, error: `feature_id '${targetId}' not found in script's features.` };

--- a/src/agent/mcp/tools/paramsUpdate.ts
+++ b/src/agent/mcp/tools/paramsUpdate.ts
@@ -43,10 +43,16 @@ export async function paramsUpdateTool(input: ParamsUpdateInput): Promise<Params
   try {
     const result = await active.session.params.update(input.edits);
     const tailId = active.session.getRecords().at(-1)?.id ?? active.tailId ?? '<unknown>';
+    // A param update never changes the record chain, so the root id carries
+    // through; its shape is refreshed from the session cache the update
+    // repopulated.
+    const rootId = active.rootId;
     setActiveMcpSession({
       session: active.session,
       tailId,
       tailShape: result.shape,
+      rootId,
+      rootShape: rootId ? active.session.cachedShapes.get(rootId) : undefined,
     });
     return {
       ok: true,

--- a/src/agent/mcp/tools/reviewCad.ts
+++ b/src/agent/mcp/tools/reviewCad.ts
@@ -168,6 +168,8 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
     session: model.session,
     tailId: model.tailId,
     tailShape: model.tailShape,
+    rootId: model.rootId,
+    rootShape: model.rootShape,
   });
 
   const arm = selectAssembly(model.session.assemblies as Map<string, Assembly>, input.assembly);
@@ -342,10 +344,11 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
 }
 
 /**
- * Run pairwise BREP interference detection on the BuiltModel's tail scene
- * for the Studio HUD's raw-count channel. We deliberately read from
- * `model.tailShape` (the already-lowered scene returned by the script's
- * own `arm.solvedModel(poses, ...)`) instead of calling
+ * Run pairwise BREP interference detection on the BuiltModel's lowered
+ * scene for the Studio HUD's raw-count channel. We deliberately read the
+ * lowered scene of the script's RETURN value (`model.rootShape`, falling
+ * back to `model.tailShape` — the scene returned by the script's own
+ * `arm.solvedModel(poses, ...)`) instead of calling
  * `detectInterferencesForPoses(arm, {})` — the latter re-records a new
  * `solvedAssembly` with EMPTY poses, which trips the lowerer's
  * "joint requires a pose value" check for revolute/prismatic joints and
@@ -363,7 +366,7 @@ function safeDetectDefaultPoseInterferences(
   epsilonMm3?: number,
 ): InterferencePair[] {
   try {
-    const tail = model.tailShape;
+    const tail = model.rootShape ?? model.tailShape;
     if (!tail || !isSceneBackend(tail)) return [];
     const epsilon = epsilonMm3 ?? 0.01;
     return detectInterferences(tail, epsilon, new Set<string>()).pairs;

--- a/src/agent/render/headlessRender.ts
+++ b/src/agent/render/headlessRender.ts
@@ -33,8 +33,8 @@ declare const window: {
       width: number;
       height: number;
     }) => HeadlessInspectionCapture;
-    setRenderView: (view: RenderView) => void;
-    setRenderPose: (azDeg: number, elDeg: number) => void;
+    setRenderView: (view: RenderView, outputAspect?: number) => void;
+    setRenderPose: (azDeg: number, elDeg: number, outputAspect?: number) => void;
     setReferenceImagesVisible: (visible: boolean) => void;
     setRenderEnvironment: (spec: unknown) => Promise<void>;
   };
@@ -137,7 +137,6 @@ export interface HeadlessRenderResult {
 }
 
 const HEADLESS_VIEWPORT = { width: 1920, height: 1080 } as const;
-const SCENE_BACKGROUND = { r: 144, g: 144, b: 144, alpha: 1 } as const;
 
 export async function headlessRender(opts: HeadlessRenderOpts): Promise<HeadlessRenderResult> {
   const baseUrl = opts.baseUrl ?? 'http://localhost:5173';
@@ -270,8 +269,12 @@ export async function headlessRender(opts: HeadlessRenderOpts): Promise<Headless
     const inspectionPngsByChannel: Partial<Record<HeadlessAuxInspectionChannel, Partial<Record<RenderView, Buffer>>>> = {};
     const inspectionChannelMetadata: HeadlessInspectionCapture['metadata'] = {};
     let maskObjects: HeadlessMaskObject[] | undefined;
+    const outputAspect = opts.viewportWidth / opts.viewportHeight;
     for (const view of views) {
-      await page.evaluate((v) => window.__demoPlayer!.setRenderView(v), view);
+      await page.evaluate(
+        ({ v, a }) => window.__demoPlayer!.setRenderView(v, a),
+        { v: view, a: outputAspect },
+      );
       if (captureRgb) {
         const buf = await normalizeTile(await page.screenshot({ type: 'png' }), opts);
         pngsByView[view] = buf;
@@ -314,8 +317,8 @@ export async function headlessRender(opts: HeadlessRenderOpts): Promise<Headless
           throw new Error(`headlessRender: invalid --pose value '${poseKey}' (expected '<az>,<el>')`);
         }
         await page.evaluate(
-          ({ a, e }) => window.__demoPlayer!.setRenderPose(a, e),
-          { a: az, e: el },
+          ({ a, e, asp }) => window.__demoPlayer!.setRenderPose(a, e, asp),
+          { a: az, e: el, asp: outputAspect },
         );
         const buf = await normalizeTile(await page.screenshot({ type: 'png' }), opts);
         pngsByPose[poseKey] = buf;
@@ -343,17 +346,38 @@ export async function headlessRender(opts: HeadlessRenderOpts): Promise<Headless
   }
 }
 
-async function normalizeTile(buf: Buffer, opts: HeadlessRenderOpts): Promise<Buffer> {
-  if (opts.viewportWidth === HEADLESS_VIEWPORT.width && opts.viewportHeight === HEADLESS_VIEWPORT.height) {
-    return buf;
-  }
-  return sharp(buf)
-    .resize(opts.viewportWidth, opts.viewportHeight, {
-      fit: 'contain',
-      background: SCENE_BACKGROUND,
+/** Center-crop `buf` to the output aspect, then resize to the requested
+ *  tile dimensions. The camera fit (`setRenderView` / `setRenderPose` with
+ *  `outputAspect`) guarantees the model sits inside that centered region,
+ *  so no geometry is lost and no letterbox bars are introduced. */
+async function cropToAspect(
+  buf: Buffer,
+  outW: number,
+  outH: number,
+  resizeOpts: { kernel?: keyof sharp.KernelEnum },
+): Promise<Buffer> {
+  const img = sharp(buf);
+  const meta = await img.metadata();
+  const srcW = meta.width ?? HEADLESS_VIEWPORT.width;
+  const srcH = meta.height ?? HEADLESS_VIEWPORT.height;
+  if (srcW === outW && srcH === outH) return buf;
+  const outAspect = outW / outH;
+  const cropW = Math.min(srcW, Math.round(srcH * outAspect));
+  const cropH = Math.min(srcH, Math.round(srcW / outAspect));
+  return img
+    .extract({
+      left: Math.floor((srcW - cropW) / 2),
+      top: Math.floor((srcH - cropH) / 2),
+      width: cropW,
+      height: cropH,
     })
+    .resize(outW, outH, resizeOpts)
     .png()
     .toBuffer();
+}
+
+async function normalizeTile(buf: Buffer, opts: HeadlessRenderOpts): Promise<Buffer> {
+  return cropToAspect(buf, opts.viewportWidth, opts.viewportHeight, {});
 }
 
 async function normalizeInspectionTile(
@@ -361,20 +385,8 @@ async function normalizeInspectionTile(
   opts: Pick<HeadlessRenderOpts, 'viewportWidth' | 'viewportHeight'>,
   channel: 'mask' | HeadlessAuxInspectionChannel,
 ): Promise<Buffer> {
-  if (opts.viewportWidth === HEADLESS_VIEWPORT.width && opts.viewportHeight === HEADLESS_VIEWPORT.height) {
-    return buf;
-  }
-  const background = channel === 'mask'
-    ? { r: 0, g: 0, b: 0, alpha: 1 }
-    : { r: 0, g: 0, b: 0, alpha: 0 };
-  return sharp(buf)
-    .resize(opts.viewportWidth, opts.viewportHeight, {
-      fit: 'contain',
-      kernel: 'nearest',
-      background,
-    })
-    .png()
-    .toBuffer();
+  void channel; // mask/depth/normals all use nearest to preserve id/sentinel pixels
+  return cropToAspect(buf, opts.viewportWidth, opts.viewportHeight, { kernel: 'nearest' });
 }
 
 export async function normalizeInspectionTileForTest(

--- a/src/agent/render/headlessRender.ts
+++ b/src/agent/render/headlessRender.ts
@@ -104,7 +104,7 @@ export interface HeadlessRenderOpts {
   views?: readonly RenderView[];
   /** Additional arbitrary-pose captures keyed by `"<az>,<el>"`. */
   poses?: readonly string[];
-  /** URL of a running studio dev server; defaults to localhost:5173. */
+  /** URL of a running studio dev server; defaults to DEFAULT_RENDER_BASE_URL. */
   baseUrl?: string;
   /** When true, hides the `__referenceImages` overlay group before taking
    *  screenshots. Useful for clean engineering-view captures without overlays. */
@@ -138,8 +138,14 @@ export interface HeadlessRenderResult {
 
 const HEADLESS_VIEWPORT = { width: 1920, height: 1080 } as const;
 
+/** Single source of truth for the studio dev-server URL. The CLI render
+ *  commands use this as the `--base-url` option default; no other port
+ *  literal may exist in the render pipeline (guarded by
+ *  tests/unit/cli/renderBaseUrlDefault.test.ts). */
+export const DEFAULT_RENDER_BASE_URL = 'http://localhost:5173';
+
 export async function headlessRender(opts: HeadlessRenderOpts): Promise<HeadlessRenderResult> {
-  const baseUrl = opts.baseUrl ?? 'http://localhost:5173';
+  const baseUrl = opts.baseUrl ?? DEFAULT_RENDER_BASE_URL;
   const views = opts.views ?? ALL_VIEWS;
   const inspectionChannels = opts.inspectionChannels ?? ['rgb'];
   const captureRgb = inspectionChannels.includes('rgb');

--- a/src/agent/skills/kernelcad-authoring/SKILL.md
+++ b/src/agent/skills/kernelcad-authoring/SKILL.md
@@ -511,7 +511,7 @@ When you need a canonical pattern, call MCP tool `lookup_cookbook(query, k?)` to
 - Always declare params at the top of the script with units; the kernel evaluates them and surfaces them as live sliders to the studio.
 - Prefer `target.hole(face, opts)` for cylindrical bores (single hole), `target.holes(face, opts)` for bolt patterns, and `target.cutout(profile, opts)` for irregular subtractive shapes (slots, D-pockets) over `subtract(cylinder)` — they emit named created refs (`'wall'`, `'floor'`, `'wall-back'`, `'counterbore-wall'`, `'counterbore-floor'`, `'countersink-cone'`) that downstream `.fillet()` / `.shell()` can address.
 - Apply transforms AFTER edge/face features when the face filter matters; transforms commute with everything except face-ref resolution.
-- Always `return` a single shape from the top of the script — the kernelCAD CLI exports whatever you return.
+- Always `return` a single shape from the top of the script — the kernelCAD CLI exports whatever you return. Only the returned shape is honored by export / probe / measurement surfaces; "the last thing I created" is NOT a fallback you can rely on — mutating transforms (`.translate()`, `.rotate()`) re-use their record, and any helper shape created after the main body silently becomes the newest record. If a probe reports the same bbox no matter what you edit, you are measuring a stale or decoy record: check what the script returns.
 - For symmetric parts, prefer `.mirror(plane)` (union of source + reflection) over manual duplication. Use `.reflect(plane)` when you only want the reflected geometry without the original.
 - For helical features (coils, springs, threads), generate the rail with `helix(...)` and sweep a closed `path()` profile with `frenet: true`.
 

--- a/src/agent/skills/kernelcad-authoring/SKILL.md
+++ b/src/agent/skills/kernelcad-authoring/SKILL.md
@@ -452,11 +452,10 @@ kernelcad export 3mf  path/to/script.kcad.ts -o /tmp/out.3mf   # slicer mesh wit
 kernelcad export glb  path/to/script.kcad.ts -o /tmp/out.glb   # web / AR viewer; PBR materials
 
 # Render a 4-view PNG (front/right/top/iso) for visual review.
-# Always pass --width 1920 --height 1080: the demo-player page layout is
-# fixed at 1920×1080 (terminal pane 640 + viewer pane 1280); rendering at
-# the CLI default 1024×1024 silently clips the viewer pane and crops the
-# model on the right side.
-kernelcad render path/to/script.kcad.ts --width 1920 --height 1080 -o /tmp/out.png
+# Tiles are framed to the requested --width/--height: the camera fits the
+# visible geometry to the output aspect and the capture is center-cropped,
+# so the default 1024×1024 square tiles frame correctly.
+kernelcad render path/to/script.kcad.ts -o /tmp/out.png
 
 # Detect BREP interferences between Scene parts (industry-standard clash check)
 kernelcad interference path/to/script.kcad.ts

--- a/src/kernel/backends/backend.ts
+++ b/src/kernel/backends/backend.ts
@@ -19,7 +19,20 @@ export interface ShapeBackend {
   subtract(other: ShapeBackend): ShapeBackend;
   intersect(other: ShapeBackend): ShapeBackend;
   splitByPlane(normal: Vec3, offset: number): [ShapeBackend, ShapeBackend];
-  boundingBox(): { min: Vec3; max: Vec3 };
+  /**
+   * Axis-aligned bounding box.
+   *
+   * Default (no opts): OCCT Bnd_Box. Fast, but PADDED on curved faces
+   * produced by fillets, blends, trims, and imports — a filleted ⌀20
+   * cylinder reports ~⌀21.6. Fine for culling and rough framing; wrong
+   * for print-volume tables and silhouette checks.
+   *
+   * `{ exact: true }`: meshes the shape with the standard mesher and folds
+   * the vertex AABB. Vertices lie ON the surface, so the box is tight to
+   * within the mesh deflection (slightly UNDER on convex curvature, ≲0.1mm
+   * at default tolerances). Costs a tessellation per call.
+   */
+  boundingBox(opts?: { exact?: boolean }): { min: Vec3; max: Vec3 };
   volume(): number;
   surfaceArea(): number;
   isEmpty(): boolean;

--- a/src/kernel/backends/occt/occtBackend.ts
+++ b/src/kernel/backends/occt/occtBackend.ts
@@ -1074,11 +1074,18 @@ export class OcctBackend implements ShapeBackend {
     throw new Error('splitByPlane not implemented in v0.1');
   }
 
-  boundingBox(): { min: Vec3; max: Vec3 } {
+  boundingBox(opts?: { exact?: boolean }): { min: Vec3; max: Vec3 } {
+    if (opts?.exact) {
+      const exact = this.tessellatedBoundingBox();
+      if (exact) return exact;
+      // Empty / unmeshable shape — fall through to Bnd_Box.
+    }
     const bb = this.shape.boundingBox;
     const [minP, maxP] = bb.bounds;
     // OCCT's Bnd_Box inflates bounds by a tolerance gap; remove it so that
-    // exact-axis-aligned primitives report integral coordinates.
+    // exact-axis-aligned primitives report integral coordinates. NOTE: even
+    // gap-corrected, Bnd_Box stays padded on curved B-spline faces (control-
+    // point hull); pass { exact: true } for a tessellation-tight box.
     const wrapped = (bb as unknown as { wrapped?: { GetGap?: () => number } }).wrapped;
     const gap =
       wrapped && typeof wrapped.GetGap === 'function' ? wrapped.GetGap() : 0;
@@ -1086,6 +1093,24 @@ export class OcctBackend implements ShapeBackend {
       min: [minP[0] + gap, minP[1] + gap, minP[2] + gap] as Vec3,
       max: [maxP[0] - gap, maxP[1] - gap, maxP[2] - gap] as Vec3,
     };
+  }
+
+  /** Fold the standard-mesher vertex AABB. Returns undefined when the
+   *  shape yields no triangles (empty compound). */
+  private tessellatedBoundingBox(): { min: Vec3; max: Vec3 } | undefined {
+    const p = this.getMesh().positions;
+    if (p.length === 0) return undefined;
+    let minX = Infinity, minY = Infinity, minZ = Infinity;
+    let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+    for (let i = 0; i < p.length; i += 3) {
+      if (p[i] < minX) minX = p[i];
+      if (p[i] > maxX) maxX = p[i];
+      if (p[i + 1] < minY) minY = p[i + 1];
+      if (p[i + 1] > maxY) maxY = p[i + 1];
+      if (p[i + 2] < minZ) minZ = p[i + 2];
+      if (p[i + 2] > maxZ) maxZ = p[i + 2];
+    }
+    return { min: [minX, minY, minZ] as Vec3, max: [maxX, maxY, maxZ] as Vec3 };
   }
 
   /**

--- a/src/modeling/buildModel.ts
+++ b/src/modeling/buildModel.ts
@@ -11,6 +11,8 @@ import type { CaptureSession } from './capture/captureSession';
 import type { SoftWarning } from '../shared/runtime/softWarning';
 import { runScript } from './runtime/runScript';
 import { KernelError } from '../shared/intent/kernelError';
+import { Shape } from './capture/proxy';
+import { Scene } from './validation/scene';
 
 export interface BuildModelInput {
   code: string;
@@ -32,7 +34,21 @@ export interface BuiltModel {
   health: Map<FeatureId, 'healthy' | 'warning' | 'error'>;
   warnings: SoftWarning[];
   tailId?: FeatureId;
+  /**
+   * WARNING — last-CREATED record, NOT the script's return value. Mutating
+   * transforms (`.translate()` / `.rotate()`) append to an existing record,
+   * so `return part.translate(...)` does not move the tail — but a helper
+   * shape created after the main body DOES. Use `rootShape` for anything
+   * that measures, probes, or exports "the model". Kept for transform /
+   * animation consumers that genuinely want the newest record.
+   */
   tailShape?: ShapeBackend;
+  /** Feature id of the script's `return` value (Shape or Scene). Falls
+   *  back to `tailId` when the script returned nothing lowerable. */
+  rootId?: FeatureId;
+  /** Lowered shape of the script's `return` value. Prefer this over
+   *  `tailShape` in export / probe / measurement consumers. */
+  rootShape?: ShapeBackend;
 }
 
 export interface ParamUpdateEdit {
@@ -71,6 +87,8 @@ export async function buildModel(input: BuildModelInput): Promise<BuiltModel> {
   populateCache(session, result.shapes);
   const tailId = run.records.length > 0 ? run.records[run.records.length - 1].id : undefined;
   const tailShape = tailId ? result.shapes.get(tailId) : undefined;
+  const rootId = resolveRootId(run.returnValue, tailId);
+  const rootShape = rootId ? result.shapes.get(rootId) : undefined;
 
   return {
     session,
@@ -81,6 +99,8 @@ export async function buildModel(input: BuildModelInput): Promise<BuiltModel> {
     warnings: session.warnings.slice(warningsBefore),
     tailId,
     tailShape,
+    rootId,
+    rootShape,
   };
 }
 
@@ -95,6 +115,21 @@ export function populateCache(session: CaptureSession, shapes: Map<FeatureId, Sh
   for (const [id, shape] of shapes) {
     session.cachedShapes.set(id, shape);
   }
+}
+
+/**
+ * Resolve the FeatureId of the value the script `return`ed.
+ * Shape → its feature id; Scene → the upstream solvedAssembly /
+ * assemblyModel record id; anything else (Region, plain data, no
+ * return) → fall back to the chain tail.
+ */
+export function resolveRootId(
+  returnValue: unknown,
+  tailId: FeatureId | undefined,
+): FeatureId | undefined {
+  if (returnValue instanceof Shape) return returnValue.id;
+  if (returnValue instanceof Scene) return returnValue.__sourceFeatureId() ?? tailId;
+  return tailId;
 }
 
 export async function updateModelParams(
@@ -172,6 +207,7 @@ export async function updateModelParams(
     warnings: session.warnings.slice(warningsBefore),
     tailId,
     tailShape,
+    rootShape: model.rootId ? result.shapes.get(model.rootId) : undefined,
   };
 
   // Slice 2E: notify `onRelower` subscribers with the records re-lowered by

--- a/src/modeling/capture/captureSession.ts
+++ b/src/modeling/capture/captureSession.ts
@@ -34,7 +34,8 @@ import { lazyEvalCurve } from '../backends/occt/curve3dEval';
 import type { VariableSweepMetadata, VariableSweepSection } from '../../shared/intent/variableSweepRecord';
 import { imageDimensions } from './imageDimensions';
 import { existsSync } from 'node:fs';
-import { resolve as resolvePath, extname } from 'node:path';
+import { extname } from 'node:path';
+import { resolveScriptRelativePath } from '../../shared/runtime/scriptRelativePath';
 import type { CompilerDiagnostic } from '../../shared/diagnostics/diagnostic';
 import { HINT_TEMPLATES } from '../../shared/diagnostics/registry';
 import { Shape } from './proxy';
@@ -470,8 +471,7 @@ export class CaptureSession {
     }
 
     // ── 2. Resolve and validate path existence ───────────────────────────────
-    const scriptDir = this.scriptDir ?? process.cwd();
-    const resolvedPath = resolvePath(scriptDir, args.path);
+    const resolvedPath = resolveScriptRelativePath(this.scriptDir, args.path);
     let fileExists = false;
     if (validExts.has(ext)) {
       // Only check existence when format is valid (avoid spurious second error).

--- a/src/modeling/parts/fromSTEP.ts
+++ b/src/modeling/parts/fromSTEP.ts
@@ -8,7 +8,7 @@
 
 import * as replicad from 'replicad';
 import { readFile } from 'node:fs/promises';
-import { isAbsolute, resolve } from 'node:path';
+import { resolveScriptRelativePath } from '../../shared/runtime/scriptRelativePath';
 import { OcctBackend, initOcct } from '../../kernel/backends/occt/occtBackend';
 import { Shape } from '../capture/proxy';
 import type { CaptureSession } from '../capture/captureSession';
@@ -32,11 +32,7 @@ export async function fromSTEP(ctx: FromSTEPContext, path: string): Promise<Shap
     );
   }
 
-  const absPath = isAbsolute(path)
-    ? path
-    : ctx.scriptDir
-      ? resolve(ctx.scriptDir, path)
-      : resolve(process.cwd(), path);
+  const absPath = resolveScriptRelativePath(ctx.scriptDir, path);
 
   let buf: Buffer;
   try {

--- a/src/shared/runtime/scriptRelativePath.ts
+++ b/src/shared/runtime/scriptRelativePath.ts
@@ -1,0 +1,16 @@
+import { isAbsolute, resolve } from 'node:path';
+
+/**
+ * Resolve a user-script-relative asset path (`lib.fromSTEP`,
+ * `referenceImage`, texture refs) identically in every consumer:
+ * absolute paths pass through; relative paths anchor at the script's
+ * directory; with no known script directory (inline code), fall back
+ * to process.cwd().
+ */
+export function resolveScriptRelativePath(
+  scriptDir: string | undefined,
+  path: string,
+): string {
+  if (isAbsolute(path)) return path;
+  return resolve(scriptDir ?? process.cwd(), path);
+}

--- a/src/studio/components/demoPlayer/DemoPlayerPage.tsx
+++ b/src/studio/components/demoPlayer/DemoPlayerPage.tsx
@@ -20,6 +20,7 @@ import { applyEnvironment } from '../../../shared/render/environment';
 import { buildMaterialFromPBR, DEFAULT_MESH_COLOR, disposeMaterialDeep } from './buildMaterialFromPBR';
 import { buildReferenceImagePlane } from './buildReferenceImagePlane';
 import { apiCall, rewritePath } from '../../api/apiBase';
+import { fitDistanceForBounds } from './cameraFit';
 import type { RenderView } from '../../../shared/render/views';
 export type { RenderView };
 
@@ -118,13 +119,16 @@ export interface DemoPlayerWindow {
   /** Snap camera to one of four standard engineering views and force a
    *  render. Used by `kernelcad render` for headless multi-view PNG
    *  capture. Caller should `forceFullOpacity()` first so faded-in meshes
-   *  appear at full visibility. */
-  setRenderView(view: RenderView): void;
+   *  appear at full visibility. `outputAspect` (optional) is the aspect of
+   *  the centered region cropped out of the canvas for the output tile —
+   *  the fit guarantees the geometry sits inside that region. */
+  setRenderView(view: RenderView, outputAspect?: number): void;
   /** Snap camera to an arbitrary az/el pose (degrees). az=0 looks down -Y
    *  (front view); az increases CCW around +Z (top-down); el increases looking
    *  up (positive el = camera above the horizon). Used by `kernelcad render
-   *  --pose <az,el>` for headless reference-photo-pose scoring. */
-  setRenderPose(azDeg: number, elDeg: number): void;
+   *  --pose <az,el>` for headless reference-photo-pose scoring.
+   *  `outputAspect` as in `setRenderView`. */
+  setRenderPose(azDeg: number, elDeg: number, outputAspect?: number): void;
   /** Set every loaded FeatureMesh material to opacity 1.0 and re-render.
    *  Used by `kernelcad render` to skip the build-animation fade-in. */
   forceFullOpacity(): void;
@@ -372,40 +376,45 @@ function fitCameraToBounds(
   camera: THREE.PerspectiveCamera,
   bounds: { min: [number, number, number]; max: [number, number, number] },
   view: RenderView | 'demo' = 'demo',
+  outputAspect?: number,
 ): void {
-  const dx = bounds.max[0] - bounds.min[0];
-  const dy = bounds.max[1] - bounds.min[1];
-  const dz = bounds.max[2] - bounds.min[2];
-  const cx = (bounds.min[0] + bounds.max[0]) / 2;
-  const cy = (bounds.min[1] + bounds.max[1]) / 2;
-  const cz = (bounds.min[2] + bounds.max[2]) / 2;
-  // Use the largest extent (not diagonal) so the model fills the viewport tightly.
-  const maxExtent = Math.max(dx, dy, dz);
-  const fov = camera.fov * (Math.PI / 180);
-  // Tighter framing for mobile-readable videos: the viewer is letterboxed next
-  // to the terminal, so the model should fill the 3D pane without clipping.
-  const distance = (maxExtent / 2 / Math.tan(fov / 2)) * 0.95;
-
-  // kernelCAD is Z-up. Each engineering view fixes camera position + up
-  // vector so the rendered tile matches first-angle drafting convention.
-  // 'demo' uses the same Z-up 3/4-front-right angle as the CLI's 'iso'
-  // view so plates lie horizontally as authored (not rotated 90° onto
-  // their side, which the legacy Y-up framing did).
-  let pos: [number, number, number];
+  const center: [number, number, number] = [
+    (bounds.min[0] + bounds.max[0]) / 2,
+    (bounds.min[1] + bounds.max[1]) / 2,
+    (bounds.min[2] + bounds.max[2]) / 2,
+  ];
+  // kernelCAD is Z-up. Each engineering view fixes the view direction +
+  // up vector so the rendered tile matches first-angle drafting
+  // convention. 'demo' shares the Z-up 3/4-front-right angle with 'iso'.
+  const isoLen = Math.hypot(0.7, 0.7, 0.5);
+  let camDir: [number, number, number];
   let up: [number, number, number] = [0, 0, 1];
   switch (view) {
-    case 'front': pos = [0, -distance, 0]; break;
-    case 'right': pos = [distance, 0, 0]; break;
-    case 'top':   pos = [0, 0, distance]; up = [0, 1, 0]; break;
-    case 'iso':   pos = [distance * 0.7, -distance * 0.7, distance * 0.5]; break;
+    case 'front': camDir = [0, -1, 0]; break;
+    case 'right': camDir = [1, 0, 0]; break;
+    case 'top':   camDir = [0, 0, 1]; up = [0, 1, 0]; break;
+    case 'iso':
     case 'demo':
     default:
-      pos = [distance * 0.7, -distance * 0.7, distance * 0.5];
+      camDir = [0.7 / isoLen, -0.7 / isoLen, 0.5 / isoLen];
       break;
   }
+  const distance = fitDistanceForBounds({
+    bounds,
+    target: center,
+    camDir,
+    worldUp: view === 'top' ? [0, 1, 0] : [0, 0, 1],
+    fovYDeg: camera.fov,
+    canvasAspect: camera.aspect,
+    outputAspect,
+  });
   camera.up.set(up[0], up[1], up[2]);
-  camera.position.set(cx + pos[0], cy + pos[1], cz + pos[2]);
-  camera.lookAt(cx, cy, cz);
+  camera.position.set(
+    center[0] + camDir[0] * distance,
+    center[1] + camDir[1] * distance,
+    center[2] + camDir[2] * distance,
+  );
+  camera.lookAt(center[0], center[1], center[2]);
   camera.near = Math.max(0.1, distance / 100);
   camera.far = distance * 20;
   camera.updateProjectionMatrix();
@@ -510,7 +519,7 @@ export function DemoPlayerPage(): React.JSX.Element {
         }
       },
       setVersion: (v) => setVersion(v),
-      setRenderView: (view) => {
+      setRenderView: (view, outputAspect) => {
         if (!sceneRef.current) throw new Error('demo-player: scene not ready');
         const ctx = sceneRef.current;
         // Reuse the bounds the loadFeatureMeshes path computed (mesh
@@ -527,10 +536,11 @@ export function DemoPlayerPage(): React.JSX.Element {
           ctx.camera,
           { min: [minV.x, minV.y, minV.z], max: [maxV.x, maxV.y, maxV.z] },
           view,
+          outputAspect,
         );
         ctx.renderer.render(ctx.scene, ctx.camera);
       },
-      setRenderPose: (azDeg, elDeg) => {
+      setRenderPose: (azDeg, elDeg, outputAspect) => {
         if (!sceneRef.current) throw new Error('demo-player: scene not ready');
         const ctx = sceneRef.current;
         const bbox = new THREE.Box3();
@@ -563,37 +573,20 @@ export function DemoPlayerPage(): React.JSX.Element {
               camTgt.target[2] - off[2],
             )
           : bbox.getCenter(new THREE.Vector3());
-        // Build the screen-aligned basis at the target.
-        const worldUp = new THREE.Vector3(0, 0, 1);
-        const right = new THREE.Vector3().crossVectors(worldUp, camDir).normalize();
-        const up = new THREE.Vector3().crossVectors(camDir, right).normalize();
-        // Project all 8 bbox corners RELATIVE TO THE TARGET onto the screen-
-        // plane axes. The max |right-component| / aspect and |up-component|
-        // set the required half-extents that must fit the FOV. Operate on
-        // raw min/max components so we don't allocate 8 Vector3s per call.
-        const aspect = ctx.camera.aspect;
-        const rx = right.x, ry = right.y, rz = right.z;
-        const ux = up.x, uy = up.y, uz = up.z;
-        const xs = [bbox.min.x - target.x, bbox.max.x - target.x];
-        const ys = [bbox.min.y - target.y, bbox.max.y - target.y];
-        const zs = [bbox.min.z - target.z, bbox.max.z - target.z];
-        let halfHoriz = 0;
-        let halfVert = 0;
-        for (const cx of xs) for (const cy of ys) for (const cz of zs) {
-          const h = Math.abs(cx * rx + cy * ry + cz * rz);
-          const u = Math.abs(cx * ux + cy * uy + cz * uz);
-          if (h > halfHoriz) halfHoriz = h;
-          if (u > halfVert) halfVert = u;
-        }
-        const fovY = ctx.camera.fov * (Math.PI / 180);
-        const tanHalfFovY = Math.tan(fovY / 2);
-        const tanHalfFovX = tanHalfFovY * aspect;
-        // distance needed so projected radius fits both axes (with 5% margin).
+        // Aspect- and corner-depth-aware perspective fit (5% margin).
         // setCameraDistance override (when present) skips the auto-fit and
         // pins the camera at the user-supplied distance from the target.
-        const distFromVert = halfVert / tanHalfFovY;
-        const distFromHoriz = halfHoriz / tanHalfFovX;
-        const autoDist = Math.max(distFromVert, distFromHoriz) * 1.05;
+        const autoDist = fitDistanceForBounds({
+          bounds: {
+            min: [bbox.min.x, bbox.min.y, bbox.min.z],
+            max: [bbox.max.x, bbox.max.y, bbox.max.z],
+          },
+          target: [target.x, target.y, target.z],
+          camDir: [camDir.x, camDir.y, camDir.z],
+          fovYDeg: ctx.camera.fov,
+          canvasAspect: ctx.camera.aspect,
+          outputAspect,
+        });
         const distance = camTgt?.distance ?? autoDist;
         const x = target.x + distance * camDir.x;
         const y = target.y + distance * camDir.y;

--- a/src/studio/components/demoPlayer/cameraFit.ts
+++ b/src/studio/components/demoPlayer/cameraFit.ts
@@ -1,0 +1,74 @@
+// Perspective-fit math shared by the demo player's engineering-view camera
+// (fitCameraToBounds / setRenderView) and arbitrary-pose camera
+// (setRenderPose). Computes the camera distance at which all eight bounds
+// corners fit inside the frustum with a margin — compensating per-corner
+// depth (near corners subtend a larger angle) and an output crop aspect
+// that differs from the canvas aspect.
+
+export interface FitBounds {
+  min: [number, number, number];
+  max: [number, number, number];
+}
+
+export interface FitDistanceInput {
+  bounds: FitBounds;
+  /** Camera look-at target (world). */
+  target: [number, number, number];
+  /** Unit vector from target TOWARD the camera. */
+  camDir: [number, number, number];
+  /** World up for the screen basis. Pass [0, 1, 0] when camDir ∥ ±Z
+   *  (top view); default [0, 0, 1] (kernelCAD is Z-up). */
+  worldUp?: [number, number, number];
+  fovYDeg: number;
+  /** camera.aspect of the render canvas. */
+  canvasAspect: number;
+  /** Aspect of the centered region cropped out of the canvas for the
+   *  output tile. Defaults to canvasAspect (no crop). */
+  outputAspect?: number;
+  /** Fill margin: 1.05 leaves ~5% air on the binding axis. */
+  margin?: number;
+}
+
+export function fitDistanceForBounds(input: FitDistanceInput): number {
+  const { bounds, target, camDir } = input;
+  const worldUp = input.worldUp ?? ([0, 0, 1] as [number, number, number]);
+  const margin = input.margin ?? 1.05;
+  const outputAspect = input.outputAspect ?? input.canvasAspect;
+
+  // Screen basis: right = worldUp × camDir, up = camDir × right.
+  const right = normalize(cross(worldUp, camDir));
+  const up = normalize(cross(camDir, right));
+
+  // Effective half-angles of the centered output-aspect crop region.
+  const tanHalfY = Math.tan((input.fovYDeg * Math.PI) / 360);
+  const tanYEff = tanHalfY * Math.min(1, input.canvasAspect / outputAspect);
+  const tanXEff = tanHalfY * Math.min(input.canvasAspect, outputAspect);
+
+  const xs = [bounds.min[0] - target[0], bounds.max[0] - target[0]];
+  const ys = [bounds.min[1] - target[1], bounds.max[1] - target[1]];
+  const zs = [bounds.min[2] - target[2], bounds.max[2] - target[2]];
+  let dist = 0;
+  for (const cx of xs) for (const cy of ys) for (const cz of zs) {
+    const h = Math.abs(cx * right[0] + cy * right[1] + cz * right[2]);
+    const u = Math.abs(cx * up[0] + cy * up[1] + cz * up[2]);
+    // Corner depth along the view axis, positive toward the camera — each
+    // corner must fit the frustum at its OWN depth, not the target's.
+    const dAlong = cx * camDir[0] + cy * camDir[1] + cz * camDir[2];
+    const required = Math.max(h / tanXEff, u / tanYEff) * margin + dAlong;
+    if (required > dist) dist = required;
+  }
+  return dist;
+}
+
+function cross(a: readonly number[], b: readonly number[]): [number, number, number] {
+  return [
+    a[1] * b[2] - a[2] * b[1],
+    a[2] * b[0] - a[0] * b[2],
+    a[0] * b[1] - a[1] * b[0],
+  ];
+}
+
+function normalize(v: [number, number, number]): [number, number, number] {
+  const len = Math.hypot(v[0], v[1], v[2]);
+  return len > 0 ? [v[0] / len, v[1] / len, v[2] / len] : [0, 0, 1];
+}

--- a/tests/integration/cli/exportFromStepRelative.test.ts
+++ b/tests/integration/cli/exportFromStepRelative.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initOcct } from '../../../src/kernel/backends/occt/occtBackend';
+import { runAndExport } from '../../../src/agent/script-runtime/export';
+import { exportScript } from '../../../src/agent/cli/commands/export';
+
+describe('CLI export resolves lib.fromSTEP relative to the script', () => {
+  let scriptPath: string;
+
+  beforeAll(async () => {
+    await initOcct();
+    const dir = await mkdtemp(join(tmpdir(), 'kcad-export-rel-'));
+    await mkdir(join(dir, 'parts'), { recursive: true });
+    const step = await runAndExport({
+      code: 'return box(1, 1, 1, true);',
+      fileName: 'cube.kcad.ts',
+      format: 'step',
+    });
+    expect(step.diagnostics.filter(d => d.severity === 'error')).toEqual([]);
+    await writeFile(join(dir, 'parts', 'cube-1mm.step'), step.bytes);
+    scriptPath = join(dir, 'model.kcad.ts');
+    await writeFile(scriptPath, "return await lib.fromSTEP('parts/cube-1mm.step');\n");
+  }, 120_000);
+
+  it('exports STL while cwd is the repo root, not the script dir', async () => {
+    const out = scriptPath.replace(/\.kcad\.ts$/, '.stl');
+    const r = await exportScript({ file: scriptPath, format: 'stl', out });
+    expect(r.diagnostics.filter(d => d.severity === 'error')).toEqual([]);
+    expect(r.exitCode).toBe(0);
+    expect(r.bytesWritten).toBeGreaterThan(0);
+  }, 120_000);
+});

--- a/tests/integration/mcp/getShapeInfoRootShape.test.ts
+++ b/tests/integration/mcp/getShapeInfoRootShape.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { getShapeInfoTool } from '../../../src/agent/mcp/tools/getShapeInfo';
+
+describe('get_shape_info defaults to the returned shape', () => {
+  it('measures the returned shape when a decoy is created after it', async () => {
+    const r = await getShapeInfoTool({
+      code: `
+        const main = box(10, 10, 10, true);
+        const decoy = box(1, 1, 1, true).translate(100, 100, 100);
+        return main;
+      `,
+    });
+    expect(r.ok).toBe(true);
+    expect(r.shape!.bbox.max[0]).toBeCloseTo(5, 3);
+    expect(r.shape!.volume).toBeCloseTo(1000, 0);
+  });
+});

--- a/tests/render_framing.spec.ts
+++ b/tests/render_framing.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+import sharp from 'sharp';
+import { normalizeInspectionTileForTest } from './../src/agent/render/headlessRender';
+
+test.use({ viewport: { width: 1920, height: 1080 } });
+
+/** 12-triangle cuboid FeatureMesh face, centered at origin. */
+function boxFace(w: number, d: number, h: number) {
+  const x = w / 2, y = d / 2, z = h / 2;
+  const c = [
+    [-x, -y, -z], [x, -y, -z], [x, y, -z], [-x, y, -z],
+    [-x, -y, z], [x, -y, z], [x, y, z], [-x, y, z],
+  ];
+  const quads: [number, number, number, number, number[]][] = [
+    [0, 1, 5, 4, [0, -1, 0]], [2, 3, 7, 6, [0, 1, 0]], [1, 2, 6, 5, [1, 0, 0]],
+    [3, 0, 4, 7, [-1, 0, 0]], [4, 5, 6, 7, [0, 0, 1]], [3, 2, 1, 0, [0, 0, -1]],
+  ];
+  const vertices: number[] = [], normals: number[] = [], indices: number[] = [];
+  for (const [a, b, cc, dd, n] of quads) {
+    const base = vertices.length / 3;
+    for (const ci of [a, b, cc, dd]) { vertices.push(...c[ci]); normals.push(...n); }
+    indices.push(base, base + 1, base + 2, base, base + 2, base + 3);
+  }
+  return { vertices, indices, normals, faceId: 0 };
+}
+
+async function maskBBox(png: Buffer) {
+  const { data, info } = await sharp(png).raw().toBuffer({ resolveWithObject: true });
+  let minX = Infinity, minY = Infinity, maxX = -1, maxY = -1;
+  for (let y = 0; y < info.height; y++) for (let x = 0; x < info.width; x++) {
+    const i = (y * info.width + x) * info.channels;
+    if (data[i] !== 0 || data[i + 1] !== 0 || data[i + 2] !== 0) {
+      if (x < minX) minX = x; if (x > maxX) maxX = x;
+      if (y < minY) minY = y; if (y > maxY) maxY = y;
+    }
+  }
+  return { minX, minY, maxX, maxY, width: info.width, height: info.height };
+}
+
+async function loadTallBox(page: import('@playwright/test').Page) {
+  await page.goto('/demo-player?headless=1');
+  await page.waitForFunction(() => window.__demoPlayer !== undefined, { timeout: 15000 });
+  await page.evaluate(({ face }) => {
+    window.__demoPlayer!.loadFeatureMeshes(
+      [{ featureId: 'box_1', featureKind: 'box', predecessors: [], faces: [face] }],
+      { min: [-15, -5, -50], max: [15, 5, 50] },
+    );
+    window.__demoPlayer!.forceFullOpacity();
+    window.__demoPlayer!.showOnlyTailFeatures();
+  }, { face: boxFace(30, 10, 100) });
+}
+
+test('square inspect tile: mask clears the frame and fills ≥70% of the long axis', async ({ page }) => {
+  await loadTallBox(page);
+  await page.evaluate(() => window.__demoPlayer!.setRenderView('front', 1));
+  const cap = await page.evaluate(() => window.__demoPlayer!.captureMaskPng());
+  const raw = Buffer.from(cap.pngDataUrl.replace(/^data:image\/png;base64,/, ''), 'base64');
+  const tile = await normalizeInspectionTileForTest(raw, {
+    viewportWidth: 1024, viewportHeight: 1024, channel: 'mask',
+  });
+  const bb = await maskBBox(tile);
+  expect(bb.minX).toBeGreaterThan(0);
+  expect(bb.minY).toBeGreaterThan(0);
+  expect(bb.maxX).toBeLessThan(bb.width - 1);
+  expect(bb.maxY).toBeLessThan(bb.height - 1);
+  const longAxis = Math.max(bb.maxX - bb.minX + 1, bb.maxY - bb.minY + 1);
+  expect(longAxis).toBeGreaterThanOrEqual(0.70 * Math.max(bb.width, bb.height));
+});
+
+test('native-aspect view: mask does not clip at the frame edge', async ({ page }) => {
+  await loadTallBox(page);
+  await page.evaluate(() => window.__demoPlayer!.setRenderView('front'));
+  const cap = await page.evaluate(() => window.__demoPlayer!.captureMaskPng());
+  const raw = Buffer.from(cap.pngDataUrl.replace(/^data:image\/png;base64,/, ''), 'base64');
+  const bb = await maskBBox(raw);
+  expect(bb.minX).toBeGreaterThan(0);
+  expect(bb.minY).toBeGreaterThan(0);
+  expect(bb.maxX).toBeLessThan(bb.width - 1);
+  expect(bb.maxY).toBeLessThan(bb.height - 1);
+});

--- a/tests/unit/backends/occt/boundingBoxExact.test.ts
+++ b/tests/unit/backends/occt/boundingBoxExact.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { buildModel } from '../../../../src/modeling/buildModel';
+
+describe('boundingBox({ exact: true })', () => {
+  it('tessellation box is tight where Bnd_Box pads (filleted cylinder)', async () => {
+    const model = await buildModel({
+      code: 'return cylinder(30, 10).fillet(3);',
+      fileName: 'bbox-exact.kcad.ts',
+    });
+    expect(model.diagnostics.filter(d => d.severity === 'error')).toEqual([]);
+    const shape = model.rootShape!;
+
+    const padded = shape.boundingBox();
+    const exact = shape.boundingBox({ exact: true });
+
+    // Default Bnd_Box pads the post-fillet B-spline face (~10.82 for r=10).
+    expect(padded.max[0]).toBeGreaterThan(10.5);
+    // Exact box is tight to the true radius within mesh deflection.
+    expect(exact.max[0]).toBeLessThanOrEqual(10 + 1e-6);
+    expect(exact.max[0]).toBeGreaterThan(9.9);
+    expect(exact.min[2]).toBeCloseTo(0, 3);
+    expect(exact.max[2]).toBeCloseTo(30, 3);
+    // Exact ⊆ default on every axis.
+    for (let a = 0; a < 3; a++) {
+      expect(exact.min[a]).toBeGreaterThanOrEqual(padded.min[a] - 1e-6);
+      expect(exact.max[a]).toBeLessThanOrEqual(padded.max[a] + 1e-6);
+    }
+  });
+
+  it('default and exact agree on planar shapes', async () => {
+    const model = await buildModel({ code: 'return box(10, 20, 30);', fileName: 'bbox-box.kcad.ts' });
+    const shape = model.rootShape!;
+    const padded = shape.boundingBox();
+    const exact = shape.boundingBox({ exact: true });
+    for (let a = 0; a < 3; a++) {
+      expect(exact.min[a]).toBeCloseTo(padded.min[a], 4);
+      expect(exact.max[a]).toBeCloseTo(padded.max[a], 4);
+    }
+  });
+});

--- a/tests/unit/cli/renderBaseUrlDefault.test.ts
+++ b/tests/unit/cli/renderBaseUrlDefault.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { renderCommand } from '../../../src/agent/cli/commands/render';
+import { DEFAULT_RENDER_BASE_URL } from '../../../src/agent/render/headlessRender';
+
+describe('render base-url single source of truth', () => {
+  it('render and render inspect both default --base-url to the shared constant', () => {
+    const cmd = renderCommand();
+    const baseOpt = cmd.options.find(o => o.long === '--base-url');
+    expect(baseOpt?.defaultValue).toBe(DEFAULT_RENDER_BASE_URL);
+    const inspect = cmd.commands.find(c => c.name() === 'inspect');
+    const inspectOpt = inspect?.options.find(o => o.long === '--base-url');
+    expect(inspectOpt?.defaultValue).toBe(DEFAULT_RENDER_BASE_URL);
+  });
+
+  it('no port literal outside the constant definition', () => {
+    const renderSrc = readFileSync('src/agent/cli/commands/render.ts', 'utf8');
+    expect(renderSrc.includes('5173')).toBe(false);
+    const headlessSrc = readFileSync('src/agent/render/headlessRender.ts', 'utf8');
+    expect(headlessSrc.match(/5173/g) ?? []).toHaveLength(1); // DEFAULT_RENDER_BASE_URL only
+  });
+});

--- a/tests/unit/cli/renderCommand.test.ts
+++ b/tests/unit/cli/renderCommand.test.ts
@@ -13,7 +13,12 @@ vi.mock('../../../src/agent/render/headlessRender', () => {
   const ALL_VIEWS = ['front', 'right', 'top', 'iso'] as const;
   const mockHeadlessRender = vi.fn();
   const composite2x2 = vi.fn().mockResolvedValue(Buffer.alloc(0));
-  return { headlessRender: mockHeadlessRender, composite2x2, ALL_VIEWS };
+  return {
+    headlessRender: mockHeadlessRender,
+    composite2x2,
+    ALL_VIEWS,
+    DEFAULT_RENDER_BASE_URL: 'http://localhost:5173',
+  };
 });
 
 // Import after mock registration.

--- a/tests/unit/modeling/buildModelRootShape.test.ts
+++ b/tests/unit/modeling/buildModelRootShape.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { buildModel } from '../../../src/modeling/buildModel';
+
+describe('buildModel root shape (script return value)', () => {
+  it('rootShape follows the returned shape, not the last-created record', async () => {
+    const model = await buildModel({
+      code: `
+        const main = box(10, 10, 10, true);
+        const decoy = box(1, 1, 1, true).translate(100, 100, 100);
+        return main;
+      `,
+      fileName: 'root-shape.kcad.ts',
+    });
+    expect(model.diagnostics.filter(d => d.severity === 'error')).toEqual([]);
+    expect(model.rootId).toBeDefined();
+    expect(model.rootId).not.toBe(model.tailId);
+    const bb = model.rootShape!.boundingBox();
+    expect(bb.min[0]).toBeCloseTo(-5, 3);
+    expect(bb.max[0]).toBeCloseTo(5, 3);
+    // The trap this fix closes: the tail is the decoy.
+    const tailBb = model.tailShape!.boundingBox();
+    expect(tailBb.max[0]).toBeGreaterThan(50);
+  });
+
+  it('falls back to the tail when the script returns nothing lowerable', async () => {
+    const model = await buildModel({ code: 'box(2, 2, 2, true);', fileName: 'no-return.kcad.ts' });
+    expect(model.rootId).toBe(model.tailId);
+    expect(model.rootShape).toBe(model.tailShape);
+  });
+
+  it('resolves a returned Scene to its solvedAssembly record', async () => {
+    const model = await buildModel({
+      code: `
+        const asm = assembly('a');
+        const p = asm.part('body', box(10, 10, 10, true));
+        p.connector('mount', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 0] } });
+        const scene = asm.solvedModel({});
+        const decoy = box(1, 1, 1, true).translate(200, 200, 200);
+        return scene;
+      `,
+      fileName: 'scene-root.kcad.ts',
+    });
+    expect(model.diagnostics.filter(d => d.severity === 'error')).toEqual([]);
+    expect(model.rootId).not.toBe(model.tailId);   // tail is the decoy
+    expect(model.rootShape).toBeDefined();
+  });
+});

--- a/tests/unit/render/headlessRenderInspectionNormalize.test.ts
+++ b/tests/unit/render/headlessRenderInspectionNormalize.test.ts
@@ -3,7 +3,7 @@ import sharp from 'sharp';
 import { normalizeInspectionTileForTest } from '../../../src/agent/render/headlessRender';
 
 describe('headlessRender inspection channel normalization', () => {
-  it('resizes object-id masks with nearest sampling and black background sentinel', async () => {
+  it('center-crops object-id masks to the output aspect with nearest sampling', async () => {
     const source = await sharp({
       create: {
         width: 2,
@@ -28,14 +28,17 @@ describe('headlessRender inspection channel normalization', () => {
 
     expect(info.width).toBe(4);
     expect(info.height).toBe(4);
+    // The 2×1 source center-crops to the 1×1 region at floor((2-1)/2) = 0
+    // (the LEFT pixel) and nearest-resizes — no background sentinel is
+    // injected because padding no longer exists.
     const colors = new Set<string>();
     for (let i = 0; i < data.length; i += info.channels) {
       colors.add(`${data[i]},${data[i + 1]},${data[i + 2]},${data[i + 3]}`);
     }
-    expect(colors).toEqual(new Set(['0,0,0,255', '0,0,1,255', '0,0,2,255']));
+    expect(colors).toEqual(new Set(['0,0,1,255']));
   });
 
-  it('resizes packed depth with nearest sampling and transparent background sentinel', async () => {
+  it('center-crops packed depth to the output aspect with nearest sampling', async () => {
     const source = await sharp({
       create: {
         width: 2,
@@ -58,10 +61,12 @@ describe('headlessRender inspection channel normalization', () => {
     });
     const { data, info } = await sharp(normalized).raw().toBuffer({ resolveWithObject: true });
 
+    expect(info.width).toBe(4);
+    expect(info.height).toBe(4);
     const colors = new Set<string>();
     for (let i = 0; i < data.length; i += info.channels) {
       colors.add(`${data[i]},${data[i + 1]},${data[i + 2]},${data[i + 3]}`);
     }
-    expect(colors).toEqual(new Set(['0,0,0,0', '10,20,30,255', '40,50,60,255']));
+    expect(colors).toEqual(new Set(['10,20,30,255']));
   });
 });

--- a/tests/unit/studio/cameraFit.test.ts
+++ b/tests/unit/studio/cameraFit.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { fitDistanceForBounds } from '../../../src/studio/components/demoPlayer/cameraFit';
+
+describe('fitDistanceForBounds', () => {
+  // Tall 30×10×100 box centered at origin, front view (camera toward -Y),
+  // fovY 45°, 16:9 canvas, square output crop.
+  const bounds = { min: [-15, -5, -50] as [number, number, number], max: [15, 5, 50] as [number, number, number] };
+
+  it('vertical-bound fit with depth compensation and 1.05 margin', () => {
+    const d = fitDistanceForBounds({
+      bounds, target: [0, 0, 0], camDir: [0, -1, 0],
+      fovYDeg: 45, canvasAspect: 16 / 9, outputAspect: 1,
+    });
+    // tanYEff = tan(22.5°) = 0.41421; binding corner u=50 at depth +5
+    // → 50 / 0.41421 * 1.05 + 5 = 131.75
+    expect(d).toBeCloseTo(131.75, 1);
+  });
+
+  it('wider output than canvas shrinks the vertical budget', () => {
+    const d = fitDistanceForBounds({
+      bounds, target: [0, 0, 0], camDir: [0, -1, 0],
+      fovYDeg: 45, canvasAspect: 16 / 9, outputAspect: 2,
+    });
+    // tanYEff = 0.41421 * (16/9)/2 = 0.36819 → 50/0.36819*1.05 + 5 = 147.6
+    expect(d).toBeCloseTo(147.6, 1);
+  });
+});


### PR DESCRIPTION
Five independent commits closing the W1 paper cuts:

1. **Returned shape honored** — `buildModel` exposes the script's return value as `rootShape`/`rootId`; `get_shape_info`, the MCP active session, and `review_cad` measure the returned shape instead of the last-created record. `tailShape` stays, with a JSDoc warning naming the trap.
2. **Exact bbox** — `boundingBox({ exact: true })` folds the tessellation vertex AABB (filleted ⌀20 cylinder: ±10.0 vs Bnd_Box ±10.82). Default stays Bnd_Box, documented as padded on curved faces.
3. **Render framing** — one perspective-fit (aspect- and corner-depth-aware, 5% margin) shared by engineering views and poses; tiles center-crop to the requested aspect instead of letterboxing. Rendered-mask test asserts no frame-edge contact and ≥70% long-axis fill.
4. **Base-url** — one exported `DEFAULT_RENDER_BASE_URL` feeds both `--base-url` option defaults and the headless renderer fallback; a guard test bans any other port literal.
5. **Path resolver** — `resolveScriptRelativePath` shared by `lib.fromSTEP`, `referenceImage`, and both export entry points (CLI + MCP), which previously resolved against cwd.