### PR TITLE
fix(studio): recover hosted gallery examples

### DIFF
--- a/scripts/lib/galleryEntries.test.ts
+++ b/scripts/lib/galleryEntries.test.ts
@@ -125,13 +125,14 @@ describe('parseGalleryEntries', () => {
     expect(result.entries[0].codeLocal).toBe(entry.codeLocal);
   });
 
-  it('keeps the release gallery focused on the new watch and stool', () => {
+  it('keeps the release gallery focused on the watch, stool, and spice dispenser', () => {
     const entriesPath = path.resolve(__dirname, '../../site/gallery/entries.json');
     const parsed = parseGalleryEntries(JSON.parse(readFileSync(entriesPath, 'utf8')));
     const slugs = parsed.entries.map(entry => entry.slug);
 
     expect(slugs).toContain('royal-pop-pocket-watch');
     expect(slugs).toContain('ratchet-height-adjust-stool');
+    expect(slugs).toContain('spice-dispenser-carousel');
     expect(slugs).not.toContain('pink-pocket-watch');
     expect(slugs.filter(slug => slug.includes('watch'))).toEqual(['royal-pop-pocket-watch']);
   });

--- a/site/gallery/entries.json
+++ b/site/gallery/entries.json
@@ -53,6 +53,31 @@
       "appUrl": null
     },
     {
+      "slug": "spice-dispenser-carousel",
+      "title": "Spice Dispenser Carousel",
+      "author": {
+        "handle": "kernelcad",
+        "url": "https://x.com/kernelcad"
+      },
+      "version": "v0.12.0",
+      "prompt": "Design a compact countertop spice dispenser in a Ø88 × 110 mm mug format that doses a measured ~0.5 ml on demand. Use a six-chamber drum that indexes one chamber pitch over a single metering station, plus a separate pocket metering disc that fills, swings to an enclosed drop chute, dwells, and returns. Keep the dose path enclosed, the electronics bay isolated, and deliver the full dispense cycle as a looping cutaway animation with collision-free motion.",
+      "source": "curated",
+      "video": "../../docs/demos/v0.12/spice-dispenser-carousel/demo.mp4",
+      "codeLocal": "../../examples/spice-dispenser-carousel.kcad.ts",
+      "code": "https://github.com/w1ne/kernelCAD-web/blob/main/examples/spice-dispenser-carousel.kcad.ts",
+      "tags": [
+        "consumer-product",
+        "assembly",
+        "carousel",
+        "dosing",
+        "animation",
+        "words-to-geometry"
+      ],
+      "featured": false,
+      "createdAt": "2026-06-09",
+      "appUrl": null
+    },
+    {
       "slug": "meta-glasses",
       "title": "Ray-Ban Meta \u2014 Full Wayfarer-Style Smart Glasses",
       "author": {

--- a/site/scripts/build-gallery.test.ts
+++ b/site/scripts/build-gallery.test.ts
@@ -36,6 +36,7 @@ describe('buildGallery', () => {
     expect(out.entries[0].promptUrl).toBe('/gallery/fixture-build/prompt.md');
     expect(out.entries[0].studioUrl).toBe('https://app.kernelcad.com/studio?gallery=fixture-build');
     expect(out.entries[0].sourceUrl).toBe('/gallery/fixture-build/source.kcad.ts');
+    expect(out.entries[0].scriptPath).toBe('simple-box.kcad.ts');
 
     expect(existsSync(path.join(publicDir, 'gallery/fixture-build/video.mp4'))).toBe(true);
     expect(existsSync(path.join(publicDir, 'gallery/fixture-build/poster.jpg'))).toBe(true);

--- a/site/scripts/build-gallery.ts
+++ b/site/scripts/build-gallery.ts
@@ -35,11 +35,13 @@ interface PublishedEntry extends Omit<GalleryEntry, 'video' | 'codeLocal'> {
   modelUrl: string;
   promptUrl: string;
   sourceUrl: string | null;
+  scriptPath: string | null;
   studioUrl: string;
 }
 
 const GLB_SIZE_HARD_CAP = 500_000;
 const STUDIO_ORIGIN = 'https://app.kernelcad.com';
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 /**
  * Builds the `ScriptReviewSummary` the hosted Studio consumes (see
  * GeometryContext) from the already-evaluated session — reusing the loaded
@@ -123,6 +125,9 @@ export async function buildGallery(opts: BuildGalleryOptions): Promise<void> {
     const dstPrompt = path.join(slugDir, 'prompt.md');
     const dstSource = path.join(slugDir, 'source.kcad.ts');
     const sourceUrl = entry.source === 'curated' ? `/gallery/${entry.slug}/source.kcad.ts` : null;
+    const scriptPath = entry.source === 'curated'
+      ? entry.codeLocal.split(path.sep).join('/')
+      : null;
     const studioUrl = entry.source === 'curated'
       ? `${STUDIO_ORIGIN}/studio?gallery=${encodeURIComponent(entry.slug)}`
       : entry.appUrl;
@@ -207,6 +212,7 @@ export async function buildGallery(opts: BuildGalleryOptions): Promise<void> {
       modelUrl: `/gallery/${entry.slug}/model.glb`,
       promptUrl: `/gallery/${entry.slug}/prompt.md`,
       sourceUrl,
+      scriptPath,
       studioUrl,
     });
   }
@@ -217,8 +223,6 @@ export async function buildGallery(opts: BuildGalleryOptions): Promise<void> {
 
 // CLI entrypoint
 if (import.meta.url === `file://${process.argv[1]}`) {
-  const __dirname = path.dirname(fileURLToPath(import.meta.url));
-  const REPO_ROOT = path.resolve(__dirname, '../..');
   buildGallery({
     entriesPath: path.join(REPO_ROOT, 'site/gallery/entries.json'),
     publicDir: path.join(REPO_ROOT, 'site/public'),

--- a/src/studio/context/GeometryContext.test.tsx
+++ b/src/studio/context/GeometryContext.test.tsx
@@ -110,6 +110,7 @@ describe('GeometryContext latest-intent-wins', () => {
   afterEach(() => {
     cleanup();
     vi.useRealTimers();
+    vi.unstubAllGlobals();
   });
 
   it('ignores stale execute responses that finish after a newer request', async () => {
@@ -370,6 +371,70 @@ describe('GeometryContext latest-intent-wins', () => {
     expect(screen.getByTestId('script-param-name').textContent).toBe('shoulderDeg');
     expect(screen.getByTestId('script-review-ok').textContent).toBe('false');
     expect(screen.getByTestId('script-review-repair').textContent).toContain('supported clevis');
+  });
+
+  it('falls back to hosted mesh-by-source when hosted script sessions are unavailable', async () => {
+    window.history.pushState(
+      {},
+      '',
+      '/?script=examples/gallery/ratchet-stool.kcad.ts',
+    );
+    vi.stubGlobal('window', {
+      ...window,
+      location: { ...window.location, hostname: 'app.kernelcad.com', search: '?script=examples/gallery/ratchet-stool.kcad.ts' },
+      localStorage: window.localStorage,
+      history: window.history,
+      crypto: window.crypto,
+    });
+
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: 'not found' }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          features: [
+            {
+              featureId: 'seat',
+              featureKind: 'box',
+              predecessors: [],
+              faces: [
+                {
+                  vertices: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+                  indices: [0, 1, 2],
+                  normals: [0, 0, 1, 0, 0, 1, 0, 0, 1],
+                  faceId: 0,
+                },
+              ],
+            },
+          ],
+          featureRecords: [],
+          bounds: { min: [0, 0, 0], max: [1, 1, 0] },
+          params: {},
+          review: { ok: true, diagnostics: [] },
+        }),
+      } as Response);
+
+    render(
+      <GeometryProvider code={'export default box(1, 1, 1);'}>
+        <Probe />
+      </GeometryProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchUrl(fetchMock, 1)).toBe('/__kernelcad/session?script=examples%2Fgallery%2Fratchet-stool.kcad.ts');
+    expect(fetchUrl(fetchMock, 2)).toContain('https://kernelcad.com/gallery/_mesh/');
+    expect(screen.getByTestId('face-count').textContent).toBe('1');
+    expect(screen.getByTestId('script-review-ok').textContent).toBe('true');
   });
 
   it('refreshes mesh AND review when params relower over SSE', async () => {

--- a/src/studio/context/GeometryContext.tsx
+++ b/src/studio/context/GeometryContext.tsx
@@ -277,6 +277,58 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
             : `/__kernelcad/review?script=${encodeURIComponent(script)}`;
 
         let aborted = false;
+        if (!token && shouldUseHostedMesh()) {
+            const promise = meshSourceHosted(code)
+                .then((payload) => {
+                    if (revision !== mainRevisionRef.current) {
+                        setStaleMainResponsesDropped((prev) => prev + 1);
+                        return;
+                    }
+                    setGeometries(featureMeshesToGeometries(payload.features));
+                    setGeometryTransformOverrides({});
+                    setFeatureRecords(payload.featureRecords ?? []);
+                    setRecomputeMs(Math.max(0, Math.round(performance.now() - fetchStart)));
+                    setScriptParams(Object.values(payload.params ?? {}));
+                    setScriptReview(payload.review ?? null);
+                    setSketchesGeometries([]);
+                    setPreviewGeometries([]);
+                    setError(null);
+                    setLastSuccessfulRevision(revision);
+                    pushExecutionRecord({
+                        revision,
+                        status: 'success',
+                        executionCountAtRecord: revision,
+                    });
+                })
+                .catch((err: unknown) => {
+                    if (revision !== mainRevisionRef.current) {
+                        setStaleMainResponsesDropped((prev) => prev + 1);
+                        return;
+                    }
+                    const message = err instanceof Error ? err.message : String(err);
+                    setError(message);
+                    if (!opts?.keepExistingOnError) {
+                        setScriptParams([]);
+                        setScriptReview(null);
+                    }
+                    pushExecutionRecord({
+                        revision,
+                        status: 'error',
+                        error: message,
+                        executionCountAtRecord: revision,
+                    });
+                })
+                .finally(() => {
+                    if (revision === mainRevisionRef.current && !aborted) {
+                        setIsComputing(false);
+                        setExecutionCount((prev) => prev + 1);
+                    } else if (revision === mainRevisionRef.current) {
+                        setIsComputing(false);
+                    }
+                });
+            return { revision, promise };
+        }
+
         const promise = apiCall().then(({ base, headers }) => {
             const meshUrl = rewritePath(meshPath, base);
             const reviewUrl = rewritePath(reviewPath, base);

--- a/src/studio/gallerySource.ts
+++ b/src/studio/gallerySource.ts
@@ -3,6 +3,7 @@
 export interface GalleryManifestEntry {
   slug: string;
   sourceUrl: string | null;
+  scriptPath?: string | null;
 }
 
 const MARKETING_GALLERY_ORIGIN = 'https://kernelcad.com';
@@ -53,6 +54,21 @@ export async function findGallerySourceUrl(slug: string): Promise<string> {
   const entry = entries.find(candidate => candidate.slug === slug);
   if (!entry) throw new Error(`Gallery entry not found: ${slug}`);
   if (!entry.sourceUrl) throw new Error(`Gallery entry has no source: ${slug}`);
+
+  return resolveGalleryAssetUrl(entry.sourceUrl, manifestUrl);
+}
+
+export async function findGallerySourceUrlForScriptPath(scriptPath: string): Promise<string | null> {
+  const manifestUrl = galleryManifestUrl();
+  const response = await fetch(manifestUrl);
+  if (!response.ok) throw new Error(`Failed to load gallery manifest: ${response.status}`);
+
+  const payload = await response.json();
+  const entries = Array.isArray(payload?.entries)
+    ? payload.entries as GalleryManifestEntry[]
+    : [];
+  const entry = entries.find((candidate) => candidate.scriptPath === scriptPath);
+  if (!entry?.sourceUrl) return null;
 
   return resolveGalleryAssetUrl(entry.sourceUrl, manifestUrl);
 }

--- a/src/studio/scriptSource.test.ts
+++ b/src/studio/scriptSource.test.ts
@@ -97,6 +97,45 @@ describe('loadStudioScriptSource', () => {
       expect.anything(),
     );
   });
+
+  it('resolves hosted curated script links through the marketing gallery manifest', async () => {
+    vi.stubGlobal('window', { location: { hostname: 'app.kernelcad.com' } });
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === 'https://kernelcad.com/gallery.json') {
+        return {
+          ok: true,
+          json: async () => ({
+            entries: [
+              {
+                slug: 'ratchet-height-adjust-stool',
+                sourceUrl: '/gallery/ratchet-height-adjust-stool/source.kcad.ts',
+                scriptPath: 'examples/gallery/ratchet-stool.kcad.ts',
+              },
+            ],
+          }),
+        };
+      }
+
+      return {
+        ok: true,
+        text: async () => 'export default box(3, 3, 3);',
+      };
+    }) as unknown as typeof fetch;
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(loadStudioScriptSource('examples/gallery/ratchet-stool.kcad.ts'))
+      .resolves.toContain('box(3');
+
+    expect(fetchMock).toHaveBeenCalledWith('https://kernelcad.com/gallery.json');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://kernelcad.com/gallery/ratchet-height-adjust-stool/source.kcad.ts',
+    );
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      expect.stringContaining('/__kernelcad/source?script=examples%2Fgallery%2Fratchet-stool.kcad.ts'),
+      expect.anything(),
+    );
+  });
 });
 
 describe('loadGalleryScriptSource', () => {

--- a/src/studio/scriptSource.ts
+++ b/src/studio/scriptSource.ts
@@ -1,25 +1,59 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
-import { findGallerySourceUrl, galleryPrecomputedMeshUrl } from './gallerySource';
+import {
+  findGallerySourceUrl,
+  findGallerySourceUrlForScriptPath,
+  galleryPrecomputedMeshUrl,
+} from './gallerySource';
 import { apiCall, rewritePath } from './api/apiBase';
 import type { SerializedParamTable } from '../shared/runtime/paramTable';
 import type { ScriptReviewSummary } from './context/GeometryContext';
+import type { FeatureMeshSerialized } from '../modeling/capture/featureMeshSerialize';
+import type { FeatureRecord } from '../shared/intent/featureRecord';
+
+async function parseJsonOrThrowHelpful(response: Response, fallbackMessage: string): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    const text = await response.text().catch(() => '');
+    if (text.includes('<!doctype html') || text.includes('<html')) {
+      throw new Error(fallbackMessage);
+    }
+    throw new Error(fallbackMessage);
+  }
+}
 
 export async function loadStudioScriptSource(script: string): Promise<string> {
+  if (shouldUseHostedMesh()) {
+    const curatedSourceUrl = await findGallerySourceUrlForScriptPath(script);
+    if (curatedSourceUrl) {
+      const curatedResponse = await fetch(curatedSourceUrl);
+      if (!curatedResponse.ok) {
+        throw new Error(`Failed to load gallery source: ${curatedResponse.status}`);
+      }
+      return curatedResponse.text();
+    }
+  }
+
   const { base, headers } = await apiCall();
   const response = await fetch(
     rewritePath(`/__kernelcad/source?script=${encodeURIComponent(script)}`, base),
     { headers },
   );
-  const payload = await response.json();
+  const payload = await parseJsonOrThrowHelpful(
+    response,
+    'Hosted script link is not public. Use a curated gallery link or sign in.',
+  );
   if (!response.ok) {
-    const message = typeof payload?.error === 'string' ? payload.error : response.statusText;
+    const message = payload && typeof payload === 'object' && typeof (payload as { error?: unknown }).error === 'string'
+      ? (payload as { error: string }).error
+      : response.statusText;
     throw new Error(message);
   }
-  if (typeof payload?.source !== 'string') {
+  if (!payload || typeof payload !== 'object' || typeof (payload as { source?: unknown }).source !== 'string') {
     throw new Error('Source endpoint did not return source code.');
   }
-  return payload.source;
+  return (payload as { source: string }).source;
 }
 
 export async function loadGalleryScriptSource(slug: string): Promise<string> {
@@ -35,8 +69,8 @@ export async function loadGalleryScriptSource(slug: string): Promise<string> {
  * GeometryContext success handler can consume it the same way.
  */
 export interface BackendMeshPayload {
-  features: unknown[];
-  featureRecords?: unknown[];
+  features: FeatureMeshSerialized[];
+  featureRecords?: FeatureRecord[];
   bounds: { min: [number, number, number]; max: [number, number, number] };
   params?: SerializedParamTable;
   /** Deterministic review baked at build time (precompute) or returned by the


### PR DESCRIPTION
## Summary
- recover hosted Studio opening for curated `?script=` links by resolving gallery sources and hosted mesh fallbacks
- publish `spice-dispenser-carousel` from `examples` into the curated gallery so it can be opened in Studio for renders
- cover the hosted script-source and gallery manifest behavior with focused tests

## Validation
- `npm test -- scripts/lib/galleryEntries.test.ts site/scripts/build-gallery.test.ts src/studio/scriptSource.test.ts src/studio/context/GeometryContext.test.tsx`
