### PR TITLE
feat(studio): hidable Inspector panel

### DIFF
--- a/src/studio/Inspector.tsx
+++ b/src/studio/Inspector.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { ReactNode } from 'react';
 import type { TabId } from './types';
 import { useRecomputeResult } from './hooks/useRecomputeResult';
+import { useShellStore } from './store/useShellStore';
 import { getVisibleTabs } from './logic/adaptiveTabs';
 import { InspectorTabs } from './InspectorTabs';
 
@@ -11,6 +12,7 @@ interface InspectorProps {
 
 export function Inspector({ tabSlots }: InspectorProps) {
     const result = useRecomputeResult();
+    const { inspectorOpen } = useShellStore();
     const visibleTabs = getVisibleTabs(result);
 
     const [activeTab, setActiveTab] = useState<TabId>('scene');
@@ -23,9 +25,13 @@ export function Inspector({ tabSlots }: InspectorProps) {
     const effectiveTab: TabId = visibleTabs.includes(activeTab) ? activeTab : 'scene';
 
     return (
+        // Width collapses to 0 when hidden (mirrors AgentRail) so the
+        // viewport reclaims the space without unmounting tab state.
         <div
-            className="flex flex-col shrink-0 bg-[#111] border-l border-[#333] text-gray-300"
-            style={{ width: 290 }}
+            className="flex flex-col shrink-0 overflow-hidden bg-[#111] border-l border-[#333] text-gray-300"
+            style={{ width: inspectorOpen ? 290 : 0 }}
+            aria-hidden={!inspectorOpen}
+            data-open={inspectorOpen}
             data-testid="inspector"
         >
             <InspectorTabs

--- a/src/studio/StudioShell.tsx
+++ b/src/studio/StudioShell.tsx
@@ -30,7 +30,7 @@ import { useProject } from './context/ProjectContext';
  */
 export function StudioShell() {
     const workbench = useWorkbench();
-    const { agentRailOpen, selectedFeatureId, markingMode, sectionMode } = useShellStore();
+    const { agentRailOpen, inspectorOpen, selectedFeatureId, markingMode, sectionMode } = useShellStore();
     const handleToggleMarkingMode = useCallback(() => {
         shellStore.toggleMarkingMode();
     }, []);
@@ -95,6 +95,10 @@ export function StudioShell() {
     const handleToggleAgentRail = useCallback(() => {
         shellStore.setAgentRailOpen(!agentRailOpen);
     }, [agentRailOpen]);
+
+    const handleToggleInspector = useCallback(() => {
+        shellStore.toggleInspectorOpen();
+    }, []);
 
     const [referenceImagesVisible, setReferenceImagesVisible] = useState(true);
     const referenceImagesPresent = useMemo(
@@ -190,6 +194,8 @@ export function StudioShell() {
                 onToggleMarkingMode={handleToggleMarkingMode}
                 sectionMode={sectionMode}
                 onToggleSectionMode={handleToggleSectionMode}
+                inspectorOpen={inspectorOpen}
+                onToggleInspector={handleToggleInspector}
             />
 
             <div className="flex-1 flex overflow-hidden relative">

--- a/src/studio/Toolbar.tsx
+++ b/src/studio/Toolbar.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, Play, MessageSquare, Image as ImageIcon, Plug, Brush, Scissors } from 'lucide-react';
+import { CheckCircle2, Play, MessageSquare, Image as ImageIcon, Plug, Brush, Scissors, PanelRight } from 'lucide-react';
 
 interface ToolbarProps {
     isModified: boolean;
@@ -29,6 +29,9 @@ interface ToolbarProps {
     /** Section/cut tool — clips the model with one movable plane to reveal internals. */
     sectionMode: boolean;
     onToggleSectionMode: () => void;
+    /** Right-side Inspector panel visibility. */
+    inspectorOpen: boolean;
+    onToggleInspector: () => void;
 }
 
 export function Toolbar({
@@ -48,6 +51,8 @@ export function Toolbar({
     onToggleMarkingMode,
     sectionMode,
     onToggleSectionMode,
+    inspectorOpen,
+    onToggleInspector,
 }: ToolbarProps) {
     return (
         <div
@@ -170,6 +175,22 @@ export function Toolbar({
                         Env: {renderEnvironmentPresetLabel}
                     </button>
                 )}
+                <button
+                    type="button"
+                    data-testid="toolbar-inspector"
+                    onClick={onToggleInspector}
+                    title={inspectorOpen ? 'Hide the inspector panel' : 'Show the inspector panel'}
+                    aria-label={inspectorOpen ? 'Hide inspector panel' : 'Show inspector panel'}
+                    aria-pressed={inspectorOpen}
+                    className={`inline-flex items-center gap-1 px-2 py-1 rounded transition-colors ${
+                        inspectorOpen
+                            ? 'bg-[#333] text-white'
+                            : 'text-gray-300 hover:text-white hover:bg-[#222]'
+                    }`}
+                >
+                    <PanelRight size={12} />
+                    Inspector
+                </button>
             </div>
         </div>
     );

--- a/src/studio/__tests__/Inspector.test.tsx
+++ b/src/studio/__tests__/Inspector.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { StudioRecomputeResult } from '../types';
 import { ParamTable } from '../../shared/runtime/paramTable';
@@ -11,6 +11,7 @@ vi.mock('../hooks/useRecomputeResult', () => ({
 }));
 
 import { Inspector } from '../Inspector';
+import { shellStore } from '../store/shellStore';
 
 function emptyResult(): StudioRecomputeResult {
     return {
@@ -31,6 +32,7 @@ function withOneParam(): StudioRecomputeResult {
 
 afterEach(() => {
     cleanup();
+    shellStore.reset();
 });
 
 beforeEach(() => {
@@ -102,5 +104,30 @@ describe('Inspector', () => {
 
         expect(screen.getByTestId('scene-slot').textContent).toBe('SCENE BODY');
         expect(screen.queryByTestId('params-slot')).toBeNull();
+    });
+
+    it('collapses to zero width when inspectorOpen is false', () => {
+        mockUseRecomputeResult.mockReturnValue(emptyResult());
+
+        render(<Inspector tabSlots={{ scene: <div>SCENE BODY</div> }} />);
+
+        const panel = screen.getByTestId('inspector');
+        expect(panel.style.width).toBe('290px');
+        expect(panel.getAttribute('data-open')).toBe('true');
+
+        act(() => {
+            shellStore.setInspectorOpen(false);
+        });
+
+        expect(panel.style.width).toBe('0px');
+        expect(panel.getAttribute('data-open')).toBe('false');
+        expect(panel.getAttribute('aria-hidden')).toBe('true');
+
+        act(() => {
+            shellStore.setInspectorOpen(true);
+        });
+
+        expect(panel.style.width).toBe('290px');
+        expect(panel.getAttribute('aria-hidden')).toBe('false');
     });
 });

--- a/src/studio/__tests__/Toolbar.test.tsx
+++ b/src/studio/__tests__/Toolbar.test.tsx
@@ -15,6 +15,12 @@ function renderToolbar(overrides: Partial<Parameters<typeof Toolbar>[0]> = {}) {
         referenceImagesPresent: false,
         referenceImagesVisible: true,
         onToggleReferenceImages: vi.fn(),
+        markingMode: false,
+        onToggleMarkingMode: vi.fn(),
+        sectionMode: false,
+        onToggleSectionMode: vi.fn(),
+        inspectorOpen: true,
+        onToggleInspector: vi.fn(),
         ...overrides,
     };
     render(<Toolbar {...props} />);
@@ -103,6 +109,24 @@ describe('Toolbar', () => {
         const props = renderToolbar({ referenceImagesPresent: true });
         fireEvent.click(screen.getByRole('button', { name: /reference images?/i }));
         expect(props.onToggleReferenceImages).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires onToggleInspector when the panel button is clicked', () => {
+        const props = renderToolbar();
+        fireEvent.click(screen.getByTestId('toolbar-inspector'));
+        expect(props.onToggleInspector).toHaveBeenCalledTimes(1);
+    });
+
+    it('reflects inspectorOpen state in the panel toggle', () => {
+        renderToolbar({ inspectorOpen: true });
+        const btn = screen.getByRole('button', { name: 'Hide inspector panel' });
+        expect(btn.getAttribute('aria-pressed')).toBe('true');
+    });
+
+    it('reflects hidden inspector state in the panel toggle', () => {
+        renderToolbar({ inspectorOpen: false });
+        const btn = screen.getByRole('button', { name: 'Show inspector panel' });
+        expect(btn.getAttribute('aria-pressed')).toBe('false');
     });
 
     it('renders the Connect link pointing at /connect', () => {

--- a/src/studio/__tests__/shellStore.test.ts
+++ b/src/studio/__tests__/shellStore.test.ts
@@ -37,6 +37,31 @@ describe('ShellStore', () => {
         expect(store.getSnapshot().selectedFeatureId).toBeNull();
     });
 
+    it('inspector starts open by default', () => {
+        store = new ShellStore();
+        expect(store.getSnapshot().inspectorOpen).toBe(true);
+    });
+
+    it('setInspectorOpen is idempotent on same value', () => {
+        store = new ShellStore();
+        const listener = vi.fn();
+        store.subscribe(listener);
+
+        store.setInspectorOpen(false);
+        store.setInspectorOpen(false);
+        store.setInspectorOpen(true);
+
+        expect(listener).toHaveBeenCalledTimes(2);
+    });
+
+    it('toggleInspectorOpen flips the state each call', () => {
+        store = new ShellStore();
+        store.toggleInspectorOpen();
+        expect(store.getSnapshot().inspectorOpen).toBe(false);
+        store.toggleInspectorOpen();
+        expect(store.getSnapshot().inspectorOpen).toBe(true);
+    });
+
     it('setAgentRailOpen is idempotent on same value', () => {
         store = new ShellStore();
         const listener = vi.fn();

--- a/src/studio/store/shellStore.ts
+++ b/src/studio/store/shellStore.ts
@@ -29,6 +29,7 @@ export interface StagedEdit {
 export interface ShellState {
     readonly selectedFeatureId: SelectedFeatureId;
     readonly agentRailOpen: boolean;
+    readonly inspectorOpen: boolean;
     readonly previousValidity: ValidatorResult | null;
     readonly currentValidity: ValidatorResult | null;
     readonly stagedEdit: StagedEdit | null;
@@ -39,9 +40,31 @@ export interface ShellState {
     readonly sectionPosition: number;
 }
 
+const STORAGE_KEY_INSPECTOR_OPEN = 'kernelcad:inspectorOpen';
+
+function readStoredInspectorOpen(): boolean {
+    if (typeof window === 'undefined') return true;
+    try {
+        // Default open: only an explicit stored 'false' collapses the panel.
+        return window.localStorage.getItem(STORAGE_KEY_INSPECTOR_OPEN) !== 'false';
+    } catch {
+        return true;
+    }
+}
+
+function writeStoredInspectorOpen(open: boolean): void {
+    if (typeof window === 'undefined') return;
+    try {
+        window.localStorage.setItem(STORAGE_KEY_INSPECTOR_OPEN, String(open));
+    } catch {
+        // Private-mode / quota failures degrade to session-only state.
+    }
+}
+
 const INITIAL_STATE: ShellState = {
     selectedFeatureId: null,
     agentRailOpen: false,
+    inspectorOpen: true,
     previousValidity: null,
     currentValidity: null,
     stagedEdit: null,
@@ -55,7 +78,9 @@ const INITIAL_STATE: ShellState = {
 type Listener = () => void;
 
 export class ShellStore {
-    private state: ShellState = INITIAL_STATE;
+    // Inspector visibility persists across reloads (mirrors the validity
+    // drawer's localStorage pattern); everything else starts from defaults.
+    private state: ShellState = { ...INITIAL_STATE, inspectorOpen: readStoredInspectorOpen() };
     private readonly listeners = new Set<Listener>();
 
     getSnapshot = (): ShellState => this.state;
@@ -81,6 +106,17 @@ export class ShellStore {
         if (this.state.agentRailOpen === open) return;
         this.state = { ...this.state, agentRailOpen: open };
         this.emit();
+    };
+
+    setInspectorOpen = (open: boolean): void => {
+        if (this.state.inspectorOpen === open) return;
+        this.state = { ...this.state, inspectorOpen: open };
+        writeStoredInspectorOpen(open);
+        this.emit();
+    };
+
+    toggleInspectorOpen = (): void => {
+        this.setInspectorOpen(!this.state.inspectorOpen);
     };
 
     setMarkingMode = (on: boolean): void => {


### PR DESCRIPTION
## What
Adds a toolbar toggle that hides/shows the right-side Inspector panel in Studio.

## How
- `inspectorOpen` state in `shellStore` with `setInspectorOpen`/`toggleInspectorOpen`, persisted via localStorage (`kernelcad:inspectorOpen`, default open)
- Inspector collapses to zero width — same pattern as the agent rail — so the viewport reclaims the space and tab state survives the round-trip
- New **Inspector** button in the toolbar right section (`data-testid=toolbar-inspector`)

## Verification
- `npm run typecheck` clean
- Unit tests added: store default/idempotence/toggle, toolbar button fire + aria-pressed, Inspector collapse/expand width + aria-hidden (41 tests green across affected suites)
- Manually verified in the dev server: toggle hides/shows the panel, state survives a reload
