### PR TITLE
fix(cli): use fileURLToPath for __dirname so the WASM loads on Windows

### DIFF
--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -30,12 +30,19 @@ await esbuild.build({
     'verb-nurbs': verbNurbsPath,
   },
   banner: {
+    // __filename/__dirname shim for the ESM bundle. MUST use fileURLToPath, not
+    // `new URL(...).pathname`: on Windows the latter yields "/D:/path" (leading
+    // slash + drive letter), so when the OCCT loader joins it with the wasm
+    // filename the drive doubles into "D:\D:\...\replicad_single.wasm" and the
+    // load fails. fileURLToPath produces a native path ("D:\path") on Windows
+    // and "/path" on POSIX, so the wasm resolves on every platform.
     js: [
       '#!/usr/bin/env node',
       "import{createRequire as __bcr}from'node:module';",
+      "import{fileURLToPath as __furl}from'node:url';",
       'const require=__bcr(import.meta.url);',
-      "const __filename=new URL(import.meta.url).pathname;",
-      "const __dirname=new URL('.',import.meta.url).pathname;",
+      "const __filename=__furl(import.meta.url);",
+      "const __dirname=__furl(new URL('.',import.meta.url));",
     ].join('\n'),
   },
 });

--- a/scripts/build-cli.test.ts
+++ b/scripts/build-cli.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const buildCli = readFileSync(resolve(here, 'build-cli.mjs'), 'utf8');
+
+// Regression guard for the Windows WASM-path bug: the CLI bundle's __dirname/
+// __filename shim MUST use fileURLToPath, never `new URL(...).pathname`. On
+// Windows, `new URL('file:///D:/x/').pathname` is "/D:/x/" (leading slash +
+// drive), so the OCCT loader joins it into "D:\D:\...\replicad_single.wasm"
+// and the kernel fails to load. fileURLToPath yields a native path on every OS.
+describe('build-cli banner (Windows WASM-path safety)', () => {
+  it('derives __dirname/__filename via fileURLToPath, not URL.pathname', () => {
+    expect(buildCli).toContain('fileURLToPath');
+    expect(buildCli).toContain('const __filename=__furl(import.meta.url);');
+    expect(buildCli).toContain("const __dirname=__furl(new URL('.',import.meta.url));");
+  });
+
+  it('never reintroduces the exact Windows-broken `.pathname` banner lines', () => {
+    expect(buildCli).not.toContain('const __filename=new URL(import.meta.url).pathname;');
+    expect(buildCli).not.toContain("const __dirname=new URL('.',import.meta.url).pathname;");
+  });
+});


### PR DESCRIPTION
## Bug

On Windows, the CLI failed to load `replicad_single.wasm` with a doubled drive letter: `D:\D:\...\replicad_single.wasm`.

## Cause

`scripts/build-cli.mjs` injected the ESM `__dirname`/`__filename` shim via `new URL(import.meta.url).pathname`. On Windows, `new URL('file:///D:/path/').pathname` returns `/D:/path/` — a POSIX-style string with a **leading slash + drive letter**. When the bundled OCCT (`replicad-opencascadejs`) loader joins that with the wasm filename, the drive doubles → `D:\D:\...`. `.pathname` is platform-agnostic and always wrong for Windows file URLs.

## Fix

Use `fileURLToPath()` in the banner instead:
- Windows: `file:///D:/path/` → `D:\path\` (native, correct)
- POSIX: `file:///path/` → `/path/` (identical to the old `.pathname`, so no Linux change)

## Test
- Added `scripts/build-cli.test.ts` — guards that the banner uses `fileURLToPath` and never reintroduces the `.pathname` lines.
- Linux regression: `node dist/cli/index.js evaluate examples/bracket-with-hole.kcad.ts` → `Features: 4 / OK`; `export stl` → 4.9 MB STL. OCCT loads + serializes geometry through the new shim.

Note: the kernelCAD-server bundles (vendor:build/session:build) use the same `.pathname` banner but run Linux-only (Hetzner), so no Windows impact; can be aligned for hygiene separately.