### PR TITLE
docs(skills): interlocking joinery guidance for flat-pack/CNC/laser stock

### DIFF
--- a/cookbook/snippets/tab-slot-flush-joint.md
+++ b/cookbook/snippets/tab-slot-flush-joint.md
@@ -1,0 +1,40 @@
+---
+id: tab-slot-flush-joint
+title: Flat-pack tab-and-slot joint — flush tab, clearance on the slot
+tags: [joinery, subtract, union, plate, pocket, parameter]
+keywords:
+  - tab and slot joint for laser-cut or CNC flat stock
+  - through-tab flush or slightly proud of the mating face
+  - slot widened by fit clearance, tab stays nominal
+  - finger joint box joint plywood acrylic
+  - kerf and endmill clearance for interlocking parts
+when_to_use: You are joining flat stock (laser/CNC plywood, acrylic, sheet) with an interlocking tab-and-slot. The through-tab must span the full mating wall thickness — flush or slightly proud, never recessed — and the fit clearance belongs on the slot, not on the tab.
+---
+
+```typescript
+// Rule 1: the through-tab spans the FULL wall thickness and stands slightly
+// proud of the outer face (flush-trim after assembly) — never recessed.
+// Rule 2: the fit clearance widens the SLOT; the tab stays at nominal size.
+const t = 6;      // stock thickness
+const tabW = 18;  // nominal tab width
+// Per-side slot clearance — process-dependent: laser 0–0.1 (kerf supplies the
+// rest), CNC router 0.1–0.25, mating 3D-printed parts 0.15–0.3.
+const tabFit = param('tabFit', 0.15, { min: 0, max: 0.5 });
+const tabProud = param('tabProud', 0.3, { min: 0, max: 1 });
+
+// Vertical wall: outer face at x = 0, inner face at x = t.
+const wall = box(t, 60, 50);
+
+// Horizontal shelf butting the inner wall face at mid-height (z = 22).
+const shelf = box(40, 60, t).translate(t, 0, 22);
+
+// Tab at nominal cross-section (tabW × t): through the wall, proud of the
+// outer face, with 1 mm overlap into the shelf so the union is unambiguous.
+const tab = box(tabProud.add(t + 1), tabW, t).translate(tabProud.negate(), 21, 22);
+
+// Slot: tab cross-section + tabFit per side, cut clean through the wall.
+const slot = box(t + 2, tabFit.multiply(2).add(tabW), tabFit.multiply(2).add(t))
+  .translate(-1, tabFit.negate().add(21), tabFit.negate().add(22));
+
+return wall.subtract(slot).union(shelf.union(tab));
+```

--- a/cookbook/tags.json
+++ b/cookbook/tags.json
@@ -20,6 +20,7 @@
   "hole",
   "pocket",
   "plate",
+  "joinery",
   "bracket",
   "stacking",
   "symmetry"

--- a/src/agent/skills/kernelcad-authoring/SKILL.md
+++ b/src/agent/skills/kernelcad-authoring/SKILL.md
@@ -671,6 +671,7 @@ When you need a canonical pattern, call MCP tool `lookup_cookbook(query, k?)` to
 | path-spline-organic-outline | You need a freeform 2D outline (eyewear brow, ergonomic grip silhouette, sneaker midsole) authored as a sequence of measured waypoints, and arc primitives + smoothSpline are too rigid. Drop a single .spline([...]) call into the path() chain after moveTo; the path interpolates through every waypoint at degree 3. |
 | revolve-rectangular-profile | You want a thin cylindrical wall, ring, or tube — author the rectangular profile via path() with the inner radius as the x offset, then call .revolve() to sweep it around Z. |
 | subtract-then-fillet-rim | You want a parametric plate, drill a through-hole, and round the rim where the hole meets the top face. |
+| tab-slot-flush-joint | You are joining flat stock (laser/CNC plywood, acrylic, sheet) with an interlocking tab-and-slot. The through-tab must span the full mating wall thickness — flush or slightly proud, never recessed — and the fit clearance belongs on the slot, not on the tab. |
 | union-of-stacked-primitives | You want to compose multiple primitives into one part by translating each into place and unioning them, without volume overlap. |
 
 <!-- COOKBOOK:END -->
