### PR TITLE
fix(parts): serve catalog via advanced-mode _worker.js

### DIFF
--- a/scripts/ingestParts.test.ts
+++ b/scripts/ingestParts.test.ts
@@ -49,7 +49,7 @@ describe('ingestParts', () => {
     // Deployable tree.
     expect(existsSync(join(out, 'step', 'mount-plate.step'))).toBe(true);
     expect(existsSync(join(out, 'v1', 'parts', 'mount-plate.json'))).toBe(true);
-    expect(existsSync(join(out, 'functions', 'v1', 'parts', '[[path]].ts'))).toBe(true);
+    expect(existsSync(join(out, '_worker.js'))).toBe(true);
     const index = JSON.parse(
       readFileSync(join(out, 'v1', 'catalog', 'parts.index.json'), 'utf8'),
     ) as { catalog: { partCount: number }; items: Array<{ id: string }> };

--- a/scripts/ingestParts.ts
+++ b/scripts/ingestParts.ts
@@ -183,7 +183,6 @@ export async function ingestDirectory(
   mkdirSync(join(outDir, 'step'), { recursive: true });
   mkdirSync(join(outDir, 'v1', 'parts'), { recursive: true });
   mkdirSync(join(outDir, 'v1', 'catalog'), { recursive: true });
-  mkdirSync(join(outDir, 'functions', 'v1', 'parts'), { recursive: true });
 
   const records: CatalogRecord[] = [];
   const shaManifest: Record<string, string> = {};
@@ -214,40 +213,49 @@ export async function ingestDirectory(
   );
   writeFileSync(join(outDir, 'sha256-manifest.json'), JSON.stringify(shaManifest, null, 2));
   // The serving shim (search + detail over the static index) for Cloudflare Pages.
-  writeFileSync(join(outDir, 'functions', 'v1', 'parts', '[[path]].ts'), PAGES_FUNCTION, {
-    flag: 'w',
-  });
+  writeFileSync(join(outDir, '_worker.js'), PAGES_WORKER, { flag: 'w' });
   return records;
 }
 
-// A ~static Cloudflare Pages Function implementing the two endpoints the remote
-// adapter calls, over the bundled index. Emitted into the catalog so the whole
-// outDir deploys as one Pages project. See remoteClient.ts for the contract.
-const PAGES_FUNCTION = `// SPDX-License-Identifier: MIT
+// A single advanced-mode Cloudflare Pages Worker (`_worker.js` at the deploy
+// root) implementing the two endpoints the remote adapter calls, over the
+// bundled static index. Advanced mode is used instead of a `functions/` route
+// because a `[[path]]` catch-all sharing the `/v1/parts` prefix with the static
+// per-part `.json` assets does not route reliably (static-asset precedence +
+// zero-segment catch-all both 404). The Worker intercepts `/v1/parts` itself and
+// passes everything else through to `env.ASSETS` (the .step / .json / index).
+// See remoteClient.ts for the contract.
+const PAGES_WORKER = `// SPDX-License-Identifier: MIT
 // Serves /v1/parts?q=... (search) and /v1/parts/{id} (detail) from the static
-// /v1/catalog/parts.index.json asset (fetched at runtime, not build-imported,
-// so the index lives outside the functions tree). Deploy this directory to
-// Cloudflare Pages and point KERNELCAD_PARTS_BASE_URL at it.
-interface Rec { id: string; name: string; tags?: string[] }
+// /v1/catalog/parts.index.json asset; all other paths fall through to static
+// assets. Deploy this directory to Cloudflare Pages and point
+// KERNELCAD_PARTS_BASE_URL at it.
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const m = url.pathname.match(/^\\/v1\\/parts(?:\\/(.+))?$/);
+    if (!m) return env.ASSETS.fetch(request);
 
-export const onRequest: PagesFunction = async ({ params, request }) => {
-  const url = new URL(request.url);
-  const res = await fetch(url.origin + '/v1/catalog/parts.index.json');
-  if (!res.ok) return new Response('catalog index unavailable', { status: 502 });
-  const items = ((await res.json()) as { items: Rec[] }).items;
+    const idxReq = new Request(url.origin + '/v1/catalog/parts.index.json');
+    const res = await env.ASSETS.fetch(idxReq);
+    if (!res.ok) return new Response('catalog index unavailable', { status: 502 });
+    const items = (await res.json()).items;
 
-  const path = ([] as string[]).concat((params.path as string[]) ?? []).join('/');
-  if (path) {
-    const rec = items.find((r) => r.id === path);
-    return rec ? Response.json(rec) : new Response('not found', { status: 404 });
-  }
-  const q = (url.searchParams.get('q') ?? '').toLowerCase();
-  const hits = q
-    ? items.filter((r) =>
-        [r.id, r.name, ...(r.tags ?? [])].join(' ').toLowerCase().includes(q),
-      )
-    : items;
-  return Response.json({ items: hits, total: hits.length });
+    const id = m[1] ? m[1].replace(/\\.json$/, '') : '';
+    if (id) {
+      const rec = items.find((r) => r.id === id);
+      return rec
+        ? Response.json(rec)
+        : new Response('not found', { status: 404 });
+    }
+    const q = (url.searchParams.get('q') || '').toLowerCase();
+    const hits = q
+      ? items.filter((r) =>
+          [r.id, r.name, ...(r.tags || [])].join(' ').toLowerCase().includes(q),
+        )
+      : items;
+    return Response.json({ items: hits, total: hits.length });
+  },
 };
 `;
 


### PR DESCRIPTION
## What

The Parts Catalog deploy ([run 27406602266](https://github.com/w1ne/kernelCAD-web/actions/runs/27406602266)) shipped 23 bearings to https://kernelcad-parts.pages.dev, but the dynamic endpoints 404'd:

- `/v1/catalog/parts.index.json` → 200 ✅ (static)
- per-part `/v1/parts/{id}.json` + `/step/{id}.step` → 200 ✅ (static)
- `/v1/parts?q=` (search) → **404** ❌
- `/v1/parts/{id}` (detail) → **404** ❌

Search + detail are exactly what the remote adapter (`remoteClient.ts`) calls, so `find_part` discovery against the catalog was non-functional.

## Why

The emitted `functions/v1/parts/[[path]].ts` catch-all shares the `/v1/parts` prefix with the static per-part `.json` assets. Static-asset precedence plus the zero-segment catch-all means neither the bare `/v1/parts` nor `/v1/parts/{id}` routes to the function.

## Fix

Emit a single advanced-mode `_worker.js` at the catalog root. It intercepts `/v1/parts` itself and passes every other path through to `env.ASSETS` (deterministic). Test updated to assert `_worker.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)