### PR TITLE
fix(studio): ephemeral funnel project no longer clobbers live code edits

### DIFF
--- a/src/studio/App.ephemeralFunnel.test.tsx
+++ b/src/studio/App.ephemeralFunnel.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment happy-dom
+/**
+ * Regression guard for the /g/$genId live-code-clobber bug.
+ *
+ * The ephemeral funnel project (initialCode, no viewerMode) must:
+ *   1. seed the workbench with initialCode on first mount
+ *   2. never overwrite subsequent external setCode calls with the stale
+ *      mount-time snapshot stored in the ephemeral project object
+ */
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+const INITIAL_CODE = '// INITIAL_GEN_CODE';
+const LIVE_UPDATE_CODE = '// LIVE_AGENT_UPDATE';
+const EPHEMERAL_ID = '__funnel_ephemeral__';
+
+const mocks = vi.hoisted(() => ({
+  // Must use a literal here — vi.hoisted runs before module initialization
+  // so named constants are not yet bound.
+  currentCode: '// INITIAL_GEN_CODE',
+  saveActiveProject: vi.fn(),
+  setCode: vi.fn((nextCode: string) => {
+    mocks.currentCode = nextCode;
+  }),
+  setViewMode: vi.fn(),
+  setViewMode3D: vi.fn(),
+}));
+
+vi.mock('./context/WorkbenchContext', async () => {
+  const React = await import('react');
+
+  return {
+    WorkbenchProvider: ({ children, initialCode }: { children: ReactNode; initialCode?: string }) => {
+      const [code, setCode] = React.useState(initialCode ?? '// DEFAULT');
+      mocks.currentCode = code;
+      return <div data-testid="workbench-provider">{children}</div>;
+    },
+    useWorkbench: () => ({
+      code: mocks.currentCode,
+      setCode: mocks.setCode,
+      viewMode: 'code',
+      setViewMode: mocks.setViewMode,
+      viewMode3D: 'shadedWithEdges',
+      setViewMode3D: mocks.setViewMode3D,
+      sidePanelVisible: true,
+      showSketches: true,
+    }),
+  };
+});
+
+// Mock ProjectContext — expose activeProjectId = EPHEMERAL_ID so the guard
+// in App.tsx can detect the ephemeral funnel path.
+vi.mock('./context/ProjectContext', () => ({
+  useProject: () => ({
+    activeProject: {
+      code: INITIAL_CODE,
+      viewState: {
+        viewMode: 'code',
+        viewMode3D: 'shadedWithEdges',
+        agentRailOpen: false,
+      },
+    },
+    activeProjectId: EPHEMERAL_ID,
+    saveActiveProject: mocks.saveActiveProject,
+  }),
+  isEphemeralProjectId: (id: string | null) => id === EPHEMERAL_ID,
+}));
+
+vi.mock('./store/useShellStore', () => ({
+  useShellStore: () => ({ agentRailOpen: false }),
+}));
+
+vi.mock('./store/shellStore', () => ({
+  shellStore: {
+    setAgentRailOpen: vi.fn(),
+  },
+}));
+
+vi.mock('./StudioShell', () => ({
+  StudioShell: () => (
+    <main data-testid="studio-shell">
+      <span data-testid="workbench-code">{mocks.currentCode}</span>
+    </main>
+  ),
+}));
+
+import App from './App';
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  mocks.currentCode = INITIAL_CODE;
+  mocks.saveActiveProject.mockClear();
+  mocks.setCode.mockClear();
+  mocks.setViewMode.mockClear();
+  mocks.setViewMode3D.mockClear();
+  consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  window.history.pushState(null, '', '/g/00000000-0000-0000-0000-000000000001');
+});
+
+afterEach(() => {
+  cleanup();
+  consoleErrorSpy.mockRestore();
+  vi.unstubAllGlobals();
+});
+
+describe('App ephemeral funnel route (/g/$genId)', () => {
+  it('seeds the workbench with initialCode on first mount', async () => {
+    render(<App initialCode={INITIAL_CODE} />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // The sync effect must have seeded initialCode via setCode.
+    expect(mocks.setCode).toHaveBeenCalledWith(INITIAL_CODE);
+  });
+
+  it('does not revert to initialCode after an external setCode call', async () => {
+    render(<App initialCode={INITIAL_CODE} />);
+
+    // Let the initialization effect run (seeds initialCode).
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Simulate a live agent update — drive new code directly through setCode
+    // as LiveCodeApplier would on a /p route, or as any programmatic caller would.
+    act(() => {
+      mocks.setCode(LIVE_UPDATE_CODE);
+    });
+
+    // Flush all pending effects (including the sync effect re-run).
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The sync effect must NOT have reverted the code back to INITIAL_CODE.
+    expect(mocks.currentCode).toBe(LIVE_UPDATE_CODE);
+
+    // Specifically: setCode must not have been called a second time with
+    // the stale INITIAL_CODE after the live update.
+    const callsWithInitial = mocks.setCode.mock.calls.filter(
+      ([arg]) => arg === INITIAL_CODE,
+    );
+    const callsWithLive = mocks.setCode.mock.calls.filter(
+      ([arg]) => arg === LIVE_UPDATE_CODE,
+    );
+    // At most one seeding call with INITIAL_CODE (the initialization call).
+    expect(callsWithInitial.length).toBeLessThanOrEqual(1);
+    // The live update call must be present.
+    expect(callsWithLive.length).toBeGreaterThanOrEqual(1);
+    // The LAST setCode call must be the live update, not a revert.
+    const lastCall = mocks.setCode.mock.calls.at(-1)?.[0];
+    expect(lastCall).toBe(LIVE_UPDATE_CODE);
+  });
+});

--- a/src/studio/App.gallerySource.test.tsx
+++ b/src/studio/App.gallerySource.test.tsx
@@ -51,8 +51,14 @@ vi.mock('./context/ProjectContext', () => ({
         agentRailOpen: false,
       },
     },
+    // Non-ephemeral id: gallery source route uses a ?gallery= param and
+    // returns early before the ephemeral guard, so this value is irrelevant
+    // there — but must be present to avoid undefined-function crashes on
+    // any effects that reach the guard.
+    activeProjectId: 'local-project-id',
     saveActiveProject: mocks.saveActiveProject,
   }),
