### PR TITLE
fix: default starter model uses ParamRef arithmetic (.add/.divide)

### DIFF
--- a/src/shared/worker/geometryEngine.ts
+++ b/src/shared/worker/geometryEngine.ts
@@ -29,7 +29,7 @@ const h = param('Height', 40, { unit: 'mm' });
 const t = param('Thickness', 5, { unit: 'mm' });
 
 const base = box(w, h, t);
-const hole = cylinder(t + 2, 4).translate(w / 2, h / 2, -1);
+const hole = cylinder(t.add(2), 4).translate(w.divide(2), h.divide(2), -1);
 return base.subtract(hole);
 `;
 


### PR DESCRIPTION
The blank-project starter (`geometryEngine.ts` `defaultCode`) used raw JS operators on ParamRefs — `cylinder(t + 2, 4)`, `translate(w / 2, h / 2, -1)`. JS can't overload operators on a ParamRef object, so `t + 2` stringifies to `'[object Object]2'` and the kernel rejects it (*'h must be a finite number or a numeric ParamRef'*). On the hosted backend the default model failed to render with exactly that error.

Fix: use the ParamRef arithmetic API (`.add(2)`, `.divide(2)`) — builds a real expression AST and keeps the param→geometry link, so editing Width/Thickness still moves the hole. Verified rendering against the live backend mesh endpoint.