### PR TITLE
fix(emboss): un-mirror glyphs (UV-handedness probe) + engrave into the body + no-op guard

### DIFF
--- a/src/modeling/backends/occt/embossTextLowerer.test.ts
+++ b/src/modeling/backends/occt/embossTextLowerer.test.ts
@@ -166,3 +166,135 @@ describe('lowerEmbossText — created face-ref propagation', () => {
     expect(resolve.ok).toBe(true);
   });
 });
+
+// #392 / #393 regression coverage — these tests assert GEOMETRY, not labels:
+// the earlier suite passed while cuts no-op'ed and glyphs mirrored because it
+// only checked bbox growth and historyMap label presence.
+describe('lowerEmbossText — geometry correctness (#392/#393)', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  function fRecord(
+    depth: number,
+    opts: { rotation?: number; anchorU?: number; anchorV?: number } = {},
+  ): FeatureRecord {
+    return {
+      id: 'emboss-geom-1',
+      kind: 'embossText',
+      params: {},
+      inputs: {
+        parent: { kind: 'feature', id: 'parent-0' },
+        face: {
+          kind: 'face',
+          featureId: 'parent-0',
+          ref: { kind: 'canonical', face: 'top' },
+        },
+      },
+      transforms: [],
+      suppressed: false,
+      metadata: {
+        // 'F' is asymmetric: the stem fills the LEFT half (reading from
+        // outside), the right half only carries the two arms.
+        textContent: 'F',
+        size: { expression: '6', unit: 'mm', evaluated: 6 },
+        depth: { expression: String(depth), unit: 'mm', evaluated: depth },
+        align: 'center',
+        anchorU: { expression: String(opts.anchorU ?? 0.5), unit: 'unitless', evaluated: opts.anchorU ?? 0.5 },
+        anchorV: { expression: String(opts.anchorV ?? 0.5), unit: 'unitless', evaluated: opts.anchorV ?? 0.5 },
+        rotation: { expression: String(opts.rotation ?? 0), unit: 'deg', evaluated: opts.rotation ?? 0 },
+        scaleMode: 'original',
+        faceRef: { kind: 'canonical', face: 'top' },
+      },
+    };
+  }
+
+  /** Volume of `backend ∩ axis-aligned box` spanning [x0,x1]×[y0,y1]×[z0,z1].
+   *  `OcctBackend.box` is corner-based (spans 0..w / 0..h / 0..d), so the
+   *  slab is positioned by translating its min corner to (x0, y0, z0). */
+  function regionVolume(
+    backend: OcctBackend,
+    x0: number, x1: number, y0: number, y1: number, z0: number, z1: number,
+  ): number {
+    const slab = OcctBackend.box(x1 - x0, y1 - y0, z1 - z0).translate([x0, y0, z0]);
+    return backend.intersect(slab).volume();
+  }
+
+  it('cut removes material on a box top (volume strictly decreases)', async () => {
+    const parent = OcctBackend.box(40, 20, 4);
+    const res = await lowerEmbossText(fRecord(-1), parent, undefined, undefined);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.backend.volume()).toBeLessThan(parent.volume() - 0.5);
+    // and the cavity is BELOW the entry face, not above
+    expect(res.backend.boundingBox().max[2]).toBeCloseTo(4, 5);
+  });
+
+  it('cut removes material on a cylinder end-cap (#393)', async () => {
+    const parent = OcctBackend.cylinder(4, 20);
+    const res = await lowerEmbossText(fRecord(-1), parent, undefined, undefined);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.backend.volume()).toBeLessThan(parent.volume() - 0.5);
+    expect(res.backend.boundingBox().max[2]).toBeCloseTo(4, 5);
+  });
+
+  it('emboss adds material on a cylinder end-cap', async () => {
+    const parent = OcctBackend.cylinder(4, 20);
+    const res = await lowerEmbossText(fRecord(1), parent, undefined, undefined);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.backend.volume()).toBeGreaterThan(parent.volume() + 0.5);
+    expect(res.backend.boundingBox().max[2]).toBeCloseTo(5, 5);
+  });
+
+  it("glyphs read correctly from outside on a box top (#392): 'F' stem lands in the left half", async () => {
+    const parent = OcctBackend.box(40, 20, 4);
+    const res = await lowerEmbossText(fRecord(1), parent, undefined, undefined);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    // Material ABOVE the entry plane (z 4..5), split at the glyph
+    // centerline. OcctBackend.box is corner-based, so the face centre (and
+    // glyph anchor) sits at (20, 10).
+    const left = regionVolume(res.backend, 10, 20, 0, 20, 4.001, 5.2);
+    const right = regionVolume(res.backend, 20, 30, 0, 20, 4.001, 5.2);
+    expect(left).toBeGreaterThan(0.5);
+    // Correct reading: stem (full-height bar) in the left half outweighs the
+    // arms-only right half. Mirrored output inverts this inequality.
+    expect(left).toBeGreaterThan(right * 1.3);
+  });
+
+  it("glyphs read correctly from outside on a cylinder end-cap (#392)", async () => {
+    const parent = OcctBackend.cylinder(4, 20);
+    const res = await lowerEmbossText(fRecord(1), parent, undefined, undefined);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const left = regionVolume(res.backend, -10, 0, -10, 10, 4.001, 5.2);
+    const right = regionVolume(res.backend, 0, 10, -10, 10, 4.001, 5.2);
+    expect(left).toBeGreaterThan(0.5);
+    expect(left).toBeGreaterThan(right * 1.3);
+  });
+
+  it('rotation is CCW as seen from outside: +90° turns the F stem toward -y', async () => {
+    const parent = OcctBackend.box(40, 20, 4);
+    const res = await lowerEmbossText(fRecord(1, { rotation: 90 }), parent, undefined, undefined);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    // (x, y) → (-y, x) under +90 CCW viewed from +z: the stem (was left,
+    // x<0) lands in the y<0 half. A wrong rotation sign puts it at y>0.
+    // Corner-based box: glyph anchor at (20, 10); the y-halves split there.
+    const yNeg = regionVolume(res.backend, 10, 30, 0, 10, 4.001, 5.2);
+    const yPos = regionVolume(res.backend, 10, 30, 10, 20, 4.001, 5.2);
+    expect(yNeg).toBeGreaterThan(yPos * 1.3);
+  });
+
+  it('emits feature.emboss-text.boolean-noop when the cut changes nothing (glyph over a hole)', async () => {
+    // Anchor far past the face bounds (capture-side validation is bypassed
+    // by hand-crafting the record): the engrave prism descends through air
+    // beside the cylinder, so the cut removes nothing — the exact silent
+    // failure #393 shipped with.
+    const parent = OcctBackend.cylinder(4, 20);
+    const res = await lowerEmbossText(fRecord(-0.5, { anchorU: 1.4 }), parent, undefined, undefined);
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.diagnostics.some((d) => d.code === 'feature.emboss-text.boolean-noop')).toBe(true);
+  });
+});

