### PR TITLE
fix(studio): hosted Studio renders modern .kcad.ts (gallery/MCP) without acorn gate

### DIFF
--- a/src/studio/context/GeometryContext.test.tsx
+++ b/src/studio/context/GeometryContext.test.tsx
@@ -437,6 +437,68 @@ describe('GeometryContext latest-intent-wins', () => {
     expect(screen.getByTestId('script-review-ok').textContent).toBe('true');
   });
 
+  // Regression: gallery/MCP models authored as modern .kcad.ts carry TypeScript
+  // syntax (type annotations). The old acorn pre-check (`parseCode`, a JS-only
+  // parser) threw "Unexpected token (line:col)" and blanked the model on the
+  // hosted app — even though the server mesh transpiles TS and renders it fine.
+  // The hosted path must NOT run the acorn guard.
+  it('hosted: renders modern TypeScript .kcad.ts via server mesh (no acorn parse error)', async () => {
+    vi.stubGlobal('window', {
+      ...window,
+      location: { ...window.location, hostname: 'app.kernelcad.com', search: '' },
+      localStorage: window.localStorage,
+      history: window.history,
+      crypto: window.crypto,
+    });
+
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        features: [
+          {
+            featureId: 'b',
+            featureKind: 'box',
+            predecessors: [],
+            faces: [
+              {
+                vertices: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+                indices: [0, 1, 2],
+                normals: [0, 0, 1, 0, 0, 1, 0, 0, 1],
+                faceId: 0,
+              },
+            ],
+          },
+        ],
+        featureRecords: [],
+        bounds: { min: [0, 0, 0], max: [1, 1, 0] },
+        params: {},
+        review: { ok: true, diagnostics: [] },
+      }),
+    } as Response);
+
+    // The `: number` annotations make this invalid JavaScript — acorn would
+    // throw "Unexpected token". The fix skips acorn on the hosted path.
+    const tsCode = 'const widen = (x: number): number => x * 2;\nexport default box(widen(1), 1, 1);';
+    render(
+      <GeometryProvider code={tsCode}>
+        <Probe />
+      </GeometryProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('error').textContent).toBe('');
+    expect(screen.getByTestId('face-count').textContent).toBe('1');
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
   it('refreshes mesh AND review when params relower over SSE', async () => {
     // PR #315 / I1: relower MUST re-run review so the StudioShell HUD
     // (interferences: N) reflects the post-param model. Old behavior

--- a/src/studio/context/GeometryContext.tsx
+++ b/src/studio/context/GeometryContext.tsx
@@ -769,23 +769,31 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
             const revision = ++mainRevisionRef.current;
             setCurrentCodeRevision(revision);
             let staleRecorded = false;
-            try {
-                parseCode(code);
-            } catch (err) {
-                if (revision !== mainRevisionRef.current) {
-                    setStaleMainResponsesDropped((prev) => prev + 1);
-                    staleRecorded = true;
+            // Only the legacy in-browser worker (plain-JS `new Function`) needs an
+            // acorn syntax pre-check — acorn can't parse TypeScript. The hosted and
+            // dev-kernel paths transpile TS server-side and surface their own
+            // diagnostics, so acorn must NOT gate them: it throws "Unexpected token
+            // (line:col)" on type annotations in modern .kcad.ts (e.g. gallery
+            // models), blanking a model the server renders fine.
+            if (!hosted && !routesToDevKernel) {
+                try {
+                    parseCode(code);
+                } catch (err) {
+                    if (revision !== mainRevisionRef.current) {
+                        setStaleMainResponsesDropped((prev) => prev + 1);
+                        staleRecorded = true;
+                        return;
+                    }
+                    const message = err instanceof Error ? err.message : String(err);
+                    setError(message);
+                    pushExecutionRecord({
+                        revision,
+                        status: 'error',
+                        error: message,
+                        executionCountAtRecord: executionCount + 1,
+                    });
                     return;
                 }
-                const message = err instanceof Error ? err.message : String(err);
-                setError(message);
-                pushExecutionRecord({
-                    revision,
-                    status: 'error',
-                    error: message,
-                    executionCountAtRecord: executionCount + 1,
-                });
-                return;
             }
             if (hosted) {
                 setIsComputing(true);
@@ -986,18 +994,23 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
     const executeGeometry = useCallback(async (codeToExecute: string) => {
         const revision = ++mainRevisionRef.current;
         setCurrentCodeRevision(revision);
-        try {
-            parseCode(codeToExecute);
-        } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            setError(message);
-            pushExecutionRecord({
-                revision,
-                status: 'error',
-                error: message,
-                executionCountAtRecord: executionCount + 1,
-            });
-            return;
+        // Acorn can't parse TypeScript; only the legacy worker path below needs
+        // this pre-check. The hosted server-mesh path transpiles modern .kcad.ts
+        // itself, so acorn must not block it (it throws "Unexpected token" on TS).
+        if (!shouldUseHostedMesh()) {
+            try {
+                parseCode(codeToExecute);
+            } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                setError(message);
+                pushExecutionRecord({
+                    revision,
+                    status: 'error',
+                    error: message,
+                    executionCountAtRecord: executionCount + 1,
+                });
+                return;
+            }
         }
 
         // Hosted deploy (app.kernelcad.com): no local kernel backend, and the


### PR DESCRIPTION
## Problem

Gallery links (and any modern `.kcad.ts` opened via MCP) showed **"Unexpected token (line:col)"** with 0 bodies on `app.kernelcad.com`, even though the server mesh endpoint rendered them fine (returned 200).

Root cause: `GeometryContext` runs an acorn pre-check (`parseCode`) **before** the hosted server-mesh branch. acorn is a JS-only parser; modern `.kcad.ts` carries TypeScript type annotations (e.g. gallery line 258: `origin: [number, number, number]`), so acorn throws and blanks the model before the (capable) server path runs.

This is distinct from the `export default` bug (#463/#464) — same symptom family, different gate.

## Fix

Gate the acorn pre-check to the **legacy in-browser worker path only** (it runs plain-JS v0.1 and genuinely needs the fast syntax check). The hosted and dev-kernel paths transpile TS server-side and report their own diagnostics, so acorn must not gate them. Applied at both the auto-run execution loop and the explicit `executeGeometry` path.

Result: hosted gallery + MCP-opened modern models render through the server engine that already handles them. Frontend-only — auto-deploys via Cloudflare Pages on merge; no backend change.

## Verification

- New regression test: hosted + TypeScript-annotated source renders via server mesh with **no parse error** (previously errored, 0 bodies). 9/9 GeometryContext tests green, 33 studio-context tests green, typecheck clean.
- Will verify on the live gallery link post-deploy.

Part of the engine-unification effort (interim fix so gallery/MCP work today; full one-engine-in-the-worker migration tracked separately in #466 + the private plan).