### PR TITLE
fix(studio): run module-style .kcad scripts in open_in_studio

### DIFF
--- a/src/kernel/backends/occt/worker.ts
+++ b/src/kernel/backends/occt/worker.ts
@@ -8,6 +8,7 @@ import { createSafeReplicad, SafeSketcher } from '../../../shared/worker/safeSke
 import { withTemporaryGlobals } from '../../../shared/worker/withTemporaryGlobals';
 import { createUserGlobals } from '../../../shared/worker/userGlobals';
 import { createV01ApiGlobals, unwrapV01Shape } from '../../../shared/worker/v01ApiShim';
+import { normalizeUserScript } from '../../../shared/runtime/normalizeUserScript';
 import {
   type ExecutionResult,
   type GeometryResult,
@@ -112,7 +113,7 @@ self.onmessage = (e: MessageEvent<unknown>) => {
     if (type === 'EXECUTE') {
       try {
         await init();
-        const code = request.code;
+        const code = normalizeUserScript(request.code);
         if (DEBUG) console.log(`Worker: Executing code: ${code.substring(0, 100)}...`);
 
         const activeSketches: SafeSketcher[] = [];
@@ -287,7 +288,7 @@ self.onmessage = (e: MessageEvent<unknown>) => {
     if (type === 'EXPORT_STEP' || type === 'EXPORT_STL') {
       try {
         await init();
-        const code = request.code;
+        const code = normalizeUserScript(request.code);
         const safeReplicad = createSafeReplicad(replicad);
 
         const wrappedStartSketch = () => {

--- a/src/modeling/HeadlessKernel.ts
+++ b/src/modeling/HeadlessKernel.ts
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import * as replicad from 'replicad';
 import opencascade from 'replicad-opencascadejs';
+import { normalizeUserScript } from '../shared/runtime/normalizeUserScript';
 
 let isInitialized = false;
 
@@ -98,6 +99,10 @@ export class HeadlessKernel implements HeadlessContext {
         // Note: This needs better logic for partial updates in real agent scenarios
         this.code = code;
 
+        // Agent-authored scripts are often ES modules (`export default <model>`);
+        // rewrite module-isms into function-body statements before sandboxing.
+        const executable = normalizeUserScript(code);
+
         try {
             // Function constructor to sandbox basic execution
             // Note: This is NOT secure sandbox, but sufficient for internal agent
@@ -106,7 +111,7 @@ export class HeadlessKernel implements HeadlessContext {
                 'console',
                 `"use strict";
                 try {
-                    ${code}
+                    ${executable}
                 } catch (e) {
                     throw e;
                 }

--- a/src/shared/runtime/normalizeUserScript.test.ts
+++ b/src/shared/runtime/normalizeUserScript.test.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { describe, it, expect } from 'vitest';
+import { normalizeUserScript } from './normalizeUserScript';
+
+/**
+ * Studio runs a .kcad script as the body of `new Function(...)` whose return
+ * value is the model. Agent-authored scripts are idiomatic TS/ESM modules
+ * (`export default <model>`, `export const`, top-level `import`), which are a
+ * SyntaxError inside a function body ("Unexpected token 'export'"). The
+ * normalizer rewrites those module-isms into runnable function-body statements.
+ */
+describe('normalizeUserScript', () => {
+  // Canonical kcad scripts already use `return` — must pass through untouched.
+  it('leaves a canonical return-based script unchanged', () => {
+    const code = [
+      'const w = 60;',
+      'const base = box(w, 40, 5);',
+      'return base.fillet(1);',
+    ].join('\n');
+    expect(normalizeUserScript(code)).toBe(code);
+  });
+
+  it('rewrites `export default <expr>;` to `return <expr>;`', () => {
+    const out = normalizeUserScript('const box = cube(20);\nexport default box;');
+    expect(out).not.toMatch(/\bexport\b/);
+    expect(out).toContain('return box;');
+  });
+
+  it('rewrites `export default <expr>` without a trailing semicolon', () => {
+    const out = normalizeUserScript('export default cube(20)');
+    expect(out).not.toMatch(/\bexport\b/);
+    expect(out).toContain('return cube(20)');
+  });
+
+  it('rewrites a multi-line `export default` chained expression', () => {
+    const out = normalizeUserScript(
+      'export default base\n  .subtract(hole)\n  .fillet(1);',
+    );
+    expect(out).not.toMatch(/\bexport\b/);
+    expect(out).toContain('return base');
+    expect(out).toContain('.fillet(1);');
+  });
+
+  it('strips the `export` keyword from exported declarations', () => {
+    const out = normalizeUserScript(
+      'export const w = 60;\nexport function make() { return box(w, w, w); }\nexport default make();',
+    );
+    expect(out).not.toMatch(/\bexport\b/);
+    expect(out).toContain('const w = 60;');
+    expect(out).toContain('function make()');
+    expect(out).toContain('return make();');
+  });
+
+  it('strips `export` from `export let`, `export var`, `export class`, `export async function`', () => {
+    const out = normalizeUserScript(
+      [
+        'export let a = 1;',
+        'export var b = 2;',
+        'export class C {}',
+        'export async function d() {}',
+      ].join('\n'),
+    );
+    expect(out).not.toMatch(/\bexport\b/);
+    expect(out).toContain('let a = 1;');
+    expect(out).toContain('var b = 2;');
+    expect(out).toContain('class C {}');
+    expect(out).toContain('async function d() {}');
+  });
+
+  it('drops top-level ES import statements (named, default, namespace, side-effect)', () => {
+    const out = normalizeUserScript(
+      [
+        "import { foo } from 'bar';",
+        "import baz from 'qux';",
+        "import * as ns from 'mod';",
+        "import 'side-effect';",
+        'const x = box(10, 10, 10);',
+        'return x;',
+      ].join('\n'),
+    );
+    expect(out).not.toMatch(/\bimport\b/);
+    expect(out).toContain('const x = box(10, 10, 10);');
+    expect(out).toContain('return x;');
+  });
+
+  it('drops `export { ... }` re-export statements', () => {
+    const out = normalizeUserScript('const x = box(1, 1, 1);\nexport { x };\nreturn x;');
+    expect(out).not.toMatch(/\bexport\b/);
+    expect(out).toContain('const x = box(1, 1, 1);');
+    expect(out).toContain('return x;');
+  });
+
+  it('keeps `export default function`/`class` as a declaration (strips export default)', () => {
+    const out = normalizeUserScript('export default function model() { return box(1, 1, 1); }');
+    expect(out).not.toMatch(/\bexport\b/);
+    expect(out).toContain('function model()');
+    // Must not produce `return function ...` (a function is not a model value).
+    expect(out).not.toMatch(/return\s+function/);
+  });
+
+  it('does not touch the word "export" inside a string literal', () => {
+    const code = 'const label = "export this part";\nreturn box(1, 1, 1);';
+    expect(normalizeUserScript(code)).toBe(code);
+  });
+
+  it('is a no-op for empty / whitespace input', () => {
+    expect(normalizeUserScript('')).toBe('');
+    expect(normalizeUserScript('   \n  ')).toBe('   \n  ');
+  });
+});

--- a/src/shared/runtime/normalizeUserScript.ts
+++ b/src/shared/runtime/normalizeUserScript.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+/**
+ * Studio executes a `.kcad` script as the body of `new Function(...)`, where the
+ * model is whatever the script `return`s (see `kernel/backends/occt/worker.ts`
+ * and `modeling/HeadlessKernel.ts`). Agent-authored scripts, however, are
+ * idiomatic TypeScript/ES modules: they end with `export default <model>`, use
+ * `export const`/`export function`, and sometimes carry top-level `import`s.
+ * Any of those is a `SyntaxError` inside a function body — surfaced to the user
+ * as "Unexpected token 'export'" with 0 bodies rendered.
+ *
+ * `normalizeUserScript` rewrites those module-isms into equivalent function-body
+ * statements so the same script runs whether it was written module-style or
+ * return-style:
+ *   - `export default <expr>`      → `return <expr>`   (the model value)
+ *   - `export default function|class` → strip `export default ` (keep the decl)
+ *   - `export const|let|var|function|class|async function` → strip `export `
+ *   - `export { ... }` (re-exports) → dropped
+ *   - top-level `import ...`        → dropped (bare specifiers can't resolve in
+ *                                      `new Function`; the API is injected as
+ *                                      globals, not imported)
+ *
+ * The transforms are line-anchored, so the word `export`/`import` appearing
+ * mid-line (e.g. inside a string literal) is left untouched. Multi-line `import`
+ * / `export { }` statements are not handled — agents do not emit them in kcad
+ * scripts, and the canonical authoring form is a flat `return`.
+ */
+export function normalizeUserScript(code: string): string {
+  if (typeof code !== 'string' || code.trim() === '') return code;
+
+  let out = code;
+
+  // 1. Drop top-level ES import statements (named, default, namespace,
+  //    side-effect). Dynamic `import(...)` used as an expression is not
+  //    line-anchored to `import` and is therefore preserved.
+  out = out.replace(/^[ \t]*import\b[^\n]*\n?/gm, '');
+
+  // 2. Drop `export { ... }` re-export statements (with optional `from '...'`).
+  out = out.replace(/^[ \t]*export\s*\{[^}]*\}[^\n]*\n?/gm, '');
+
+  // 3. `export default function|class` → keep the declaration, drop the prefix.
+  //    (A function/class is not itself a model value, so we must NOT turn this
+  //    into `return function ...`.)
+  out = out.replace(
+    /^([ \t]*)export\s+default\s+(?=(?:async\s+)?function\b|class\b)/gm,
+    '$1',
+  );
+
+  // 4. `export default <expr>` → `return <expr>` (the model the script produces).
+  out = out.replace(/^([ \t]*)export\s+default\s+/gm, '$1return ');
+
+  // 5. `export <decl>` → strip the `export ` keyword, keep the declaration.
+  out = out.replace(
+    /^([ \t]*)export\s+(?=const\b|let\b|var\b|function\b|class\b|async\b)/gm,
+    '$1',
+  );
+
+  return out;
+}


### PR DESCRIPTION
## Problem

Opening an agent-built model via `open_in_studio` on a `/p/<slug>` page failed with **"Unexpected token 'export'"** and rendered **0 bodies**.

Root cause: Studio executes a `.kcad` script as the body of `new Function(...)`, where the model is whatever the script `return`s. But agent-authored scripts are idiomatic ES modules — they end with `export default <model>`, use `export const`, and sometimes carry top-level `import`s. Any of those is a `SyntaxError` inside a function body.

## Fix

`normalizeUserScript()` rewrites module-isms into runnable function-body statements before execution:

- `export default <expr>` → `return <expr>` (the model value)
- `export default function|class` → strip `export default ` (keep the declaration)
- `export const|let|var|function|class|async function` → strip `export `
- `export { ... }` re-exports → dropped
- top-level `import ...` → dropped (the API is injected as globals, not imported)

Transforms are line-anchored, so `export`/`import` inside a string literal is left untouched. Canonical `return`-style scripts pass through unchanged.

Applied at all three execution sites: the OCCT worker (`EXECUTE` + `EXPORT_STEP/STL`) and the headless kernel.

## Verification

- 11 unit tests covering every transform + passthrough/no-op cases.
- Full `npm run typecheck` clean; `src/modeling` suite (419 tests) green.
- **End-to-end in a real browser:** a project whose source is `export default part;`, loaded from prod Supabase through the patched worker, now renders cleanly — **1 body, "Ready — No diagnostics"** — where it previously showed "Unexpected token 'export'" and 0 bodies.