--- a/src/modeling/backends/occt/embossTextLowerer.ts
+++ b/src/modeling/backends/occt/embossTextLowerer.ts
@@ -106,6 +106,19 @@ export async function lowerEmbossText(
     return { ok: false, diagnostics };
   }
 
+  // 4-pre. Handedness correction (#392). `sketchOnFace` maps the drawing
+  // through the surface parameterisation S(u, v) verbatim. When the face's
+  // (∂S/∂u × ∂S/∂v) frame is LEFT-handed relative to the oriented outward
+  // normal (e.g. the top face of an OCCT box — while a cylinder end-cap is
+  // right-handed), the mapped glyphs appear mirror-imaged to a viewer
+  // outside the body. Detect the handedness at the face and pre-mirror the
+  // drawing (and negate the rotation sense) so text always reads correctly
+  // from OUTSIDE.
+  const leftHanded = faceUvIsLeftHanded(face);
+  if (leftHanded) {
+    drawing = drawing.mirror([0, 1], [0, 0], 'plane'); // x → -x about the origin
+  }
+
   // 4a. Alignment translate (so the chosen anchor lands on (0, 0)).
   const bb = drawing.boundingBox;
   const [minPt, maxPt] = bb.bounds;
@@ -117,9 +130,11 @@ export async function lowerEmbossText(
     drawing = drawing.translate(-(minPt[0] + maxPt[0]) / 2, -(minPt[1] + maxPt[1]) / 2);
   }
 
-  // 4b. Rotation around origin (now == chosen anchor).
+  // 4b. Rotation around origin (now == chosen anchor). The spec sense is
+  // CCW as seen from outside the body; under a mirrored UV frame the same
+  // visual sense requires the opposite parametric sign.
   if (meta.rotation.evaluated !== 0) {
-    drawing = drawing.rotate(meta.rotation.evaluated, [0, 0]);
+    drawing = drawing.rotate(leftHanded ? -meta.rotation.evaluated : meta.rotation.evaluated, [0, 0]);
   }
 
   // 5. UV anchor translate. Read UV bounds off the resolved face and offset
