### PR TITLE
feat(parts): scheduled FreeCAD-library catalog ingest + deploy Action

### DIFF
--- a/.github/workflows/parts-catalog.yml
+++ b/.github/workflows/parts-catalog.yml
@@ -1,0 +1,63 @@
+name: Parts Catalog
+
+# Builds a self-hosted, license-clean parts catalog from the CC-BY FreeCAD
+# parts_library and deploys it to Cloudflare Pages (project: kernelcad-parts).
+# Point KERNELCAD_PARTS_BASE_URL at https://kernelcad-parts.pages.dev to use it
+# as kernelCAD's remote source instead of a third-party API.
+
+on:
+  schedule:
+    - cron: '0 4 * * 1' # weekly, Monday 04:00 UTC
+  workflow_dispatch:
+    inputs:
+      subdir:
+        description: 'FreeCAD-library subtree to ingest (e.g. "Mechanical Parts/Bearings" for a quick run)'
+        type: string
+        default: 'Mechanical Parts'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: parts-catalog
+  cancel-in-progress: false
+
+jobs:
+  ingest-and-deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - run: npm ci
+
+      - name: Ingest FreeCAD library
+        run: >
+          npx tsx scripts/ingestFreecadLibrary.ts
+          --out catalog
+          --subdir "${{ github.event.inputs.subdir || 'Mechanical Parts' }}"
+          --base-url https://kernelcad-parts.pages.dev
+
+      - name: Summarize
+        run: |
+          COUNT=$(node -e "console.log(require('./catalog/v1/catalog/parts.index.json').catalog.partCount)")
+          echo "Ingested **$COUNT** parts." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Ensure Cloudflare Pages project exists
+        run: npx wrangler@4.94.0 pages project create kernelcad-parts --production-branch=main || true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Deploy catalog to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: '4.94.0'
+          command: pages deploy catalog --project-name=kernelcad-parts --branch=main --commit-dirty=true --skip-caching

