### PR TITLE
feat(agent): parts discipline — structure diagnostic, evaluate parts summary, skill rules

### DIFF
--- a/src/agent/cli/commands/evaluate.ts
+++ b/src/agent/cli/commands/evaluate.ts
@@ -14,6 +14,7 @@ import {
   reviewPoseEnvelope,
   type PoseEnvelopeDiagnostic,
 } from '../../../modeling/mates/poseEnvelope';
+import { detectUnstructuredBodies } from '../../../modeling/validation/unstructuredBodies';
 
 export interface EvaluateInput {
   file?: string;
@@ -98,6 +99,19 @@ export async function evaluateAndBuildScript(input: EvaluateInput): Promise<Eval
     };
   }
   const fatal = model.diagnostics.some(d => d.severity === 'error');
+
+  // Agent-parts-discipline: flag multi-body models authored as loose
+  // top-level bodies instead of named `assembly().part(...)`. Runs on a
+  // clean build only — a broken build surfaces its own failure first.
+  // Emitting here (the shared producer for `evaluate_script` AND the
+  // `/__kernelcad/review` payload, plus the CLI) surfaces the info
+  // diagnostic on every authoring surface from a single seam, and — unlike
+  // the assembly validator — runs for NON-assembly scripts too.
+  if (!fatal) {
+    model.diagnostics.push(
+      ...detectUnstructuredBodies({ returnValue: model.returnValue, code: model.code }),
+    );
+  }
 
   // W3 DFM enforcement: when the script declares dfmSpec(...), run the
   // declared gates and merge their diagnostics into the model's. This one

--- a/src/agent/mcp/toolRegistry.ts
+++ b/src/agent/mcp/toolRegistry.ts
@@ -104,6 +104,8 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
       name: 'evaluate_script',
       description:
         'Run a kernelCAD .kcad.ts script and report pass/fail + feature count + diagnostics. ' +