@@ -148,9 +163,17 @@ export async function lowerEmbossText(
     if (typeof (lifted as { extrude?: unknown }).extrude !== 'function') {
       throw new Error('sketchOnFace returned a non-extrudable sketch (multi-face glyph?)');
     }
+    // The sketch's default extrusion direction is the face's ORIENTED
+    // (outward) normal. Emboss raises the prism outward; engrave (#393)
+    // must descend INTO the body — a positive-distance extrusion would
+    // place the cut tool in the air above the face and the boolean would
+    // silently change nothing.
+    const signedDepth = meta.depth.evaluated > 0
+      ? Math.abs(meta.depth.evaluated)
+      : -Math.abs(meta.depth.evaluated);
     const extruded = (lifted as unknown as {
       extrude: (d: number) => replicad.Shape3D;
-    }).extrude(Math.abs(meta.depth.evaluated));
+    }).extrude(signedDepth);
     solid = extruded;
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -214,6 +237,24 @@ export async function lowerEmbossText(
     return { ok: false, diagnostics };
   }
 
+  // No-op guard: a boolean that leaves the volume unchanged means the glyph
+  // tool never touched the body (e.g. an engrave descending into a void, or
+  // a glyph anchored off the solid). Silently returning the unchanged parent
+  // is the worst failure mode for an agent caller — fail loudly instead.
+  const volBefore = parent.volume();
+  const volAfter = resultIntermediate.volume();
+  if (Math.abs(volAfter - volBefore) < Math.max(1e-6, volBefore * 1e-9)) {
+    diagnostics.push({
+      target: 'export-occt',
+      code: 'feature.emboss-text.boolean-noop',
+      featureId: r.id,
+      severity: 'error',
+      message: `embossText ${fuse ? 'emboss' : 'engrave'} changed nothing: result volume equals the parent volume (${volBefore.toFixed(3)} mm³). The glyph tool did not intersect the body.`,
+      hint: HINT_TEMPLATES['feature.emboss-text.boolean-noop'].template,
+    });
+    return { ok: false, diagnostics };
+  }
+
   // Merge parent + tool histories with the boolean's evolution callbacks.
   // The parent's `historyMap` is undefined for primitives constructed via
   // `OcctBackend.box(...)` directly (e.g. in tests). The lowerer pipeline
