### PR TITLE
fix(studio): run module-style scripts in the hosted mesh path (runScript)

### DIFF
--- a/src/modeling/runtime/runScript.test.ts
+++ b/src/modeling/runtime/runScript.test.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { describe, it, expect } from 'vitest';
+import { runScript } from './runScript';
+
+/**
+ * Regression for the hosted `/__kernelcad/mesh` path: agent-authored scripts
+ * arrive as ES modules (`export default <model>`). The runtime transpiles then
+ * wraps the body in an IIFE, so `export` was a SyntaxError ("Unexpected token
+ * 'export'") and the model failed to render in Studio. `runScript` must
+ * normalize module syntax into the `return` form the IIFE captures.
+ *
+ * These cases use plain values (not OCCT shapes) so they run without the
+ * geometry kernel — they exercise transpile → normalize → isolate → capture.
+ */
+describe('runScript — module-style scripts', () => {
+  it('captures `export default <expr>` as the return value', async () => {
+    const res = await runScript({ code: 'export default 21 * 2;', fileName: 'model.kcad.ts' });
+    expect(res.returnValue).toBe(42);
+  });
+
+  it('still supports the canonical top-level `return`', async () => {
+    const res = await runScript({ code: 'const x = 7;\nreturn x + 1;', fileName: 'model.kcad.ts' });
+    expect(res.returnValue).toBe(8);
+  });
+
+  it('handles `export const` + `export default` together', async () => {
+    const res = await runScript({
+      code: 'export const w = 10;\nexport default w * 3;',
+      fileName: 'model.kcad.ts',
+    });
+    expect(res.returnValue).toBe(30);
+  });
+
+  it('drops a top-level `import` that cannot resolve in the sandbox', async () => {
+    const res = await runScript({
+      code: "import { foo } from 'bar';\nexport default 5;",
+      fileName: 'model.kcad.ts',
+    });
+    expect(res.returnValue).toBe(5);
+  });
+});

--- a/src/modeling/runtime/runScript.ts
+++ b/src/modeling/runtime/runScript.ts
@@ -4,6 +4,7 @@ import { CaptureSession } from '../capture/captureSession';
 import { createApi } from '../api';
 import type { FeatureRecord } from '../../shared/intent/featureRecord';
 import type { ParamTable } from '../../shared/runtime/paramTable';
+import { normalizeUserScript } from '../../shared/runtime/normalizeUserScript';
 import { transpileTs } from './transpile';
 import { runIsolated } from './isolation';
 
@@ -45,7 +46,15 @@ export async function runScript(input: RunScriptInput): Promise<RunScriptResult>
   session.scriptDir = scriptDir;
   const api = createApi({ session, scriptDir });
 
-  const transpiled = transpileTs(code, fileName);
+  // Agent-authored scripts are idiomatic ES modules: they end with
+  // `export default <model>`, use `export const`, or carry top-level `import`s.
+  // The runtime wraps the body in an IIFE (`wrapReturn`) and captures the
+  // top-level `return`, so module syntax is a SyntaxError ("Unexpected token
+  // 'export'"). Rewrite module-isms into function-body statements first —
+  // `export default <expr>` becomes the `return <expr>` the IIFE expects.
+  const normalized = normalizeUserScript(code);
+
+  const transpiled = transpileTs(normalized, fileName);
 
   // Two surface forms are supported inside `.kcad.ts` scripts:
   //   - Top-level globals (`box(...)`, `q.face(...)`) via the api spread.


### PR DESCRIPTION
## Problem

PR #463 fixed the **client** OCCT worker, but the hosted Studio (`/p/<slug>` on app.kernelcad.com) does **not** render via that worker — it POSTs the script to the backend `POST /__kernelcad/mesh`, which evaluates through `runScript` (`transpileTs` → `runIsolated` vm with `wrapReturn`). That is an entirely different engine, and it was untouched.

So agent-built models authored as ES modules (`export default <model>`) still failed on prod with **"Unexpected token 'export'"** / 0 bodies: `transpileTs` keeps `export` for the ESNext target, then `runIsolated` wraps the body in `(async function(){ … })()`, making the `export` illegal inside a function.

Confirmed live: `POST https://api.kernelcad.com/__kernelcad/mesh` returns **500** for a project whose source is `export default part;` — even though the client worker bundle already carries the #463 fix.

## Fix

Apply the same shared `normalizeUserScript()` at the start of `runScript`, before transpile, so `export default <expr>` becomes the top-level `return <expr>` that the IIFE already captures. This is the same normalization the client worker and headless kernel use — one shared function, applied at each evaluator boundary.

## Verification

- New `runScript.test.ts`: export-default → captured return, canonical top-level return still works, `export const` + `export default`, and import-drop. All pass without the geometry kernel.
- `typecheck` clean.
- The prod 500 is the red case this turns green.

## Deploy note

The hosted backend is the Hetzner server (kernelCAD-server), which vendors this engine and deploys manually. After this merges, the server's `vendor/kernelcad` pin must be bumped and the backend redeployed for the fix to reach app.kernelcad.com.