### PR TITLE
chore: hold copyright as kernelCAD contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Andrii Shylenko
+Copyright (c) 2026 kernelCAD contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tests/unit/scripts/distGrepGate.test.ts
+++ b/tests/unit/scripts/distGrepGate.test.ts
@@ -159,7 +159,7 @@ describe('distGrepGate', () => {
   it('does not scan LICENSE (legal text) or the LICENSE word in headers', () => {
     const root = mkdtempSync(join(tmpdir(), 'kc-grep-license-'));
     try {
-      writeFileSync(join(root, 'LICENSE'), 'MIT License\n\nCopyright (c) Andrii Shylenko\n');
+      writeFileSync(join(root, 'LICENSE'), 'MIT License\n\nCopyright (c) kernelCAD contributors\n');
       const r = runGrepGate(root);
       expect(r.ok).toBe(true);
     } finally {


### PR DESCRIPTION
Neutralize the LICENSE copyright holder (and the test fixture mirroring it) to `kernelCAD contributors` — standard form for a project intended to be assigned to an entity later.