### PR TITLE
perf(gallery): weld duplicate vertices in GLB export (−20% tile size)

### DIFF
--- a/scripts/lib/exportGlb.ts
+++ b/scripts/lib/exportGlb.ts
@@ -10,7 +10,7 @@ import {
   MeshStandardMaterial,
   Scene as ThreeScene,
 } from 'three';
-import { GLTFExporter } from 'three-stdlib';
+import { GLTFExporter, mergeVertices } from 'three-stdlib';
 import { evaluateAndBuildScript } from '../../src/agent/cli/commands/evaluate';
 import { pbrFromMetadata, type OcctBackend } from '../../src/kernel/backends/occt/occtBackend';
 import { loadScriptFeatures } from '../../src/modeling/runtime/scriptLoader';
@@ -65,7 +65,12 @@ function addSingleMesh(
   geometry.setAttribute('position', new BufferAttribute(positions, 3));
   geometry.setAttribute('normal', new BufferAttribute(normals, 3));
   geometry.setIndex(new BufferAttribute(indices, 1));
-  scene.add(new Mesh(geometry, makeMaterial(color, material)));
+  // OCCT meshes each face independently, so shared edges carry duplicate
+  // vertices (coordinate-equal, index-distinct). Weld them — lossless, and at
+  // hard edges the differing normals keep the vertices split so shading is
+  // preserved. Shrinks the exported GLB with no visual change.
+  const welded = mergeVertices(geometry);
+  scene.add(new Mesh(welded, makeMaterial(color, material)));
 }
 
 function addFeatureMesh(scene: ThreeScene, fm: FeatureMesh): void {

--- a/site/scripts/build-gallery.ts
+++ b/site/scripts/build-gallery.ts
@@ -39,13 +39,12 @@ interface PublishedEntry extends Omit<GalleryEntry, 'video' | 'codeLocal'> {
   studioUrl: string;
 }
 
-// Per-tile GLB budget for the gallery 3D preview. This is a load-time budget,
-// not a correctness gate — it keeps tiles snappy. Detailed hero mechanisms
-// (e.g. the 95-body spice-dispenser carousel at ~565 KB) legitimately exceed
-// the original 500 KB; 768 KB stays comfortably under the entry's own video
-// payload (~630 KB) while leaving headroom. Revisit with mesh quantization /
-// Draco if tiles ever feel heavy.
-const GLB_SIZE_HARD_CAP = 768_000;
+// Per-tile GLB budget for the gallery 3D preview — a load-time budget that
+// keeps tiles snappy. Held at 500 KB: vertex welding in exportGlb (lossless
+// dedup of OCCT's per-face boundary duplicates) keeps even the 95-body
+// spice-dispenser carousel under it (~452 KB). Next lever if tiles ever grow:
+// mesh quantization / Draco.
+const GLB_SIZE_HARD_CAP = 500_000;
 const STUDIO_ORIGIN = 'https://app.kernelcad.com';
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 /**


### PR DESCRIPTION
## What

OCCT meshes each face independently, so a shape's exported GLB carried **duplicate vertices at every shared edge** (coordinate-equal, index-distinct). This welds them with three's `mergeVertices` in `exportGlb`'s single mesh funnel.

- **Lossless** — hard edges stay split because their differing normals block the merge, so shading is unchanged.
- Restores `GLB_SIZE_HARD_CAP` to **500 KB** (it was bumped to 768 KB in #469 only to fit the un-welded spice GLB).

## Measured (gallery corpus)

| tile | before | after |
|---|---|---|
| spice-dispenser-carousel (95 bodies) | 564,924 | **452,548** (−20%) |

Every tile shrinks; smaller payloads → faster Studio first paint.

## Verification
- Full gallery build passes at the 500 KB cap; `exportGlb` tests 4/4 green; typecheck clean.

## Context
First of the "highest-return CAD optimizations." The mesh path is already fairly tuned (relative deflection on export, preview-grade tolerances, per-part mesh reuse, source-hash mesh cache), so the bigger remaining levers are GLB/bridge **quantization** (needs a viewer-side decoder) and cross-process mesh caching — tracked separately.