### PR TITLE
Review-paint brush works on hosted /p pages

### DIFF
--- a/src/studio/components/viewer/overlays/MarkingOverlay.tsx
+++ b/src/studio/components/viewer/overlays/MarkingOverlay.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { shellStore } from '../../../store/shellStore';
 import { rendererSnapshot } from '../rendererSnapshot';
+import { resolveReviewPaintTargets } from './reviewPaintTargets';
 
 /**
  * Inpainting-style review overlay. When `markingMode` is on, a transparent
@@ -17,8 +18,9 @@ import { rendererSnapshot } from '../rendererSnapshot';
  *
  * Save: on unmount (toolbar toggle off, Esc, or markingMode→false from any
  * other path) the overlay fire-and-forget POSTs the canvas + a viewport
- * screenshot to `/__kernelcad/review-paint`. `keepalive: true` lets the
- * fetch survive the component unmount.
+ * screenshot. Targets come from `resolveReviewPaintTargets`: hosted /p pages
+ * go to the backend (`/api/v1/review-paint`, packet keyed by project slug),
+ * local dev goes to the :5174 save server, same-origin as fallback either way.
  */
 
 const FIXED_BRUSH_PX = 24;
@@ -304,6 +306,17 @@ export function MarkingOverlay({ visible }: { visible: boolean }) {
     const { parts: struckParts, debug: raycastDebug } = struckPartsFromMask();
     console.log(`[marking-overlay] struck parts:`, struckParts, 'debug:', raycastDebug);
     const scriptParam = new URLSearchParams(window.location.search).get('script');
+    // Same env resolution order as apiBase.ts, but NOT session-gated:
+    // anonymous brushing on hosted /p pages is the point, so the backend
+    // target comes straight from the build env — no Supabase session needed.
+    const apiBase =
+      import.meta.env.VITE_KERNELCAD_API_BASE ??
+      import.meta.env.VITE_API_BASE_URL ??
+      undefined;
+    const { slug, urls } = resolveReviewPaintTargets(
+      window.location.pathname,
+      apiBase,
+    );
     const meta = {
       note: '',
       scriptPath: scriptParam,
@@ -312,18 +325,21 @@ export function MarkingOverlay({ visible }: { visible: boolean }) {
       screenshotMissing: screenshot === null,
       struckParts,
       raycastDebug,
+      // On hosted /p pages the backend keys the packet by project slug so
+      // `review_paint_peek_latest {slug}` can fetch it without auth.
+      ...(slug ? { projectSlug: slug } : {}),
     };
-    // POST to the standalone save server (port 5174, auto-spawned by vite as
-    // a worker thread) so saves keep working when vite's main thread
-    // saturates on OCCT/replicad transforms.
+    // Local dev: POST to the standalone save server (port 5174, auto-spawned
+    // by vite as a worker thread) so saves keep working when vite's main
+    // thread saturates on OCCT/replicad transforms. Hosted /p pages: POST to
+    // the backend first. Either way, same-origin is the fallback.
     //
     // We deliberately do NOT set `keepalive: true`: Chrome silently rejects
     // keepalive fetches with bodies over 64 KB, and a viewport screenshot +
     // mask base64-encoded blows through that cap easily. Without keepalive,
     // the fetch fires as a normal request — the component is unmounting but
     // the request is in flight on the global queue and completes regardless.
-    const saveUrl =
-      `${window.location.protocol}//${window.location.hostname}:5174/__kernelcad/review-paint`;
+    const [saveUrl, fallbackUrl] = urls;
     // mask is always present; screenshot may be empty string if renderer canvas
     // was missing — server stores both keys regardless.
     const body = JSON.stringify({ screenshot: screenshot ?? '', mask, meta });
@@ -338,13 +354,13 @@ export function MarkingOverlay({ visible }: { visible: boolean }) {
         console.log(`[marking-overlay] mark saved (${saveUrl})`);
       })
       .catch((err) => {
-        console.warn('[marking-overlay] save to :5174 failed, trying same-origin fallback:', err);
-        fetch('/__kernelcad/review-paint', {
+        console.warn(`[marking-overlay] save to ${saveUrl} failed, trying fallback:`, err);
+        fetch(fallbackUrl, {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
           body,
         }).catch((err2) => {
-          console.warn('[marking-overlay] same-origin fallback also failed:', err2);
+          console.warn('[marking-overlay] fallback save also failed:', err2);
         });
       });
   }

--- a/src/studio/components/viewer/overlays/reviewPaintTargets.test.ts
+++ b/src/studio/components/viewer/overlays/reviewPaintTargets.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { resolveReviewPaintTargets } from './reviewPaintTargets';
+
+// jsdom default origin is http://localhost:3000 — the local-dev chain derives
+// its first target from window.location.protocol/hostname + :5174.
+const LOCAL_CHAIN = [
+  'http://localhost:5174/__kernelcad/review-paint',
+  '/__kernelcad/review-paint',
+];
+
+describe('resolveReviewPaintTargets', () => {
+  it('targets the hosted backend first on a /p page when apiBase is set', () => {
+    expect(
+      resolveReviewPaintTargets('/p/abc123', 'https://api.kernelcad.com'),
+    ).toEqual({
+      slug: 'abc123',
+      urls: [
+        'https://api.kernelcad.com/api/v1/review-paint',
+        '/__kernelcad/review-paint',
+      ],
+    });
+  });
+
+  it('keeps the local-dev chain on a /p page when no apiBase is configured', () => {
+    expect(resolveReviewPaintTargets('/p/abc123', undefined)).toEqual({
+      slug: 'abc123',
+      urls: LOCAL_CHAIN,
+    });
+  });
+
+  it('treats an empty apiBase as unconfigured', () => {
+    expect(resolveReviewPaintTargets('/p/abc123', '')).toEqual({
+      slug: 'abc123',
+      urls: LOCAL_CHAIN,
+    });
+  });
+
+  it('uses the local-dev chain with no slug on non-project pages', () => {
+    expect(
+      resolveReviewPaintTargets('/', 'https://api.kernelcad.com'),
+    ).toEqual({ slug: null, urls: LOCAL_CHAIN });
+  });
+
+  it('does not match nested or malformed /p paths', () => {
+    expect(resolveReviewPaintTargets('/p/abc/extra', undefined).slug).toBeNull();
+    expect(resolveReviewPaintTargets('/p/', undefined).slug).toBeNull();
+    expect(resolveReviewPaintTargets('/project/abc', undefined).slug).toBeNull();
+  });
+});

--- a/src/studio/components/viewer/overlays/reviewPaintTargets.ts
+++ b/src/studio/components/viewer/overlays/reviewPaintTargets.ts
@@ -1,0 +1,40 @@
+/**
+ * Resolve the ordered list of POST targets for a review-paint packet.
+ *
+ * Returns `{ slug, urls }` where `slug` is the `/p/<slug>` project slug
+ * (or null on non-project pages) and `urls` is an ordered array of
+ * candidate endpoints — first successful POST wins.
+ *
+ * Priority:
+ *  1. On a `/p/<slug>` page AND `apiBase` is set → hosted backend first,
+ *     then same-origin fallback (harmless on hosted; catches split-origin dev).
+ *  2. Otherwise → local dev server (:5174) first, then same-origin fallback.
+ */
+export function resolveReviewPaintTargets(
+  pathname: string,
+  apiBase: string | undefined,
+): { slug: string | null; urls: string[] } {
+  const match = pathname.match(/^\/p\/([A-Za-z0-9_-]+)$/);
+  const slug = match?.[1] ?? null;
+
+  if (slug && apiBase) {
+    // Hosted /p/<slug> page: talk to the backend first, same-origin as fallback.
+    return {
+      slug,
+      urls: [
+        `${apiBase}/api/v1/review-paint`,
+        '/__kernelcad/review-paint',
+      ],
+    };
+  }
+
+  // Local dev (with or without a /p page) or hosted non-/p page: use the
+  // existing :5174 → same-origin chain so local dev stays unchanged.
+  return {
+    slug,
+    urls: [
+      `${window.location.protocol}//${window.location.hostname}:5174/__kernelcad/review-paint`,
+      '/__kernelcad/review-paint',
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- New `resolveReviewPaintTargets` helper picks the packet POST chain: hosted `/p/<slug>` with a configured API base goes to the backend `/api/v1/review-paint` first; everywhere else keeps the existing `:5174` → same-origin local-dev chain (bit-for-bit unchanged locally).
- `persistMark` tags packet meta with `projectSlug` on `/p` pages so the backend keys it for anonymous `review_paint_peek_latest {slug}`.
- Unit tests for the target resolution; stale header comment fixed.

Server counterpart: kernelCAD-server `feat/review-paint-by-slug` (slug-capability packets, anonymous saves, peek by slug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)