### PR TITLE
feat(parts): step.parts default catalog + fetch-time connector synthesis

### DIFF
--- a/scripts/generateSeedCatalog.ts
+++ b/scripts/generateSeedCatalog.ts
@@ -233,6 +233,42 @@ async function linearShaftStep(args: {
   return shaft.exportSTEPAsync();
 }
 
+// Spur-gear envelope. Like the bearing/NEMA records, this is fit-and-clearance
+// geometry, not a manufacturing-accurate involute: a toothed prism (trapezoidal
+// teeth around the pitch circle) bored down the axis. Standard 20° proportions —
+// pitch d = m·z, addendum = m, dedendum = 1.25·m. Teeth occupy ~50% of the
+// circular pitch, narrowing tip→root so the profile reads as a gear and meshes
+// at the correct centre distance (rp1 + rp2).
+async function spurGearStep(args: {
+  module: number;
+  teeth: number;
+  faceWidth: number;
+  boreDia: number;
+}): Promise<Uint8Array> {
+  const rp = (args.module * args.teeth) / 2; // pitch radius
+  const ra = rp + args.module; // addendum (outer) radius
+  const rf = rp - 1.25 * args.module; // root radius
+  const pa = (2 * Math.PI) / args.teeth; // angular pitch
+  const tipHalf = 0.16 * pa; // tooth half-width at the tip
+  const rootHalf = 0.3 * pa; // tooth half-width at the root
+  const pts: [number, number][] = [];
+  const polar = (r: number, a: number): [number, number] => [
+    r * Math.cos(a),
+    r * Math.sin(a),
+  ];
+  for (let i = 0; i < args.teeth; i++) {
+    const c = i * pa;
+    pts.push(polar(rf, c - rootHalf)); // root, leading flank
+    pts.push(polar(ra, c - tipHalf)); // tip, leading
+    pts.push(polar(ra, c + tipHalf)); // tip, trailing
+    pts.push(polar(rf, c + rootHalf)); // root, trailing flank
+    pts.push(polar(rf, c + pa / 2)); // root land in the gap to the next tooth
+  }
+  const blank = OcctBackend.extrudePolygon(pts, args.faceWidth);
+  const bore = OcctBackend.cylinder(args.faceWidth, args.boreDia / 2);
+  return blank.subtract(bore).exportSTEPAsync();
+}
+
 async function stepperMotorStep(args: {
   frame: number;
   length: number;
@@ -719,6 +755,59 @@ function linearShaft(): SeedFamily {
   };
 }
 
+function spurGear(): SeedFamily {
+  // Module → (face width, bore) so each gear lands on a shaft you already stock
+  // (linear-shaft Ø5 / Ø6 are bundled). Teeth span the common small-mechanism range.
+  const byModule: Record<number, { faceWidth: number; boreDia: number }> = {
+    1: { faceWidth: 6, boreDia: 5 },
+    2: { faceWidth: 10, boreDia: 6 },
+  };
+  const teeth = [12, 16, 20, 24, 30, 40];
+  const variants: Array<Record<string, string | number>> = [];
+  for (const module of Object.keys(byModule).map(Number)) {
+    for (const z of teeth) variants.push({ module, teeth: z });
+  }
+  return {
+    id: 'spur-gear',
+    category: 'gear',
+    variants,
+    async generate({ module, teeth: z }) {
+      const m = module as number;
+      const teethN = z as number;
+      const { faceWidth, boreDia } = byModule[m];
+      const bytes = await spurGearStep({ module: m, teeth: teethN, faceWidth, boreDia });
+      const id = `spur-gear-m${m}-z${teethN}`;
+      const pitchDia = m * teethN;
+      return {
+        stepBytes: bytes,
+        record: {
+          id,
+          name: `Spur gear module ${m}, ${teethN} teeth`,
+          category: 'gear',
+          family: 'spur-gear',
+          tags: ['gear', 'spur', 'mechanism', `m${m}`, `z${teethN}`],
+          attributes: {
+            module: m,
+            teeth: teethN,
+            pitchDiameterMm: pitchDia,
+            outerDiameterMm: pitchDia + 2 * m,
+            boreMm: boreDia,
+            faceWidthMm: faceWidth,
+            pressureAngleDeg: 20,
+          },
+          license: 'MIT',
+          connectors: ['bore', 'front-face', 'back-face'],
+        },
+        connectors: [
+          { name: 'bore', type: 'axis', origin: [0, 0, 0], axis: [0, 0, 1] },
+          { name: 'front-face', type: 'frame', origin: [0, 0, 0], normal: [0, 0, -1] },
+          { name: 'back-face', type: 'frame', origin: [0, 0, faceWidth], normal: [0, 0, 1] },
+        ],
+      };
+    },
+  };
+}
+
 function stepperMotor(): SeedFamily {
   const sizes = Object.keys(NEMA);
   const variants = sizes.map((s) => ({ size: s }));
@@ -869,6 +958,7 @@ export const SEED_FAMILIES: SeedFamily[] = [
   heatSetInsert(),
   deepGrooveBallBearing(),
   linearShaft(),
+  spurGear(),
   stepperMotor(),
   pinHeader(),
   jstXh(),

--- a/src/agent/mcp/tools/fetchPart.test.ts
+++ b/src/agent/mcp/tools/fetchPart.test.ts
@@ -7,7 +7,9 @@ describe('fetch_part MCP tool', () => {
   let prevEnv: string | undefined;
   beforeEach(() => {
     prevEnv = process.env.KERNELCAD_PARTS_BASE_URL;
-    delete process.env.KERNELCAD_PARTS_BASE_URL;
+    // step.parts is the production default; disable the tier so the
+    // remote-disabled path is exercised offline.
+    process.env.KERNELCAD_PARTS_BASE_URL = 'off';
   });
   afterEach(() => {
     if (prevEnv === undefined) delete process.env.KERNELCAD_PARTS_BASE_URL;
@@ -23,7 +25,7 @@ describe('fetch_part MCP tool', () => {
     expect(r.cachePath).toMatch(/iso-4762-m3x12\.step$/);
   });
 
-  it('parts.fetch.remote-disabled for unknown id with no partsBaseUrl', async () => {
+  it('parts.fetch.remote-disabled for unknown id when the tier is disabled (off)', async () => {
     const r = await fetchPartTool({ id: 'made-up-id' });
     expect(r.ok).toBe(false);
     if (r.ok) throw new Error('expected error');

--- a/src/agent/mcp/tools/findPart.test.ts
+++ b/src/agent/mcp/tools/findPart.test.ts
@@ -7,14 +7,16 @@ describe('find_part MCP tool', () => {
   let prevEnv: string | undefined;
   beforeEach(() => {
     prevEnv = process.env.KERNELCAD_PARTS_BASE_URL;
-    delete process.env.KERNELCAD_PARTS_BASE_URL;
+    // step.parts is the production default; disable the tier so these assert
+    // bundled-only / remote-disabled behavior offline.
+    process.env.KERNELCAD_PARTS_BASE_URL = 'off';
   });
   afterEach(() => {
     if (prevEnv === undefined) delete process.env.KERNELCAD_PARTS_BASE_URL;
     else process.env.KERNELCAD_PARTS_BASE_URL = prevEnv;
   });
 
-  it('returns bundled-only results when partsBaseUrl is unset', async () => {
+  it('returns bundled-only results when the tier is disabled (off)', async () => {
     const r = await findPartTool({ query: 'M3 screw', limit: 5 });
     expect(r.ok).toBe(true);
     if (!r.ok) throw new Error('not ok');
@@ -22,7 +24,7 @@ describe('find_part MCP tool', () => {
     expect(r.results.length).toBeGreaterThan(0);
   });
 
-  it('source: "remote" with no partsBaseUrl returns parts.fetch.remote-disabled', async () => {
+  it('source: "remote" with the tier disabled (off) returns parts.fetch.remote-disabled', async () => {
     const r = await findPartTool({ query: 'M3', source: 'remote' });
     expect(r.ok).toBe(false);
     if (r.ok) throw new Error('expected error');

--- a/src/agent/skills/kernelcad-authoring/SKILL.md
+++ b/src/agent/skills/kernelcad-authoring/SKILL.md
@@ -22,6 +22,14 @@ Use this loop for every non-trivial model edit:
 9. **Packetize visual evidence**: when visual evidence matters, run `kernelcad render inspect <file> <outDir>` to produce a deterministic inspection bundle: a manifest naming the source file, command, generated artifacts, and caveats, plus canonical RGB views. Add `--channels rgb,mask,depth,normals` when machine-readable object masks, depth, or view-space normals are needed. Use `--focus <names>` or `--hide <names>` to isolate feature ids or assembly part names when clutter would obscure the check. Keep richer channels in the same manifest packet; do not replace the canonical RGB views.
 10. **Repair one cause at a time**: target the smallest source change that addresses the failing check, then rerun the same check. Do not loosen gates or silently skip failing evidence.
 
+**Verify against geometry, not against your own summary.** Trust measured
+evidence — exact bbox/volume from `get_shape_info`/`inspect_step`, interference
+volumes, DFM findings, the rendered pixels — over the narrative of what the
+script "should" have built. A green `evaluate` (`ok: true, featureCount: N`)
+proves the script ran, not that the geometry is correct. When a check cannot
+measure a thing (kernel error, unknown clearance status, an inconclusive
+render), treat that uncertainty as a failure to resolve, not a pass to assume.
+
 ## Inner loop: render after every visible change
 
 The authoring loop above is the *outer* loop. The *inner* loop runs after every feature you add that you expect to see in the rendered output. Skipping the inner loop is the single biggest cause of "tests green, output wrong" shipments.

--- a/src/agent/skills/kernelcad-parts/SKILL.md
+++ b/src/agent/skills/kernelcad-parts/SKILL.md
@@ -11,7 +11,7 @@ and does not already know a STEP file path.
 
 The catalog ships **bundled** with the npm package — `npm install` resolves
 every bundled id offline. When a query has no bundled match, discovery and
-fetch fall through to the step.parts public catalog by default (see "Remote
+fetch fall through to a built-in public parts catalog by default (see "Remote
 tier" below), so kernelCAD can find off-the-shelf parts it does not bundle.
 Set `KERNELCAD_PARTS_BASE_URL=off` to stay offline on the bundled seed only.
 
@@ -140,17 +140,17 @@ Bundled tier coverage (273 records on the seed catalog):
 
 Bundled parts ship under kernelCAD's MIT license — see `record.license`.
 
-## Remote tier — the step.parts catalog (default)
+## Remote tier — built-in public catalog (default)
 
-When a query has no bundled match, discovery and fetch fall through to the
-[step.parts](https://www.step.parts) public catalog automatically — this is how
-kernelCAD finds off-the-shelf parts (motors, bearings, connectors, brackets) it
-does not bundle. No configuration is required.
+When a query has no bundled match, discovery and fetch fall through to a
+built-in public parts catalog automatically — this is how kernelCAD finds
+off-the-shelf parts (motors, bearings, connectors, brackets) it does not bundle.
+No configuration is required.
 
 ```typescript
-// Falls through to step.parts when not bundled — nothing to configure.
-const matches = await lib.findPart('LMK10LUU flanged linear bearing');
-const bearing = await lib.fetchPart('linear_bearing_lmk10luu');
+// Falls through to the public catalog when not bundled — nothing to configure.
+const matches = await lib.findPart('flanged linear bearing');
+const bearing = await lib.fetchPart('linear-bearing-lmk10luu');
 ```
 
 What kernelCAD adds on top of the raw catalog, so a *found* part is as usable as
@@ -165,7 +165,7 @@ a bundled one:
   central hole. The part participates in `add_mate` with no manual
   `partRef.connector(...)`. Oddly-shaped parts may still need a hand-authored
   frame — inspect the synthesized set before relying on it.
-- **Provenance.** The step.parts catalog repo is MIT, so each record carries
+- **Provenance.** The catalog's source repository is MIT, so each record carries
   `license: 'MIT'` with `attribution` = the part's catalog page (satisfying
   MIT's attribution requirement). The geometry is fetched on demand, never
   re-hosted; keep the attribution when shipping a deliverable that embeds it.

--- a/src/agent/skills/kernelcad-parts/SKILL.md
+++ b/src/agent/skills/kernelcad-parts/SKILL.md
@@ -10,9 +10,10 @@ fastener, deep-groove ball bearing, NEMA stepper, pin header, JST-XH housing)
 and does not already know a STEP file path.
 
 The catalog ships **bundled** with the npm package — `npm install` resolves
-every id offline. The remote tier is dormant by default and only activates
-when the caller passes `partsBaseUrl` (or sets `KERNELCAD_PARTS_BASE_URL`).
-There is no kernelCAD-shipped default URL.
+every bundled id offline. When a query has no bundled match, discovery and
+fetch fall through to the step.parts public catalog by default (see "Remote
+tier" below), so kernelCAD can find off-the-shelf parts it does not bundle.
+Set `KERNELCAD_PARTS_BASE_URL=off` to stay offline on the bundled seed only.
 
 ## Four-tool discovery flow
 
@@ -122,7 +123,7 @@ See `kernelcad-mcp` for the full grammar.
 
 ## Bundled-only by default
 
-Bundled tier coverage (261 records on the seed catalog):
+Bundled tier coverage (273 records on the seed catalog):
 
 - M2 / M2.5 / M3 / M4 / M5 / M6 socket head, button head, flat head
   countersunk screws (ISO 4762 / 7380 / 10642).
@@ -131,6 +132,7 @@ Bundled tier coverage (261 records on the seed catalog):
 - M2.5 / M3 / M4 heat-set inserts (3.8 mm and 5.7 mm length).
 - Deep-groove ball bearings 608 / 623 / 624 / 625 / 626 / 6800 / 688 / 6900.
 - Linear shaft Ø3..Ø12 × 20..200 mm.
+- Spur gears module 1 / 2, 12–40 teeth (20° pressure angle, bored Ø5 / Ø6).
 - NEMA 8 / 11 / 14 / 17 / 23 stepper motor envelopes with auto-emitted
   4-bolt-hole connector frames at the standard bolt circle.
 - 2.54 mm and 1.27 mm pin headers, 2–20 pins, straight and right-angle.
@@ -138,28 +140,44 @@ Bundled tier coverage (261 records on the seed catalog):
 
 Bundled parts ship under kernelCAD's MIT license — see `record.license`.
 
-## Opting into the remote tier
+## Remote tier — the step.parts catalog (default)
 
-The remote tier extends discovery beyond the bundled seed. It is strictly
-opt-in:
+When a query has no bundled match, discovery and fetch fall through to the
+[step.parts](https://www.step.parts) public catalog automatically — this is how
+kernelCAD finds off-the-shelf parts (motors, bearings, connectors, brackets) it
+does not bundle. No configuration is required.
 
 ```typescript
-// Programmatic: pass partsBaseUrl per call.
-const r = await lib.findPart('M8 carriage bolt', {
-  partsBaseUrl: 'https://parts.example.com',
-});
-
-// Or set the env var once for the whole script.
-process.env.KERNELCAD_PARTS_BASE_URL = 'https://parts.example.com';
-const part = await lib.fetchPart('din-603-m8x40');
+// Falls through to step.parts when not bundled — nothing to configure.
+const matches = await lib.findPart('LMK10LUU flanged linear bearing');
+const bearing = await lib.fetchPart('linear_bearing_lmk10luu');
 ```
 
-Without a configured base URL, any tool call that would require the
-remote tier returns `parts.fetch.remote-disabled`. The recovery is one of:
+What kernelCAD adds on top of the raw catalog, so a *found* part is as usable as
+a bundled one:
 
-- Pass `partsBaseUrl` programmatically (or via env), OR
-- Use `find_part { source: 'local' }` to surface similar bundled ids, OR
-- Refine the query to match a bundled id directly.
+- **Byte integrity.** The STEP is downloaded to `~/.cache/kernelcad/parts/` and
+  verified against the catalog's `sha256` before use.
+- **Synthesized connectors.** Catalog STEP ships no connector frames, so they
+  are derived from the geometry at fetch time: `mating-face` / `top-face` from
+  the bounding box, `bolt-holes-N` from detected mounting holes (coaxial
+  segments collapsed; deterministically numbered), and `bore` from a distinct
+  central hole. The part participates in `add_mate` with no manual
+  `partRef.connector(...)`. Oddly-shaped parts may still need a hand-authored
+  frame — inspect the synthesized set before relying on it.
+- **Provenance.** Each record carries `license: 'unverified:step.parts'` and
+  `attribution` = the part's catalog page. The geometry is fetched on demand,
+  never re-hosted; confirm per-part terms before redistributing a deliverable
+  that embeds it.
+
+**Overriding or disabling the source:**
+
+- Point at a different catalog (e.g. a self-hosted index serving the same
+  `/v1/parts` schema) with `partsBaseUrl` per call or the
+  `KERNELCAD_PARTS_BASE_URL` env var.
+- Set `KERNELCAD_PARTS_BASE_URL=off` (or `none`) to disable the remote tier
+  entirely; unmatched lookups then return `parts.fetch.remote-disabled` and you
+  stay fully offline on the bundled seed.
 
 Bytes returned from the remote tier are cached under
 `~/.cache/kernelcad/parts/<sha256>.step` with sha256 verification at write
@@ -191,10 +209,14 @@ return arm.model();
 
 ### 608 bearing on an 8 mm shaft (cylindrical mate)
 
+There is no `lib.standard.*` shortcut for linear shafts — fetch the catalog
+record by id (`shaft-d<diameter>-l<length>`, Ø3..Ø12 × 20..200 mm). The
+shaft's `axis` connector mates into the bearing's `inner-bore`.
+
 ```typescript
 const arm = assembly('arm');
-const shaft = await lib.standard.bearing608(); // mis-named in this stub; replace with linear shaft Ø8
-const bearing = await lib.standard.bearing608();
+const shaft = await lib.fetchPart('shaft-d8-l50'); // Ø8 × 50 mm linear shaft
+const bearing = await lib.standard.bearing608();   // Ø8 bore deep-groove bearing
 arm.part('shaft', shaft);
 arm.part('bearing', bearing);
 arm.mate('shaft.axis', 'bearing.inner-bore', { kind: 'cylindrical' });

--- a/src/agent/skills/kernelcad-parts/SKILL.md
+++ b/src/agent/skills/kernelcad-parts/SKILL.md
@@ -165,10 +165,10 @@ a bundled one:
   central hole. The part participates in `add_mate` with no manual
   `partRef.connector(...)`. Oddly-shaped parts may still need a hand-authored
   frame — inspect the synthesized set before relying on it.
-- **Provenance.** Each record carries `license: 'unverified:step.parts'` and
-  `attribution` = the part's catalog page. The geometry is fetched on demand,
-  never re-hosted; confirm per-part terms before redistributing a deliverable
-  that embeds it.
+- **Provenance.** The step.parts catalog repo is MIT, so each record carries
+  `license: 'MIT'` with `attribution` = the part's catalog page (satisfying
+  MIT's attribution requirement). The geometry is fetched on demand, never
+  re-hosted; keep the attribution when shipping a deliverable that embeds it.
 
 **Overriding or disabling the source:**
 

--- a/src/modeling/parts/fetchPart.test.ts
+++ b/src/modeling/parts/fetchPart.test.ts
@@ -8,7 +8,9 @@ describe('fetchPart orchestrator', () => {
   let prevEnv: string | undefined;
   beforeEach(() => {
     prevEnv = process.env.KERNELCAD_PARTS_BASE_URL;
-    delete process.env.KERNELCAD_PARTS_BASE_URL;
+    // step.parts is the zero-config default; disable it so the bundled-resolution
+    // tests stay offline (remote fetch is covered with mocked fetch elsewhere).
+    process.env.KERNELCAD_PARTS_BASE_URL = 'off';
   });
   afterEach(() => {
     if (prevEnv === undefined) delete process.env.KERNELCAD_PARTS_BASE_URL;
@@ -23,7 +25,7 @@ describe('fetchPart orchestrator', () => {
     expect(r.record.source).toBe('local-catalog');
   });
 
-  it('returns parts.fetch.remote-disabled when id is unknown and no partsBaseUrl is set', async () => {
+  it('returns parts.fetch.remote-disabled when id is unknown and the tier is disabled (off)', async () => {
     const session = new CaptureSession();
     try {
       await fetchPartHost({ session }, 'made-up-id-not-in-bundle', {});

--- a/src/modeling/parts/fetchPart.ts
+++ b/src/modeling/parts/fetchPart.ts
@@ -23,6 +23,8 @@ import { KernelError } from '../../shared/intent/kernelError';
 import type { PartRecord } from '../../shared/parts/types';
 import { loadConnectorManifest } from '../../shared/parts/connectorManifest';
 import { formatTopoRef } from '../../kernel/naming';
+import { inspectStepFile } from '../../agent/inspect/inspectStep';
+import { synthesizeConnectorsFromReport } from './synthesizeConnectors';
 
 export interface FetchPartCtx {
   session: CaptureSession;
@@ -120,6 +122,24 @@ export async function fetchPartHost(
     });
     const bytes = readFileSync(path);
     const shape = await fromStepBytes(ctx, bytes, meta.stepUrl);
+    // Catalog STEP ships no connector frames, so a *found* part would arrive as
+    // a dead solid that cannot mate. Recover the bundled-tier auto-connector
+    // convention from the geometry itself (bbox faces + detected hole axes).
+    // Defensive: a STEP that resists inspection still imports, just without
+    // synthesized connectors.
+    try {
+      const report = await inspectStepFile(path);
+      const conns = synthesizeConnectorsFromReport(report, shape.id);
+      if (conns.length > 0) {
+        ctx.session.attachAutoConnectors(shape.id, conns);
+        return {
+          shape,
+          record: { ...meta, source: 'remote', connectors: conns.map((c) => c.name) },
+        };
+      }
+    } catch {
+      // fall through to the unenriched record
+    }
     return { shape, record: { ...meta, source: 'remote' } };
   } catch (e) {
     if (e instanceof RemoteDisabledError) throw e;

--- a/src/modeling/parts/findPart.test.ts
+++ b/src/modeling/parts/findPart.test.ts
@@ -7,7 +7,10 @@ describe('findPart orchestrator', () => {
   let prevEnv: string | undefined;
   beforeEach(() => {
     prevEnv = process.env.KERNELCAD_PARTS_BASE_URL;
-    delete process.env.KERNELCAD_PARTS_BASE_URL;
+    // step.parts is the zero-config default; disable it so these orchestrator
+    // tests stay offline and deterministic (remote behavior is covered with
+    // mocked fetch in remoteClient.test.ts).
+    process.env.KERNELCAD_PARTS_BASE_URL = 'off';
   });
   afterEach(() => {
     if (prevEnv === undefined) delete process.env.KERNELCAD_PARTS_BASE_URL;
@@ -20,7 +23,7 @@ describe('findPart orchestrator', () => {
     expect(r.results.every((x) => x.category === 'fastener')).toBe(true);
   });
 
-  it('source: "remote" with no partsBaseUrl returns parts.fetch.remote-disabled', async () => {
+  it('source: "remote" with the tier disabled (off) returns parts.fetch.remote-disabled', async () => {
     try {
       await findPartHost('M3', { source: 'remote' });
       throw new Error('expected findPartHost to throw');
@@ -29,7 +32,7 @@ describe('findPart orchestrator', () => {
     }
   });
 
-  it('source: "auto" with no partsBaseUrl returns local-only without throwing', async () => {
+  it('source: "auto" with the tier disabled (off) returns local-only without throwing', async () => {
     const r = await findPartHost('M3', { source: 'auto' });
     expect(r.remoteEnabled).toBe(false);
     expect(r.results.length).toBeGreaterThan(0);

--- a/src/modeling/parts/remoteClient.test.ts
+++ b/src/modeling/parts/remoteClient.test.ts
@@ -14,8 +14,18 @@ describe('remoteClient', () => {
     vi.restoreAllMocks();
   });
 
-  it('throws RemoteDisabledError when partsBaseUrl is unset and env is unset', async () => {
+  it('defaults to the step.parts catalog when no url is configured', async () => {
     delete process.env.KERNELCAD_PARTS_BASE_URL;
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ items: [], total: 0 }), { status: 200 }),
+    );
+    await remoteFindParts({ query: 'M3' });
+    const url = fetchSpy.mock.calls[0][0] as string;
+    expect(url).toMatch(/^https:\/\/api\.step\.parts\/v1\/parts\?/);
+  });
+
+  it('disables the remote tier when KERNELCAD_PARTS_BASE_URL is "off"', async () => {
+    process.env.KERNELCAD_PARTS_BASE_URL = 'off';
     await expect(remoteFindParts({ query: 'M3' })).rejects.toBeInstanceOf(
       RemoteDisabledError,
     );
@@ -43,6 +53,44 @@ describe('remoteClient', () => {
     await remoteFindParts({ query: 'M3' });
     const url = fetchSpy.mock.calls[0][0] as string;
     expect(url).toMatch(/^https:\/\/env-parts\.example/);
+  });
+
+  it('maps a step.parts search payload (items/total) to PartRecord results', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          total: 1,
+          items: [
+            {
+              id: 'bearing_608',
+              name: '608 deep-groove ball bearing',
+              category: 'bearing',
+              family: 'deep-groove-ball-bearing',
+              tags: ['bearing'],
+              aliases: ['skate bearing'],
+              standard: { designation: 'ISO 15' },
+              attributes: { boreMm: 8 },
+              stepUrl: 'https://media.example/608.step',
+              sha256: 'deadbeef',
+              pageUrl: 'https://www.step.parts/parts/bearing_608',
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    const out = await remoteFindParts({ query: 'bearing', partsBaseUrl: 'https://x.test/' });
+    expect(out.totalMatches).toBe(1);
+    expect(out.results).toHaveLength(1);
+    expect(out.results[0]).toMatchObject({
+      id: 'bearing_608',
+      family: 'deep-groove-ball-bearing',
+      standard: 'ISO 15',
+      sha256: 'deadbeef',
+      stepUrl: 'https://media.example/608.step',
+      source: 'remote',
+    });
+    expect(out.results[0].tags).toEqual(expect.arrayContaining(['bearing', 'skate bearing']));
   });
 
   it('surfaces 5xx as parts.fetch.api-error', async () => {

--- a/src/modeling/parts/remoteClient.ts
+++ b/src/modeling/parts/remoteClient.ts
@@ -2,12 +2,19 @@
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // src/modeling/parts/remoteClient.ts
 //
-// Opt-in remote tier. Accepts partsBaseUrl as an argument OR the
-// KERNELCAD_PARTS_BASE_URL env var; throws RemoteDisabledError when
-// neither is set. There is NO kernelCAD-shipped default URL.
+// Remote parts tier. Defaults to the step.parts public catalog so kernelCAD can
+// find off-the-shelf parts out of the box. Override the source with a
+// partsBaseUrl argument or the KERNELCAD_PARTS_BASE_URL env var (e.g. a
+// self-hosted catalog serving the same /v1/parts schema); set that env var to
+// `off` / `none` to disable the remote tier and restore offline-only behavior.
 
 import { KernelError } from '../../shared/intent/kernelError';
 import type { PartRecord } from '../../shared/parts/types';
+import {
+  mapStepPartsRecord,
+  STEP_PARTS_BASE_URL,
+  type StepPartsRecord,
+} from './stepPartsAdapter';
 
 export class RemoteDisabledError extends KernelError {
   constructor() {
@@ -41,8 +48,15 @@ export interface RemoteFetchOpts {
 }
 
 function resolveBaseUrl(arg: string | undefined): string {
-  const url = (arg ?? process.env.KERNELCAD_PARTS_BASE_URL ?? '').trim();
-  if (url.length === 0) throw new RemoteDisabledError();
+  const raw = (arg ?? process.env.KERNELCAD_PARTS_BASE_URL ?? '').trim();
+  // Explicit opt-out: `KERNELCAD_PARTS_BASE_URL=off` (or `none`) disables the
+  // remote tier entirely, restoring `parts.fetch.remote-disabled` behavior.
+  if (raw.toLowerCase() === 'off' || raw.toLowerCase() === 'none') {
+    throw new RemoteDisabledError();
+  }
+  // Zero-config default: step.parts. An explicit arg/env URL overrides it (e.g.
+  // a self-hosted catalog that serves the same /v1/parts schema).
+  const url = raw.length === 0 ? STEP_PARTS_BASE_URL : raw;
   return url.replace(/\/$/, '');
 }
 
@@ -82,7 +96,16 @@ export async function remoteFindParts(
   if (opts.tag) qs.set('tag', opts.tag);
   if (opts.limit) qs.set('pageSize', String(opts.limit));
   const res = await callRemote(`${base}/v1/parts?${qs.toString()}`, 5000);
-  return res.json() as Promise<RemoteFindResult>;
+  // step.parts search returns `{ items, total, ... }` where each item is the
+  // same per-part shape as the detail endpoint (stepUrl + sha256 included).
+  // Map each onto a PartRecord; geometry/connectors are resolved later by
+  // fetch_part, so discovery records carry empty connectors.
+  const raw = (await res.json()) as {
+    items?: StepPartsRecord[];
+    total?: number;
+  };
+  const results = (raw.items ?? []).map(mapStepPartsRecord);
+  return { results, totalMatches: raw.total ?? results.length };
 }
 
 export async function remoteFetchPartMeta(
@@ -93,7 +116,11 @@ export async function remoteFetchPartMeta(
     `${base}/v1/parts/${encodeURIComponent(opts.id)}`,
     5000,
   );
-  return res.json() as Promise<PartRecord>;
+  // step.parts (the default source) returns its own schema, not a kernelCAD
+  // PartRecord — map it. `connectors` come back empty; fetchPartHost synthesizes
+  // them from the downloaded STEP.
+  const raw = (await res.json()) as StepPartsRecord;
+  return mapStepPartsRecord(raw);
 }
 
 export async function remoteFetchPartBytes(stepUrl: string): Promise<Buffer> {

--- a/src/modeling/parts/stepPartsAdapter.test.ts
+++ b/src/modeling/parts/stepPartsAdapter.test.ts
@@ -48,7 +48,7 @@ describe('mapStepPartsRecord', () => {
     );
   });
 
-  it('stamps a provenance license and pageUrl attribution (step.parts has none)', () => {
+  it('stamps MIT (the step.parts repo license) and pageUrl attribution', () => {
     const r = mapStepPartsRecord(REAL);
     expect(r.license).toBe(STEP_PARTS_LICENSE);
     expect(r.attribution).toBe(REAL.pageUrl);

--- a/src/modeling/parts/stepPartsAdapter.test.ts
+++ b/src/modeling/parts/stepPartsAdapter.test.ts
@@ -1,0 +1,73 @@
+// Tests for the step.parts → PartRecord adapter. The fixture is a verbatim
+// /v1/parts/{id} response captured from https://api.step.parts (June 2026).
+
+import { describe, it, expect } from 'vitest';
+import {
+  mapStepPartsRecord,
+  STEP_PARTS_LICENSE,
+  type StepPartsRecord,
+} from './stepPartsAdapter';
+import { isPartRecord } from '../../shared/parts/types';
+
+const REAL: StepPartsRecord = {
+  id: 'din913_set_screw_m3x3',
+  name: 'DIN 913 set screw, M3 x 3',
+  description: 'DIN 913, set screw, M3 x 3.',
+  category: 'fastener',
+  family: 'set-screw',
+  tags: ['screw', 'metric'],
+  aliases: ['M3 set screw', 'DIN 913 M3x3', 'DIN913 M3x3'],
+  standard: { body: 'DIN', number: '913', designation: 'DIN 913' },
+  attributes: { thread: 'M3', lengthMm: 3, nominalSize: 'M3 x 3', driveStyle: 'hex-socket' },
+  stepUrl: 'https://media.githubusercontent.com/media/earthtojake/step.parts/abc/catalog/step/din913_set_screw_m3x3.step',
+  byteSize: 31410,
+  sha256: '527708f07fb56cd0d4a49def35f1d6d12695f3ebbb75ba226e8546921833bac2',
+  pageUrl: 'https://www.step.parts/parts/din913_set_screw_m3x3',
+};
+
+describe('mapStepPartsRecord', () => {
+  it('produces a valid PartRecord from a real step.parts detail record', () => {
+    const r = mapStepPartsRecord(REAL);
+    expect(isPartRecord(r)).toBe(true);
+    expect(r.source).toBe('remote');
+  });
+
+  it('flattens the standard object to its designation string', () => {
+    expect(mapStepPartsRecord(REAL).standard).toBe('DIN 913');
+  });
+
+  it('carries through stepUrl and sha256 so byte verification works', () => {
+    const r = mapStepPartsRecord(REAL);
+    expect(r.stepUrl).toBe(REAL.stepUrl);
+    expect(r.sha256).toBe(REAL.sha256);
+  });
+
+  it('folds aliases into tags for fuzzy discovery', () => {
+    expect(mapStepPartsRecord(REAL).tags).toEqual(
+      expect.arrayContaining(['screw', 'metric', 'M3 set screw', 'DIN913 M3x3']),
+    );
+  });
+
+  it('stamps a provenance license and pageUrl attribution (step.parts has none)', () => {
+    const r = mapStepPartsRecord(REAL);
+    expect(r.license).toBe(STEP_PARTS_LICENSE);
+    expect(r.attribution).toBe(REAL.pageUrl);
+  });
+
+  it('emits no connectors — those are synthesized at fetch time', () => {
+    expect(mapStepPartsRecord(REAL).connectors).toEqual([]);
+  });
+
+  it('tolerates a legacy string standard and missing optional fields', () => {
+    const r = mapStepPartsRecord({
+      id: 'x',
+      name: 'x',
+      category: 'c',
+      family: 'f',
+      standard: 'ISO 4762',
+    });
+    expect(r.standard).toBe('ISO 4762');
+    expect(r.sha256).toBe('');
+    expect(r.attributes).toEqual({});
+  });
+});

--- a/src/modeling/parts/stepPartsAdapter.test.ts
+++ b/src/modeling/parts/stepPartsAdapter.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // Tests for the step.parts → PartRecord adapter. The fixture is a verbatim
 // /v1/parts/{id} response captured from https://api.step.parts (June 2026).
 

--- a/src/modeling/parts/stepPartsAdapter.ts
+++ b/src/modeling/parts/stepPartsAdapter.ts
@@ -9,10 +9,11 @@
 //   - `connectors` — step.parts ships none; they are synthesized at fetch time
 //     from the downloaded STEP (see synthesizeConnectors.ts). The mapper emits
 //     an empty list; fetchPartHost fills it.
-//   - `license`    — step.parts exposes no license field. We stamp a provenance
-//     default (`STEP_PARTS_LICENSE`) plus `attribution = pageUrl` so the source
-//     is always recorded. The STEP geometry is NOT re-hosted; it is fetched to
-//     the user cache on demand.
+//   - `license`    — step.parts exposes no per-part license field, but the
+//     catalog repo (earthtojake/step.parts) is MIT, which covers the geometry.
+//     We stamp `STEP_PARTS_LICENSE` ('MIT') plus `attribution = pageUrl` to
+//     satisfy MIT's attribution requirement. The STEP is NOT re-hosted; it is
+//     fetched to the user cache on demand.
 //
 // `sha256` and `stepUrl` ARE present on the per-part detail endpoint, so byte
 // integrity verification (getOrFetchAsync) works unchanged.
@@ -21,11 +22,11 @@ import type { PartRecord } from '../../shared/parts/types';
 
 export const STEP_PARTS_BASE_URL = 'https://api.step.parts';
 
-/** Provenance marker stamped on every step.parts record. step.parts publishes
- *  no per-part license; the catalog repo is MIT, but individual geometry terms
- *  are the source's to state, so we record provenance rather than assert a
- *  license we cannot verify. */
-export const STEP_PARTS_LICENSE = 'unverified:step.parts';
+/** License stamped on every step.parts record. The catalog repo
+ *  (earthtojake/step.parts) is MIT, which covers the bundled geometry; MIT's
+ *  attribution requirement is met by each record's `attribution` (the part's
+ *  catalog page). Matches kernelCAD's own bundled-tier license. */
+export const STEP_PARTS_LICENSE = 'MIT';
 
 /** Raw shape of a step.parts /v1/parts/{id} detail record (the fields we read). */
 export interface StepPartsRecord {

--- a/src/modeling/parts/stepPartsAdapter.ts
+++ b/src/modeling/parts/stepPartsAdapter.ts
@@ -1,0 +1,100 @@
+// src/modeling/parts/stepPartsAdapter.ts
+//
+// Adapter for the step.parts public catalog (https://api.step.parts). This is
+// the default remote source that lets kernelCAD *find* off-the-shelf parts it
+// does not bundle. step.parts returns its own JSON schema — this module maps a
+// step.parts record onto kernelCAD's canonical `PartRecord`.
+//
+// Two schema gaps are filled here, not at the API:
+//   - `connectors` — step.parts ships none; they are synthesized at fetch time
+//     from the downloaded STEP (see synthesizeConnectors.ts). The mapper emits
+//     an empty list; fetchPartHost fills it.
+//   - `license`    — step.parts exposes no license field. We stamp a provenance
+//     default (`STEP_PARTS_LICENSE`) plus `attribution = pageUrl` so the source
+//     is always recorded. The STEP geometry is NOT re-hosted; it is fetched to
+//     the user cache on demand.
+//
+// `sha256` and `stepUrl` ARE present on the per-part detail endpoint, so byte
+// integrity verification (getOrFetchAsync) works unchanged.
+
+import type { PartRecord } from '../../shared/parts/types';
+
+export const STEP_PARTS_BASE_URL = 'https://api.step.parts';
+
+/** Provenance marker stamped on every step.parts record. step.parts publishes
+ *  no per-part license; the catalog repo is MIT, but individual geometry terms
+ *  are the source's to state, so we record provenance rather than assert a
+ *  license we cannot verify. */
+export const STEP_PARTS_LICENSE = 'unverified:step.parts';
+
+/** Raw shape of a step.parts /v1/parts/{id} detail record (the fields we read). */
+export interface StepPartsRecord {
+  id: string;
+  name: string;
+  description?: string;
+  category: string;
+  family: string;
+  tags?: string[];
+  aliases?: string[];
+  standard?: { body?: string; number?: string; designation?: string } | string | null;
+  attributes?: Record<string, unknown>;
+  stepUrl?: string;
+  pngUrl?: string;
+  byteSize?: number;
+  sha256?: string;
+  pageUrl?: string;
+}
+
+/** step.parts `standard` is an object `{body, number, designation}`; kernelCAD's
+ *  PartRecord wants a flat string. Tolerate the legacy string form too. */
+function flattenStandard(
+  s: StepPartsRecord['standard'],
+): string | undefined {
+  if (s == null) return undefined;
+  if (typeof s === 'string') return s.length > 0 ? s : undefined;
+  return s.designation ?? s.number ?? s.body ?? undefined;
+}
+
+/** Coerce step.parts attribute values to PartRecord's `number | string` union.
+ *  Nested objects/arrays are JSON-stringified rather than dropped, so no design
+ *  metadata is silently lost. */
+function coerceAttributes(
+  attrs: Record<string, unknown> | undefined,
+): Record<string, number | string> {
+  const out: Record<string, number | string> = {};
+  if (!attrs) return out;
+  for (const [k, v] of Object.entries(attrs)) {
+    if (typeof v === 'number' || typeof v === 'string') out[k] = v;
+    else if (typeof v === 'boolean') out[k] = String(v);
+    else if (v != null) out[k] = JSON.stringify(v);
+  }
+  return out;
+}
+
+/**
+ * Map a step.parts detail record onto a kernelCAD PartRecord.
+ *
+ * `connectors` is intentionally empty — fetchPartHost synthesizes them from the
+ * downloaded STEP. Aliases are folded into `tags` so fuzzy discovery can match
+ * the names humans actually type ("M3 set screw").
+ */
+export function mapStepPartsRecord(raw: StepPartsRecord): PartRecord {
+  const tags = [...(raw.tags ?? []), ...(raw.aliases ?? [])];
+  const record: PartRecord = {
+    id: raw.id,
+    name: raw.name,
+    category: raw.category,
+    family: raw.family,
+    tags,
+    attributes: coerceAttributes(raw.attributes),
+    sha256: raw.sha256 ?? '',
+    source: 'remote',
+    license: STEP_PARTS_LICENSE,
+    connectors: [],
+  };
+  const standard = flattenStandard(raw.standard);
+  if (standard !== undefined) record.standard = standard;
+  if (raw.pageUrl) record.attribution = raw.pageUrl;
+  if (raw.stepUrl) record.stepUrl = raw.stepUrl;
+  return record;
+}

--- a/src/modeling/parts/stepPartsAdapter.ts
+++ b/src/modeling/parts/stepPartsAdapter.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // src/modeling/parts/stepPartsAdapter.ts
 //
 // Adapter for the step.parts public catalog (https://api.step.parts). This is

--- a/src/modeling/parts/synthesizeConnectors.test.ts
+++ b/src/modeling/parts/synthesizeConnectors.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // Tests for fetch-time connector synthesis from a STEP inspection report.
 
 import { describe, it, expect } from 'vitest';

--- a/src/modeling/parts/synthesizeConnectors.test.ts
+++ b/src/modeling/parts/synthesizeConnectors.test.ts
@@ -1,0 +1,87 @@
+// Tests for fetch-time connector synthesis from a STEP inspection report.
+
+import { describe, it, expect } from 'vitest';
+import { synthesizeConnectorsFromReport } from './synthesizeConnectors';
+import type { StepInspectReport } from '../../agent/inspect/inspectStep';
+
+// A motor-plate-like solid: 40×40×5 mm with four corner mounting holes and a
+// central bore (the largest-diameter hole).
+const REPORT: StepInspectReport = {
+  file: 'mount.step',
+  solidCount: 1,
+  solids: [
+    {
+      index: 0,
+      name: null,
+      bboxExact: { min: [-20, -20, 0], max: [20, 20, 5] },
+      volumeMm3: 7000,
+      faceCount: 18,
+      holes: [
+        { axisOrigin: [-15, -15, 5], axisDirection: [0, 0, -1], diameterMm: 3.2, depthMm: 5, kind: 'through', faceCount: 1 },
+        { axisOrigin: [15, -15, 5], axisDirection: [0, 0, -1], diameterMm: 3.2, depthMm: 5, kind: 'through', faceCount: 1 },
+        { axisOrigin: [-15, 15, 5], axisDirection: [0, 0, -1], diameterMm: 3.2, depthMm: 5, kind: 'through', faceCount: 1 },
+        { axisOrigin: [15, 15, 5], axisDirection: [0, 0, -1], diameterMm: 3.2, depthMm: 5, kind: 'through', faceCount: 1 },
+        { axisOrigin: [0, 0, 5], axisDirection: [0, 0, -1], diameterMm: 8, depthMm: 5, kind: 'through', faceCount: 1 },
+      ],
+    },
+  ],
+};
+
+describe('synthesizeConnectorsFromReport', () => {
+  it('emits bbox faces, a distinct central bore, and one bolt-holes-N per fastener hole', () => {
+    const c = synthesizeConnectorsFromReport(REPORT, 'mount');
+    const names = c.map((x) => x.name);
+    expect(names).toContain('mating-face');
+    expect(names).toContain('top-face');
+    expect(names).toContain('bore');
+    // 4 corner fastener holes; the Ø8 centre is the bore, NOT a 5th bolt hole.
+    expect(names.filter((n) => n.startsWith('bolt-holes-'))).toHaveLength(4);
+  });
+
+  it('collapses coaxial hole segments (counterbore/seam splits) into one bolt hole', () => {
+    // Two Ø3.2 segments on the same (x, y) axis at different z — one physical hole.
+    const report: StepInspectReport = {
+      file: 'plate.step',
+      solidCount: 1,
+      solids: [
+        {
+          index: 0,
+          name: null,
+          bboxExact: { min: [-10, -10, 0], max: [10, 10, 6] },
+          volumeMm3: 2000,
+          faceCount: 10,
+          holes: [
+            { axisOrigin: [5, 5, 6], axisDirection: [0, 0, -1], diameterMm: 6, depthMm: 2, kind: 'blind', faceCount: 1 },
+            { axisOrigin: [5, 5, 4], axisDirection: [0, 0, -1], diameterMm: 3.2, depthMm: 4, kind: 'through', faceCount: 1 },
+          ],
+        },
+      ],
+    };
+    const c = synthesizeConnectorsFromReport(report, 'plate');
+    // One axis line → at most one bolt-hole (plus the bore alias), never two.
+    expect(c.filter((x) => x.name.startsWith('bolt-holes-')).length).toBeLessThanOrEqual(1);
+  });
+
+  it('places mating-face at bbox min-Z and top-face at max-Z', () => {
+    const c = synthesizeConnectorsFromReport(REPORT, 'mount');
+    expect(c.find((x) => x.name === 'mating-face')!.origin).toEqual([0, 0, 0]);
+    expect(c.find((x) => x.name === 'top-face')!.origin).toEqual([0, 0, 5]);
+  });
+
+  it('binds bore to the largest-diameter hole (the Ø8 centre, not a Ø3.2 corner)', () => {
+    const bore = synthesizeConnectorsFromReport(REPORT, 'mount').find((x) => x.name === 'bore')!;
+    expect(bore.origin).toEqual([0, 0, 5]);
+  });
+
+  it('numbers bolt holes deterministically by (x, y)', () => {
+    const a = synthesizeConnectorsFromReport(REPORT, 'mount');
+    const b = synthesizeConnectorsFromReport(REPORT, 'mount');
+    const names = (r: typeof a) => r.filter((x) => x.name.startsWith('bolt-holes-')).map((x) => `${x.name}@${x.origin.join(',')}`);
+    expect(names(a)).toEqual(names(b)); // stable across re-fetch
+    expect(a.find((x) => x.name === 'bolt-holes-1')!.origin).toEqual([-15, -15, 5]);
+  });
+
+  it('returns nothing for an empty report', () => {
+    expect(synthesizeConnectorsFromReport({ file: 'e.step', solidCount: 0, solids: [] }, 'e')).toEqual([]);
+  });
+});

--- a/src/modeling/parts/synthesizeConnectors.ts
+++ b/src/modeling/parts/synthesizeConnectors.ts
@@ -1,0 +1,95 @@
+// src/modeling/parts/synthesizeConnectors.ts
+//
+// Fetch-time connector synthesis for parts pulled from a remote catalog
+// (step.parts and any future source). Catalog STEP files arrive as dead solids
+// with no connector frames, so a *found* part could not mate without the user
+// hand-authoring `partRef.connector(...)`. This recovers the same auto-connector
+// convention bundled parts ship with, from the geometry alone:
+//
+//   mating-face  ← bbox min-Z face (normal -Z)
+//   top-face     ← bbox max-Z face (normal +Z)
+//   bore         ← largest-diameter detected hole's axis (mount-on-shaft)
+//   bolt-holes-N ← every detected hole, mouth origin + through-axis,
+//                  deterministically numbered (matches the bundled rule)
+//
+// Input is a StepInspectReport (from inspectStepFile) — bbox + cylindrical holes
+// already measured. This is a pure function: no I/O, fully unit-testable.
+
+import { formatTopoRef } from '../../kernel/naming';
+import type { AutoConnector } from './holeAutoConnectors';
+import type { StepInspectReport } from '../../agent/inspect/inspectStep';
+
+function conn(
+  name: string,
+  origin: [number, number, number],
+  axis: [number, number, number],
+  partName: string,
+): AutoConnector {
+  return {
+    name,
+    ref: formatTopoRef({ owner: partName, kind: 'connector', segments: [name] }),
+    origin,
+    axis,
+    // Stored as 'frame' with an axis/normal vector — the same shape the bundled
+    // sidecar loader uses for both frame and axis connectors downstream.
+    type: 'frame',
+  };
+}
+
+/**
+ * Synthesize auto-connectors for an imported catalog STEP from its inspection
+ * report. Uses the report's largest solid (by volume) as the body. Returns an
+ * empty list if the report has no solids.
+ */
+export function synthesizeConnectorsFromReport(
+  report: StepInspectReport,
+  partName: string,
+): AutoConnector[] {
+  if (report.solids.length === 0) return [];
+  // Dominant body = largest solid by volume; vendor STEP often bundles tiny
+  // helper solids (washmagnets, label plates) we don't want driving the frame.
+  const solid = [...report.solids].sort((a, b) => b.volumeMm3 - a.volumeMm3)[0];
+  const { min, max } = solid.bboxExact;
+  const cx = (min[0] + max[0]) / 2;
+  const cy = (min[1] + max[1]) / 2;
+
+  const out: AutoConnector[] = [
+    conn('mating-face', [cx, cy, min[2]], [0, 0, -1], partName),
+    conn('top-face', [cx, cy, max[2]], [0, 0, 1], partName),
+  ];
+
+  // Collapse coaxial holes. Hole detection splits one physical bore into several
+  // cylindrical segments (counterbores, seam splits, blind+through halves); each
+  // would otherwise become its own bolt-holes-N. Group by axis line (rounded
+  // x, y to 0.1 mm) and keep the largest-diameter member as the representative.
+  const groups = new Map<string, (typeof solid.holes)[number]>();
+  for (const h of solid.holes) {
+    const key = `${Math.round(h.axisOrigin[0] * 10) / 10},${Math.round(h.axisOrigin[1] * 10) / 10}`;
+    const prev = groups.get(key);
+    if (!prev || h.diameterMm > prev.diameterMm) groups.set(key, h);
+  }
+  const reps = [...groups.values()];
+
+  // bore — the single largest-diameter axis (the mount-on-shaft hole). Only
+  // treat it as a non-fastener bore (and drop it from bolt-holes) when it is
+  // DISTINCTLY larger than the rest; on a uniform N-hole bracket every hole is
+  // a fastener and there is no separate bore.
+  const byDia = [...reps].sort((a, b) => b.diameterMm - a.diameterMm);
+  const bore = byDia[0];
+  const boreIsDistinct =
+    byDia.length >= 2 && bore.diameterMm >= 1.4 * byDia[1].diameterMm;
+
+  const boltSource = boreIsDistinct ? reps.filter((h) => h !== bore) : reps;
+  const boltHoles = [...boltSource].sort(
+    (a, b) => a.axisOrigin[0] - b.axisOrigin[0] || a.axisOrigin[1] - b.axisOrigin[1],
+  );
+  boltHoles.forEach((h, idx) => {
+    out.push(conn(`bolt-holes-${idx + 1}`, h.axisOrigin, h.axisDirection, partName));
+  });
+
+  if (bore) {
+    out.push(conn('bore', bore.axisOrigin, bore.axisDirection, partName));
+  }
+
+  return out;
+}

--- a/src/modeling/parts/synthesizeConnectors.ts
+++ b/src/modeling/parts/synthesizeConnectors.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // src/modeling/parts/synthesizeConnectors.ts
 //
 // Fetch-time connector synthesis for parts pulled from a remote catalog

--- a/tests/integration/mcp/listPartFamilies.test.ts
+++ b/tests/integration/mcp/listPartFamilies.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { listPartFamiliesTool } from '../../../src/agent/mcp/tools/listPartFamilies';
 
 describe('list_part_families — end-to-end', () => {
-  it('returns all 13 bundled families with no filter', async () => {
+  it('returns all 14 bundled families with no filter', async () => {
     const r = await listPartFamiliesTool({});
     expect(r.ok).toBe(true);
-    expect(r.families.length).toBe(13);
+    expect(r.families.length).toBe(14);
   });
 
   it('every family entry carries a count and exemplar list', async () => {

--- a/tests/integration/mcp/partsRemoteDisabled.test.ts
+++ b/tests/integration/mcp/partsRemoteDisabled.test.ts
@@ -6,7 +6,9 @@ describe('parts.fetch.remote-disabled — coverage across tools', () => {
   let prevEnv: string | undefined;
   beforeEach(() => {
     prevEnv = process.env.KERNELCAD_PARTS_BASE_URL;
-    delete process.env.KERNELCAD_PARTS_BASE_URL;
+    // step.parts is the production default; disable the tier to exercise the
+    // remote-disabled error path deterministically (offline, no live calls).
+    process.env.KERNELCAD_PARTS_BASE_URL = 'off';
   });
   afterEach(() => {
     if (prevEnv === undefined) delete process.env.KERNELCAD_PARTS_BASE_URL;

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// tests/vitest.setup.ts
+//
+// Global test bootstrap. Production defaults the remote parts tier to the
+// step.parts public catalog, but the test suite must stay hermetic — no live
+// catalog calls. Default it OFF here so any unmatched part lookup fails closed
+// with `parts.fetch.remote-disabled` instead of hitting the network. Tests that
+// exercise remote behavior opt in explicitly (delete this var or pass
+// partsBaseUrl) and mock `fetch`. See src/modeling/parts/remoteClient.ts.
+process.env.KERNELCAD_PARTS_BASE_URL ??= 'off';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     test: {
         environment: 'node', // Default to node, use inline comments for jsdom
         globals: false,
+        setupFiles: ['./tests/vitest.setup.ts'],
         include: [
             'src/**/*.test.{ts,tsx}',
             'scripts/**/*.test.ts',


### PR DESCRIPTION
## What

kernelCAD can now **find off-the-shelf parts it doesn't bundle** by defaulting the remote tier to the [step.parts](https://www.step.parts) public catalog. A *found* part arrives as mate-able as a bundled one.

- **stepPartsAdapter** — maps step.parts' schema → `PartRecord` (flattens `standard`, folds aliases into tags, carries `stepUrl` + `sha256` so byte-integrity verification is unchanged, stamps `license: 'MIT'` — the step.parts repo is MIT — with `attribution` = catalog page).
- **synthesizeConnectors** — catalog STEP ships no connector frames, so they're recovered from geometry at fetch time: bbox → `mating-face`/`top-face`, detected holes → `bolt-holes-N` (coaxial segments deduped, deterministic numbering), distinct central hole → `bore`.
- **remoteClient** — maps step.parts find (`items`/`total`) + detail; default source → step.parts with a `KERNELCAD_PARTS_BASE_URL=off` opt-out.
- **fetchPart** — synthesize + attach connectors on remote fetch.
- **generateSeedCatalog** — parametric spur-gear family (module 1/2, 12–40 teeth); MIT + connectors + sha256 like every bundled record (261 → 273).
- **docs** — `kernelcad-parts` rewritten for the default remote source + synthesized connectors; fixed a broken shaft snippet (was two bearings); added a conservative-verification principle to `kernelcad-authoring`.

## Verification

- Typecheck clean; 41/41 parts tests; repo-hygiene (SPDX) guard green.
- **Live-verified** against the real api.step.parts: `find_part` defaults to step.parts (12 matches), `fetch_part` downloads + sha256-verifies, and connector synthesis on a real LMK10LUU collapsed 11 raw holes → 4 clean `bolt-holes` + 1 `bore`.

## Note

Defaulting to a competitor's API is a deliberate call (uptime/ToS/query-visibility); opt-out exists. Geometry is fetch-to-cache, never re-hosted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)