### PR TITLE
[codex] Add Studio view cube navigation gizmo

### DIFF
--- a/src/studio/components/Viewer.tsx
+++ b/src/studio/components/Viewer.tsx
@@ -28,6 +28,8 @@ import { SnapIndicator } from "./viewer/overlays/SnapIndicator";
 import { HighlightOverlay } from "./viewer/overlays/HighlightOverlay";
 import { SelectionOutline } from "./viewer/overlays/SelectionOutline";
 import { SceneBackground } from "./viewer/SceneBackground";
+import { ViewGizmo } from "./viewer/overlays/ViewGizmo";
+import type { ViewTarget } from "./viewer/controllers/cameraPose";
 
 // Constants
 export const SKETCH_FOV = 40;
@@ -102,6 +104,7 @@ export default function Viewer({ geometries, previewGeometries, sketchesGeometri
 
     const [hoveredItem, setHoveredItem] = useState<HoverResult | null>(null);
     const [snapPoint, setSnapPoint] = useState<SnapResult | null>(null);
+    const [navigationRequest, setNavigationRequest] = useState<{ target: ViewTarget; id: number } | null>(null);
 
     useEffect(() => {
         if (hoveredItem?.object?.userData?.ownerId) {
@@ -243,9 +246,30 @@ export default function Viewer({ geometries, previewGeometries, sketchesGeometri
 
                 <PlaneLayer planes={planes} />
                 {sketchMode.active && <ParametricLayer />}
-                <OrbitControls makeDefault enabled={!sketchMode.active} />
-                <CameraHandler geometries={geometries} />
+                <OrbitControls
+                    makeDefault
+                    enabled={!sketchMode.active}
+                    mouseButtons={{
+                        LEFT: THREE.MOUSE.ROTATE,
+                        MIDDLE: THREE.MOUSE.PAN,
+                        RIGHT: THREE.MOUSE.PAN,
+                    }}
+                    touches={{
+                        ONE: THREE.TOUCH.ROTATE,
+                        TWO: THREE.TOUCH.DOLLY_PAN,
+                    }}
+                    screenSpacePanning
+                    enableDamping
+                    dampingFactor={0.12}
+                />
+                <CameraHandler geometries={geometries} navigationRequest={navigationRequest} />
             </Canvas>
+            <ViewGizmo
+                onNavigate={(target) => setNavigationRequest((prev) => ({
+                    target,
+                    id: (prev?.id ?? 0) + 1,
+                }))}
+            />
             <div className="absolute top-4 left-4 text-white/50 text-xs pointer-events-none font-mono">
                 kernelCAD v{typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'DEV'} ({typeof __COMMIT_HASH__ !== 'undefined' ? __COMMIT_HASH__ : 'DEV'}) | {viewMode3D === 'shadedWithEdges' ? 'Shaded + Edges' :
                     viewMode3D === 'wireframe' ? 'Wireframe' : 'Shaded'}

--- a/src/studio/components/viewer/controllers/CameraHandler.tsx
+++ b/src/studio/components/viewer/controllers/CameraHandler.tsx
@@ -4,12 +4,19 @@ import { useEffect, useRef } from "react";
 import { useWorkbench } from "../../../context/WorkbenchContext";
 import type { GeometryResult } from "../../../../shared/worker/geometryEngine";
 import { computeGeometryBounds } from "./cameraBounds";
+import { buildCameraPose, buildFitCameraPose, type ViewTarget } from "./cameraPose";
 
 // Using the exported constants if needed, but they are defined in Viewer.tsx conventionally.
 // For now I will hardcode or use the same values.
 const SKETCH_DISTANCE = 20;
 
-export function CameraHandler({ geometries }: { geometries: GeometryResult[] }) {
+export function CameraHandler({
+    geometries,
+    navigationRequest,
+}: {
+    geometries: GeometryResult[];
+    navigationRequest?: { target: ViewTarget; id: number } | null;
+}) {
     const { selectedFace, sketchMode } = useWorkbench();
     const { camera, controls } = useThree();
     const cameraRef = useRef(camera);
@@ -45,14 +52,31 @@ export function CameraHandler({ geometries }: { geometries: GeometryResult[] }) 
         lastFitBounds.current = { center: bounds.center.clone(), radius: bounds.radius };
 
         const distance = Math.max(bounds.radius * 2.8, SKETCH_DISTANCE);
-        const direction = new THREE.Vector3(1, 1, 0.75).normalize();
-        const nextPosition = bounds.center.clone().add(direction.multiplyScalar(distance));
-
-        targetState.current = { position: nextPosition, lookAt: bounds.center };
+        const pose = buildFitCameraPose(bounds.center, distance);
+        cameraRef.current.up.copy(pose.up);
+        targetState.current = { position: pose.position, lookAt: pose.lookAt };
         cameraRef.current.near = Math.max(distance / 500, 0.01);
         cameraRef.current.far = Math.max(distance * 20, 1000);
         cameraRef.current.updateProjectionMatrix();
     }, [geometries, sketchMode.active]);
+
+    useEffect(() => {
+        if (!navigationRequest || geometries.length === 0 || sketchMode.active) return;
+
+        const bounds = computeGeometryBounds(geometries);
+        if (!bounds) return;
+
+        const distance = Math.max(bounds.radius * 2.8, SKETCH_DISTANCE);
+        const pose = navigationRequest.target === 'fit'
+            ? buildFitCameraPose(bounds.center, distance)
+            : buildCameraPose(navigationRequest.target, bounds.center, distance);
+
+        cameraRef.current.up.copy(pose.up);
+        cameraRef.current.near = Math.max(distance / 500, 0.01);
+        cameraRef.current.far = Math.max(distance * 20, 1000);
+        cameraRef.current.updateProjectionMatrix();
+        targetState.current = { position: pose.position, lookAt: pose.lookAt };
+    }, [navigationRequest, geometries, sketchMode.active]);
 
     useEffect(() => {
         const isSketching = sketchMode.active;

--- a/src/studio/components/viewer/controllers/cameraPose.test.ts
+++ b/src/studio/components/viewer/controllers/cameraPose.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import * as THREE from 'three';
+import { buildCameraPose } from './cameraPose';
+
+const center = new THREE.Vector3(10, 20, 30);
+
+describe('buildCameraPose', () => {
+    it('snaps arrow views around the z-up model center', () => {
+        expect(buildCameraPose('x', center, 100).position.toArray()).toEqual([110, 20, 30]);
+        expect(buildCameraPose('y', center, 100).position.toArray()).toEqual([10, 120, 30]);
+        expect(buildCameraPose('z', center, 100).position.toArray()).toEqual([10, 20, 130]);
+    });
+
+    it('snaps plane views to their normals', () => {
+        expect(buildCameraPose('xy', center, 100).position.toArray()).toEqual([10, 20, 130]);
+        expect(buildCameraPose('xz', center, 100).position.toArray()).toEqual([10, -80, 30]);
+        expect(buildCameraPose('yz', center, 100).position.toArray()).toEqual([110, 20, 30]);
+    });
+
+    it('uses a stable z-up vector except when looking straight down z', () => {
+        expect(buildCameraPose('x', center, 100).up.toArray()).toEqual([0, 0, 1]);
+        expect(buildCameraPose('xy', center, 100).up.toArray()).toEqual([0, 1, 0]);
+    });
+});

--- a/src/studio/components/viewer/controllers/cameraPose.ts
+++ b/src/studio/components/viewer/controllers/cameraPose.ts
@@ -1,0 +1,44 @@
+import * as THREE from 'three';
+
+export type ViewTarget = 'x' | 'y' | 'z' | 'xy' | 'xz' | 'yz' | 'fit';
+
+export interface CameraPose {
+    position: THREE.Vector3;
+    lookAt: THREE.Vector3;
+    up: THREE.Vector3;
+}
+
+const DIRECTIONS: Record<Exclude<ViewTarget, 'fit'>, [number, number, number]> = {
+    x: [1, 0, 0],
+    y: [0, 1, 0],
+    z: [0, 0, 1],
+    xy: [0, 0, 1],
+    xz: [0, -1, 0],
+    yz: [1, 0, 0],
+};
+
+export function buildCameraPose(
+    target: Exclude<ViewTarget, 'fit'>,
+    center: THREE.Vector3,
+    distance: number,
+): CameraPose {
+    const direction = new THREE.Vector3(...DIRECTIONS[target]).normalize();
+    const up = Math.abs(direction.z) > 0.95
+        ? new THREE.Vector3(0, 1, 0)
+        : new THREE.Vector3(0, 0, 1);
+
+    return {
+        position: center.clone().add(direction.multiplyScalar(distance)),
+        lookAt: center.clone(),
+        up,
+    };
+}
+
+export function buildFitCameraPose(center: THREE.Vector3, distance: number): CameraPose {
+    const direction = new THREE.Vector3(1, 1, 0.75).normalize();
+    return {
+        position: center.clone().add(direction.multiplyScalar(distance)),
+        lookAt: center.clone(),
+        up: new THREE.Vector3(0, 0, 1),
+    };
+}

--- a/src/studio/components/viewer/overlays/ViewGizmo.test.tsx
+++ b/src/studio/components/viewer/overlays/ViewGizmo.test.tsx
@@ -1,0 +1,38 @@
+/** @vitest-environment happy-dom */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { ViewGizmo } from './ViewGizmo';
+
+afterEach(() => cleanup());
+
+describe('ViewGizmo', () => {
+    it('renders Fusion-style axis, plane, and fit controls', () => {
+        render(<ViewGizmo onNavigate={vi.fn()} />);
+
+        expect(screen.getByTestId('view-cube')).toBeDefined();
+        expect(screen.getByTestId('view-axis-arrows')).toBeDefined();
+
+        for (const label of [
+            'View along X axis',
+            'View along Y axis',
+            'View along Z axis',
+            'View XY plane',
+            'View XZ plane',
+            'View YZ plane',
+            'Fit model to view',
+        ]) {
+            expect(screen.getByRole('button', { name: label })).toBeDefined();
+        }
+    });
+
+    it('sends the requested view target when a control is clicked', () => {
+        const onNavigate = vi.fn();
+        render(<ViewGizmo onNavigate={onNavigate} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'View YZ plane' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Fit model to view' }));
+
+        expect(onNavigate).toHaveBeenNthCalledWith(1, 'yz');
+        expect(onNavigate).toHaveBeenNthCalledWith(2, 'fit');
+    });
+});

--- a/src/studio/components/viewer/overlays/ViewGizmo.tsx
+++ b/src/studio/components/viewer/overlays/ViewGizmo.tsx
@@ -1,0 +1,142 @@
+import { Home } from 'lucide-react';
+import type { ViewTarget } from '../controllers/cameraPose';
+
+interface ViewGizmoProps {
+    onNavigate: (target: ViewTarget) => void;
+}
+
+function Hotspot({
+    label,
+    children,
+    className,
+    style,
+    onClick,
+}: {
+    label: string;
+    children: React.ReactNode;
+    className: string;
+    style?: React.CSSProperties;
+    onClick: () => void;
+}) {
+    return (
+        <button
+            type="button"
+            aria-label={label}
+            title={label}
+            onClick={onClick}
+            className={className}
+            style={style}
+        >
+            {children}
+        </button>
+    );
+}
+
+export function ViewGizmo({ onNavigate }: ViewGizmoProps) {
+    return (
+        <div
+            data-testid="view-gizmo"
+            className="absolute bottom-14 right-5 z-20 h-36 w-36 select-none"
+        >
+            <svg
+                data-testid="view-axis-arrows"
+                className="pointer-events-none absolute inset-0 drop-shadow-[0_6px_12px_rgba(0,0,0,0.45)]"
+                viewBox="0 0 144 144"
+                aria-hidden="true"
+            >
+                <defs>
+                    <marker id="view-gizmo-x-arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+                        <path d="M0,0 L8,4 L0,8 Z" fill="#f87171" />
+                    </marker>
+                    <marker id="view-gizmo-y-arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+                        <path d="M0,0 L8,4 L0,8 Z" fill="#34d399" />
+                    </marker>
+                    <marker id="view-gizmo-z-arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+                        <path d="M0,0 L8,4 L0,8 Z" fill="#38bdf8" />
+                    </marker>
+                    <linearGradient id="view-gizmo-top" x1="42" y1="36" x2="103" y2="67" gradientUnits="userSpaceOnUse">
+                        <stop stopColor="#8a8f98" />
+                        <stop offset="1" stopColor="#535965" />
+                    </linearGradient>
+                    <linearGradient id="view-gizmo-left" x1="42" y1="53" x2="75" y2="99" gradientUnits="userSpaceOnUse">
+                        <stop stopColor="#646b75" />
+                        <stop offset="1" stopColor="#2e333b" />
+                    </linearGradient>
+                    <linearGradient id="view-gizmo-right" x1="103" y1="53" x2="75" y2="99" gradientUnits="userSpaceOnUse">
+                        <stop stopColor="#565d68" />
+                        <stop offset="1" stopColor="#242932" />
+                    </linearGradient>
+                </defs>
+
+                <line x1="75" y1="66" x2="121" y2="90" stroke="#f87171" strokeWidth="2.5" markerEnd="url(#view-gizmo-x-arrow)" />
+                <line x1="75" y1="66" x2="28" y2="91" stroke="#34d399" strokeWidth="2.5" markerEnd="url(#view-gizmo-y-arrow)" />
+                <line x1="75" y1="66" x2="75" y2="17" stroke="#38bdf8" strokeWidth="2.5" markerEnd="url(#view-gizmo-z-arrow)" />
+
+                <g data-testid="view-cube-art">
+                    <polygon points="48,52 75,38 102,52 75,66" fill="url(#view-gizmo-top)" stroke="rgba(255,255,255,0.42)" strokeWidth="1.2" />
+                    <polygon points="48,52 75,66 75,97 48,83" fill="url(#view-gizmo-left)" stroke="rgba(255,255,255,0.28)" strokeWidth="1.2" />
+                    <polygon points="102,52 75,66 75,97 102,83" fill="url(#view-gizmo-right)" stroke="rgba(255,255,255,0.24)" strokeWidth="1.2" />
+                    <text x="75" y="54" textAnchor="middle" fill="#f8fafc" fontSize="9" fontWeight="700">XY</text>
+                    <text x="61" y="79" textAnchor="middle" fill="#f8fafc" fontSize="9" fontWeight="700">XZ</text>
+                    <text x="89" y="79" textAnchor="middle" fill="#f8fafc" fontSize="9" fontWeight="700">YZ</text>
+                </g>
+            </svg>
+
+            <div data-testid="view-cube" className="absolute inset-0">
+                <Hotspot
+                    label="View XY plane"
+                    onClick={() => onNavigate('xy')}
+                    className="absolute left-12 top-[38px] h-8 w-14 bg-cyan-300/0 text-transparent transition hover:bg-cyan-300/20 focus:outline-none focus:ring-2 focus:ring-cyan-300"
+                    style={{ clipPath: 'polygon(0 45%, 50% 0, 100% 45%, 50% 88%)' }}
+                >
+                    XY
+                </Hotspot>
+                <Hotspot
+                    label="View YZ plane"
+                    onClick={() => onNavigate('yz')}
+                    className="absolute left-[74px] top-[52px] h-12 w-8 bg-red-300/0 text-transparent transition hover:bg-red-300/20 focus:outline-none focus:ring-2 focus:ring-cyan-300"
+                    style={{ clipPath: 'polygon(0 28%, 100% 0, 100% 72%, 0 100%)' }}
+                >
+                    YZ
+                </Hotspot>
+                <Hotspot
+                    label="View XZ plane"
+                    onClick={() => onNavigate('xz')}
+                    className="absolute left-12 top-[52px] h-12 w-8 bg-emerald-300/0 text-transparent transition hover:bg-emerald-300/20 focus:outline-none focus:ring-2 focus:ring-cyan-300"
+                    style={{ clipPath: 'polygon(0 0, 100% 28%, 100% 100%, 0 72%)' }}
+                >
+                    XZ
+                </Hotspot>
+            </div>
+
+            <Hotspot
+                label="View along X axis"
+                onClick={() => onNavigate('x')}
+                className="absolute right-[1px] top-[78px] flex h-7 w-7 items-center justify-center rounded-full border border-red-200/50 bg-red-950/90 text-xs font-bold text-red-100 shadow-lg transition hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-cyan-300"
+            >
+                X
+            </Hotspot>
+            <Hotspot
+                label="View along Y axis"
+                onClick={() => onNavigate('y')}
+                className="absolute left-1 top-[79px] flex h-7 w-7 items-center justify-center rounded-full border border-emerald-200/50 bg-emerald-950/90 text-xs font-bold text-emerald-100 shadow-lg transition hover:bg-emerald-600 focus:outline-none focus:ring-2 focus:ring-cyan-300"
+            >
+                Y
+            </Hotspot>
+            <Hotspot
+                label="View along Z axis"
+                onClick={() => onNavigate('z')}
+                className="absolute left-[58px] top-0 flex h-7 w-7 items-center justify-center rounded-full border border-sky-200/50 bg-sky-950/90 text-xs font-bold text-sky-100 shadow-lg transition hover:bg-sky-600 focus:outline-none focus:ring-2 focus:ring-cyan-300"
+            >
+                Z
+            </Hotspot>
+            <Hotspot
+                label="Fit model to view"
+                onClick={() => onNavigate('fit')}
+                className="absolute bottom-0 right-0 flex h-8 w-8 items-center justify-center rounded-md border border-white/20 bg-neutral-950/85 text-white shadow-lg backdrop-blur transition hover:bg-neutral-800 focus:outline-none focus:ring-2 focus:ring-cyan-300"
+            >
+                <Home size={15} aria-hidden="true" />
+            </Hotspot>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- Adds a Fusion-style Studio view cube with clickable XY/XZ/YZ faces, X/Y/Z axis endpoints, and a fit/home control.
- Routes gizmo actions through bounded camera-pose helpers so snaps target the current model center.
- Tunes Studio mouse controls for more predictable orbit, pan, and zoom behavior.

## Context
This is based on current `origin/develop`, which includes the latest animated spice-dispenser carousel model and Studio animation tab work. The PR intentionally contains only the navigation/gizmo change.

## Validation
- `npm test -- src/studio/components/viewer/controllers/cameraPose.test.ts src/studio/components/viewer/overlays/ViewGizmo.test.tsx`
- `npm run typecheck`
- Restarted local Studio stack and verified `examples/spice-dispenser-carousel.kcad.ts` loads via the Studio route and mesh endpoint.