### PR TITLE
fix(cli): render inspect --focus/--hide/--width silently dropped (option routing)

### DIFF
--- a/src/agent/cli/commands/render.ts
+++ b/src/agent/cli/commands/render.ts
@@ -472,7 +472,12 @@ export async function renderInspectBundle(input: RenderInspectInput): Promise<Re
 
 export function renderCommand(): Command {
   const cmd = new Command('render')
-    .description('Render a .kcad.ts script to multi-view PNG (front, right, top, iso)');
+    .description('Render a .kcad.ts script to multi-view PNG (front, right, top, iso)')
+    // Without positional options, `render`'s own --width/--height/--focus/
+    // --hide (composite mode) greedily claim the identically-named flags
+    // written after `render inspect <file> <outDir>`, so the inspect
+    // subcommand silently never received them (#394).
+    .enablePositionalOptions();
 
   cmd
     .command('inspect')

--- a/src/agent/cli/index.ts
+++ b/src/agent/cli/index.ts
@@ -31,6 +31,11 @@ const program = new Command();
 program
   .name('kernelcad')
   .description('kernelCAD — agent-first parametric CAD CLI')
+  // Positional options: required so `render` (which has both its own
+  // options and an `inspect` subcommand sharing flag names like --width /
+  // --focus) routes options written after the subcommand name to the
+  // subcommand instead of greedily claiming them for the parent.
+  .enablePositionalOptions()
   .version(pkg.version);
 
 program.addCommand(evaluateCommand());

--- a/tests/unit/cli/renderOptionRouting.test.ts
+++ b/tests/unit/cli/renderOptionRouting.test.ts
@@ -1,0 +1,62 @@
+// #394 regression: `render` (composite mode) declares --width/--height/
+// --focus/--hide for itself AND has an `inspect` subcommand declaring the
+// same flags. Without positional options, commander let the parent greedily
+// claim those flags even when written after `render inspect <file> <outDir>`,
+// so the inspect action silently never received them — `--focus drum` and
+// `--width 2048` were no-ops while subcommand-unique flags (--channels)
+// worked, which made the drop look like a renderer bug.
+//
+// The test wires the PRODUCTION command tree (renderCommand() under a
+// program with enablePositionalOptions, mirroring src/agent/cli/index.ts)
+// and replaces the inspect action handler with a spy — commander's
+// .action() overrides the registered handler — so parsing runs the real
+// flag definitions and routing without launching a browser.
+import { describe, it, expect } from 'vitest';
+import { Command } from 'commander';
+import { renderCommand } from '../../../src/agent/cli/commands/render';
+
+function buildProgramWithSpy(): {
+  program: Command;
+  captured: { file?: string; outDir?: string; opts?: Record<string, unknown> };
+} {
+  const captured: { file?: string; outDir?: string; opts?: Record<string, unknown> } = {};
+  const program = new Command()
+    .name('kernelcad')
+    .enablePositionalOptions()
+    .exitOverride();
+  const render = renderCommand();
+  const inspect = render.commands.find((c) => c.name() === 'inspect');
+  if (!inspect) throw new Error('inspect subcommand not found');
+  inspect.action((file: string, outDir: string, opts: Record<string, unknown>) => {
+    captured.file = file;
+    captured.outDir = outDir;
+    captured.opts = opts;
+  });
+  program.addCommand(render);
+  return { program, captured };
+}
+
+describe('render inspect option routing (#394)', () => {
+  it('delivers --focus, --width and --channels written after the subcommand', async () => {
+    const { program, captured } = buildProgramWithSpy();
+    await program.parseAsync([
+      'node', 'kernelcad', 'render', 'inspect', 'model.kcad.ts', '/tmp/out',
+      '--focus', 'drum', '--width', '2048', '--channels', 'rgb,depth',
+    ]);
+    expect(captured.file).toBe('model.kcad.ts');
+    expect(captured.outDir).toBe('/tmp/out');
+    expect(captured.opts?.focus).toBe('drum');
+    expect(captured.opts?.width).toBe(2048);
+    expect(captured.opts?.channels).toBe('rgb,depth');
+  });
+
+  it('delivers --hide and --height regardless of flag order', async () => {
+    const { program, captured } = buildProgramWithSpy();
+    await program.parseAsync([
+      'node', 'kernelcad', 'render', 'inspect', 'model.kcad.ts', '/tmp/out',
+      '--channels', 'rgb', '--hide', 'cap,wall', '--height', '512',
+    ]);
+    expect(captured.opts?.hide).toBe('cap,wall');
+    expect(captured.opts?.height).toBe(512);
+  });
+});


### PR DESCRIPTION
Closes #394.

`render` (composite mode) and its `inspect` subcommand declare identically-named flags (`--width`/`--height`/`--focus`/`--hide`). commander's default parsing lets the parent greedily claim flags it knows even when written after the subcommand name, so `render inspect <file> <out> --focus drum --width 2048` delivered **neither** to the inspect action — while subcommand-unique flags (`--channels`) worked, which made the drop masquerade as a renderer bug (the original issue blamed the headlessRender plumbing; that plumbing was correct all along).

Fix: `enablePositionalOptions()` on the program and on `render` — options after the subcommand name now belong to the subcommand.

Verified end-to-end:
- bogus `--focus zzz` → exit 1 with `focus filter matched no visible objects. Available: box_1|box, embossText_1|embossText`
- `--focus embossText_1 --width 512` → 512px tiles, manifest records `filters.object` + per-object `objects.visible/hidden`
- parent composite path unaffected (`render <file> -o out.png --width 256` → 512px 2×2 grid)
- new routing regression test wires the production command tree with a spy action (98 CLI tests pass, tsc + eslint clean)