### PR TITLE
fix: thread mate edges through the .model() assembly validation path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Fix: `.model()` assemblies validate mate-aware (#448).** The record-level assembly validator (`kernelcad validate`, and any consumer of `validateAssembly({ records })`) now reads mate edges from `assemblyModel` records as well as `solvedAssembly` records. Previously a mated multi-part assembly returned via `.model()` emitted spurious `assembly.part.floating` warnings while the identical assembly via `solvedModel({})` validated clean. Genuinely unmated parts still warn on both paths.
 - `/p/<slug>` is now a live read-only review page: when a connected agent updates a saved project, the open tab re-renders in real time.
 - **`evaluate_script` dry-run mode.** `{ dryRun: true }` validates a script via transpile + capture + capture-light checks without OCCT lowering, DFM gates, or meshing — milliseconds instead of seconds on boolean/fillet-heavy scripts. Catches script throws, capture-time API misuse, and assembly validity-gate failures; lowering failures and `dfmSpec` diagnostics still require a full evaluation. Dry runs never set or clear the active MCP session.
 - **`diff_scripts` MCP tool.** Structured geometric delta between a baseline (`baseFile`/`baseCode`) and a revised (`file`/`code`) script: per-part added/removed/renamed/changed with volume + exact-bbox deltas (numbers match `list_part_stats`), per-side interference totals + delta with pair detail, mate-graph changes, and param changes. Single-shape scripts diff as one `(root)` pseudo-part. Read-only.

--- a/src/modeling/mates/validator.test.ts
+++ b/src/modeling/mates/validator.test.ts
@@ -81,6 +81,48 @@ describe('validateAssembly', () => {
     expect(floatingCodes.length).toBe(6);
   });
 
+  // Issue #448 — mate edges must reach the record-level validator through
+  // BOTH scene-producing record kinds. `Assembly.solvedModel` writes mates
+  // onto a `solvedAssembly` record; `Assembly.model()` writes the identical
+  // metadata onto an `assemblyModel` record. The validator used to walk only
+  // `solvedAssembly`, so the same mated assembly validated clean via
+  // `solvedModel({})` but emitted spurious floating warnings via `.model()`.
+  it('sees mate edges on an assemblyModel record — .model() path (issue #448)', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('t');
+    arm
+      .part('a', kcad.box(1, 1, 1))
+      .connector('top', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 1] } });
+    arm
+      .part('b', kcad.box(1, 1, 1))
+      .connector('bot', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 0] } });
+    arm.mate('a-b', 'a.top', 'b.bot', 'fastened');
+    arm.model(); // records `assemblyModel` (NOT `solvedAssembly`) with mate metadata
+    const r = validateAssembly({ records: session.getRecords() });
+    expect(r.diagnostics.filter((d) => d.code === 'assembly.part.floating')).toEqual([]);
+    expect(r.status).toBe('solved');
+  });
+
+  it('still flags a genuinely unmated part when siblings are mated via .model()', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('t');
+    arm
+      .part('a', kcad.box(1, 1, 1))
+      .connector('top', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 1] } });
+    arm
+      .part('b', kcad.box(1, 1, 1))
+      .connector('bot', { type: 'frame', origin: { kind: 'vec3', value: [0, 0, 0] } });
+    arm.part('stray', kcad.box(1, 1, 1)); // authored but never mated — must warn
+    arm.mate('a-b', 'a.top', 'b.bot', 'fastened');
+    arm.model();
+    const r = validateAssembly({ records: session.getRecords() });
+    const floating = r.diagnostics.filter((d) => d.code === 'assembly.part.floating');
+    expect(floating.map((d) => d.partName)).toEqual(['stray']);
+    expect(r.status).toBe('warning');
+  });
+
   it('flags an orphan sub-assembly disconnected from the main mechanism', () => {
     nextId = 0;
     const base = mkPart('base');

--- a/src/modeling/mates/validator.ts
+++ b/src/modeling/mates/validator.ts
@@ -298,16 +298,23 @@ function collectParts(records: readonly FeatureRecord[]): PartInfo[] {
 }
 
 /**
- * Walk `solvedAssembly` records and pull v0.6 mate edges into a flat list
- * of `[aPartName, bPartName]` pairs. Mate refs are `'partName.connectorName'`
- * strings; we slice off the connector and keep the part. Returns [] when no
- * solvedAssembly record carries mates (v0.5-only assemblies or pre-solve
- * record streams).
+ * Walk scene-producing assembly records (`solvedAssembly` AND `assemblyModel`)
+ * and pull v0.6 mate edges into a flat list of `[aPartName, bPartName]`
+ * pairs. Mate refs are `'partName.connectorName'` strings; we slice off the
+ * connector and keep the part. Returns [] when no record carries mates
+ * (v0.5-only assemblies or pre-solve record streams).
+ *
+ * Both record kinds matter (issue #448): `Assembly.solvedModel` writes mate
+ * metadata onto a `solvedAssembly` record, while `Assembly.model()` writes
+ * the identical metadata onto an `assemblyModel` record. Walking only
+ * `solvedAssembly` made the same mated assembly validate clean via
+ * `solvedModel({})` but emit spurious floating-part warnings via `.model()` —
+ * which trains agents to ignore the floating-part gate.
  */
 function collectMateEdges(records: readonly FeatureRecord[]): readonly (readonly [string, string])[] {
   const out: [string, string][] = [];
   for (const r of records) {
-    if (r.kind !== 'solvedAssembly') continue;
+    if (r.kind !== 'solvedAssembly' && r.kind !== 'assemblyModel') continue;
     const meta = r.metadata as { mates?: ReadonlyArray<{ a: string; b: string }> } | undefined;
     const mates = meta?.mates;
     if (!Array.isArray(mates)) continue;

--- a/tests/unit/mates/validateAssemblyMateAwareness.test.ts
+++ b/tests/unit/mates/validateAssemblyMateAwareness.test.ts
@@ -80,4 +80,53 @@ describe('validateAssembly is v0.6 mate-aware', () => {
     expect(result.diagnostics.filter((d) => d.code === 'assembly.part.floating')).toHaveLength(0);
     expect(result.diagnostics.filter((d) => d.code === 'assembly.part.orphan')).toHaveLength(0);
   });
+
+  // Issue #448 — the `.model()` path must be just as mate-aware as the
+  // `solvedModel({})` path. `Assembly.model()` records the same mate
+  // metadata on an `assemblyModel` record; pre-fix the validator only
+  // walked `solvedAssembly` records, so the SAME assembly validated clean
+  // via `solvedModel({})` but warned spuriously via `.model()` — training
+  // agents to ignore floating-part warnings.
+  it('does NOT flag floating for mated parts returned via .model() (issue #448)', async () => {
+    const model = await buildModel({
+      fileName: 'mate-only-model.kcad.ts',
+      code: `
+        const arm = assembly('test');
+        arm.part('base', box(10, 10, 10))
+           .connector('p', { type: 'frame', origin: { kind: 'vec3', value: [5, 0, 0] } });
+        arm.part('child', box(10, 10, 10))
+           .connector('q', { type: 'frame', origin: { kind: 'vec3', value: [-5, 0, 0] } });
+        arm.mate('m', 'base.p', 'child.q', 'fastened');
+        // .model() instead of solvedModel({}) — same mate graph, and the
+        // validator must see it through the assemblyModel record.
+        return arm.model();
+      `,
+    });
+    const result = validateAssembly({ records: model.records });
+    const floating = result.diagnostics.filter((d) => d.code === 'assembly.part.floating');
+    expect(floating).toHaveLength(0);
+    expect(result.status).toBe('solved');
+  });
+
+  it('still flags a genuinely unmated part via .model() (gate not weakened)', async () => {
+    const model = await buildModel({
+      fileName: 'one-floating-model.kcad.ts',
+      code: `
+        const arm = assembly('test');
+        arm.part('base', box(10, 10, 10))
+           .connector('p', { type: 'frame', origin: { kind: 'vec3', value: [5, 0, 0] } });
+        arm.part('child', box(10, 10, 10))
+           .connector('q', { type: 'frame', origin: { kind: 'vec3', value: [-5, 0, 0] } });
+        // 'lonely' has no mate at all — must STILL warn on the .model() path.
+        arm.part('lonely', box(5, 5, 5));
+        arm.mate('m', 'base.p', 'child.q', 'fastened');
+        return arm.model();
+      `,
+    });
+    const result = validateAssembly({ records: model.records });
+    const floating = result.diagnostics.filter((d) => d.code === 'assembly.part.floating');
+    expect(floating).toHaveLength(1);
+    expect(floating[0].partName).toBe('lonely');
+    expect(result.status).toBe('warning');
+  });
 });


### PR DESCRIPTION
Fixes #448

## Problem

For an assembly with mates, validating via `.model()` produced spurious `assembly.part.floating` warnings, while the identical assembly via `solvedModel({})` validated clean. This trains agents to dismiss floating-part warnings, undermining the validity gate.

## Root cause

`collectMateEdges` in `src/modeling/mates/validator.ts` only walked `solvedAssembly` records (written by `Assembly.solvedModel`). `Assembly.model()` writes the identical mate metadata onto an `assemblyModel` record, so the record-level validator (`kernelcad validate`, `validateAssembly({ records })`) never saw the mate graph on the `.model()` path and flagged every mated part as floating.

## Fix

`collectMateEdges` now walks both `solvedAssembly` and `assemblyModel` records. The chosen contract is mate-aware `.model()` — the mate metadata was already recorded there for the lowerer/Studio; the validator was the only consumer skipping it.

## Gate not weakened

- Genuinely unmated parts still warn on both `.model()` and `solvedModel({})` paths — covered by new tests (`still flags a genuinely unmated part via .model()`).
- Interference gate semantics/thresholds untouched.
- MCP `validate_assembly` / `review_cad` use `validateAssemblyWithMates(arm)`, which reads `arm.__mates()` directly and was already correct for `.model()` scripts; `evaluate_script` dry-run/parts-summary uses `detectUnstructuredBodies`, which does not emit floating-part diagnostics — no other surface hits this seam.

## Tests

- `src/modeling/mates/validator.test.ts` — synthetic record-stream repro (+ unweakened-gate guard).
- `tests/unit/mates/validateAssemblyMateAwareness.test.ts` — end-to-end `buildModel` repro mirroring the `kernelcad validate` CLI path (+ unweakened-gate guard).
- CHANGELOG entry under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)