--- a/scripts/ingestFreecadLibrary.ts
+++ b/scripts/ingestFreecadLibrary.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/ingestFreecadLibrary.ts
+//
+// Seed a self-hosted parts catalog from the CC-BY FreeCAD parts_library
+// (github.com/FreeCAD/FreeCAD-library) — a license-clean STEP source you own,
+// instead of a third-party API. Sparse-clones only the requested subtree's STEP
+// files (the full repo is large), then runs the shared ingestDirectory pipeline
+// (measured attributes + synthesized connectors + sha256 + /v1/parts tree).
+//
+// Operational tool (network + git); no CI test — the ingest core is covered by
+// scripts/ingestParts.test.ts.
+//
+// Usage:
+//   npx tsx scripts/ingestFreecadLibrary.ts --out <dir> \
+//     [--subdir "Mechanical Parts/Bearings"] [--base-url https://parts.example.com]
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ingestDirectory } from './ingestParts';
+
+const REPO = 'https://github.com/FreeCAD/FreeCAD-library';
+const ATTRIBUTION = 'FreeCAD parts_library (CC-BY-3.0)';
+
+function parseArgs(argv: string[]): Record<string, string> {
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i].startsWith('--')) flags[argv[i].slice(2)] = argv[++i];
+  }
+  return flags;
+}
+
+async function main(): Promise<void> {
+  const flags = parseArgs(process.argv.slice(2));
+  const outDir = flags['out'];
+  if (!outDir) {
+    console.error('usage: ingestFreecadLibrary --out <dir> [--subdir "<path>"] [--base-url <url>]');
+    process.exit(2);
+  }
+  const subdir = flags['subdir'] ?? '';
+
+  const cloneDir = mkdtempSync(join(tmpdir(), 'fclib-'));
+  console.log(`sparse-cloning ${subdir || 'STEP files'} from FreeCAD-library …`);
+  execFileSync(
+    'git',
+    ['clone', '--depth', '1', '--filter=blob:none', '--sparse', REPO, cloneDir],
+    { stdio: 'inherit' },
+  );
+  // Cone-mode sparse set pulls only the requested directory's blobs.
+  if (subdir) {
+    execFileSync('git', ['-C', cloneDir, 'sparse-checkout', 'set', subdir], { stdio: 'inherit' });
+  }
+
+  const srcDir = subdir ? join(cloneDir, subdir) : cloneDir;
+  const records = await ingestDirectory(srcDir, outDir, {
+    baseUrl: flags['base-url'] ?? '',
+    license: 'CC-BY-3.0',
+    attribution: ATTRIBUTION,
+  });
+  console.log(`ingested ${records.length} FreeCAD parts into ${outDir}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/ingestParts.ts
+++ b/scripts/ingestParts.ts
@@ -224,27 +224,27 @@ export async function ingestDirectory(
 // adapter calls, over the bundled index. Emitted into the catalog so the whole
 // outDir deploys as one Pages project. See remoteClient.ts for the contract.
 const PAGES_FUNCTION = `// SPDX-License-Identifier: MIT
-// Serves /v1/parts?q=... (search) and /v1/parts/{id} (detail) from the bundled
-// parts.index.json. Deploy this directory to Cloudflare Pages and point
-// KERNELCAD_PARTS_BASE_URL at it.
-import index from '../../catalog/parts.index.json';
+// Serves /v1/parts?q=... (search) and /v1/parts/{id} (detail) from the static
+// /v1/catalog/parts.index.json asset (fetched at runtime, not build-imported,
+// so the index lives outside the functions tree). Deploy this directory to
+// Cloudflare Pages and point KERNELCAD_PARTS_BASE_URL at it.
+interface Rec { id: string; name: string; tags?: string[] }
 
-export const onRequest: PagesFunction = ({ params, request }) => {
-  const items = (index as { items: Array<Record<string, unknown>> }).items;
+export const onRequest: PagesFunction = async ({ params, request }) => {
+  const url = new URL(request.url);
+  const res = await fetch(url.origin + '/v1/catalog/parts.index.json');
+  if (!res.ok) return new Response('catalog index unavailable', { status: 502 });
+  const items = ((await res.json()) as { items: Rec[] }).items;
+
   const path = ([] as string[]).concat((params.path as string[]) ?? []).join('/');
   if (path) {
     const rec = items.find((r) => r.id === path);
-    return rec
-      ? Response.json(rec)
-      : new Response('not found', { status: 404 });
+    return rec ? Response.json(rec) : new Response('not found', { status: 404 });
   }
-  const q = new URL(request.url).searchParams.get('q')?.toLowerCase() ?? '';
+  const q = (url.searchParams.get('q') ?? '').toLowerCase();
   const hits = q
     ? items.filter((r) =>
-        [r.id, r.name, ...((r.tags as string[]) ?? [])]
-          .join(' ')
-          .toLowerCase()
-          .includes(q),
+        [r.id, r.name, ...(r.tags ?? [])].join(' ').toLowerCase().includes(q),
       )
     : items;
   return Response.json({ items: hits, total: hits.length });

--- a/scripts/ingestParts.ts
+++ b/scripts/ingestParts.ts
@@ -131,7 +131,8 @@ export async function ingestStepFile(
   // Derive category/family from the source folder layout when no sidecar:
   // <srcRoot>/<category>/<family>/part.step
   const relParts = relative(srcRoot, dirname(stepPath)).split(/[\\/]/).filter(Boolean);
-  const category = meta.category ?? relParts[0] ?? 'imported';
+  const rootName = slugify(basename(srcRoot)) || 'imported';
+  const category = meta.category ?? relParts[0] ?? rootName;
   const family = meta.family ?? relParts[relParts.length - 1] ?? category;
 
   const report = await inspectStepFile(stepPath);
@@ -186,12 +187,24 @@ export async function ingestDirectory(
 
   const records: CatalogRecord[] = [];
   const shaManifest: Record<string, string> = {};
+  const skipped: { file: string; reason: string }[] = [];
   for (const stepPath of stepFiles) {
-    const { record, bytes } = await ingestStepFile(stepPath, srcDir, opts);
-    writeFileSync(join(outDir, 'step', `${record.id}.step`), bytes);
-    writeFileSync(join(outDir, 'v1', 'parts', `${record.id}.json`), JSON.stringify(record, null, 2));
-    records.push(record);
-    shaManifest[record.id] = record.sha256;
+    // Real-world catalogs carry STEP the kernel can't parse (surface-only
+    // exports, non-solid bodies). Skip and record them rather than aborting the
+    // whole ingest on one bad file.
+    try {
+      const { record, bytes } = await ingestStepFile(stepPath, srcDir, opts);
+      writeFileSync(join(outDir, 'step', `${record.id}.step`), bytes);
+      writeFileSync(join(outDir, 'v1', 'parts', `${record.id}.json`), JSON.stringify(record, null, 2));
+      records.push(record);
+      shaManifest[record.id] = record.sha256;
+    } catch (e) {
+      skipped.push({ file: relative(srcDir, stepPath), reason: e instanceof Error ? e.message : String(e) });
+    }
+  }
+  if (skipped.length > 0) {
+    writeFileSync(join(outDir, 'skipped.json'), JSON.stringify(skipped, null, 2));
+    console.warn(`skipped ${skipped.length} unparseable STEP file(s) → ${join(outDir, 'skipped.json')}`);
   }
 
   // Discovery index (step.parts-compatible: { catalog, items }).


### PR DESCRIPTION
## What

Closes the loop on owning the parts catalog: a scheduled GitHub Action that builds a license-clean catalog from the CC-BY FreeCAD parts_library and deploys it to Cloudflare Pages, so it self-maintains and the third-party dependency can be retired.

- **`.github/workflows/parts-catalog.yml`** — weekly cron + `workflow_dispatch`. Sparse-clones a FreeCAD-library subtree, runs the ingest pipeline, ensures the `kernelcad-parts` Pages project exists, and deploys. The dispatch `subdir` input narrows the run (default `Mechanical Parts` ≈ 2.4k STEP: bearings, fasteners, profiles, chains, pulleys).
- **`scripts/ingestFreecadLibrary.ts`** — the sparse-clone + ingest wrapper (recovered: it was stranded when #460's auto-merge raced and merged only the first commit).
- **resilient ingest** — `ingestDirectory` now skips-and-logs STEP the kernel can't parse (real catalogs carry surface-only exports) instead of aborting; category/family fall back to the folder name.
- **Pages function fix** — the emitted serving function fetches `/v1/catalog/parts.index.json` at runtime instead of build-importing it from a wrong path.

## To go live (one-time, needs your Cloudflare account)

The `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets already exist (used by the app deploy). After merge, run the workflow once (Actions → Parts Catalog → Run), then set `KERNELCAD_PARTS_BASE_URL=https://kernelcad-parts.pages.dev` — kernelCAD is then on your owned catalog, off the third-party API.

## Verification

- Ingest core unit-tested; lint + typecheck clean.
- Pipeline run live on `Mechanical Parts/Bearings`: 23 bearings ingested, 1 unparseable skipped gracefully, each enriched with measured bbox + connectors + sha256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)