### PR TITLE
feat(studio): live read-only project viewer (/p/<slug>)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # kernelCAD v0.12.0
 
+## Unreleased
+
+- `/p/<slug>` is now a live read-only review page: when a connected agent updates a saved project, the open tab re-renders in real time.
+
 ## v0.12.0 — 2026-06-09
 
 Headline release folding all post-v0.11.0 workstreams (themed sections below):

--- a/src/funnel/lib/liveProject.test.ts
+++ b/src/funnel/lib/liveProject.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { shouldApplyProjectUpdate } from './liveProject';
+
+describe('shouldApplyProjectUpdate', () => {
+  it('applies when incoming version is newer', () => {
+    expect(shouldApplyProjectUpdate(2, 3)).toBe(true);
+  });
+  it('drops stale or duplicate events', () => {
+    expect(shouldApplyProjectUpdate(3, 3)).toBe(false);
+    expect(shouldApplyProjectUpdate(3, 2)).toBe(false);
+  });
+  it('applies when either side has no version (legacy rows)', () => {
+    expect(shouldApplyProjectUpdate(null, 1)).toBe(true);
+    expect(shouldApplyProjectUpdate(2, null)).toBe(true);
+  });
+});

--- a/src/funnel/lib/liveProject.ts
+++ b/src/funnel/lib/liveProject.ts
@@ -1,0 +1,6 @@
+/** Monotonic guard for realtime project updates: drop stale/duplicate events.
+ *  Null versions (legacy rows / oversized-payload refetch) always apply. */
+export function shouldApplyProjectUpdate(current: number | null | undefined, incoming: number | null | undefined): boolean {
+  if (current == null || incoming == null) return true;
+  return incoming > current;
+}

--- a/src/studio/App.liveViewer.test.tsx
+++ b/src/studio/App.liveViewer.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment happy-dom
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+const mocks = vi.hoisted(() => ({
+    currentCode: '// DEFAULT_WORKBENCH_CODE',
+    localProjectCode: '// LOCAL_PROJECT_CODE',
+    saveActiveProject: vi.fn(),
+    setCode: vi.fn((nextCode: string) => {
+        mocks.currentCode = nextCode;
+    }),
+    setViewMode: vi.fn(),
+    setViewMode3D: vi.fn(),
+}));
+
+vi.mock('./context/WorkbenchContext', async () => {
+    const React = await import('react');
+
+    return {
+        WorkbenchProvider: ({ children, initialCode }: { children: ReactNode; initialCode?: string }) => {
+            const [code, setCode] = React.useState(initialCode ?? '// DEFAULT_WORKBENCH_CODE');
+            mocks.currentCode = code;
+
+            return (
+                <div data-testid="workbench-provider">
+                    {children}
+                </div>
+            );
+        },
+        useWorkbench: () => ({
+            code: mocks.currentCode,
+            setCode: mocks.setCode,
+            viewMode: 'code',
+            setViewMode: mocks.setViewMode,
+            viewMode3D: 'shadedWithEdges',
+            setViewMode3D: mocks.setViewMode3D,
+            sidePanelVisible: true,
+            showSketches: true,
+        }),
+    };
+});
+
+vi.mock('./context/ProjectContext', () => ({
+    useProject: () => ({
+        activeProject: {
+            code: mocks.localProjectCode,
+            viewState: {
+                viewMode: 'code',
+                viewMode3D: 'shadedWithEdges',
+                agentRailOpen: false,
+            },
+        },
+        saveActiveProject: mocks.saveActiveProject,
+    }),
+}));
+
+vi.mock('./store/useShellStore', () => ({
+    useShellStore: () => ({ agentRailOpen: false }),
+}));
+
+vi.mock('./store/shellStore', () => ({
+    shellStore: {
+        setAgentRailOpen: vi.fn(),
+    },
+}));
+
+// StudioShell mock reads viewerMode from StudioChromeContext so the agent-rail
+// toggle visibility test can verify context propagation without pulling in all
+// of StudioShell's heavy dependencies.
+vi.mock('./StudioShell', async () => {
+    const React = await import('react');
+    const { useStudioChrome } = await import('./context/StudioChromeContext');
+
+    return {
+        StudioShell: () => {
+            const { viewerMode } = useStudioChrome();
+            return (
+                <main data-testid="studio-shell">
+                    <span data-testid="workbench-code">{mocks.currentCode}</span>
+                    {!viewerMode && (
+                        <button aria-label="Open agent rail" data-testid="agent-rail-toggle">
+                            Agent
+                        </button>
+                    )}
+                </main>
+            );
+        },
+    };
+});
+
+import App from './App';
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+    mocks.currentCode = '// DEFAULT_WORKBENCH_CODE';
+    mocks.localProjectCode = '// LOCAL_PROJECT_CODE';
+    mocks.saveActiveProject.mockClear();
+    mocks.setCode.mockClear();
+    mocks.setViewMode.mockClear();
+    mocks.setViewMode3D.mockClear();
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    window.history.pushState(null, '', '/studio');
+});
+
+afterEach(() => {
+    cleanup();
+    consoleErrorSpy.mockRestore();
+    vi.unstubAllGlobals();
+});
+
+describe('App live viewer', () => {
+    it('applies liveCode updates to the workbench code', async () => {
+        const { rerender } = render(<App initialCode="cube();" viewerMode />);
+
+        rerender(<App initialCode="cube();" viewerMode liveCode="sphere();" />);
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(mocks.setCode).toHaveBeenCalledWith('sphere();');
+    });
+
+    it('hides the agent rail toggle in viewer mode', () => {
+        // Positive control: agent toggle IS present without viewerMode
+        render(<App initialCode="cube();" />);
+        expect(screen.getByTestId('agent-rail-toggle')).toBeTruthy();
+        cleanup();
+
+        // Negative assertion: toggle is ABSENT in viewerMode
+        render(<App initialCode="cube();" viewerMode />);
+        expect(screen.queryByTestId('agent-rail-toggle')).toBeNull();
+    });
+});