@@ -684,6 +685,19 @@ When you need a canonical pattern, call MCP tool `lookup_cookbook(query, k?)` to
 - For symmetric parts, prefer `.mirror(plane)` (union of source + reflection) over manual duplication. Use `.reflect(plane)` when you only want the reflected geometry without the original.
 - In booleans, prefer ≥0.1 mm of overlap (unions) or offset (subtractions/clearances) over exact tangency or coincidence between solids — exact-tangent junctions stress the export mesher; the export pipeline heals the resulting cracks, but offsets keep meshes clean at the source.
 - For helical features (coils, springs, threads), generate the rail with `helix(...)` and sweep a closed `path()` profile with `spine: 'smooth'` — the dense helix rail needs a single B-spline spine to produce a sewn, watertight tube; the default polyline spine emits per-segment tubes that fail the watertight export verify. `frenet` is unnecessary with a smooth spine.
+
+## Interlocking joinery (flat-pack / laser / CNC)
+
+Tab-and-slot and finger joints in flat stock follow a fixed discipline; getting it backwards produces joints that read as empty slots and carry no load.
+
+- **Through-tabs sit flush or slightly proud — never recessed.** Model the tab to span the FULL thickness of the mating wall; add 0.2–0.5 mm of proud allowance when the face will be sanded or flush-trimmed after assembly. A tab whose end face stops short of the mating surface — even by 0.2 mm — looks like an empty slot and leaves the glue/bearing area undersized.
+- **Fit clearance goes on the slot/pocket, not the tab.** Keep the tab at nominal width and thickness; widen the slot by a per-side clearance. Shortening or thinning the tab destroys both the flush face and the joint's reference geometry.
+- **Clearance is process-dependent — encode it as a named param (`tabFit`)** so it can be retuned per machine and material without touching geometry:
+  - Laser: the beam removes a kerf (~0.1–0.3 mm depending on material and thickness) that already loosens nominal-drawn joints by roughly one kerf width; `tabFit` of 0–0.1 mm per side usually yields a snug press fit.
+  - CNC router: `tabFit` 0.1–0.25 mm per side, plus dog-bone / T-bone corner relief at internal slot corners (relief radius ≥ endmill radius) so square tab corners can seat fully.
+  - Mating 3D-printed parts: `tabFit` 0.15–0.3 mm per side.
+- **Finger joints (box joints):** finger width 1–2× material thickness; finger depth equals the mating wall thickness exactly (plus the same proud allowance) so finger ends finish flush with the outer face; prefer an odd finger count for a symmetric edge.
+- Canonical pattern: cookbook snippet `tab-slot-flush-joint` — `lookup_cookbook("tab and slot flush joint")`.
 
 ## Sample
 


### PR DESCRIPTION
## What

Closes an authoring-knowledge gap: interlocking joinery (tab-and-slot, finger joints) in flat stock was being modeled with tabs recessed below the mating surface, which reads as empty slots and carries no load. This PR adds the missing engineering guidance on both agent surfaces.

- **New cookbook snippet `tab-slot-flush-joint`** (`cookbook/snippets/`): canonical wall + shelf tab/slot pair. Through-tab spans the full wall thickness and stands proud via a `tabProud` param; the slot is widened by a per-side `tabFit` param while the tab stays nominal. Body evaluates clean (`cookbook:evaluate`, all 17 snippets) and ranks first for "tab and slot", "finger joint", and "kerf clearance" queries.
- **New `kernelcad-authoring` SKILL.md section** "Interlocking joinery (flat-pack / laser / CNC)": flush-or-proud rule, clearance-on-the-slot rule, process-dependent clearance ranges (laser kerf, CNC endmill + dog-bone corner relief, mating printed parts), finger-joint sizing relative to material thickness, pointer to the snippet.
- New cookbook tag `joinery` (no existing tag covers interlocking flat-stock joints).
- Cookbook index table regenerated with `cookbook:build` (idempotent).

## Verification

- `npm run cookbook:validate` — 17 snippets validated
- `npm run cookbook:evaluate` — all 17 snippet bodies evaluate clean
- `npm run cookbook:build` — index up to date, `git diff --exit-code src/agent/skills` clean after regen
- `npx vitest run src/agent/cookbook src/agent/mcp/tools/lookupCookbook.test.ts tests/unit/skill` — pass
- `npm run proof:dist-skills` — 52 tests pass
- `npm run typecheck` — clean
- Rendered the snippet body (`kernelcad render`) and visually inspected: tab passes fully through the wall and finishes proud of the outer face; no recess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)