### PR TITLE
chore(npm): declare repository so --provenance publish succeeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "private": false,
   "version": "0.12.0",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/w1ne/kernelCAD-web.git"
+  },
+  "homepage": "https://github.com/w1ne/kernelCAD-web#readme",
+  "bugs": {
+    "url": "https://github.com/w1ne/kernelCAD-web/issues"
+  },
   "engines": {
     "node": ">=22.12.0",
     "npm": ">=10.0.0"


### PR DESCRIPTION
Fixes the npm publish failure on the `v0.12.0` tag.

## Root cause
`npm publish --provenance` failed with:
```
npm error 422 — Error verifying sigstore provenance bundle:
package.json: "repository.url" is "", expected to match "https://github.com/w1ne/kernelCAD-web"
```
`package.json` had **no `repository` field**, so the sigstore provenance bundle couldn't validate the repo. This is the same reason **v0.11.3 never reached npm** (npm latest was stuck at 0.11.2).

## Fix
Add `repository` (+ `homepage`, `bugs`) pointing at the GitHub repo. Version stays `0.12.0`.

## After merge
Re-point the `v0.12.0` tag at the fixed commit and re-push to re-trigger `publish-npm.yml`.