### PR TITLE
feat(parts): self-hosted catalog ingest pipeline

### DIFF
--- a/scripts/ingestParts.test.ts
+++ b/scripts/ingestParts.test.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { OcctBackend, initOcct } from '../src/kernel/backends/occt/occtBackend';
+import { ingestDirectory } from './ingestParts';
+
+describe('ingestParts', () => {
+  it('ingests a STEP dir into a /v1/parts catalog with measured attrs + synthesized connectors', async () => {
+    await initOcct();
+    const src = mkdtempSync(join(tmpdir(), 'kc-ingest-src-'));
+    const out = mkdtempSync(join(tmpdir(), 'kc-ingest-out-'));
+
+    // A bored plate (through-hole) so synthesis emits bbox faces + a bore.
+    const plate = OcctBackend.box(40, 40, 5).subtract(
+      OcctBackend.cylinder(8, 4).translate(20, 20, -1),
+    );
+    const bytes = await plate.exportSTEPAsync();
+    // Folder layout drives category/family with no sidecar: <src>/bracket/mount/.
+    mkdirSync(join(src, 'bracket', 'mount'), { recursive: true });
+    writeFileSync(join(src, 'bracket', 'mount', 'mount-plate.step'), Buffer.from(bytes));
+
+    const records = await ingestDirectory(src, out, {
+      baseUrl: 'https://parts.test',
+      license: 'CC-BY-3.0',
+      attribution: 'fixture',
+    });
+
+    expect(records).toHaveLength(1);
+    const r = records[0];
+    expect(r.id).toBe('mount-plate');
+    expect(r.category).toBe('bracket');
+    expect(r.family).toBe('mount');
+    expect(r.license).toBe('CC-BY-3.0');
+    expect(r.attribution).toBe('fixture');
+    expect(r.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(r.byteSize).toBeGreaterThan(0);
+    expect(r.stepUrl).toBe('https://parts.test/step/mount-plate.step');
+    // Measured, not guessed.
+    expect(r.attributes.bboxXmm).toBeGreaterThan(39);
+    expect(r.attributes.bboxZmm).toBeCloseTo(5, 0);
+    // Synthesized frames from the geometry.
+    expect(r.connectors.map((c) => c.name)).toEqual(
+      expect.arrayContaining(['mating-face', 'top-face', 'bore']),
+    );
+
+    // Deployable tree.
+    expect(existsSync(join(out, 'step', 'mount-plate.step'))).toBe(true);
+    expect(existsSync(join(out, 'v1', 'parts', 'mount-plate.json'))).toBe(true);
+    expect(existsSync(join(out, 'functions', 'v1', 'parts', '[[path]].ts'))).toBe(true);
+    const index = JSON.parse(
+      readFileSync(join(out, 'v1', 'catalog', 'parts.index.json'), 'utf8'),
+    ) as { catalog: { partCount: number }; items: Array<{ id: string }> };
+    expect(index.catalog.partCount).toBe(1);
+    expect(index.items[0].id).toBe('mount-plate');
+    const sha = JSON.parse(readFileSync(join(out, 'sha256-manifest.json'), 'utf8'));
+    expect(sha['mount-plate']).toBe(r.sha256);
+  });
+});

--- a/scripts/ingestParts.ts
+++ b/scripts/ingestParts.ts
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/ingestParts.ts
+//
+// Ingest a directory of off-the-shelf STEP files into a self-hosted parts
+// catalog that kernelCAD's remote tier can consume directly — same `/v1/parts`
+// schema the bundled remote adapter already speaks, so the output is a drop-in
+// source: point KERNELCAD_PARTS_BASE_URL at the deployed catalog and stop.
+//
+// Reuses the EXACT runtime pipeline that enriches remotely-fetched parts:
+//   inspectStepFile  → bbox + cylindrical holes (measured, not guessed)
+//   synthesizeConnectorsFromReport → mating-face / top-face / bolt-holes-N / bore
+//
+// Each ingested STEP yields: a copied .step, a per-part detail JSON, an entry in
+// parts.index.json, and a sha256. An optional `<name>.meta.json` sidecar beside
+// a STEP overrides any derived field (id, name, category, family, standard,
+// tags, attributes, license, attribution).
+//
+// Seed it from any license-clean source you control — e.g. the CC-BY FreeCAD
+// parts_library (github.com/FreeCAD/FreeCAD-library) plus your own STEP — so the
+// catalog is richer than a third-party API AND owned by you.
+//
+// Usage:
+//   npx tsx scripts/ingestParts.ts <srcDir> <outDir> \
+//     [--base-url https://parts.example.com] [--license CC-BY-3.0] \
+//     [--attribution "FreeCAD parts_library"]
+
+import {
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+  existsSync,
+} from 'node:fs';
+import { join, relative, basename, extname, dirname } from 'node:path';
+import { createHash } from 'node:crypto';
+import { inspectStepFile } from '../src/agent/inspect/inspectStep';
+import { synthesizeConnectorsFromReport } from '../src/modeling/parts/synthesizeConnectors';
+
+// -----------------------------------------------------------------------------
+// Types — the served record matches the remote adapter's StepPartsRecord shape.
+// -----------------------------------------------------------------------------
+
+export interface IngestSidecar {
+  id?: string;
+  name?: string;
+  description?: string;
+  category?: string;
+  family?: string;
+  standard?: string;
+  tags?: string[];
+  attributes?: Record<string, number | string>;
+  license?: string;
+  attribution?: string;
+}
+
+export interface CatalogRecord {
+  id: string;
+  name: string;
+  category: string;
+  family: string;
+  standard?: string;
+  tags: string[];
+  attributes: Record<string, number | string>;
+  stepUrl: string;
+  sha256: string;
+  byteSize: number;
+  license: string;
+  attribution?: string;
+  /** Pre-synthesized so a consumer can skip re-inspection; the runtime adapter
+   *  still re-synthesizes on fetch, so this is richness, not a contract. */
+  connectors: { name: string; origin: [number, number, number]; axis: [number, number, number] }[];
+}
+
+export interface IngestOpts {
+  baseUrl: string;
+  license: string;
+  attribution?: string;
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function humanize(s: string): string {
+  return s.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()).trim();
+}
+
+function listStepFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const abs = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...listStepFiles(abs));
+    else if (/\.(step|stp)$/i.test(entry.name)) out.push(abs);
+  }
+  return out;
+}
+
+function loadSidecar(stepPath: string): IngestSidecar {
+  const sidecar = stepPath.replace(/\.(step|stp)$/i, '.meta.json');
+  if (!existsSync(sidecar)) return {};
+  try {
+    return JSON.parse(readFileSync(sidecar, 'utf8')) as IngestSidecar;
+  } catch {
+    return {};
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Ingest one STEP → a catalog record (measured attributes + synthesized frames)
+// -----------------------------------------------------------------------------
+
+export async function ingestStepFile(
+  stepPath: string,
+  srcRoot: string,
+  opts: IngestOpts,
+): Promise<{ record: CatalogRecord; bytes: Buffer }> {
+  const bytes = readFileSync(stepPath);
+  const sha256 = createHash('sha256').update(bytes).digest('hex');
+  const meta = loadSidecar(stepPath);
+
+  const baseName = basename(stepPath, extname(stepPath));
+  const id = meta.id ?? slugify(baseName);
+  // Derive category/family from the source folder layout when no sidecar:
+  // <srcRoot>/<category>/<family>/part.step
+  const relParts = relative(srcRoot, dirname(stepPath)).split(/[\\/]/).filter(Boolean);
+  const category = meta.category ?? relParts[0] ?? 'imported';
+  const family = meta.family ?? relParts[relParts.length - 1] ?? category;
+
+  const report = await inspectStepFile(stepPath);
+  const solid = [...report.solids].sort((a, b) => b.volumeMm3 - a.volumeMm3)[0];
+  const conns = synthesizeConnectorsFromReport(report, id);
+
+  const measured: Record<string, number> = solid
+    ? {
+        bboxXmm: Math.round((solid.bboxExact.max[0] - solid.bboxExact.min[0]) * 100) / 100,
+        bboxYmm: Math.round((solid.bboxExact.max[1] - solid.bboxExact.min[1]) * 100) / 100,
+        bboxZmm: Math.round((solid.bboxExact.max[2] - solid.bboxExact.min[2]) * 100) / 100,
+        volumeMm3: Math.round(solid.volumeMm3 * 100) / 100,
+        solidCount: report.solidCount,
+        holeCount: solid.holes.length,
+      }
+    : { solidCount: report.solidCount };
+
+  const record: CatalogRecord = {
+    id,
+    name: meta.name ?? humanize(baseName),
+    category,
+    family,
+    tags: meta.tags ?? Array.from(new Set([category, family, ...relParts].map(slugify).filter(Boolean))),
+    attributes: { ...measured, ...(meta.attributes ?? {}) },
+    stepUrl: `${opts.baseUrl.replace(/\/$/, '')}/step/${id}.step`,
+    sha256,
+    byteSize: bytes.length,
+    license: meta.license ?? opts.license,
+    connectors: conns.map((c) => ({ name: c.name, origin: c.origin, axis: c.axis })),
+  };
+  if (meta.standard) record.standard = meta.standard;
+  const attribution = meta.attribution ?? opts.attribution;
+  if (attribution) record.attribution = attribution;
+
+  return { record, bytes };
+}
+
+// -----------------------------------------------------------------------------
+// Ingest a directory → a deployable /v1/parts catalog tree
+// -----------------------------------------------------------------------------
+
+export async function ingestDirectory(
+  srcDir: string,
+  outDir: string,
+  opts: IngestOpts,
+): Promise<CatalogRecord[]> {
+  const stepFiles = listStepFiles(srcDir);
+  mkdirSync(join(outDir, 'step'), { recursive: true });
+  mkdirSync(join(outDir, 'v1', 'parts'), { recursive: true });
+  mkdirSync(join(outDir, 'v1', 'catalog'), { recursive: true });
+  mkdirSync(join(outDir, 'functions', 'v1', 'parts'), { recursive: true });
+
+  const records: CatalogRecord[] = [];
+  const shaManifest: Record<string, string> = {};
+  for (const stepPath of stepFiles) {
+    const { record, bytes } = await ingestStepFile(stepPath, srcDir, opts);
+    writeFileSync(join(outDir, 'step', `${record.id}.step`), bytes);
+    writeFileSync(join(outDir, 'v1', 'parts', `${record.id}.json`), JSON.stringify(record, null, 2));
+    records.push(record);
+    shaManifest[record.id] = record.sha256;
+  }
+
+  // Discovery index (step.parts-compatible: { catalog, items }).
+  writeFileSync(
+    join(outDir, 'v1', 'catalog', 'parts.index.json'),
+    JSON.stringify({ catalog: { partCount: records.length }, items: records }, null, 2),
+  );
+  writeFileSync(join(outDir, 'sha256-manifest.json'), JSON.stringify(shaManifest, null, 2));
+  // The serving shim (search + detail over the static index) for Cloudflare Pages.
+  writeFileSync(join(outDir, 'functions', 'v1', 'parts', '[[path]].ts'), PAGES_FUNCTION, {
+    flag: 'w',
+  });
+  return records;
+}
+
+// A ~static Cloudflare Pages Function implementing the two endpoints the remote
+// adapter calls, over the bundled index. Emitted into the catalog so the whole
+// outDir deploys as one Pages project. See remoteClient.ts for the contract.
+const PAGES_FUNCTION = `// SPDX-License-Identifier: MIT
+// Serves /v1/parts?q=... (search) and /v1/parts/{id} (detail) from the bundled
+// parts.index.json. Deploy this directory to Cloudflare Pages and point
+// KERNELCAD_PARTS_BASE_URL at it.
+import index from '../../catalog/parts.index.json';
+
+export const onRequest: PagesFunction = ({ params, request }) => {
+  const items = (index as { items: Array<Record<string, unknown>> }).items;
+  const path = ([] as string[]).concat((params.path as string[]) ?? []).join('/');
+  if (path) {
+    const rec = items.find((r) => r.id === path);
+    return rec
+      ? Response.json(rec)
+      : new Response('not found', { status: 404 });
+  }
+  const q = new URL(request.url).searchParams.get('q')?.toLowerCase() ?? '';
+  const hits = q
+    ? items.filter((r) =>
+        [r.id, r.name, ...((r.tags as string[]) ?? [])]
+          .join(' ')
+          .toLowerCase()
+          .includes(q),
+      )
+    : items;
+  return Response.json({ items: hits, total: hits.length });
+};
+`;
+
+// -----------------------------------------------------------------------------
+// CLI
+// -----------------------------------------------------------------------------
+
+function parseArgs(argv: string[]): { srcDir: string; outDir: string; opts: IngestOpts } {
+  const pos: string[] = [];
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i].startsWith('--')) flags[argv[i].slice(2)] = argv[++i];
+    else pos.push(argv[i]);
+  }
+  return {
+    srcDir: pos[0],
+    outDir: pos[1],
+    opts: {
+      baseUrl: flags['base-url'] ?? '',
+      license: flags['license'] ?? 'CC-BY-3.0',
+      ...(flags['attribution'] ? { attribution: flags['attribution'] } : {}),
+    },
+  };
+}
+
+const isMain =
+  typeof process !== 'undefined' &&
+  Array.isArray(process.argv) &&
+  process.argv[1] !== undefined &&
+  /ingestParts\.(ts|js)$/.test(process.argv[1]);
+
+if (isMain) {
+  const { srcDir, outDir, opts } = parseArgs(process.argv.slice(2));
+  if (!srcDir || !outDir) {
+    console.error('usage: ingestParts <srcDir> <outDir> [--base-url URL] [--license SPDX] [--attribution TEXT]');
+    process.exit(2);
+  }
+  ingestDirectory(srcDir, outDir, opts)
+    .then((r) => console.log(`ingested ${r.length} parts into ${outDir}`))
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## What

A scaffold to build a parts catalog **you own** — a drop-in alternative to a third-party remote source. Ingests a directory of off-the-shelf STEP files into the same `/v1/parts` schema kernelCAD's remote adapter already speaks; point `KERNELCAD_PARTS_BASE_URL` at the deployed output and it's live, zero code change.

`npx tsx scripts/ingestParts.ts <srcDir> <outDir> --base-url <url> --license CC-BY-3.0 --attribution "..."`

Per STEP it reuses the **runtime enrichment pipeline** (not a parallel one):
- `inspectStepFile` → measured bbox + cylindrical holes
- `synthesizeConnectorsFromReport` → `mating-face` / `top-face` / `bolt-holes-N` / `bore`

and emits: a copied `.step`, a per-part detail JSON, a `parts.index.json` entry, a sha256, plus a Cloudflare Pages function that serves search + detail over the static index — so the whole `outDir` deploys as one project. Category/family fall out of the folder layout; an optional `<name>.meta.json` sidecar overrides any field.

## Why

Gets kernelCAD off a competitor's infrastructure and onto a richer, license-clean catalog you control. Seed it from e.g. the **CC-BY FreeCAD parts_library** + your own STEP + the procedural generators.

## Verification

- Unit test ingests a bored plate → asserts measured attrs, synthesized connectors, sha256, the deployable tree.
- Ran live on a real 111 KB vendor linear-bearing STEP: folder-derived category/family, 11 detected holes → 4 `bolt-holes` + `bore`, correct bbox/volume/sha256.

Tooling only — no runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)