+  isEphemeralProjectId: (id: string | null) => id === '__funnel_ephemeral__',
 }));
 
 vi.mock('./store/useShellStore', () => ({

--- a/src/studio/App.liveViewer.test.tsx
+++ b/src/studio/App.liveViewer.test.tsx
@@ -51,8 +51,12 @@ vi.mock('./context/ProjectContext', () => ({
                 agentRailOpen: false,
             },
         },
+        // Non-ephemeral id: must NOT trigger the ephemeral guard so that
+        // viewerMode and real-project sync paths behave exactly as before.
+        activeProjectId: 'local-project-id',
         saveActiveProject: mocks.saveActiveProject,
     }),
+    isEphemeralProjectId: (id: string | null) => id === '__funnel_ephemeral__',
 }));
 
 vi.mock('./store/useShellStore', () => ({

--- a/src/studio/App.tsx
+++ b/src/studio/App.tsx
@@ -22,7 +22,7 @@ function isCodeParsable(code: string): boolean {
   }
 }
 
-import { useProject } from './context/ProjectContext';
+import { useProject, isEphemeralProjectId } from './context/ProjectContext';
 import { loadGalleryScriptSource, loadStudioScriptSource } from './scriptSource';
 import { registerLiveScriptTarget, unregisterLiveScriptTarget } from './liveScriptBridge';
 
@@ -42,7 +42,7 @@ function AppContent({ isDevLab }: { isDevLab: boolean }) {
     setCode, setViewMode, setViewMode3D
   } = useWorkbench();
 
-  const { activeProject, saveActiveProject } = useProject();
+  const { activeProject, activeProjectId, saveActiveProject } = useProject();
   const { viewerMode } = useStudioChrome();
   const { agentRailOpen } = useShellStore();
   const [isInitialized, setIsInitialized] = useState(false);
@@ -105,6 +105,11 @@ function AppContent({ isDevLab }: { isDevLab: boolean }) {
     // `liveCode` prop); the ephemeral project's mount-time snapshot must not
     // win the diff below and clobber updates back to the initial code.
     if (viewerMode) return;
+    // Ephemeral funnel project (/g/$genId): seed the workbench once on the
+    // first run, then step aside. After initialization, external/programmatic
+    // setCode calls (e.g. live agent updates) must not be overwritten by the
+    // frozen mount-time initialCode snapshot stored in the ephemeral project.
+    if (isInitialized && isEphemeralProjectId(activeProjectId)) return;
 
     // Only sync on initial load or project switch
     if (!isInitialized || activeProject.code !== code) {
@@ -117,7 +122,7 @@ function AppContent({ isDevLab }: { isDevLab: boolean }) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsInitialized(true);
     }
-  }, [activeProject, isDevLab, setCode, setViewMode, setViewMode3D, isInitialized, code, viewMode3D, scriptParam, galleryParam, viewerMode]);
+  }, [activeProject, activeProjectId, isDevLab, setCode, setViewMode, setViewMode3D, isInitialized, code, viewMode3D, scriptParam, galleryParam, viewerMode]);
 
   // Auto-save: workbench state -> active project
   useEffect(() => {

--- a/src/studio/context/ProjectContext.tsx
+++ b/src/studio/context/ProjectContext.tsx
@@ -19,6 +19,15 @@ export const ProjectContext = createContext<ProjectContextType | undefined>(unde
 
 const EPHEMERAL_ID = '__funnel_ephemeral__';
 
+/** Returns true when the active project id belongs to the in-memory funnel
+ * project created by ProjectProvider for /g/$genId and /p/$slug routes.
+ * Ephemeral projects must seed the workbench once but must never overwrite
+ * live code afterward. */
+// eslint-disable-next-line react-refresh/only-export-components
+export function isEphemeralProjectId(id: string | null): boolean {
+    return id === EPHEMERAL_ID;
+}
+
 export function ProjectProvider({ children, initialCode, projectName }: {
     children: React.ReactNode;
     initialCode?: string;


### PR DESCRIPTION
Closes the latent pitfall left open by #434: `AppContent`'s activeProject→workbench sync effect resets code to the ephemeral funnel project's frozen mount-time `initialCode` whenever they diverge. #434 guarded `/p` via `viewerMode`, but `/g/<genId>` renders without it, so any external `setCode` there snapped back to stale code.

Fix: ephemeral projects seed the workbench once (`!isInitialized` path unchanged), then step aside — `isInitialized && isEphemeralProjectId(activeProjectId)` skips the sync-back. Saved-project switching and `/p` viewer behavior are bit-for-bit unchanged; the autosave effect already writes ephemeral state in-memory only, so it needs no guard.

Regression test mounts App with `initialCode` (no viewerMode), drives an external `setCode`, and asserts no revert after effects flush.