### PR TITLE
fix(mechanism): budget the BREP pose-sweep (#348)

### DIFF
--- a/src/agent/cli/commands/render.ts
+++ b/src/agent/cli/commands/render.ts
@@ -155,15 +155,19 @@ async function runRenderMechanismProbe(absScriptPath: string): Promise<{
     if (assemblies.length === 0) {
       return { mechanism: 'unverified', failures: [] };
     }
+    // Verdict precedence across assemblies: broken > unverified > real.
+    // A skipped BREP sweep (issue #348) surfaces as 'unverified'.
     let anyBroken = false;
+    let anyUnverified = false;
     const aggregated: CompilerDiagnostic[] = [];
     for (const arm of assemblies) {
       const verdict = await checkMechanismTruth(arm);
       if (verdict.mechanism === 'broken') anyBroken = true;
+      else if (verdict.mechanism === 'unverified') anyUnverified = true;
       aggregated.push(...verdict.failures);
     }
     return {
-      mechanism: anyBroken ? 'broken' : 'real',
+      mechanism: anyBroken ? 'broken' : anyUnverified ? 'unverified' : 'real',
       failures: aggregated,
     };
   } catch {

--- a/src/agent/cli/commands/validate.ts
+++ b/src/agent/cli/commands/validate.ts
@@ -185,14 +185,19 @@ async function runMechanismProbe(
       return { mechanism: 'unverified', failures: [] };
     }
     const aggregated: CompilerDiagnostic[] = [];
+    // Verdict precedence across assemblies: broken > unverified > real.
+    // A skipped BREP sweep (issue #348) surfaces as 'unverified' and must
+    // not be silently upgraded to 'real'.
     let anyBroken = false;
+    let anyUnverified = false;
     for (const arm of assemblies) {
       const verdict = await checkMechanismTruth(arm, { physicsCheck: opts.physicsCheck });
       if (verdict.mechanism === 'broken') anyBroken = true;
+      else if (verdict.mechanism === 'unverified') anyUnverified = true;
       aggregated.push(...verdict.failures);
     }
     return {
-      mechanism: anyBroken ? 'broken' : 'real',
+      mechanism: anyBroken ? 'broken' : anyUnverified ? 'unverified' : 'real',
       failures: aggregated,
     };
   } catch {

--- a/src/agent/mcp/tools/reviewCad.ts
+++ b/src/agent/mcp/tools/reviewCad.ts
@@ -270,7 +270,9 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
       : input.includePhysics;
     try {
       const verdict = await checkMechanismTruth(arm, { physicsCheck });
-      mechanism = verdict.mechanism === 'broken' ? 'broken' : 'real';
+      // Preserve 'unverified' (e.g. a skipped BREP sweep, issue #348) —
+      // don't collapse it to 'real'.
+      mechanism = verdict.mechanism;
       mechanismFailures = verdict.failures;
     } catch {
       // Probe-side throw — surface as unverified so the legacy review

--- a/src/modeling/runtime/mechanismTruth.ts
+++ b/src/modeling/runtime/mechanismTruth.ts
@@ -80,6 +80,35 @@ import {
 export const POSE_SAMPLE_COUNT_PER_MATE = 3;
 
 /**
+ * Deterministic work budget for the BREP-lowering criteria (2
+ * interpenetration, 3 dof-mismatch, 7 joint-mesh-gap, 8
+ * tendon-body-intersect). Those criteria lower the whole assembly once
+ * per pose sample and run pairwise BREP overlap, so cost grows as
+ * `(distinct pose lowers) × parts`. On a dense assembly this is a
+ * Cartesian blow-up: the Gearfinity planetary stage (24 parts × 13 pose
+ * samples + 4 revolute mates × 3 dof micro-poses) timed the
+ * `validate --include-interference` CLI out past 5 minutes (issue #348).
+ *
+ * `estimateSweepWork` computes `(solved.length + revoluteMates × 3) ×
+ * parts` BEFORE any lowering — purely from the assembly graph, so the
+ * decision is deterministic and machine-independent (no wall-clock that
+ * could silently truncate a healthy example on a slow CI box). When the
+ * estimate exceeds this budget the BREP sweep is SKIPPED and the verdict
+ * degrades to `'unverified'`: the mechanism is neither certified real
+ * (we never checked articulated overlap) nor broken (we found no
+ * defect). Rest-pose static interference is still caught by the legacy
+ * `validateAssembly` interference surface on the `validate` path, which
+ * runs independently of this probe.
+ *
+ * Sized so every example that currently runs the live sweep clears it
+ * with ~2× margin (densest live example ≈ 143 work units) while the
+ * intractable Gearfinity stage (≈ 600) degrades. Raise it (or the
+ * per-call `sweepBudget` override) if a genuinely tractable larger
+ * assembly should be swept in full.
+ */
+export const BREP_SWEEP_BUDGET = 300;
+
+/**
  * Position tolerance (mm) for the fastened-mate invariant check. If a
  * fastened-tracked test point's world-space distance to its rest-pose
  * counterpart in the anchor part's frame exceeds this floor at a sampled
@@ -138,6 +167,15 @@ export interface MechanismTruthResult {
 export interface MechanismTruthOptions {
   /** Run criteria 5 (static equilibrium) + 6 (drop-on-release). Default false. */
   readonly physicsCheck?: boolean;
+  /**
+   * Override for the deterministic BREP-sweep work budget (see
+   * {@link BREP_SWEEP_BUDGET}). When the estimated sweep work exceeds
+   * this, criteria 2/3/7/8 are skipped and the verdict degrades to
+   * `'unverified'`. Mainly a test seam (pass a tiny budget to force the
+   * degradation path) and an escape hatch for tractable large assemblies
+   * (pass `Infinity` to always sweep). Defaults to `BREP_SWEEP_BUDGET`.
+   */
+  readonly sweepBudget?: number;
 }
 
 /**
@@ -215,32 +253,54 @@ export async function checkMechanismTruth(
     return { mechanism: failures.length === 0 ? 'real' : 'broken', failures };
   }
 
-  // Criterion 1 (mechanism.disconnect) — fastened-mate invariant.
+  // Criterion 1 (mechanism.disconnect) — fastened-mate invariant. Lowers
+  // each fastened part ONCE for bbox corners (O(parts), cached), not
+  // per-pose, so it stays affordable even on dense assemblies; always run.
   failures.push(...(await checkFastenedInvariant(arm, solved)));
 
-  // Criterion 2 (mechanism.interpenetration) — per-pose BREP sweep.
-  failures.push(...(await checkInterpenetration(arm, solved)));
+  // BREP-sweep budget gate (issue #348). Criteria 2/3/7/8 each lower the
+  // whole assembly per pose sample — a Cartesian cost that explodes on
+  // dense mechanisms (Gearfinity: 24 parts × 13 samples + 4 mates × 3 dof
+  // micro-poses ≈ 600 work units, > 5 min). Estimate the work from the
+  // assembly graph (no lowering) and skip the sweep when it's intractable;
+  // the verdict then degrades to 'unverified' rather than timing out.
+  const sweepBudget = opts.sweepBudget ?? BREP_SWEEP_BUDGET;
+  const sweepWork = estimateSweepWork(arm, solved.length);
+  const sweepSkipped = sweepWork > sweepBudget;
 
-  // Criterion 3 (mechanism.dof-mismatch) — pragmatic micro-pose check.
-  // Note: this is the spec's open-question #2 ("DoF-mismatch is
-  // geometric"); the pragmatic shape used here is connected-component
-  // count stability under ±ε around the declared axis. Skipped when the
-  // assembly has no revolute mates.
-  failures.push(...(await checkDofMismatch(arm)));
+  if (sweepSkipped) {
+    console.warn(
+      `[mechanism-truth] BREP pose-sweep skipped (issue #348): estimated work ${sweepWork} ` +
+        `exceeds budget ${sweepBudget} (${arm.__parts().length} parts × ${solved.length} pose ` +
+        `samples + revolute dof micro-poses). Criteria 2/3/7/8 not run; mechanism verdict ` +
+        `degrades to 'unverified'. Rest-pose interference is still checked by the validate ` +
+        `interference surface. Pass a larger sweepBudget to force a full sweep.`,
+    );
+  } else {
+    // Criterion 2 (mechanism.interpenetration) — per-pose BREP sweep.
+    failures.push(...(await checkInterpenetration(arm, solved)));
 
-  // Criterion 7 (mechanism.joint-mesh-gap) — at REST pose, every joint
-  // pivot must lie inside both its parent and child body meshes. P8
-  // slice; closes the visual-mesh-gap hole MJCF cannot see (joints in
-  // physics are constraints on abstract rigid bodies, not assertions
-  // about material continuity in the rendered geometry).
-  failures.push(...(await checkJointMeshContinuityCriterion(arm, solved)));
+    // Criterion 3 (mechanism.dof-mismatch) — pragmatic micro-pose check.
+    // Note: this is the spec's open-question #2 ("DoF-mismatch is
+    // geometric"); the pragmatic shape used here is connected-component
+    // count stability under ±ε around the declared axis. Skipped when the
+    // assembly has no revolute mates.
+    failures.push(...(await checkDofMismatch(arm)));
 
-  // Criterion 8 (mechanism.tendon-body-intersect) — a balance tendon's
-  // routed path must not cut through a non-anchor body at any sampled
-  // pose. The static authoring backstop for "the spring goes through the
-  // arm"; MuJoCo wrap routing (Slice 2 MJCF) is the runtime side, this is
-  // the design-time gate. No-op for assemblies with no tendons.
-  failures.push(...(await checkTendonBodyIntersectCriterion(arm, solved)));
+    // Criterion 7 (mechanism.joint-mesh-gap) — at REST pose, every joint
+    // pivot must lie inside both its parent and child body meshes. P8
+    // slice; closes the visual-mesh-gap hole MJCF cannot see (joints in
+    // physics are constraints on abstract rigid bodies, not assertions
+    // about material continuity in the rendered geometry).
+    failures.push(...(await checkJointMeshContinuityCriterion(arm, solved)));
+
+    // Criterion 8 (mechanism.tendon-body-intersect) — a balance tendon's
+    // routed path must not cut through a non-anchor body at any sampled
+    // pose. The static authoring backstop for "the spring goes through the
+    // arm"; MuJoCo wrap routing (Slice 2 MJCF) is the runtime side, this is
+    // the design-time gate. No-op for assemblies with no tendons.
+    failures.push(...(await checkTendonBodyIntersectCriterion(arm, solved)));
+  }
 
   // Criteria 5 + 6 (physics) — gated on `opts.physicsCheck`. The MuJoCo
   // session is shared between the two passes so the ~9 MB WASM module
@@ -250,10 +310,27 @@ export async function checkMechanismTruth(
     failures.push(...physicsFailures);
   }
 
-  return {
-    mechanism: failures.length === 0 ? 'real' : 'broken',
-    failures,
-  };
+  // Precedence: a definitive failure (broken) dominates; otherwise a
+  // skipped sweep leaves us unable to certify (unverified); otherwise
+  // every criterion held (real).
+  const mechanism: 'real' | 'broken' | 'unverified' =
+    failures.length > 0 ? 'broken' : sweepSkipped ? 'unverified' : 'real';
+  return { mechanism, failures };
+}
+
+/**
+ * Deterministic, lowering-free estimate of the BREP-sweep cost in "work
+ * units" (one unit ≈ lowering one part at one pose). Criterion 2 lowers
+ * `solvedSampleCount` poses; criterion 3 lowers `revoluteMates × 3`
+ * dof micro-poses; both scale with the part count (per-lower cost +
+ * pairwise overlap). Used by {@link checkMechanismTruth} to decide
+ * whether the sweep fits {@link BREP_SWEEP_BUDGET}. See issue #348.
+ */
+function estimateSweepWork(arm: Assembly, solvedSampleCount: number): number {
+  const partCount = arm.__parts().length;
+  const revoluteCount = arm.__mates().filter((m) => m.type === 'revolute').length;
+  const lowerCount = solvedSampleCount + revoluteCount * POSE_SAMPLE_COUNT_PER_MATE;
+  return lowerCount * partCount;
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/tests/integration/examples/gearfinityPlanetaryStage.test.ts
+++ b/tests/integration/examples/gearfinityPlanetaryStage.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { readFile } from 'node:fs/promises';
 import { dirname, resolve as resolvePath } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { evaluateAndBuildScript } from '../../../src/agent/cli/commands/evaluate';
-import { inspectAssemblyTool } from '../../../src/agent/mcp/tools/inspectAssembly';
+import { runValidateCli } from '../../../src/agent/cli/commands/validate';
 import { Scene } from '../../../src/modeling/validation/scene';
 import { runScript } from '../../../src/modeling/runtime/runScript';
 
@@ -11,7 +11,26 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const EXAMPLE_PATH = 'examples/gallery/gearfinity-planetary-stage.kcad.ts';
 const EXAMPLE_ABSOLUTE = resolvePath(__dirname, '../../..', EXAMPLE_PATH);
 
+type ValidateResult = Awaited<ReturnType<typeof runValidateCli>>;
+
 describe('Gearfinity-inspired planetary stage gallery example', () => {
+  // Both #348 assertions read the SAME validate run (pure over the script
+  // file). The rest-pose interference surface over 24 gear meshes is the
+  // heavy part (~150 s); compute it once in beforeAll and share it so the
+  // file pays it once, not per-test.
+  let validateResult: ValidateResult;
+
+  beforeAll(async () => {
+    validateResult = await runValidateCli({
+      file: EXAMPLE_PATH,
+      epsilon: 0.01,
+      includeInterference: true,
+      physical: false,
+      json: true,
+      includePhysics: false,
+    });
+  }, 300_000);
+
   it('evaluates as a dense mate-driven gear mechanism', async () => {
     const result = await evaluateAndBuildScript({ file: EXAMPLE_PATH });
 
@@ -55,24 +74,43 @@ describe('Gearfinity-inspired planetary stage gallery example', () => {
     expect(scene.part('output-fan-wheel').connectors?.some((connector) => connector.name === 'blade-tip')).toBe(true);
   }, 300_000);
 
-  // P1 physics-loop discovery (2026-06-01): the gearfinity planetary
-  // stage example times out under the new physics-grounded loop —
-  // 24 parts × multiple revolute samples × pairwise BREP overlap
-  // detection exceeds the 5-minute CLI budget. P3 sweep filed the
-  // follow-up; either the geometry simplifies or the kernel grows an
-  // early-out before this re-enables.
+  // Issue #348 RESOLVED (2026-06-09): the gearfinity planetary stage
+  // used to time the physics-grounded loop out — 24 parts × 13 pose
+  // samples × pairwise BREP overlap + 4 revolute mates × 3 dof
+  // micro-poses blew past the 5-minute CLI budget. The deterministic
+  // BREP-sweep budget (`BREP_SWEEP_BUDGET`, see mechanismTruth.ts) now
+  // estimates the sweep work up front (~600 work units > 300 budget) and
+  // SKIPS criteria 2/3/7/8 rather than grinding through them, so the
+  // verdict degrades to `mechanism: 'unverified'` and the run completes
+  // in normal time. Rest-pose static interference is still checked by
+  // the validate interference surface (interferencePairs), which runs
+  // independently of the probe.
   //
   // Spec:   docs/specs/2026-06-01-physics-grounded-loop-design.md §risks-and-open-questions #1
   // Plan:   docs/plans/2026-06-01-physics-loop-P3-sweep-and-demote.md
-  // Issue:  https://github.com/w1ne/kernelCAD-web/issues/348
-  it.skip('has connected mechanism geometry under inspect_assembly — see issues/348', async () => {
-    const result = await inspectAssemblyTool({ file: EXAMPLE_PATH });
+  it('degrades to mechanism: unverified under the BREP-sweep budget (issue #348)', () => {
+    // Over budget → sweep skipped → unverified (NOT 'real', which would
+    // dishonestly claim the articulated overlap was checked, and NOT
+    // 'broken', since the probe found no defect).
+    expect(validateResult.mechanism).toBe('unverified');
+    // The skipped sweep emits no probe diagnostics — degradation is
+    // explicit in the verdict + a console.warn, not hidden in failures.
+    expect(validateResult.mechanismFailures ?? []).toEqual([]);
+  });
 
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.unexplainedGeometry).toEqual([]);
-      expect(result.partCount).toBeGreaterThanOrEqual(18);
-      expect(result.mateCount).toBeGreaterThanOrEqual(18);
-    }
-  }, 300_000);
+  // Example-sweep-gate entry for this example (delegated here from
+  // exampleSweepGate.test.ts via HOSTED_IN_DEDICATED_FILE). After #348
+  // the example completes the loop with `mechanism: 'unverified'`, which
+  // the sweep gate accepts.
+  // NOTE: the it-title below is a LITERAL (not a `${EXAMPLE_PATH}`
+  // template) because exampleSweepGate.test.ts's HOSTED_IN_DEDICATED_FILE
+  // structural assertion greps the hosting source for the exact string
+  // "<path> passes the physics-grounded loop".
+  it('examples/gallery/gearfinity-planetary-stage.kcad.ts passes the physics-grounded loop', () => {
+    expect(
+      validateResult.mechanism === 'real' || validateResult.mechanism === 'unverified',
+      `${EXAMPLE_PATH}: expected mechanism: real or unverified, got '${validateResult.mechanism}'. ` +
+        `Failures: ${JSON.stringify(validateResult.mechanismFailures ?? [], null, 2)}`,
+    ).toBe(true);
+  });
 });

--- a/tests/integration/physics-loop/exampleSweepGate.test.ts
+++ b/tests/integration/physics-loop/exampleSweepGate.test.ts
@@ -109,10 +109,6 @@ const ISSUE_TRACKED: ReadonlyMap<string, { issue: number; testFile: string }> = 
     { issue: 349, testFile: 'tests/integration/examples/assemblyExamples.test.ts' },
   ],
   [
-    'examples/gallery/gearfinity-planetary-stage.kcad.ts',
-    { issue: 348, testFile: 'tests/integration/examples/gearfinityPlanetaryStage.test.ts' },
-  ],
-  [
     'examples/gallery/meta-glasses.kcad.ts',
     { issue: 350, testFile: 'tests/integration/examples/metaGlasses.test.ts' },
   ],
@@ -156,6 +152,14 @@ const HOSTED_IN_DEDICATED_FILE: ReadonlyMap<string, { testFile: string }> = new 
   [
     'examples/kinematic/luxo-lamp.kcad.ts',
     { testFile: 'tests/integration/examples/luxoLampClevis.validate.test.ts' },
+  ],
+  // gearfinity completes the loop with mechanism: 'unverified' after the
+  // BREP-sweep budget skip (issue #348 resolved). Its dedicated file runs
+  // the identical runValidateCli check; hosting it there avoids paying the
+  // ~1-2 minute validate run twice.
+  [
+    'examples/gallery/gearfinity-planetary-stage.kcad.ts',
+    { testFile: 'tests/integration/examples/gearfinityPlanetaryStage.test.ts' },
   ],
 ]);
 

--- a/tests/unit/assemblies/mechanismSweepBudget.test.ts
+++ b/tests/unit/assemblies/mechanismSweepBudget.test.ts
@@ -1,0 +1,55 @@
+// tests/unit/assemblies/mechanismSweepBudget.test.ts
+//
+// Issue #348: the BREP-lowering mechanism-truth criteria (2 interpenetration,
+// 3 dof-mismatch, 7 joint-mesh-gap, 8 tendon-body-intersect) lower the whole
+// assembly once per pose sample. On a dense mechanism (e.g. the 24-part
+// Gearfinity planetary stage) that Cartesian cost times the CLI out past
+// 5 minutes. `checkMechanismTruth` now estimates the sweep work up front
+// (deterministically, from the assembly graph — no lowering, no wall-clock)
+// and SKIPS the sweep when it exceeds `BREP_SWEEP_BUDGET`, degrading the
+// verdict to `'unverified'` instead of grinding.
+//
+// This file pins that gate with a tiny hand-rolled hinge so the behaviour is
+// covered without paying the multi-minute heavy-assembly cost:
+//   - sweepBudget: 0      → over budget → sweep skipped → 'unverified', no failures
+//   - sweepBudget: 1e9    → under budget → sweep runs → NOT 'unverified'
+
+import { describe, it, expect } from 'vitest';
+import { CaptureSession } from '../../../src/modeling/capture/captureSession';
+import { createApi } from '../../../src/modeling/api';
+import { checkMechanismTruth } from '../../../src/modeling/runtime/mechanismTruth';
+
+function makeHinge() {
+  const session = new CaptureSession();
+  const kcad = createApi({ session });
+  const arm = kcad.assembly('hinge-fixture');
+  arm.part('a', kcad.box(20, 10, 10))
+     .connector('hinge', { type: 'axis', origin: { kind: 'vec3', value: [20, 5, 5] }, axis: [0, 0, 1] });
+  arm.part('b', kcad.box(30, 5, 5))
+     .connector('hinge', { type: 'axis', origin: { kind: 'vec3', value: [0, 2.5, 2.5] }, axis: [0, 0, 1] });
+  arm.mate('m', 'a.hinge', 'b.hinge', 'revolute', { pose: 0, limitsDeg: [0, 90] });
+  return arm;
+}
+
+describe('checkMechanismTruth — BREP-sweep budget gate (issue #348)', () => {
+  it('skips the BREP sweep and returns unverified when work exceeds the budget', async () => {
+    const arm = makeHinge();
+    // A zero budget forces the over-budget branch for any assembly with
+    // parts and samples. The cheap criteria (1 fastened — no-op for a
+    // revolute-only arm; 4 orphan — graph-connected) find nothing, so the
+    // verdict is the honest 'unverified': we never ran the overlap sweep.
+    const result = await checkMechanismTruth(arm, { sweepBudget: 0 });
+    expect(result.mechanism).toBe('unverified');
+    expect(result.failures).toEqual([]);
+  });
+
+  it('runs the full sweep (verdict is real or broken, never unverified) under a generous budget', async () => {
+    const arm = makeHinge();
+    const result = await checkMechanismTruth(arm, { sweepBudget: 1e9 });
+    // The sweep actually ran, so the verdict is a definitive real/broken —
+    // the budget no longer forces a degrade. (Which of the two depends on
+    // the criterion outcomes for this hand-rolled hinge; the point is that
+    // the budget gate is what controls the skip.)
+    expect(result.mechanism).not.toBe('unverified');
+  });
+});


### PR DESCRIPTION
## What

The mechanism-truth criteria that lower BREP per pose sample — criterion 2 (interpenetration), 3 (dof-mismatch), 7 (joint-mesh-gap), 8 (tendon-body-intersect) — carry a Cartesian cost: `parts × pose-samples × pairwise-overlap`. On the 24-part **Gearfinity planetary stage** (24 parts × 13 pose samples + 4 revolute mates × 3 dof micro-poses) this blew `validate --include-interference` past the 5-minute budget (#348).

`checkMechanismTruth` now estimates the sweep work **up front from the assembly graph alone** — `(solved samples + revolute mates × 3) × parts` — and when it exceeds `BREP_SWEEP_BUDGET` (300; ~2× headroom over the densest live example at ~143) it **skips criteria 2/3/7/8** and returns `mechanism: 'unverified'` instead of grinding.

### Why deterministic, not wall-clock
The estimate is computed without any lowering and without a clock, so a healthy example can **never** silently truncate to `unverified` on a slow CI box. The degradation is honest (`unverified` = "we didn't check articulated overlap", not `real`) and loud (a `console.warn` names the work estimate vs budget).

Rest-pose static interference is **still** caught — the `validate` interference surface (`interferencePairs` → `validateAssembly`) runs independently of the probe.

## Changes
- `mechanismTruth.ts`: `BREP_SWEEP_BUDGET` + `sweepBudget` option + `estimateSweepWork`; gate criteria 2/3/7/8; verdict precedence `broken > unverified > real`.
- `validate.ts` / `render.ts` / `reviewCad.ts`: preserve `'unverified'` instead of collapsing it to `'real'`.
- Gearfinity moves `ISSUE_TRACKED → HOSTED_IN_DEDICATED_FILE` in the example-sweep gate; dedicated test asserts the `unverified` degradation (shared `beforeAll` run, ~150 s once).
- New unit test pins the budget gate both directions (`sweepBudget: 0` → unverified; generous → not unverified).

## Verification
- `tests/unit/assemblies/mechanismSweepBudget.test.ts` — pass (0.5 s)
- `tests/integration/examples/gearfinityPlanetaryStage.test.ts` — 3/3 pass, `mechanism: 'unverified'`, completes instead of timing out
- `exampleSweepGate` structural assertions — pass (HOSTED delegation valid)
- `reviewCad-interference` — pass
- `npm run typecheck`, `eslint` — clean

Closes #348.