--- a/src/studio/App.tsx
+++ b/src/studio/App.tsx
@@ -3,7 +3,7 @@ import { StudioShell } from './StudioShell';
 import { shellStore } from './store/shellStore';
 import { useShellStore } from './store/useShellStore';
 import { ErrorBoundary } from './components/ErrorBoundary';
-import { lazy, Suspense, useEffect, useState, type ReactNode } from 'react';
+import { lazy, Suspense, useEffect, useRef, useState, type ReactNode } from 'react';
 import { parseCode } from '../shared/codeGeneration/ast';
 import { StudioChromeProvider } from './context/StudioChromeContext';
 
@@ -164,6 +164,21 @@ function AppContent({ isDevLab }: { isDevLab: boolean }) {
   );
 }
 
+/** Applies externally-driven code updates into the workbench. Rendered inside
+ * WorkbenchProvider so it has access to setCode. Skips duplicate values to
+ * avoid re-triggering the geometry pipeline on unchanged code. */
+function LiveCodeApplier({ liveCode }: { liveCode?: string }) {
+  const { setCode } = useWorkbench();
+  const lastApplied = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    if (liveCode !== undefined && liveCode !== lastApplied.current) {
+      lastApplied.current = liveCode;
+      setCode(liveCode);
+    }
+  }, [liveCode, setCode]);
+  return null;
+}
+
 interface AppProps {
   /** Seed the workbench with this code on first mount. Used by the funnel
    * routes (/g/$genId, /p/$slug) to open generated/saved artifacts inside
@@ -175,6 +190,13 @@ interface AppProps {
   /** Funnel-route chrome injected into the Studio Header (right cluster).
    * Use for Save / Sign-in / per-project actions. */
   headerRight?: ReactNode;
+  /** Read-only live review mode for funnel project pages (/p/<slug>): code
+   * editor read-only, built-in agent rail hidden — the model is driven by
+   * an external agent, not authored here. */
+  viewerMode?: boolean;
+  /** Externally-driven code updates; each new value replaces the workbench
+   * code through the normal setCode path. */
+  liveCode?: string;
 }
 
 function AppProviders({
@@ -182,14 +204,17 @@ function AppProviders({
   isDevLab,
   headerLeft,
   headerRight,
+  viewerMode,
+  liveCode,
 }: AppProps & { isDevLab: boolean }) {
   return (
     <WorkbenchProvider initialCode={initialCode}>
-      <StudioChromeProvider value={{ headerLeft, headerRight }}>
+      <StudioChromeProvider value={{ headerLeft, headerRight, viewerMode }}>
         <ErrorBoundary>
           <AppContent isDevLab={isDevLab} />
         </ErrorBoundary>
       </StudioChromeProvider>
+      <LiveCodeApplier liveCode={liveCode} />
     </WorkbenchProvider>
   );
 }
@@ -227,7 +252,7 @@ function DevLabApp({ headerLeft, headerRight }: Pick<AppProps, 'headerLeft' | 'h
   );
 }
 
-export default function App({ initialCode: initialCodeProp, headerLeft, headerRight }: AppProps = {}) {
+export default function App({ initialCode: initialCodeProp, headerLeft, headerRight, viewerMode, liveCode }: AppProps = {}) {
   const isDevLab = typeof window !== 'undefined' && window.location.pathname.startsWith('/dev-lab');
 
   if (isDevLab && initialCodeProp === undefined) {
@@ -240,6 +265,8 @@ export default function App({ initialCode: initialCodeProp, headerLeft, headerRi
       isDevLab={isDevLab}
       headerLeft={headerLeft}
       headerRight={headerRight}
+      viewerMode={viewerMode}
+      liveCode={liveCode}
     />
   );
 }

--- a/src/studio/StudioShell.tsx
+++ b/src/studio/StudioShell.tsx
@@ -22,6 +22,7 @@ import { useShellStore, shellStore } from './store/useShellStore';
 import type { StagedEdit } from './store/shellStore';
 import { useRecomputeResult } from './hooks/useRecomputeResult';
 import { useProject } from './context/ProjectContext';
+import { useStudioChrome } from './context/StudioChromeContext';
 
 /**
  * Top-level Studio shell. Composes the six slots — Toolbar / Viewport /
@@ -32,6 +33,7 @@ import { useProject } from './context/ProjectContext';
 export function StudioShell() {
     const workbench = useWorkbench();
     const { agentRailOpen, inspectorOpen, selectedFeatureId, markingMode, sectionMode } = useShellStore();
+    const { viewerMode } = useStudioChrome();
     const handleToggleMarkingMode = useCallback(() => {
         shellStore.toggleMarkingMode();
     }, []);
@@ -185,6 +187,7 @@ export function StudioShell() {
                 onRun={handleRun}
                 agentRailOpen={agentRailOpen}
                 onToggleAgentRail={handleToggleAgentRail}
+                agentRailHidden={viewerMode}
                 referenceImagesPresent={referenceImagesPresent}
                 referenceImagesVisible={referenceImagesVisible}
                 onToggleReferenceImages={handleToggleReferenceImages}
@@ -201,7 +204,7 @@ export function StudioShell() {
             />
 
             <div className="flex-1 flex overflow-hidden relative">
-                {agentRailOpen && <AgentRail />}
+                {agentRailOpen && !viewerMode && <AgentRail />}
                 <div className="flex-1 relative">
                     <Viewport />
                     <MarkingOverlay visible={markingMode} />

--- a/src/studio/Toolbar.tsx
+++ b/src/studio/Toolbar.tsx
@@ -32,6 +32,9 @@ interface ToolbarProps {
     /** Right-side Inspector panel visibility. */
     inspectorOpen: boolean;
     onToggleInspector: () => void;
+    /** When true the agent-rail toggle button is not rendered. Used in
+     * viewer mode where the model is driven by an external agent. */
+    agentRailHidden?: boolean;
 }
 
 export function Toolbar({
@@ -53,6 +56,7 @@ export function Toolbar({
     onToggleSectionMode,
     inspectorOpen,
     onToggleInspector,
+    agentRailHidden = false,
 }: ToolbarProps) {
     return (
         <div
@@ -60,20 +64,22 @@ export function Toolbar({
             className="h-8 shrink-0 border-b border-[#2b313c] bg-[#111] flex items-center justify-between px-3 text-xs text-gray-300 select-none"
         >
             <div className="flex items-center gap-2 min-w-0">
-                <button
-                    type="button"
-                    onClick={onToggleAgentRail}
-                    aria-label={agentRailOpen ? 'Close agent rail' : 'Open agent rail'}
-                    aria-pressed={agentRailOpen}
-                    className={`inline-flex items-center gap-1 px-2 py-1 rounded transition-colors ${
-                        agentRailOpen
-                            ? 'bg-[#333] text-white'
-                            : 'text-gray-300 hover:text-white hover:bg-[#222]'
-                    }`}
-                >
-                    <MessageSquare size={12} />
-                    Agent
-                </button>
+                {!agentRailHidden && (
+                    <button
+                        type="button"
+                        onClick={onToggleAgentRail}
+                        aria-label={agentRailOpen ? 'Close agent rail' : 'Open agent rail'}
+                        aria-pressed={agentRailOpen}
+                        className={`inline-flex items-center gap-1 px-2 py-1 rounded transition-colors ${
+                            agentRailOpen
+                                ? 'bg-[#333] text-white'
+                                : 'text-gray-300 hover:text-white hover:bg-[#222]'
+                        }`}
+                    >
+                        <MessageSquare size={12} />
+                        Agent
+                    </button>
+                )}
                 <a
                     href="/connect"
                     data-testid="toolbar-connect-link"

--- a/src/studio/components/Editor.tsx
+++ b/src/studio/components/Editor.tsx
@@ -1,5 +1,6 @@
 import Editor from "@monaco-editor/react";
 import type { EditorLike } from '../../shared/types/editor';
+import { useStudioChrome } from '../context/StudioChromeContext';
 
 interface CodeEditorProps {
     value: string;
@@ -8,6 +9,8 @@ interface CodeEditorProps {
 }
 
 export default function CodeEditor({ value, onChange, onMount }: CodeEditorProps) {
+    const { viewerMode } = useStudioChrome();
+
     return (
         <div className="w-full h-full border-r border-[#333]">
             <Editor
@@ -24,6 +27,7 @@ export default function CodeEditor({ value, onChange, onMount }: CodeEditorProps
                     scrollBeyondLastLine: false,
                     automaticLayout: true,
                     padding: { top: 16 },
+                    ...(viewerMode ? { readOnly: true } : {}),
                 }}
             />
         </div>

--- a/src/studio/context/StudioChromeContext.tsx
+++ b/src/studio/context/StudioChromeContext.tsx
@@ -8,6 +8,10 @@ export interface StudioChromeValue {
   /** Extra chrome injected into the Header's right cluster, before the
    * built-in toolbar group. Used by funnel routes for Save / Sign in. */
   headerRight?: ReactNode;
+  /** Read-only live review mode for funnel project pages (/p/<slug>): code
+   * editor read-only, built-in agent rail hidden — the model is driven by
+   * an external agent, not authored here. */
+  viewerMode?: boolean;
 }
 
 const StudioChromeContext = createContext<StudioChromeValue>({});

--- a/src/studio/routes/p.$slug.tsx
+++ b/src/studio/routes/p.$slug.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import App from '../App';
 import { SignInButton } from '../../funnel/components/SignInButton';
 import { useSession } from '../../funnel/hooks/useSession';
 import { fetchProjectBySlug, claimProject, type ProjectRow } from '../../funnel/lib/apiClient';
+import { getSupabase } from '../../funnel/lib/supabaseClient';
+import { shouldApplyProjectUpdate } from '../../funnel/lib/liveProject';
 
 export const Route = createFileRoute('/p/$slug')({
   component: ProjectPage,
@@ -22,9 +24,64 @@ function ProjectPage() {
   const [err, setErr] = useState<string | null>(null);
   const [claimed, setClaimed] = useState(false);
   const [claiming, setClaiming] = useState(false);
+  const [liveCode, setLiveCode] = useState<string | undefined>();
+  const [lastLiveUpdate, setLastLiveUpdate] = useState<Date | null>(null);
+  const versionRef = useRef<number | null>(null);
 
   useEffect(() => {
     fetchProjectBySlug(slug).then(setProject).catch(e => setErr(String(e)));
+  }, [slug]);
+
+  // Seed the version guard from the initial fetch.
+  useEffect(() => {
+    if (project) versionRef.current = project.version ?? null;
+  }, [project]);
+
+  useEffect(() => {
+    const supabase = getSupabase();
+    let everSubscribed = false;
+    const applyRow = (row: { current_code?: string | null; version?: number | null }) => {
+      if (!shouldApplyProjectUpdate(versionRef.current, row.version ?? null)) return;
+      if (typeof row.current_code === 'string' && row.current_code.length > 0) {
+        // Advance the version guard only after we have the final data in hand.
+        versionRef.current = row.version ?? versionRef.current;
+        setLiveCode(row.current_code);
+        setLastLiveUpdate(new Date());
+      } else {
+        // Oversized realtime payloads omit big columns — fall back to a refetch.
+        // Do NOT advance versionRef here; advance it inside .then once we have
+        // the fetched row's version, so a concurrent applyRow with a higher
+        // version is not incorrectly dropped.
+        fetchProjectBySlug(slug)
+          .then((p) => {
+            if (p) {
+              versionRef.current = p.version ?? versionRef.current;
+              setLiveCode(p.current_code);
+              setLastLiveUpdate(new Date());
+            }
+          })
+          .catch(() => {});
+      }
+    };
+    const channel = supabase
+      .channel(`p-${slug}`)
+      .on(
+        'postgres_changes',
+        { event: 'UPDATE', schema: 'public', table: 'projects', filter: `slug=eq.${slug}` },
+        (payload) => applyRow(payload.new as { current_code?: string | null; version?: number | null }),
+      )
+      .subscribe((status) => {
+        // After a drop+resubscribe, catch anything missed while offline.
+        if (status === 'SUBSCRIBED') {
+          if (everSubscribed) {
+            fetchProjectBySlug(slug)
+              .then((p) => { if (p) applyRow(p); })
+              .catch(() => {});
+          }
+          everSubscribed = true;
+        }
+      });
+    return () => { void supabase.removeChannel(channel); };
   }, [slug]);
 
   const handleClaim = useCallback(async () => {
@@ -62,6 +119,12 @@ function ProjectPage() {
       <span className="text-[10px] uppercase tracking-widest text-gray-500 font-mono px-1.5 py-0.5 rounded border border-[#333]">
         {formatPrivacyLabel(project.privacy)}
       </span>
+      <span
+        className="text-[10px] uppercase tracking-widest font-mono px-1.5 py-0.5 rounded border border-emerald-700 text-emerald-500"
+        title={lastLiveUpdate ? `last update ${lastLiveUpdate.toLocaleTimeString()}` : 'waiting for agent updates'}
+      >
+        ● live
+      </span>
     </div>
   );
 
@@ -93,6 +156,8 @@ function ProjectPage() {
   return (
     <App
       initialCode={project.current_code}
+      liveCode={liveCode}
+      viewerMode
       headerLeft={headerLeft}
       headerRight={headerRight ?? undefined}
     />

--- a/src/studio/routes/p.$slug.tsx
+++ b/src/studio/routes/p.$slug.tsx
@@ -54,7 +54,7 @@ function ProjectPage() {
         // version is not incorrectly dropped.
         fetchProjectBySlug(slug)
           .then((p) => {
-            if (p) {
+            if (p && shouldApplyProjectUpdate(versionRef.current, p.version ?? null)) {
               versionRef.current = p.version ?? versionRef.current;
               setLiveCode(p.current_code);
               setLastLiveUpdate(new Date());


### PR DESCRIPTION
## What

- `/p/<slug>` becomes a live review cockpit: it subscribes to realtime updates on the project row (slug-filtered) and re-renders the model in place when a connected agent updates the saved project — no reload, no new link.
- New Studio `App` props: `viewerMode` (agent rail hidden, code editor read-only — the page is for reviewing, not authoring) and `liveCode` (externally-driven code updates through the normal setCode → re-lower path).
- Monotonic version guard drops stale/duplicate events; oversized realtime payloads fall back to a guarded refetch; channel re-subscribe refetches once to catch missed updates.
- "● live" pill next to the privacy chip with last-update tooltip.

## Server counterpart

kernelCAD-server #24 (merged + deployed): update-in-place by slug + `projects` added to the realtime publication (verified live — anon subscriber receives slug-filtered UPDATE events).

## Tests

New: App.liveViewer (2), liveProject guard (3). Suite: typecheck clean; 5 pre-existing AgentRail/shellStore failures also fail on develop locally and are untouched by this diff.