### PR TITLE
feat(parts): default the remote tier to kernelCAD's own catalog

### DIFF
--- a/.github/workflows/parts-catalog.yml
+++ b/.github/workflows/parts-catalog.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   ingest-and-deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
 

--- a/src/agent/skills/kernelcad-parts/SKILL.md
+++ b/src/agent/skills/kernelcad-parts/SKILL.md
@@ -165,10 +165,11 @@ a bundled one:
   central hole. The part participates in `add_mate` with no manual
   `partRef.connector(...)`. Oddly-shaped parts may still need a hand-authored
   frame — inspect the synthesized set before relying on it.
-- **Provenance.** The catalog's source repository is MIT, so each record carries
-  `license: 'MIT'` with `attribution` = the part's catalog page (satisfying
-  MIT's attribution requirement). The geometry is fetched on demand, never
-  re-hosted; keep the attribution when shipping a deliverable that embeds it.
+- **Provenance.** The default catalog is built from a license-clean mechanical
+  parts library (CC-BY-3.0), so each record carries its own `license` (commonly
+  `'CC-BY-3.0'`) plus `attribution`. Read `record.license` / `record.attribution`
+  rather than assuming — a record's terms govern it. Keep the attribution when
+  shipping a deliverable that embeds the geometry.
 
 **Overriding or disabling the source:**
 

--- a/src/modeling/parts/remoteClient.test.ts
+++ b/src/modeling/parts/remoteClient.test.ts
@@ -14,14 +14,14 @@ describe('remoteClient', () => {
     vi.restoreAllMocks();
   });
 
-  it('defaults to the step.parts catalog when no url is configured', async () => {
+  it("defaults to kernelCAD's own catalog when no url is configured", async () => {
     delete process.env.KERNELCAD_PARTS_BASE_URL;
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(JSON.stringify({ items: [], total: 0 }), { status: 200 }),
     );
     await remoteFindParts({ query: 'M3' });
     const url = fetchSpy.mock.calls[0][0] as string;
-    expect(url).toMatch(/^https:\/\/api\.step\.parts\/v1\/parts\?/);
+    expect(url).toMatch(/^https:\/\/kernelcad-parts\.pages\.dev\/v1\/parts\?/);
   });
 
   it('disables the remote tier when KERNELCAD_PARTS_BASE_URL is "off"', async () => {

--- a/src/modeling/parts/remoteClient.ts
+++ b/src/modeling/parts/remoteClient.ts
@@ -2,19 +2,24 @@
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // src/modeling/parts/remoteClient.ts
 //
-// Remote parts tier. Defaults to the step.parts public catalog so kernelCAD can
-// find off-the-shelf parts out of the box. Override the source with a
-// partsBaseUrl argument or the KERNELCAD_PARTS_BASE_URL env var (e.g. a
-// self-hosted catalog serving the same /v1/parts schema); set that env var to
-// `off` / `none` to disable the remote tier and restore offline-only behavior.
+// Remote parts tier. Defaults to kernelCAD's own public catalog
+// (kernelcad-parts.pages.dev) so kernelCAD can find off-the-shelf parts out of
+// the box with no third-party dependency. Override the source with a
+// partsBaseUrl argument or the KERNELCAD_PARTS_BASE_URL env var (e.g. point it
+// at api.step.parts, or any catalog serving the same /v1/parts schema); set
+// that env var to `off` / `none` to disable the remote tier and restore
+// offline-only behavior.
 
 import { KernelError } from '../../shared/intent/kernelError';
 import type { PartRecord } from '../../shared/parts/types';
-import {
-  mapStepPartsRecord,
-  STEP_PARTS_BASE_URL,
-  type StepPartsRecord,
-} from './stepPartsAdapter';
+import { mapStepPartsRecord, type StepPartsRecord } from './stepPartsAdapter';
+
+/** Zero-config default remote source: kernelCAD's own license-clean catalog,
+ *  built from the CC-BY FreeCAD parts_library and served from Cloudflare Pages
+ *  (see scripts/ingestFreecadLibrary.ts + .github/workflows/parts-catalog.yml).
+ *  Serves the same /v1/parts schema the step.parts adapter speaks, so the
+ *  mapper below is unchanged. Override via partsBaseUrl / KERNELCAD_PARTS_BASE_URL. */
+export const KERNELCAD_PARTS_BASE_URL = 'https://kernelcad-parts.pages.dev';
 
 export class RemoteDisabledError extends KernelError {
   constructor() {
@@ -54,9 +59,9 @@ function resolveBaseUrl(arg: string | undefined): string {
   if (raw.toLowerCase() === 'off' || raw.toLowerCase() === 'none') {
     throw new RemoteDisabledError();
   }
-  // Zero-config default: step.parts. An explicit arg/env URL overrides it (e.g.
-  // a self-hosted catalog that serves the same /v1/parts schema).
-  const url = raw.length === 0 ? STEP_PARTS_BASE_URL : raw;
+  // Zero-config default: kernelCAD's own catalog. An explicit arg/env URL
+  // overrides it (e.g. api.step.parts, or any catalog serving /v1/parts).
+  const url = raw.length === 0 ? KERNELCAD_PARTS_BASE_URL : raw;
   return url.replace(/\/$/, '');
 }
 


### PR DESCRIPTION
## What

Makes kernelCAD's **own** catalog (`kernelcad-parts.pages.dev`) the zero-config default remote parts source, replacing the step.parts public API as the default. kernelCAD now finds off-the-shelf parts out of the box with no third-party dependency and nothing to configure.

- `resolveBaseUrl()` defaults to the new `KERNELCAD_PARTS_BASE_URL` constant. Any `/v1/parts` catalog (incl. api.step.parts) is still selectable via the `partsBaseUrl` arg or `KERNELCAD_PARTS_BASE_URL` env var; `off`/`none` still disables the tier.
- The owned catalog serves the same `/v1/parts` schema, so the existing adapter/mapper is unchanged.
- SKILL provenance corrected: records carry per-part `CC-BY-3.0` (FreeCAD parts_library), not a blanket MIT — read `record.license`/`attribution`.
- `parts-catalog.yml` timeout 45→90m to cover the full `Mechanical Parts` run (~2400 STEP files through OCCT).

## Test

`remoteClient` default-URL test updated + parts suite green (42 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)