@@ -250,6 +291,40 @@ export async function lowerEmbossText(
   refreshSnapshots(merged, resultIntermediate.getReplicadShape().faces);
 
   return { ok: true, backend: new OcctBackend(wrappedResult, undefined, merged) };
+}
+
+// ---------------------------------------------------------------------------
+// Face UV handedness
+// ---------------------------------------------------------------------------
+
+/**
+ * True when the face's (∂S/∂u × ∂S/∂v) frame points AGAINST the oriented
+ * outward normal — i.e. the UV→world map is left-handed as seen from outside
+ * the body, so a drawing mapped through it appears mirror-imaged. Probed by
+ * finite differences of `pointOnSurface` (normalized UV) near the face
+ * centre. Defensive default: `false` (no mirror) when the probe degenerates.
+ */
+function faceUvIsLeftHanded(face: Face): boolean {
+  try {
+    const e = 1e-3;
+    const u0 = 0.5, v0 = 0.5;
+    const p0 = face.pointOnSurface(u0, v0);
+    const pu = face.pointOnSurface(u0 + e, v0);
+    const pv = face.pointOnSurface(u0, v0 + e);
+    const du: Vec3 = [pu.x - p0.x, pu.y - p0.y, pu.z - p0.z];
+    const dv: Vec3 = [pv.x - p0.x, pv.y - p0.y, pv.z - p0.z];
+    const crossUv: Vec3 = [
+      du[1] * dv[2] - du[2] * dv[1],
+      du[2] * dv[0] - du[0] * dv[2],
+      du[0] * dv[1] - du[1] * dv[0],
+    ];
+    const lenCross = Math.hypot(crossUv[0], crossUv[1], crossUv[2]);
+    if (lenCross < 1e-18) return false;
+    const n = faceNormalOf(face);
+    return dot(crossUv, n) < 0;
+  } catch {
+    return false;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/shared/diagnostics/registry.ts
+++ b/src/shared/diagnostics/registry.ts
@@ -114,6 +114,14 @@ export const DIAGNOSTIC_REGISTRY = {
     group: 'feature',
     description: 'embossText was called with depth === 0; no fuse or cut would change the geometry.',
   },
+  'feature.emboss-text.boolean-noop': {
+    hintTemplate:
+      'The emboss/engrave boolean left the body unchanged — the glyph tool never intersected it. Check the anchor places the text over solid material (not over a hole or off the face) and that the depth sign matches the intent (positive = emboss out, negative = engrave in).',
+    nextAction: { kind: 'fix-arg', field: 'anchorU' },
+    defaultSeverity: 'error',
+    group: 'feature',
+    description: 'embossText boolean produced a result whose volume equals the parent volume; the feature had no effect.',
+  },
   'feature.project-curve.no-intersection': {
     hintTemplate:
       'projectCurve could not intersect the source curve with the target face. For closed-curve mode, ensure the curve overlaps the face bounds. asEdge:true is currently deferred — use closed-curve projection or pre-tessellate the open wire into a closed sketch.',

--- a/tests/unit/diagnostics/codes.test.ts
+++ b/tests/unit/diagnostics/codes.test.ts
@@ -2,11 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { DIAGNOSTIC_CODES, HINT_TEMPLATES } from '../../../src/shared/diagnostics/registry';
 
 describe('diagnostic catalogue invariants', () => {
-  it('emits exactly 210 codes', () => {
+  it('emits exactly 211 codes', () => {
     // 204 from develop (NURBS analytics, Query DSL, K1-K9 kinematic, assembly/mechanism gates)
-    // + 6 parts catalog codes (parts.* — Slice C bundled parts catalog).
-    expect(DIAGNOSTIC_CODES).toHaveLength(210);
-    expect(new Set(DIAGNOSTIC_CODES).size).toBe(210);
+    // + 6 parts catalog codes (parts.* — Slice C bundled parts catalog)
+    // + 1 feature.emboss-text.boolean-noop (#393 silent no-op guard).
+    expect(DIAGNOSTIC_CODES).toHaveLength(211);
+    expect(new Set(DIAGNOSTIC_CODES).size).toBe(211);
   });
 
   it('every code has a non-empty hint template', () => {

--- a/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
+++ b/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
@@ -66,7 +66,7 @@ function emittedCodes(): Set<string> {
 describe('every diagnostic code emitted in src/ is in the catalogue', () => {
   const catalogue = new Set<string>(DIAGNOSTIC_CODES);
 
-  it('catalogue has exactly 210 codes', () => {
+  it('catalogue has exactly 211 codes', () => {
     // 47 baseline (milestone-C diagnostic-vocab spec)
     //  + 23 NURBS Slice B/C/D (Curve3D / variableSweep / surface / G2 / 2D path NURBS)
     //  + 31 Assembly fold (validator / pose-envelope / mechanical-plausibility / transmission / visual / connector)
@@ -127,7 +127,8 @@ describe('every diagnostic code emitted in src/ is in the catalogue', () => {
     //  + 1 P11 Slice 2 tendon-routing gate: mechanism.tendon-body-intersect.
     // Develop baseline = 157 - 3 + 11 + 1 + 5 + 2 + 2 + 7 + 1 + 1 + 1 + 9 + 1 + 1 + 4 + 2 + 1 + 1 = 204.
     //  +  6 Slice C parts.* codes (itemised above) = 210.
-    expect(catalogue.size).toBe(210);
+    //  +  1 feature.emboss-text.boolean-noop (#393 silent no-op guard) = 211.
+    expect(catalogue.size).toBe(211);
   });
 
   it('no emit site uses a code outside the catalogue', () => {


### PR DESCRIPTION
Closes #392, closes #393.

## Mirrored glyphs (#392)
`sketchOnFace` maps the drawing through the surface parameterisation verbatim. On faces whose `(∂S/∂u × ∂S/∂v)` frame is left-handed relative to the oriented outward normal — an OCCT box top is; a cylinder end-cap is not — glyphs appeared mirror-imaged from outside. The lowerer now probes handedness at the face (finite differences of `pointOnSurface` vs `normalAt`) and pre-mirrors the drawing, negating the rotation sense, so text always reads correctly from outside the body.

## Engrave no-op (#393 — broader than reported)
`extrude(|depth|)` always ran along the oriented outward normal, so engrave cuts subtracted a prism of **air above the face** and silently changed nothing — on every face kind, not just cylinder end-caps. The issue's cylinder-emboss case worked; all cuts were broken. Cuts now extrude into the body.

## No-op guard
A fuse/cut whose result volume equals the parent volume now fails with `feature.emboss-text.boolean-noop` (new catalogued code, 210 → 211) instead of silently returning the unchanged parent — the gates-green/render-broken trap that let both bugs ship.

## Why the old tests never caught this
They asserted bbox growth and historyMap label presence; the no-op cut still reshuffles face hashes enough to produce "new" labeled faces, so the engrave-label tests passed vacuously. The new tests assert geometry: cut volume strictly decreases on box + cylinder end-caps, an asymmetric `F` lands its stem in the correct half on both face kinds, +90° rotation turns CCW as seen from outside, and an off-face anchor surfaces the no-op diagnostic.

Verified: 63 tests across lowerer/diagnostics suites pass; `tsc --noEmit` + eslint clean; rendered `F2` emboss reads correctly in the top view (was mirrored). The 4 parts-catalog integration failures reproduce on clean develop (environment-dependent, unrelated).