### PR TITLE
feat(studio): claim anonymous project — 'sign in to save' (follow-up #2)

### DIFF
--- a/src/funnel/lib/apiClient.ts
+++ b/src/funnel/lib/apiClient.ts
@@ -84,6 +84,12 @@ export async function saveProject(input: SaveProjectInput): Promise<SaveProjectR
   return authedFetch<SaveProjectResult>('POST', '/api/v1/save', input);
 }
 
+/** "Sign in to save": claim an anonymous (owner-less) project for the signed-in
+ *  user. `claimed` is false if it was already owned. */
+export async function claimProject(slug: string): Promise<{ claimed: boolean }> {
+  return authedFetch<{ claimed: boolean }>('POST', `/api/v1/projects/${encodeURIComponent(slug)}/claim`, {});
+}
+
 export interface ProjectRow {
   id: string;
   slug: string;
@@ -94,7 +100,8 @@ export interface ProjectRow {
   parameters: Artifact['parameters'];
   version: number;
   updated_at: string;
-  owner_id: string;
+  /** Null for anonymous (public-by-link) projects — claimable via claimProject. */
+  owner_id: string | null;
 }
 
 export async function fetchProjectBySlug(slug: string): Promise<ProjectRow | null> {

--- a/src/studio/routes/p.$slug.tsx
+++ b/src/studio/routes/p.$slug.tsx
@@ -1,9 +1,9 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import App from '../App';
 import { SignInButton } from '../../funnel/components/SignInButton';
 import { useSession } from '../../funnel/hooks/useSession';
-import { fetchProjectBySlug, type ProjectRow } from '../../funnel/lib/apiClient';
+import { fetchProjectBySlug, claimProject, type ProjectRow } from '../../funnel/lib/apiClient';
 
 export const Route = createFileRoute('/p/$slug')({
   component: ProjectPage,
@@ -20,9 +20,23 @@ function ProjectPage() {
   const { session } = useSession();
   const [project, setProject] = useState<ProjectRow | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [claimed, setClaimed] = useState(false);
+  const [claiming, setClaiming] = useState(false);
 
   useEffect(() => {
     fetchProjectBySlug(slug).then(setProject).catch(e => setErr(String(e)));
+  }, [slug]);
+
+  const handleClaim = useCallback(async () => {
+    setClaiming(true);
+    try {
+      await claimProject(slug);
+      setClaimed(true);
+    } catch {
+      // Leave the button available to retry.
+    } finally {
+      setClaiming(false);
+    }
   }, [slug]);
 
   if (err) {
@@ -51,14 +65,30 @@ function ProjectPage() {
     </div>
   );
 
-  const headerRight = !session ? (
-    <SignInButton
-      redirectTo={typeof window !== 'undefined' ? window.location.href : undefined}
-      className="inline-flex items-center gap-1.5 px-3 py-1 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 transition-colors"
-    >
-      Sign in
-    </SignInButton>
-  ) : null;
+  // Anonymous (owner-less) projects — e.g. built by a web-Claude session via
+  // open_in_studio — can be claimed: "sign in to save" → claim into your account.
+  const isAnonymous = project.owner_id == null && !claimed;
+  const btnClass = 'inline-flex items-center gap-1.5 px-3 py-1 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 transition-colors';
+
+  let headerRight: ReactNode = null;
+  if (claimed) {
+    headerRight = <span className="text-[11px] text-green-500 font-mono">Saved ✓</span>;
+  } else if (isAnonymous && !session) {
+    headerRight = (
+      <SignInButton
+        redirectTo={typeof window !== 'undefined' ? window.location.href : undefined}
+        className={btnClass}
+      >
+        Sign in to save
+      </SignInButton>
+    );
+  } else if (isAnonymous && session) {
+    headerRight = (
+      <button type="button" onClick={handleClaim} disabled={claiming} className={btnClass}>
+        {claiming ? 'Saving…' : 'Save to my projects'}
+      </button>
+    );
+  }
 
   return (
     <App


### PR DESCRIPTION
Completes the anonymous open_in_studio loop. An owner-less (public-by-link) project on `/p/<slug>` can now be claimed:

- **Not signed in** → "Sign in to save" (OAuth, returns to the page)
- **Signed in + owner-less** → "Save to my projects" → `POST /api/v1/projects/:slug/claim` → sets `owner_id`, shows "Saved ✓"
- **Already owned** → no claim affordance

Pairs with the backend claim endpoint (kernelCAD-server `a68bc16`, live) which only claims unowned projects (no stealing). `ProjectRow.owner_id` is now nullable.

Model: build anonymously (no sign-in wall) → see it in Studio → sign in only to keep it. Matches the agreed design.