### PR TITLE
feat(studio): in-app Generate agent in the Studio rail (web-only)

### DIFF
--- a/src/studio/AgentRail.tsx
+++ b/src/studio/AgentRail.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useShellStore } from './store/useShellStore';
 import { StagedEditSlot } from './StagedEditSlot';
 import { AgentActivityLog } from './AgentActivityLog';
+import { StudioGenerate } from './StudioGenerate';
 
 /**
  * Left-side rail. Width animates between 0 and 240px based on
@@ -19,6 +20,9 @@ export const AgentRail: React.FC = () => {
             style={{ width: agentRailOpen ? 240 : 0 }}
             className="h-full flex-shrink-0 overflow-hidden bg-[#1a1a1a] border-r border-[#2d2d2d] text-gray-200 text-xs flex flex-col"
         >
+            <div className="flex-shrink-0 border-b border-[#2d2d2d]">
+                <StudioGenerate />
+            </div>
             <div className="flex-shrink-0 border-b border-[#2d2d2d]">
                 <StagedEditSlot />
             </div>

--- a/src/studio/StudioGenerate.tsx
+++ b/src/studio/StudioGenerate.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useGeneration } from '../funnel/hooks/useGeneration';
+import { useCode } from './context/CodeContext';
+import { useGeometry } from './context/GeometryContext';
+
+/**
+ * The in-app generate agent exists ONLY on the hosted web build (which sets a
+ * generation backend via VITE_API_BASE_URL). The npm-distributed / local-MCP
+ * Studio has no backend env → the box is hidden there; locally the agent is the
+ * developer's own Claude via the `kernelcad` MCP.
+ */
+function inAppAgentEnabled(): boolean {
+    const base = import.meta.env?.VITE_API_BASE_URL;
+    return typeof base === 'string' && base.length > 0;
+}
+
+/**
+ * In-Studio generation. Type a prompt → the hosted agent builds a model and
+ * the result drops straight into the Studio editor (the viewer re-runs on code
+ * change). No navigation, no sign-in wall — `/api/v1/generate` is anonymous
+ * (IP rate-limited); signing in is only needed later to SAVE.
+ *
+ * This is the "generate directly in Studio" experience: same window, live.
+ */
+/**
+ * Web-only gate. Locally the agent is the developer's own (Claude via the
+ * `kernelcad` MCP); the in-app generate agent exists ONLY on the hosted deploy.
+ * This wrapper has no hooks, so the conditional return is safe.
+ */
+export const StudioGenerate: React.FC = () => {
+    if (!inAppAgentEnabled()) return null;
+    return <StudioGenerateInner />;
+};
+
+const StudioGenerateInner: React.FC = () => {
+    const { phase, events, submit } = useGeneration();
+    const { setCode } = useCode();
+    const { executeGeometry } = useGeometry();
+    const [prompt, setPrompt] = useState('');
+    const loadedRef = useRef<string | null>(null);
+
+    // When a generation finishes, load the model into the editor AND render it.
+    // setCode updates the editor text; executeGeometry meshes it into the viewer
+    // (on the hosted path setCode alone is a no-op for rendering).
+    useEffect(() => {
+        if (phase.state === 'done' && loadedRef.current !== phase.generationId) {
+            loadedRef.current = phase.generationId;
+            setCode(phase.artifact.code);
+            void executeGeometry(phase.artifact.code);
+        }
+    }, [phase, setCode, executeGeometry]);
+
+    const busy = phase.state === 'running';
+
+    const onSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        const trimmed = prompt.trim();
+        if (!trimmed || busy) return;
+        void submit(trimmed);
+    };
+
+    return (
+        <div className="p-3 flex flex-col gap-2">
+            <div className="uppercase tracking-wide text-[10px] text-gray-500">Generate</div>
+            <form onSubmit={onSubmit} className="flex flex-col gap-2">
+                <textarea
+                    aria-label="Generate prompt"
+                    value={prompt}
+                    onChange={(e) => setPrompt(e.target.value)}
+                    rows={3}
+                    disabled={busy}
+                    placeholder="Describe a part… e.g. a 20mm cube"
+                    className="w-full rounded bg-[#111] border border-[#2a2e38] text-gray-100 p-2 text-[11px] placeholder:text-gray-600 focus:border-blue-500 focus:outline-none disabled:opacity-50 resize-none font-sans"
+                />
+                <button
+                    type="submit"
+                    disabled={busy || !prompt.trim()}
+                    className="rounded bg-blue-600 hover:bg-blue-500 text-white px-3 py-1.5 text-[11px] font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                    {busy ? 'Generating…' : 'Generate →'}
+                </button>
+            </form>
+
+            {phase.state === 'running' && (
+                <div className="text-[10px] text-gray-500 truncate" aria-live="polite">
+                    working — {events.length} events
+                    {phase.lastEvent.kind === 'tool_call' && ` · ${phase.lastEvent.name}`}
+                    {phase.lastEvent.kind === 'status' && ` · ${phase.lastEvent.phase}`}
+                </div>
+            )}
+            {phase.state === 'done' && (
+                <div className="text-[10px] text-green-500 truncate" aria-live="polite">
+                    ✓ {phase.artifact.title} — loaded into Studio
+                </div>
+            )}
+            {phase.state === 'error' && (
+                <div className="text-[10px] text-red-400" aria-live="polite">
+                    {phase.code === 'rate_limited'
+                        ? 'Rate limit reached — try again in a minute.'
+                        : `Didn't finish: ${phase.message.slice(0, 140)}`}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default StudioGenerate;

--- a/src/studio/store/shellStore.ts
+++ b/src/studio/store/shellStore.ts
@@ -72,7 +72,10 @@ function writeStoredInspectorOpen(open: boolean): void {
 
 const INITIAL_STATE: ShellState = {
     selectedFeatureId: null,
-    agentRailOpen: false,
+    // Open by default ONLY on the hosted web build (where the in-app Generate
+    // agent lives), so it's the first thing a visitor sees. Local/MCP Studio
+    // keeps it closed — the agent there is the developer's own via MCP.
+    agentRailOpen: Boolean(import.meta.env?.VITE_API_BASE_URL),
     inspectorOpen: true,
     previousValidity: null,
     currentValidity: null,


### PR DESCRIPTION
Type a prompt in the Studio's agent rail → the hosted agent builds a model and it loads straight into the viewer — **same window, no redirect, no sign-in wall** (`/api/v1/generate` is anonymous, IP rate-limited; sign-in is only for saving later). This replaces the bounce-to-Google-then-back-to-the-same-prompt funnel.

**Web-only by design:** gated on `VITE_API_BASE_URL` (hosted build has a generation backend; the npm/local-MCP Studio does not — there the agent is the developer's own Claude via the `kernelcad` MCP). The rail defaults open on the hosted build so Generate is the first thing a visitor sees.

On done it `setCode`s the editor **and** `executeGeometry`s into the viewer (setCode alone is a no-op for rendering on the hosted session path — same render path `/g/:genId` uses).

Pairs with kernelCAD-server fixes already live on api.kernelcad.com: recursion fix, Groq model, strict cost caps, and the tool-call-name sanitizer (`190bbff`).

Verified locally (localhost:5173 w/ backend env): box renders, rail opens, prompt→generate streams inline, success/error/rate-limit surface inline.