### PR TITLE
feat: harden session pool + SSE auth for multi-user hosting

### DIFF
--- a/src/server/middleware/animationBakeEndpoint.test.ts
+++ b/src/server/middleware/animationBakeEndpoint.test.ts
@@ -44,6 +44,7 @@ function fakePool(model: BuiltModel | null): SessionPool {
   return {
     get: (token: string) => (token === 't1' && entry ? (entry as never) : undefined),
     getOrCreate: async () => entry as never,
+    runExclusive: (fn) => fn(),
     eject() {},
     prune() {},
     entries: function* () {} as never,

--- a/src/server/middleware/eventsEndpoint.ts
+++ b/src/server/middleware/eventsEndpoint.ts
@@ -29,6 +29,34 @@ export interface EventsEndpointDeps {
   pool: SessionPool;
   /** Send a `: keepalive` comment every N ms. Set to 0 to disable. */
   heartbeatMs?: number;
+  /**
+   * OPTIONAL auth hook, called BEFORE the SSE stream is established.
+   *
+   * EventSource cannot send custom headers, so signed-in Studio cannot put
+   * the Supabase JWT in an `Authorization: Bearer` header the way every other
+   * Studio fetch does. Instead the client appends it as an `access_token`
+   * query param (see `buildEventsUrl` in `apiBase.ts`), and the hosted server
+   * injects this hook to validate it.
+   *
+   * This endpoint stays framework-agnostic and has NO Supabase client of its
+   * own — the validator lives in kernelCAD-server, which injects an
+   * implementation that:
+   *   1. reads `access_token` from `req.url`'s query,
+   *   2. verifies the JWT against Supabase, and
+   *   3. checks the JWT subject matches the owner of the `session` token
+   *      (defense-in-depth: the per-user `sessionToken` is already an
+   *      unguessable randomUUID scoped to the user, so the channel is
+   *      user-scoped by the token alone; `access_token` lets the server
+   *      additionally reject a token whose owner != the JWT subject).
+   *
+   * Default = undefined = no-op allow, which preserves the vite single-user
+   * dev path bit-for-bit (no auth, no Supabase, no `access_token`).
+   *
+   * Security note: the `access_token` rides in the query string, so it can
+   * appear in proxy/access logs. Accepted for now; the token is the
+   * short-lived Supabase JWT, not a long-lived secret.
+   */
+  authenticate?: (req: EventsReqLike) => Promise<{ ok: boolean; status?: number; error?: string }>;
 }
 
 export interface EventsReqLike {
@@ -56,6 +84,17 @@ export function createEventsEndpoint(deps: EventsEndpointDeps) {
     const entry = deps.pool.get(token);
     if (!entry) {
       return writeJson(res, 404, { error: 'unknown session token' });
+    }
+    // Optional auth gate (hosted only). Runs BEFORE we touch the engine or
+    // emit any SSE byte, so a rejected request never opens a stream. The vite
+    // dev path has no `authenticate` dep and skips this entirely.
+    if (deps.authenticate) {
+      const verdict = await deps.authenticate(req);
+      if (!verdict.ok) {
+        return writeJson(res, verdict.status ?? 401, {
+          error: verdict.error ?? 'unauthorized',
+        });
+      }
     }
     if (!entry.model.session.engine) {
       return writeJson(res, 409, {

--- a/src/server/middleware/paramsEndpoint.coalesce.test.ts
+++ b/src/server/middleware/paramsEndpoint.coalesce.test.ts
@@ -42,6 +42,7 @@ function fakePool(update: (edits: Array<{ name: string; value: number | boolean 
     return {
         get: (token: string) => (token === 't1' ? (entry as never) : undefined),
         getOrCreate: async () => entry as never,
+        runExclusive: (fn) => fn(),
         eject() {},
         prune() {},
         entries: function* () {} as never,

--- a/src/server/middleware/transformsEndpoint.test.ts
+++ b/src/server/middleware/transformsEndpoint.test.ts
@@ -44,6 +44,7 @@ function fakePool(model: unknown): SessionPool {
     return {
         get: (token: string) => (token === 't1' ? (entry as never) : undefined),
         getOrCreate: async () => entry as never,
+        runExclusive: (fn) => fn(),
         eject() {},
         prune() {},
         entries: function* () {} as never,

--- a/src/server/sessionPool.ts
+++ b/src/server/sessionPool.ts
@@ -30,6 +30,35 @@
  * `prune()` evicts entries whose `lastAccessAt` is older than `ttlMs`. The
  * `vite.config.ts` plugin runs `prune()` on a `setInterval`. `get(token)`
  * bumps `lastAccessAt` so an active SSE connection keeps the session alive.
+ *
+ * An optional `maxEntries` count cap is the hard memory backstop for the
+ * hosted server: each entry pins a whole `BuiltModel` in the OCCT WASM heap, so
+ * an unbounded pool of N authenticated users would eventually OOM the single
+ * WASM instance. When inserting a new entry would exceed `maxEntries`, the
+ * least-recently-accessed entry is evicted first via the SAME drop path TTL
+ * uses, so SSE clients see identical `session.evicted` semantics. Default
+ * (undefined) = unbounded, preserving the single-user vite dev behavior.
+ *
+ * Multi-user scoping + global kernel lock
+ * =======================================
+ * The pool keys entries by an opaque `key` the caller composes, NOT by the
+ * bare `scriptPath`. The vite dev path passes only a `scriptPath` (so the key
+ * IS the path — unchanged single-user behavior); the hosted server composes a
+ * per-user key like `${userId}|${scriptPath}` so two users opening the same
+ * script get DIFFERENT tokens/entries and a leaked/guessed token can't reach
+ * another user's live model. The owner is carried on the entry as `ownerId`
+ * (the pool does NOT enforce auth — it just records the owner so the server
+ * route can 403 on a token/owner mismatch).
+ *
+ * The hosted server shares ONE OCCT WASM instance across the pool AND its
+ * stateless `/__kernelcad/mesh` route, so every kernel-touching op must be
+ * serialized behind a global mutex the CALLER injects via `runExclusive`. The
+ * pool wraps its OWN kernel calls (the `build(...)` in `getOrCreate`/rebuild)
+ * in `runExclusive`, and re-exposes it as `pool.runExclusive` so the ENDPOINTS
+ * (param-update drain, per-frame bake solves — which live in the endpoint
+ * files, not the pool) route their kernel work through the same lock. The
+ * default `runExclusive` is an identity passthrough (`fn => fn()`), so the vite
+ * dev path runs unlocked exactly as before.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -39,6 +68,16 @@ import type { BuiltModel } from '../modeling/buildModel';
 export interface SessionPoolEntry {
   readonly token: string;
   readonly scriptPath: string;
+  /** Opaque identity key the caller composed (e.g. `${userId}|${scriptPath}`
+   *  on the hosted server, or just `scriptPath` on the vite dev path). Two
+   *  `getOrCreate` calls with the same key share one entry; different keys get
+   *  distinct entries even for the same `scriptPath`. */
+  readonly key: string;
+  /** Owner this session belongs to (the hosted server's authenticated user
+   *  id), or `undefined` in single-user dev mode. The pool only RECORDS this —
+   *  it does NOT enforce auth. The server route reads `entry.ownerId` to 403 on
+   *  a token/owner mismatch (a leaked/guessed token from another user). */
+  readonly ownerId?: string;
   /** Swapped in place by `rebuildByScript` — always read, never cache. */
   model: BuiltModel;
   /** Wall-clock ms (Date.now()) of the most recent access. */
@@ -56,15 +95,47 @@ export interface SessionPoolOptions {
   /** Time-to-live for idle sessions, in milliseconds. Entries whose
    *  `lastAccessAt` is older than `now - ttlMs` are evicted on `prune()`. */
   ttlMs: number;
+  /** Hard cap on live entries. Inserting a new entry past this evicts the
+   *  least-recently-accessed entry first (same drop path TTL uses). Default
+   *  (undefined) = unbounded, preserving single-user vite behavior. The hosted
+   *  server sets this as the OCCT-heap memory backstop across N users. */
+  maxEntries?: number;
+  /** Caller-provided global mutex. Every kernel-touching op (the pool's
+   *  `build(...)`, plus endpoint param-update/bake solves routed through
+   *  `pool.runExclusive`) runs inside this so a single shared OCCT WASM
+   *  instance is never re-entered concurrently. Default = identity passthrough
+   *  (`fn => fn()`), i.e. no locking — the vite dev path is single-user. */
+  runExclusive?: <T>(fn: () => Promise<T>) => Promise<T>;
+}
+
+/** Options for a single `getOrCreate` call. `key` defaults to the bare
+ *  `scriptPath` (single-user dev behavior); the hosted server composes a
+ *  per-user key and passes `ownerId` so the route can later authorize. */
+export interface GetOrCreateOptions {
+  /** Opaque identity key. Defaults to `scriptPath` when omitted. */
+  key?: string;
+  /** Owner recorded on the entry (the authenticated user id). */
+  ownerId?: string;
 }
 
 export interface SessionPool {
   /**
-   * Look up or build a session for the given script path. If an entry already
-   * exists for the script and hasn't been pruned, returns the same token so
-   * multiple browser tabs on the same script share a session.
+   * Look up or build a session for the given script path. Sessions are keyed by
+   * `opts.key` (defaulting to `scriptPath`): if a live entry already exists for
+   * that key, the same token is returned so multiple browser tabs sharing the
+   * key share a session. The hosted server passes a per-user `key`
+   * (`${userId}|${scriptPath}`) and an `ownerId` so distinct users never share
+   * an entry; the vite dev path passes just `scriptPath` (key === scriptPath,
+   * ownerId undefined) — unchanged single-user behavior.
+   *
+   * `scriptPath` is always the real path used to build/load the model.
    */
-  getOrCreate(scriptPath: string): Promise<SessionPoolEntry>;
+  getOrCreate(scriptPath: string, opts?: GetOrCreateOptions): Promise<SessionPoolEntry>;
+  /** Run `fn` under the pool's global kernel lock. Endpoints (param-update
+   *  drain, per-frame bake solves) MUST route their kernel work through this so
+   *  it serializes against the pool's own `build(...)` on the shared OCCT WASM
+   *  instance. Default impl is an identity passthrough (no locking). */
+  runExclusive<T>(fn: () => Promise<T>): Promise<T>;
   /** Get the entry by token. Side effect: bumps `lastAccessAt`. */
   get(token: string): SessionPoolEntry | undefined;
   /** Drop the entry (e.g. when the user closes the tab or rebuilds). */
@@ -99,8 +170,15 @@ interface EntryInternals {
 
 export function createSessionPool(opts: SessionPoolOptions): SessionPool {
   const byToken = new Map<string, SessionPoolEntry>();
-  const byScript = new Map<string, string>();
+  // Reverse index from the opaque identity key (NOT the bare scriptPath) to
+  // the token, so same-key requests share a session and different keys (e.g.
+  // two users on the same script) get distinct entries.
+  const byKey = new Map<string, string>();
   const internals = new Map<string, EntryInternals>();
+  // Identity passthrough by default — the vite dev path is single-user and
+  // runs the kernel unlocked exactly as before.
+  const runExclusive: <T>(fn: () => Promise<T>) => Promise<T> =
+    opts.runExclusive ?? ((fn) => fn());
 
   function touch(entry: SessionPoolEntry): SessionPoolEntry {
     entry.lastAccessAt = Date.now();
@@ -131,15 +209,30 @@ export function createSessionPool(opts: SessionPoolOptions): SessionPool {
     internals.delete(token);
     byToken.delete(token);
     // Only drop the reverse index if it still points at this token —
-    // a subsequent `getOrCreate` for the same script may have already
-    // re-registered the script under a different token.
-    if (byScript.get(entry.scriptPath) === token) {
-      byScript.delete(entry.scriptPath);
+    // a subsequent `getOrCreate` for the same key may have already
+    // re-registered the key under a different token.
+    if (byKey.get(entry.key) === token) {
+      byKey.delete(entry.key);
     }
   }
 
+  /** Evict the single least-recently-accessed entry. Used as the `maxEntries`
+   *  backstop on insert. Same drop path as TTL eviction → identical
+   *  `session.evicted` semantics for SSE clients. */
+  function evictLru(): void {
+    let oldestToken: string | undefined;
+    let oldestAt = Infinity;
+    for (const [token, entry] of byToken) {
+      if (entry.lastAccessAt < oldestAt) {
+        oldestAt = entry.lastAccessAt;
+        oldestToken = token;
+      }
+    }
+    if (oldestToken !== undefined) drop(oldestToken);
+  }
+
   async function rebuildEntry(entry: SessionPoolEntry): Promise<void> {
-    const model = await opts.build(entry.scriptPath);
+    const model = await runExclusive(() => opts.build(entry.scriptPath));
     entry.model = model;
     touch(entry);
     wireEngine(entry);
@@ -149,20 +242,36 @@ export function createSessionPool(opts: SessionPoolOptions): SessionPool {
   }
 
   return {
-    async getOrCreate(scriptPath: string): Promise<SessionPoolEntry> {
-      const existingToken = byScript.get(scriptPath);
+    runExclusive,
+
+    async getOrCreate(scriptPath: string, options?: GetOrCreateOptions): Promise<SessionPoolEntry> {
+      const key = options?.key ?? scriptPath;
+      const ownerId = options?.ownerId;
+      const existingToken = byKey.get(key);
       if (existingToken !== undefined) {
         const existing = byToken.get(existingToken);
         if (existing) return touch(existing);
-        // Stale reverse-index entry (entry was pruned between accesses).
-        byScript.delete(scriptPath);
+        // Stale reverse-index entry (entry was pruned/evicted between accesses).
+        byKey.delete(key);
       }
-      const model = await opts.build(scriptPath);
+      const model = await runExclusive(() => opts.build(scriptPath));
+      // Enforce the count cap AFTER the (awaited) build but BEFORE inserting,
+      // so a fresh insert never pushes the live count past maxEntries. Evict
+      // the LRU entry first — never the one we're about to add.
+      if (opts.maxEntries !== undefined) {
+        while (byToken.size >= opts.maxEntries) {
+          const before = byToken.size;
+          evictLru();
+          if (byToken.size >= before) break; // safety: nothing evictable
+        }
+      }
       const token = randomUUID();
       const listeners = new Set<(affectedIds: string[]) => void>();
       const entry: SessionPoolEntry = {
         token,
         scriptPath,
+        key,
+        ownerId,
         model,
         lastAccessAt: Date.now(),
         onRelower(cb) {
@@ -179,7 +288,7 @@ export function createSessionPool(opts: SessionPoolOptions): SessionPool {
         rebuildQueued: false,
       });
       byToken.set(token, entry);
-      byScript.set(scriptPath, token);
+      byKey.set(key, token);
       wireEngine(entry);
       return entry;
     },

--- a/src/studio/api/apiBase.test.ts
+++ b/src/studio/api/apiBase.test.ts
@@ -12,7 +12,7 @@ vi.mock('../../funnel/lib/supabaseClient', () => ({
   getSupabase: () => getSupabaseMock(),
 }));
 
-import { apiCall, rewritePath } from './apiBase';
+import { apiCall, rewritePath, bearerToken, buildEventsUrl } from './apiBase';
 
 describe('apiCall', () => {
   beforeEach(() => {
@@ -93,5 +93,47 @@ describe('rewritePath', () => {
         'https://app.kernelcad.com/api/v1',
       ),
     ).toBe('https://app.kernelcad.com/api/v1/mesh?script=foo.kcad.ts');
+  });
+});
+
+describe('bearerToken', () => {
+  it('extracts the JWT from an Authorization header', () => {
+    expect(bearerToken({ Authorization: 'Bearer tok-xyz' })).toBe('tok-xyz');
+  });
+
+  it('returns undefined when no Authorization header is present (unsigned-in)', () => {
+    expect(bearerToken({})).toBeUndefined();
+  });
+
+  it('returns undefined when the header is not a Bearer scheme', () => {
+    expect(bearerToken({ Authorization: 'Basic abc' })).toBeUndefined();
+  });
+});
+
+describe('buildEventsUrl', () => {
+  it('omits access_token when no JWT is supplied (unsigned-in / local vite)', () => {
+    expect(buildEventsUrl('', 'sess-1')).toBe(
+      '/__kernelcad/events?session=sess-1',
+    );
+  });
+
+  it('appends access_token when a JWT is supplied (signed-in)', () => {
+    expect(buildEventsUrl('', 'sess-1', 'jwt-abc')).toBe(
+      '/__kernelcad/events?session=sess-1&access_token=jwt-abc',
+    );
+  });
+
+  it('routes the base through rewritePath for the hosted endpoint', () => {
+    expect(
+      buildEventsUrl('https://app.kernelcad.com/api/v1', 'sess-1', 'jwt-abc'),
+    ).toBe(
+      'https://app.kernelcad.com/api/v1/events?session=sess-1&access_token=jwt-abc',
+    );
+  });
+
+  it('url-encodes the session token and the JWT', () => {
+    expect(buildEventsUrl('', 'a/b c', 'x+y/z')).toBe(
+      '/__kernelcad/events?session=a%2Fb%20c&access_token=x%2By%2Fz',
+    );
   });
 });

--- a/src/studio/api/apiBase.ts
+++ b/src/studio/api/apiBase.ts
@@ -69,3 +69,41 @@ export function rewritePath(localPath: string, base: string): string {
   if (base === '') return localPath;
   return base + localPath.replace(/^\/__kernelcad/, '');
 }
+
+/** Extracts the raw Supabase JWT from an `apiCall()` headers map, or
+ *  `undefined` when unsigned-in (no `Authorization` header). Lets SSE callers
+ *  reuse the exact token every other Studio fetch sends as a bearer header. */
+export function bearerToken(headers: Record<string, string>): string | undefined {
+  const auth = headers.Authorization;
+  if (!auth) return undefined;
+  const m = /^Bearer\s+(.+)$/.exec(auth);
+  return m ? m[1] : undefined;
+}
+
+/** Builds the `/__kernelcad/events` SSE URL.
+ *
+ *  `EventSource` cannot carry custom headers, so the signed-in path cannot
+ *  send `Authorization: Bearer <jwt>` the way every other Studio fetch does.
+ *  Instead we append the JWT as an `access_token` query param, which the
+ *  hosted server's injected `authenticate` hook validates (see
+ *  `eventsEndpoint.ts`). When `jwt` is absent (local vite dev, unsigned-in)
+ *  the param is omitted and behavior is bit-for-bit identical to today.
+ *
+ *  `base` is routed through `rewritePath` so signed-in users hit the hosted
+ *  endpoint and unsigned-in users hit the same-origin vite middleware.
+ *
+ *  Security note: the `access_token` rides in the query string and can land
+ *  in access logs. Accepted for now — it is the short-lived Supabase JWT, and
+ *  the `session` token is already an unguessable per-user randomUUID. */
+export function buildEventsUrl(
+  base: string,
+  sessionToken: string,
+  jwt?: string,
+): string {
+  let url = rewritePath(
+    `/__kernelcad/events?session=${encodeURIComponent(sessionToken)}`,
+    base,
+  );
+  if (jwt) url += `&access_token=${encodeURIComponent(jwt)}`;
+  return url;
+}

--- a/src/studio/context/GeometryContext.tsx
+++ b/src/studio/context/GeometryContext.tsx
@@ -6,7 +6,7 @@ import { rehydrateFromBridge, type FeatureMeshSerialized } from '../../modeling/
 import type { SerializedParamEntry, SerializedParamTable } from '../../shared/runtime/paramTable';
 import type { FeatureRecord } from '../../shared/intent/featureRecord';
 import { shouldUseHostedMesh, meshSourceHosted, devMeshAvailable, meshSourceDev, needsFullKernel, type BackendMeshPayload } from '../scriptSource';
-import { apiCall, rewritePath } from '../api/apiBase';
+import { apiCall, rewritePath, bearerToken, buildEventsUrl } from '../api/apiBase';
 
 export type ExecutionStatus = 'success' | 'error' | 'stale';
 
@@ -599,16 +599,16 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
             // the live-interference channel.)
             requestMeshAndReview(studioScript, sessionToken, { keepExistingOnError: true, liveReview: true });
         };
-        // S1: route the SSE URL through apiCall so signed-in users hit the
-        // hosted /events endpoint. (EventSource can't carry custom headers,
-        // so signed-in auth for SSE is an S3 concern — for unsigned-in the
-        // base is '' and behavior is bit-for-bit identical to today.)
-        void apiCall().then(({ base }) => {
+        // Route the SSE URL through apiCall so signed-in users hit the hosted
+        // /events endpoint. EventSource can't carry custom headers, so the
+        // Supabase JWT is appended as an `access_token` query param (the
+        // hosted server validates it via its injected authenticate hook; see
+        // eventsEndpoint.ts). For unsigned-in local dev the base is '' and the
+        // JWT is undefined, so buildEventsUrl omits access_token and behavior
+        // is bit-for-bit identical to today.
+        void apiCall().then(({ base, headers }) => {
             if (cancelled) return;
-            const url = rewritePath(
-                `/__kernelcad/events?session=${encodeURIComponent(sessionToken)}`,
-                base,
-            );
+            const url = buildEventsUrl(base, sessionToken, bearerToken(headers));
             es = new EventSource(url);
             es.addEventListener('relower', onRelower);
             // The browser auto-reconnects on transient drops; we only log here.

--- a/tests/unit/server/eventsEndpoint.test.ts
+++ b/tests/unit/server/eventsEndpoint.test.ts
@@ -164,6 +164,100 @@ describe('eventsEndpoint', () => {
     expect(JSON.parse(res.body).error).toMatch(/engine/i);
   });
 
+  it('streams as today when no authenticate dep is supplied (vite path)', async () => {
+    const engine = fakeEngine();
+    const pool = createSessionPool({
+      build: async () => fakeBuiltModelWithEngine(engine),
+      ttlMs: 60_000,
+    });
+    const entry = await pool.getOrCreate('/abs/x.kcad.ts');
+    const handler = createEventsEndpoint({ pool });
+    const req = createFakeReqWithClose(`/__kernelcad/events?session=${entry.token}`);
+    const res = createFakeRes();
+
+    void handler(req, res);
+    await Promise.resolve();
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toBe('text/event-stream');
+    expect(res.writes.some((c) => c.startsWith(': connected'))).toBe(true);
+  });
+
+  it('rejects with 401 and does NOT open the stream when authenticate denies', async () => {
+    const engine = fakeEngine();
+    const pool = createSessionPool({
+      build: async () => fakeBuiltModelWithEngine(engine),
+      ttlMs: 60_000,
+    });
+    const entry = await pool.getOrCreate('/abs/x.kcad.ts');
+    const authenticate = vi.fn(async () => ({ ok: false }));
+    const handler = createEventsEndpoint({ pool, authenticate });
+    const req = createFakeReqWithClose(
+      `/__kernelcad/events?session=${entry.token}&access_token=bad`,
+    );
+    const res = createFakeRes();
+
+    await handler(req, res);
+
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(401);
+    // No SSE preamble, no subscription — the stream never opened. (writeJson
+    // sets a JSON content-type for the error body; the stream content-type is
+    // text/event-stream, which must NOT have been set.)
+    expect(res.headers['content-type']).not.toBe('text/event-stream');
+    expect(res.writes).toHaveLength(0);
+    expect(engine.subscribers).toHaveLength(1); // only the pool entry's hub
+  });
+
+  it('honors a custom status/error from a denying authenticate hook', async () => {
+    const engine = fakeEngine();
+    const pool = createSessionPool({
+      build: async () => fakeBuiltModelWithEngine(engine),
+      ttlMs: 60_000,
+    });
+    const entry = await pool.getOrCreate('/abs/x.kcad.ts');
+    const authenticate = vi.fn(async () => ({
+      ok: false,
+      status: 403,
+      error: 'token owner mismatch',
+    }));
+    const handler = createEventsEndpoint({ pool, authenticate });
+    const req = createFakeReqWithClose(`/__kernelcad/events?session=${entry.token}`);
+    const res = createFakeRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toBe('token owner mismatch');
+    expect(res.writes).toHaveLength(0);
+  });
+
+  it('streams when authenticate allows', async () => {
+    const engine = fakeEngine();
+    const pool = createSessionPool({
+      build: async () => fakeBuiltModelWithEngine(engine),
+      ttlMs: 60_000,
+    });
+    const entry = await pool.getOrCreate('/abs/x.kcad.ts');
+    const authenticate = vi.fn(async () => ({ ok: true }));
+    const handler = createEventsEndpoint({ pool, authenticate });
+    const req = createFakeReqWithClose(
+      `/__kernelcad/events?session=${entry.token}&access_token=good-jwt`,
+    );
+    const res = createFakeRes();
+
+    void handler(req, res);
+    await Promise.resolve();
+
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toBe('text/event-stream');
+    expect(res.writes.some((c) => c.startsWith(': connected'))).toBe(true);
+
+    engine.emitRelower(['feat_1']);
+    expect(res.writes.some((c) => c.startsWith('event: relower\n'))).toBe(true);
+  });
+
   it('writes periodic keep-alive comments when heartbeatMs is set', async () => {
     vi.useFakeTimers();
     try {

--- a/tests/unit/server/sessionPool.test.ts
+++ b/tests/unit/server/sessionPool.test.ts
@@ -136,4 +136,173 @@ describe('SessionPool', () => {
     const all: SessionPoolEntry[] = [...pool.entries()];
     expect(all).toHaveLength(2);
   });
+
+  describe('maxEntries LRU cap', () => {
+    it('is unbounded by default (no maxEntries)', async () => {
+      const { createSessionPool } = await loadPoolModule();
+      const pool = createSessionPool({ build: async () => fakeBuiltModel(), ttlMs: 60_000 });
+
+      await pool.getOrCreate('/abs/a.kcad.ts');
+      await pool.getOrCreate('/abs/b.kcad.ts');
+      await pool.getOrCreate('/abs/c.kcad.ts');
+
+      expect([...pool.entries()]).toHaveLength(3);
+    });
+
+    it('evicts the least-recently-accessed entry on insert past the cap', async () => {
+      const { createSessionPool } = await loadPoolModule();
+      const pool = createSessionPool({ build: async () => fakeBuiltModel(), ttlMs: 60_000, maxEntries: 2 });
+
+      const a = await pool.getOrCreate('/abs/a.kcad.ts');
+      vi.advanceTimersByTime(10);
+      const b = await pool.getOrCreate('/abs/b.kcad.ts');
+      vi.advanceTimersByTime(10);
+      // Inserting c exceeds the cap of 2 → the LRU (a) is evicted.
+      const c = await pool.getOrCreate('/abs/c.kcad.ts');
+
+      expect([...pool.entries()]).toHaveLength(2);
+      // The evicted token now misses — same as the TTL `session.evicted` path.
+      expect(pool.get(a.token)).toBeUndefined();
+      expect(pool.get(b.token)).toBeDefined();
+      expect(pool.get(c.token)).toBeDefined();
+    });
+
+    it('keeps a recently-touched entry alive and evicts a colder one instead', async () => {
+      const { createSessionPool } = await loadPoolModule();
+      const pool = createSessionPool({ build: async () => fakeBuiltModel(), ttlMs: 60_000, maxEntries: 2 });
+
+      const a = await pool.getOrCreate('/abs/a.kcad.ts');
+      vi.advanceTimersByTime(10);
+      const b = await pool.getOrCreate('/abs/b.kcad.ts');
+      vi.advanceTimersByTime(10);
+      // Touch a so b becomes the coldest.
+      pool.get(a.token);
+      vi.advanceTimersByTime(10);
+      const c = await pool.getOrCreate('/abs/c.kcad.ts');
+
+      expect(pool.get(a.token)).toBeDefined();
+      expect(pool.get(b.token)).toBeUndefined();
+      expect(pool.get(c.token)).toBeDefined();
+    });
+  });
+
+  describe('runExclusive global lock hook', () => {
+    it('defaults to identity passthrough (kernel build still runs)', async () => {
+      const { createSessionPool } = await loadPoolModule();
+      const builder = vi.fn(async () => fakeBuiltModel());
+      const pool = createSessionPool({ build: builder, ttlMs: 60_000 });
+
+      const entry = await pool.getOrCreate('/abs/a.kcad.ts');
+      expect(entry.token).toBeDefined();
+      expect(builder).toHaveBeenCalledTimes(1);
+      // Exposed for endpoints to route their own kernel ops through.
+      await expect(pool.runExclusive(async () => 42)).resolves.toBe(42);
+    });
+
+    it('serializes the pool\'s own build() calls when a real mutex is injected', async () => {
+      const { createSessionPool } = await loadPoolModule();
+      vi.useRealTimers(); // need real microtask/timer ordering for overlap probe
+
+      // Simple promise-chained mutex.
+      let chain: Promise<unknown> = Promise.resolve();
+      const runExclusive = <T>(fn: () => Promise<T>): Promise<T> => {
+        const run = chain.then(fn, fn);
+        chain = run.then(
+          () => undefined,
+          () => undefined,
+        );
+        return run as Promise<T>;
+      };
+
+      let active = 0;
+      let maxConcurrent = 0;
+      const builder = vi.fn(async () => {
+        active += 1;
+        maxConcurrent = Math.max(maxConcurrent, active);
+        await new Promise((r) => setTimeout(r, 5));
+        active -= 1;
+        return fakeBuiltModel();
+      });
+
+      const pool = createSessionPool({ build: builder, ttlMs: 60_000, runExclusive });
+
+      // Fire three distinct-key builds concurrently; the mutex must serialize.
+      await Promise.all([
+        pool.getOrCreate('/abs/a.kcad.ts'),
+        pool.getOrCreate('/abs/b.kcad.ts'),
+        pool.getOrCreate('/abs/c.kcad.ts'),
+      ]);
+
+      expect(builder).toHaveBeenCalledTimes(3);
+      expect(maxConcurrent).toBe(1); // never overlapped
+
+      vi.useFakeTimers();
+    });
+  });
+
+  describe('per-user session scoping', () => {
+    it('same scriptPath + different keys/owners get DIFFERENT tokens and entries', async () => {
+      const { createSessionPool } = await loadPoolModule();
+      const builder = vi.fn(async () => fakeBuiltModel());
+      const pool = createSessionPool({ build: builder, ttlMs: 60_000 });
+
+      const userA = await pool.getOrCreate('/abs/shared.kcad.ts', {
+        key: 'userA|/abs/shared.kcad.ts',
+        ownerId: 'userA',
+      });
+      const userB = await pool.getOrCreate('/abs/shared.kcad.ts', {
+        key: 'userB|/abs/shared.kcad.ts',
+        ownerId: 'userB',
+      });
+
+      expect(userA.token).not.toBe(userB.token);
+      expect(builder).toHaveBeenCalledTimes(2);
+      expect(userA.scriptPath).toBe('/abs/shared.kcad.ts');
+      expect(userB.scriptPath).toBe('/abs/shared.kcad.ts');
+    });
+
+    it('same key reuses the same entry', async () => {
+      const { createSessionPool } = await loadPoolModule();
+      const builder = vi.fn(async () => fakeBuiltModel());
+      const pool = createSessionPool({ build: builder, ttlMs: 60_000 });
+
+      const a = await pool.getOrCreate('/abs/shared.kcad.ts', {
+        key: 'userA|/abs/shared.kcad.ts',
+        ownerId: 'userA',
+      });
+      const b = await pool.getOrCreate('/abs/shared.kcad.ts', {
+        key: 'userA|/abs/shared.kcad.ts',
+        ownerId: 'userA',
+      });
+
+      expect(b.token).toBe(a.token);
+      expect(builder).toHaveBeenCalledTimes(1);
+    });
+
+    it('carries ownerId on the entry so the server route can authorize', async () => {
+      const { createSessionPool } = await loadPoolModule();
+      const pool = createSessionPool({ build: async () => fakeBuiltModel(), ttlMs: 60_000 });
+
+      const entry = await pool.getOrCreate('/abs/x.kcad.ts', {
+        key: 'userA|/abs/x.kcad.ts',
+        ownerId: 'userA',
+      });
+      expect(entry.ownerId).toBe('userA');
+      expect(pool.get(entry.token)!.ownerId).toBe('userA');
+    });
+
+    it('defaults key to scriptPath and ownerId to undefined (single-user dev mode)', async () => {
+      const { createSessionPool } = await loadPoolModule();
+      const builder = vi.fn(async () => fakeBuiltModel());
+      const pool = createSessionPool({ build: builder, ttlMs: 60_000 });
+
+      const a = await pool.getOrCreate('/abs/dev.kcad.ts');
+      const b = await pool.getOrCreate('/abs/dev.kcad.ts');
+
+      expect(a.key).toBe('/abs/dev.kcad.ts');
+      expect(a.ownerId).toBeUndefined();
+      expect(b.token).toBe(a.token); // bare path reuse unchanged
+      expect(builder).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -161,6 +161,14 @@ function kernelCadMeshEndpoint(): Plugin {
               import('./src/server/middleware/animationBakeEndpoint'),
               import('./src/modeling/buildModel'),
             ]);
+            // Single-user dev pool: no `maxEntries` cap (unbounded) and no
+            // `runExclusive` lock (identity passthrough) — one local developer
+            // shares this OCCT instance, so the multi-user backstops are off.
+            // The hosted server injects a real `maxEntries` (OCCT-heap memory
+            // backstop) and a real `runExclusive` mutex (the kernel is shared
+            // with the stateless mesh route), composes a per-user `key` +
+            // `ownerId` on `getOrCreate`, and routes its param-update/bake
+            // kernel work through `pool.runExclusive`.
             const pool = createSessionPool({
               build: (scriptPath) => buildModelFromFile({ file: scriptPath }),
               ttlMs: 5 * 60 * 1000,


### PR DESCRIPTION
Web-side foundation for making signed-in Studio behave like local (live params/joints/animation on the internet). Additive with single-user-safe defaults — vite dev path unchanged.

- **Session pool hardening**: `maxEntries` LRU cap, injectable `runExclusive` lock hook (serialize kernel ops behind one OCCT mutex shared with /mesh), per-user `key`+`ownerId` scoping. Defaults preserve current behavior.
- **SSE auth**: optional `access_token` query + injected `authenticate` hook on /events (EventSource can't send Authorization); `bearerToken`/`buildEventsUrl` helpers.

Consumed by the Hetzner kernelCAD-server which mounts the same middleware (reuse = identical behavior). Tests: pool 17, events 11, apiBase 14 — green; typecheck+lint clean.