+        'When the scene is assembly-built (assembly().part(...) → .model()/.solvedModel()), ' +
+        'also returns a parts summary { count, names }. ' +
         'Pass either { file: "<path>" } or { code: "<inline source>" }.',
       inputSchema: {
         type: 'object',

--- a/src/agent/mcp/tools/evaluateScript.ts
+++ b/src/agent/mcp/tools/evaluateScript.ts
@@ -3,6 +3,7 @@ import { evaluateAndBuildScript, type EvaluateInput } from '../../cli/commands/e
 import type { CompilerDiagnostic } from '../../../shared/diagnostics/diagnostic';
 import { withNextActions } from '../../../shared/diagnostics/diagnostic';
 import { clearActiveMcpSession, setActiveMcpSession } from '../activeSession';
+import { Scene } from '../../../modeling/validation/scene';
 
 export interface EvaluateScriptInput {
   file?: string;
@@ -13,12 +14,21 @@ export interface EvaluateScriptOutput {
   ok: boolean;
   featureCount: number;
   diagnostics: CompilerDiagnostic[];
+  /**
+   * Present ONLY when the evaluated scene is assembly-built
+   * (`assembly().part(...)` → `.model()` / `.solvedModel()`). Carries the
+   * part count and ordered part names so agents can confirm the model
+   * structured its bodies as named parts. Absent for single-shape /
+   * non-assembly scripts.
+   */
+  parts?: { count: number; names: string[] };
 }
 
 /**
  * MCP `evaluate_script` tool — runs a kernelCAD script and reports
- * pass/fail + feature count + diagnostics. One-of `{ file }` (path on
- * disk) or `{ code }` (inline source). Returns a JSON-serializable
+ * pass/fail + feature count + diagnostics, plus a `parts` summary
+ * (`{ count, names }`) when the scene is assembly-built. One-of `{ file }`
+ * (path on disk) or `{ code }` (inline source). Returns a JSON-serializable
  * envelope agents can reason over.
  *
  * No side effects — does not write to disk.
@@ -51,6 +61,17 @@ export async function evaluateScriptTool(
   } else {
     clearActiveMcpSession();
   }
+  // Assembly-built scene: surface the named-part roster so agents can
+  // confirm the model carries part identity. Absent for single-shape /
+  // non-assembly returns.
+  const parts =
+    model?.returnValue instanceof Scene
+      ? {
+          count: model.returnValue.parts.length,
+          names: model.returnValue.parts.map(p => p.name),
+        }
+      : undefined;
+
   return {
     ok: r.exitCode === 0,
     featureCount: r.featureCount,
@@ -59,5 +80,6 @@ export async function evaluateScriptTool(
     // today but ensures the contract holds if a future caller bypasses
     // the eval helper.
     diagnostics: withNextActions(r.diagnostics),
+    ...(parts !== undefined ? { parts } : {}),
   };
 }

--- a/src/agent/skills/kernelcad-assemblies/SKILL.md
+++ b/src/agent/skills/kernelcad-assemblies/SKILL.md
@@ -14,6 +14,7 @@ Use `assembly()` when the model needs named mechanical parts, connector frames, 
 - **`assembly.part.floating`** — a part has no joint connecting it to any other part. The fix: declare the connection via `arm.mate(..., 'fastened')` or `arm.mate(..., 'revolute', ...)`.
 - **`assembly.part.orphan`** — a part is in a sub-assembly disconnected from the main mechanism.
 - **`assembly.interference.overlap`** — two parts share volume (promoted from `kernelcad interference`).
+- **`assembly.structure.unstructured-bodies`** (info) — a multi-body model returns loose top-level bodies with no `assembly().part(...)` structure, so the parts carry no identity for `inspect --focus`, `list_part_stats`, or per-part review. The fix: wrap each distinct body in a named `assembly().part(name, shape)`.
 
 Exit codes: 0 (solved) / 1 (warnings) / 2 (errors). Pipe-friendly:
 

--- a/src/agent/skills/kernelcad-authoring/SKILL.md
+++ b/src/agent/skills/kernelcad-authoring/SKILL.md
@@ -57,6 +57,12 @@ two-feature placement math, subtract-chain reliability, JSON-`ok`-is-not-visual-
 
 ## Assembly and mechanism loop
 
+### Think in parts
+
+- Every physically distinct component is a named `assembly().part(name, shape)` — one body per part unless the component is genuinely monolithic.
+- Anonymous loose top-level bodies in a multi-body model are a defect smell: the review loop emits `assembly.structure.unstructured-bodies` (info) with the recovery hint. Wrap each loose body in a named part.
+- Part names are the durable handles for `inspect --focus`, `list_part_stats`, and Studio's hide / keep-whole / per-part validity — choose stable, descriptive names.
+
 - If a model has moving parts, design the joint structure before styling: name the parent/child parts, joint type, axis/frame, limits, and editable pose parameters up front.
 - If two parts are intended to touch, author the relationship with connectors and mates rather than relying on raw `translate()` offsets alone. Raw offsets are acceptable for free placement, but touching load-path geometry needs named interfaces the validator and Studio can inspect.
 - Prefer `assembly().model()` for multi-part scenes so Studio receives per-part identity, material, mate, and transform metadata. Collapse with `.toCompound()` or `.toUnion()` only when a downstream export truly requires one body.

--- a/src/agent/skills/kernelcad-mcp/SKILL.md
+++ b/src/agent/skills/kernelcad-mcp/SKILL.md
@@ -15,7 +15,7 @@ When you have `kernelcad mcp` available, use the MCP tools for dynamic introspec
 
 ### Evaluation and introspection
 
-- `evaluate_script({ file? code? })` — pass/fail + featureCount + diagnostics
+- `evaluate_script({ file? code? })` — pass/fail + featureCount + diagnostics; plus a `parts` summary `{ count, names }` when the scene is assembly-built (absent for single-shape / non-assembly scripts)
 - `list_features({ file? code? })` — array of feature summaries (kind/id/params/inputs)
 - `list_assemblies({ file? code? })` — captured assembly intent: assemblies, parts, named connectors, fixed connections, joints, and aggregate models
 - `inspect_assembly({ file? | code?, assembly? })` — physical assembly inventory for agents: named parts, bboxes, connectors, mates, mechanical review facts, disconnected solids, `unexplainedGeometry`, and a next-action prompt. Run this before accepting visually suspicious mechanisms; random/floating geometry must be repaired or explicitly justified by the original prompt.

--- a/src/modeling/buildModel.ts
+++ b/src/modeling/buildModel.ts
@@ -49,6 +49,15 @@ export interface BuiltModel {
   /** Lowered shape of the script's `return` value. Prefer this over
    *  `tailShape` in export / probe / measurement consumers. */
   rootShape?: ShapeBackend;
+  /** The raw value the script `return`ed (Shape, Scene, array of Shapes, or
+   *  anything else). Threaded so the agent-parts-discipline check can tell a
+   *  multi-body non-assembly return (array of Shapes) apart from an
+   *  assembly-built Scene without re-deriving from the lowered geometry. */
+  returnValue?: unknown;
+  /** The script source text. Threaded so review/analysis passes (e.g. the
+   *  unstructured-bodies check) can read returned-variable names via the AST
+   *  helpers without re-reading the file. */
+  code?: string;
 }
 
 export interface ParamUpdateEdit {
@@ -101,6 +110,8 @@ export async function buildModel(input: BuildModelInput): Promise<BuiltModel> {
     tailShape,
     rootId,
     rootShape,
+    returnValue: run.returnValue,
+    code: input.code,
   };
 }
 

--- a/src/modeling/validation/unstructuredBodies.ts
+++ b/src/modeling/validation/unstructuredBodies.ts
@@ -1,0 +1,94 @@
+// Agent-parts-discipline check: flag multi-body models that were authored as
+// loose top-level bodies instead of named `assembly().part(name, shape)`
+// parts.
+//
+// A multi-body model that skips assembly structure loses per-part identity:
+// `inspect --focus`, `list_part_stats`, and Studio's hide / keep-whole /
+// per-part validity all key off part names. This emits the advisory
+// `assembly.structure.unstructured-bodies` (info) so the review loop nudges
+// the author toward wrapping each distinct component in a named part.
+//
+// Runs for EVERY script (assembly or not) — that is why it lives beside, not
+// inside, `validateAssemblyWithMates` (which only sees assembly-built scenes).
+// It emits at one seam (`evaluateAndBuildScript`), so both the
+// `evaluate_script` MCP tool and the `/__kernelcad/review` payload carry the
+// same diagnostic.
+
+import type { CompilerDiagnostic } from '../../shared/diagnostics/diagnostic';
+import { NEXT_ACTIONS } from '../../shared/diagnostics/registry';
+import { Shape } from '../capture/proxy';
+import { Scene } from './scene';
+import { getReturnedVariables } from '../../shared/codeGeneration/ast';
+
+export interface UnstructuredBodiesInput {
+  /** The raw value the script `return`ed. */
+  returnValue: unknown;
+  /** Script source — optional. When present, returned-variable names refine
+   *  the message (how many returned bodies are anonymous expressions). */
+  code?: string;
+}
+
+/**
+ * Inspect a script's return value and emit `assembly.structure.unstructured-bodies`
+ * (info, 0 or 1 diagnostic) when the model is multi-body WITHOUT assembly
+ * structure.
+ *
+ * Fires when the script returns an array of ≥2 `Shape`s (loose top-level
+ * bodies with no part identity).
+ *
+ * Stays silent for: a single returned `Shape` (single body), an
+ * assembly-built `Scene` (`assembly().model()` / `.solvedModel()`), a
+ * sketch-only or empty return, and any non-Shape array element (the return is
+ * not a clean multi-body solid list, so the part-discipline nudge would be
+ * noise).
+ */
+export function detectUnstructuredBodies(
+  input: UnstructuredBodiesInput,
+): CompilerDiagnostic[] {
+  const { returnValue, code } = input;
+
+  // Assembly-built scenes already carry part identity — never fire.
+  if (returnValue instanceof Scene) return [];
+
+  // Only an array return represents multiple top-level bodies. A single
+  // returned Shape is one body; a Scene is handled above.
+  if (!Array.isArray(returnValue)) return [];
+
+  const shapes = returnValue.filter((el): el is Shape => el instanceof Shape);
+  // Need at least two genuine bodies. If the array mixes in non-Shape values
+  // (sketches, virtual handles, plain data), it is not a clean multi-body
+  // solid list and the discipline nudge would be noise.
+  if (shapes.length < 2 || shapes.length !== returnValue.length) return [];
+
+  const bodyCount = shapes.length;
+  let anonymousNote = '';
+  if (code !== undefined) {
+    try {
+      const names = getReturnedVariables(code);
+      const anonymous = names.filter((n) => n === null).length;
+      if (anonymous > 0) {
+        anonymousNote =
+          anonymous === bodyCount
+            ? ' None of the returned bodies are named variables.'
+            : ` ${anonymous} of ${bodyCount} returned bodies are anonymous expressions.`;
+      }
+    } catch {
+      // AST parse failed — fall back to the count-only message.
+    }
+  }
+
+  return [
+    {
+      target: 'export-occt',
+      code: 'assembly.structure.unstructured-bodies',
+      severity: 'info',
+      message:
+        `This model returns ${bodyCount} loose top-level bodies with no assembly structure.` +
+        anonymousNote +
+        ' Each physically distinct component should be a named assembly().part(name, shape).',
+      hint:
+        'Wrap the loose bodies in assembly().part(name, shape) so each part carries identity, per-part stats, and review handles; name every returned shape.',
+      nextAction: NEXT_ACTIONS['assembly.structure.unstructured-bodies'],
+    },
+  ];
+}

--- a/src/shared/codeGeneration/ast.ts
+++ b/src/shared/codeGeneration/ast.ts
@@ -13,6 +13,17 @@ import { generate } from 'astring';
 
 type UnknownRecord = Record<string, unknown>;
 
+// Dev-only console logging guard. `import.meta.env` is a Vite/browser global;
+// this module is also reachable from the Node server graph (vite.config →
+// reviewCadTool → evaluateAndBuildScript → unstructuredBodies), where
+// `import.meta.env` is untyped/undefined. Read it defensively so the helper
+// compiles and runs under both the `vite/client` (app) and `node` tsconfig
+// projects.
+function isDevNonTest(): boolean {
+    const env = (import.meta as unknown as { env?: { DEV?: boolean; MODE?: string } }).env;
+    return Boolean(env?.DEV) && env?.MODE !== 'test';
+}
+
 const isRecord = (value: unknown): value is UnknownRecord => {
     return typeof value === 'object' && value !== null;
 };
@@ -121,7 +132,7 @@ export function parseCode(code: string): acorn.Node {
             locations: true
         });
     } catch (error) {
-        if (import.meta.env.DEV && import.meta.env.MODE !== 'test') {
+        if (isDevNonTest()) {
             console.error('Parse error:', error);
         }
         throw error;
@@ -138,7 +149,7 @@ export function generateCode(ast: acorn.Node): string {
             lineEnd: '\n',
         });
     } catch (error) {
-        if (import.meta.env.DEV && import.meta.env.MODE !== 'test') {
+        if (isDevNonTest()) {
             console.error('Code generation error:', error);
         }
         throw error;

--- a/src/shared/diagnostics/registry.ts
+++ b/src/shared/diagnostics/registry.ts
@@ -913,6 +913,17 @@ export const DIAGNOSTIC_REGISTRY = {
     group: 'assembly',
     description: 'A joint axis (mate connector origin + direction) does not intersect the part body it claims to act on.',
   },
+  'assembly.structure.unstructured-bodies': {
+    hintTemplate:
+      'Wrap the loose bodies in assembly().part(name, shape) so each part carries identity, per-part stats, and review handles; name every returned shape. This is an authoring-time signal — a multi-body model with no part names loses inspect --focus, list_part_stats, and Studio per-part validity.',
+    nextAction: {
+      kind: 'rewrite-feature',
+      guidance: 'wrap each loose top-level body in a named assembly().part(name, shape)',
+    },
+    defaultSeverity: 'info',
+    group: 'assembly',
+    description: 'A multi-body model returns loose top-level bodies with no assembly().part(...) structure, so the parts carry no identity for inspection, stats, or per-part review.',
+  },
   'assembly.joint.load-exceeded': {
     hintTemplate:
       "Increase maxLoad on this joint, reduce externalLoads, or split the load path with an additional joint.",

--- a/tests/unit/diagnostics/codes.test.ts
+++ b/tests/unit/diagnostics/codes.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { DIAGNOSTIC_CODES, HINT_TEMPLATES } from '../../../src/shared/diagnostics/registry';
 
 describe('diagnostic catalogue invariants', () => {
-  it('emits exactly 224 codes', () => {
+  it('emits exactly 225 codes', () => {
     // 204 from develop (NURBS analytics, Query DSL, K1-K9 kinematic, assembly/mechanism gates)
     // + 6 parts catalog codes (parts.* — Slice C bundled parts catalog)
     // + 1 feature.emboss-text.boolean-noop (#393 silent no-op guard)
@@ -14,8 +14,10 @@ describe('diagnostic catalogue invariants', () => {
     //   animation.param.unknown, animation.track.duplicate-param,
     //   animation.keys.invalid, animation.value.clamped,
     //   animation.view.shadowed, animation.collision.
-    expect(DIAGNOSTIC_CODES).toHaveLength(224);
-    expect(new Set(DIAGNOSTIC_CODES).size).toBe(224);
+    // + 1 assembly.structure.unstructured-bodies (agent-parts-discipline:
+    //   multi-body model with no named assembly().part(...) structure).
+    expect(DIAGNOSTIC_CODES).toHaveLength(225);
+    expect(new Set(DIAGNOSTIC_CODES).size).toBe(225);
   });
 
   it('every code has a non-empty hint template', () => {

--- a/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
+++ b/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
@@ -39,6 +39,7 @@ const EMITTING_FILES = [
   'modeling/sheetMetal.ts',                      // W2.2
   'modeling/sketch/index.ts',
   'modeling/compute/recomputeEngine.ts',
+  'modeling/validation/unstructuredBodies.ts', // agent-parts-discipline
   'agent/cli/commands/evaluate.ts',
   'agent/cli/commands/export.ts',
   'agent/script-runtime/export.ts',
@@ -145,7 +146,9 @@ describe('every diagnostic code emitted in src/ is in the catalogue', () => {
     //       animation.param.unknown + animation.track.duplicate-param +
     //       animation.keys.invalid + animation.value.clamped +
     //       animation.view.shadowed + animation.collision = 224.
-    expect(catalogue.size).toBe(224);
+    //  +  1 assembly.structure.unstructured-bodies (agent-parts-discipline:
+    //       multi-body model with no named assembly().part(...) structure) = 225.
+    expect(catalogue.size).toBe(225);
   });
 
   it('no emit site uses a code outside the catalogue', () => {

--- a/tests/unit/diagnostics/unstructuredBodies.test.ts
+++ b/tests/unit/diagnostics/unstructuredBodies.test.ts
@@ -1,0 +1,78 @@
+// tests/unit/diagnostics/unstructuredBodies.test.ts
+//
+// Agent-parts-discipline check: a multi-body model authored as loose
+// top-level bodies (no `assembly().part(...)`) emits the advisory
+// `assembly.structure.unstructured-bodies` (info). It surfaces from the
+// shared evaluate seam, so both `evaluate_script` and the
+// `/__kernelcad/review` payload (via reviewCadTool → evaluateAndBuildScript)
+// carry it. Single-body / assembly-built / sketch-only returns stay silent.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { evaluateScriptTool } from '../../../src/agent/mcp/tools/evaluateScript';
+import { initOcct } from '../../../src/kernel/backends/occt/occtBackend';
+
+const CODE = 'assembly.structure.unstructured-bodies';
+
+function has(diags: { code: string }[]): boolean {
+  return diags.some(d => d.code === CODE);
+}
+
+describe('assembly.structure.unstructured-bodies', () => {
+  beforeAll(async () => { await initOcct(); }, 60000);
+
+  it('fires on a loose 2-body return (named variables)', async () => {
+    const r = await evaluateScriptTool({
+      code: `
+        const a = box(10, 10, 10);
+        const b = box(10, 10, 10).translate(20, 0, 0);
+        return [a, b];
+      `,
+    });
+    expect(r.ok).toBe(true);
+    expect(has(r.diagnostics)).toBe(true);
+    const d = r.diagnostics.find(x => x.code === CODE)!;
+    expect(d.severity).toBe('info');
+    expect(d.hint).toMatch(/assembly\(\)\.part/);
+  });
+
+  it('fires on an anonymous multi-return (no variable names)', async () => {
+    const r = await evaluateScriptTool({
+      code: `return [box(10, 10, 10), box(10, 10, 10).translate(20, 0, 0)];`,
+    });
+    expect(r.ok).toBe(true);
+    expect(has(r.diagnostics)).toBe(true);
+    const d = r.diagnostics.find(x => x.code === CODE)!;
+    // Message notes that the returned bodies are anonymous expressions.
+    expect(d.message).toMatch(/anonymous|named variables/i);
+  });
+
+  it('is silent on a single-body model', async () => {
+    const r = await evaluateScriptTool({ code: `return box(10, 10, 10);` });
+    expect(r.ok).toBe(true);
+    expect(has(r.diagnostics)).toBe(false);
+  });
+
+  it('is silent on an assembly-built scene', async () => {
+    const r = await evaluateScriptTool({
+      code: `
+        const arm = assembly('rig');
+        arm.part('base', box(10, 10, 10));
+        arm.part('lid', box(10, 10, 2).translate(0, 0, 12));
+        return arm.model();
+      `,
+    });
+    expect(r.ok).toBe(true);
+    expect(has(r.diagnostics)).toBe(false);
+  });
+
+  it('is silent on a named single return', async () => {
+    const r = await evaluateScriptTool({
+      code: `
+        const part = box(40, 30, 5).subtract(cylinder(8, 4).translate(20, 15, -1));
+        return part;
+      `,
+    });
+    expect(r.ok).toBe(true);
+    expect(has(r.diagnostics)).toBe(false);
+  });
+});

--- a/tests/unit/mcp/tools/evaluateScript.test.ts
+++ b/tests/unit/mcp/tools/evaluateScript.test.ts
@@ -61,6 +61,27 @@ describe('evaluateScriptTool', () => {
     expect(params.params.map(p => p.name)).toEqual(['wallT']);
   }, 120_000);
 
+  it('includes a parts summary for an assembly-built scene', async () => {
+    const result = await evaluateScriptTool({
+      code: `
+        const arm = assembly('rig');
+        arm.part('base', box(10, 10, 10));
+        arm.part('lid', box(10, 10, 2).translate(0, 0, 12));
+        return arm.model();
+      `,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.parts).toBeDefined();
+    expect(result.parts!.count).toBe(2);
+    expect(result.parts!.names).toEqual(['base', 'lid']);
+  });
+
+  it('omits the parts summary for a plain single-shape script', async () => {
+    const result = await evaluateScriptTool({ code: `return box(10, 10, 10);` });
+    expect(result.ok).toBe(true);
+    expect(result.parts).toBeUndefined();
+  });
+
   it('non-dfm build failure still clears the session', async () => {
     // Establish a good session first ...
     const good = await evaluateScriptTool({ code: `return box(10, 10, 10);` });


### PR DESCRIPTION
## What
- New advisory diagnostic `assembly.structure.unstructured-bodies` (info): fires when a script returns ≥2 loose top-level bodies without assembly structure; hint instructs wrapping them in `assembly().part(name, shape)`. Surfaces in both `evaluate_script` and `/__kernelcad/review` (Studio Validity) via the shared evaluate seam.
- `evaluate_script` output gains `parts: { count, names }` for assembly-built scenes, so the agent loop sees model structure at a glance.
- kernelcad-authoring SKILL.md gains a "Think in parts" rule block; kernelcad-assemblies and kernelcad-mcp references updated to match.

## Testing
- Detector unit tests (fires on loose/anonymous multi-body; silent on single body, assembly scene, mixed arrays); diagnostic count gates 224→225; evaluate_script integration test for parts summary presence/absence.
- Acceptance: 11-part carousel fixture → no diagnostic + parts list; loose 2-body script → info diagnostic with wrap hint.