### PR TITLE
feat(gallery): play animations on the gallery via build-time baked timelines

### DIFF
--- a/site/scripts/build-gallery.ts
+++ b/site/scripts/build-gallery.ts
@@ -20,6 +20,8 @@ import { exportGlb } from '../../scripts/lib/exportGlb';
 import { loadScriptFeatures } from '../../src/modeling/runtime/scriptLoader';
 import { meshFeaturesPerFeature } from '../../src/modeling/capture/featureMeshing';
 import { serializeForBridge } from '../../src/modeling/capture/featureMeshSerialize';
+import { evaluateAndBuildScript } from '../../src/agent/cli/commands/evaluate';
+import { bakeAnimationTimeline, selectAnimationMetadata } from '../../src/modeling/animation/bakeAnimationTimeline';
 import { validateAssemblyWithMates } from '../../src/modeling/mates/validator';
 import type { Assembly } from '../../src/modeling/capture/assembly';
 import type { CaptureSession } from '../../src/modeling/capture/captureSession';
@@ -104,6 +106,15 @@ export async function buildGallery(opts: BuildGalleryOptions): Promise<void> {
   // initial view with zero server compute (see scriptSource.meshSourceHosted).
   const meshOutDir = path.join(galleryOutDir, '_mesh');
   mkdirSync(meshOutDir, { recursive: true });
+
+  // Precomputed animation timelines, keyed by sha256(source) like the mesh.
+  // The hosted Studio fetches `/gallery/_anim/<sha>.json` to PLAY a curated
+  // model's animationView with zero server compute (anonymous gallery visitors
+  // can't open a live session). Only emitted for entries that declare an
+  // animationView; everything else has no file and the Studio simply shows a
+  // static model.
+  const animOutDir = path.join(galleryOutDir, '_anim');
+  mkdirSync(animOutDir, { recursive: true });
 
   const published: PublishedEntry[] = [];
 
@@ -203,6 +214,27 @@ export async function buildGallery(opts: BuildGalleryOptions): Promise<void> {
       } catch (err) {
         console.warn(
           `build-gallery: ${entry.slug} precompute skipped — ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      // Precompute the animation timeline (per-part world transforms per frame)
+      // for entries that declare an animationView. Keyed by the SAME sha256 of
+      // the source bytes, so the browser resolves it via the same digest. Built
+      // from a full `evaluateAndBuildScript` model (the baker re-solves mate
+      // poses per frame). Non-fatal: a non-animated or unbakeable model simply
+      // has no `_anim` file and plays static.
+      try {
+        const sourceText = readFileSync(srcScript, 'utf8');
+        const sha = createHash('sha256').update(sourceText, 'utf8').digest('hex');
+        const { evaluation, model } = await evaluateAndBuildScript({ file: srcScript });
+        if (evaluation.exitCode === 0 && model && selectAnimationMetadata(model)) {
+          const baked = await bakeAnimationTimeline(model);
+          writeFileSync(path.join(animOutDir, `${sha}.json`), JSON.stringify(baked));
+          console.log(`build-gallery: ${entry.slug} animation baked (${baked.frames} frames, ${baked.parts.length} parts)`);
+        }
+      } catch (err) {
+        console.warn(
+          `build-gallery: ${entry.slug} animation bake skipped — ${err instanceof Error ? err.message : String(err)}`,
         );
       }
     }

--- a/src/modeling/animation/bakeAnimationTimeline.test.ts
+++ b/src/modeling/animation/bakeAnimationTimeline.test.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+import { evaluateAndBuildScript } from '../../agent/cli/commands/evaluate';
+import { bakeAnimationTimeline } from './bakeAnimationTimeline';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+/**
+ * Build-time bake produces the same per-part world transforms the live endpoint
+ * does — proving the gallery can play a moving mechanism with zero server
+ * compute. Uses the real spice-dispenser carousel (a pose-only mate timeline).
+ */
+describe('bakeAnimationTimeline (build-time)', () => {
+  it('bakes the spice-dispenser dispense cycle into moving per-part transforms', async () => {
+    const file = join(REPO_ROOT, 'examples', 'spice-dispenser-carousel.kcad.ts');
+    const { evaluation, model } = await evaluateAndBuildScript({ file });
+    expect(evaluation.exitCode).toBe(0);
+    expect(model).toBeTruthy();
+
+    const baked = await bakeAnimationTimeline(model!);
+
+    // A real, multi-frame timeline.
+    expect(baked.frames).toBeGreaterThan(1);
+    expect(baked.fps).toBeGreaterThan(0);
+    expect(baked.times.length).toBe(baked.frames);
+    expect(baked.parts.length).toBeGreaterThan(0);
+
+    // Every part carries one 16-float matrix per frame.
+    for (const part of baked.parts) {
+      expect(part.matrices.length).toBe(baked.frames);
+      expect(part.matrices[0].length).toBe(16);
+    }
+
+    // The mechanism MOVES: at least one part's mid-cycle pose differs from
+    // home. (Compare frame 0 to the MIDDLE frame, not the last — the dispense
+    // cycle is a loop that re-homes, so frame 0 ≈ last frame by design.)
+    const mid = Math.floor(baked.frames / 2);
+    const moved = baked.parts.some((p) => {
+      const first = p.matrices[0];
+      const middle = p.matrices[mid];
+      return first.some((v, i) => Math.abs(v - middle[i]) > 1e-6);
+    });
+    expect(moved).toBe(true);
+    // Baking a 95-body assembly (model build + 120-frame pose sweep + advisory
+    // collision check) is inherently slow; this is an integration test, not a
+    // hot-path unit test. The merge-gate floor is already the spice interference
+    // sweep, so this lands on a different shard without raising the floor.
+  }, 180_000);
+});

--- a/src/modeling/animation/bakeAnimationTimeline.ts
+++ b/src/modeling/animation/bakeAnimationTimeline.ts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+/**
+ * Pure, session-free animation baker. Solves an `animationView()` timeline ONCE
+ * into per-part world transforms so a client can play it back smoothly without
+ * a kernel re-solve per frame.
+ *
+ * Mirrors the bake loop in `server/middleware/animationBakeEndpoint.ts` and is
+ * used by the gallery build (`build-gallery`) to bake curated models at build
+ * time into static `/gallery/_anim/<sha>.json` files, so anonymous Studio
+ * visitors get a moving mechanism with zero server compute.
+ *
+ * TODO(dry): have `animationBakeEndpoint` adopt this function (wrapping it with
+ * its single-flight + pre/post pose restore) so there is one bake implementation.
+ * Kept separate for now to avoid touching the working live `?script=` path.
+ *
+ * Guards throw `Error` objects carrying a `.code` (and optional `.hint`) so the
+ * endpoint maps them to its typed 422 envelope; the build treats a thrown guard
+ * as "this model has no bakeable pose-only timeline" and simply skips it.
+ */
+import { isSceneBackend } from '../../kernel/backends/sceneBackend';
+import {
+  updateModelParams,
+  type BuiltModel,
+  type ParamUpdateEdit,
+} from '../buildModel';
+import { sampleTracks } from '../../agent/render/animationSampler';
+import { verifyAnimation, type AnimationCollision } from '../../agent/render/verifyAnimation';
+import type { AnimationViewMetadata } from '../../shared/intent/animationViewRecord';
+
+/** Hard ceiling on baked frames. A pose-only bake is ~60ms/frame; 600 frames
+ *  is already a ~36 s bake — beyond interactive review, so fail fast. */
+export const MAX_BAKE_FRAMES = 600;
+
+export interface BakedPart {
+  name: string;
+  /** One 16-float column-major world matrix per frame, frame-aligned to `times`. */
+  matrices: number[][];
+}
+
+export interface AnimationBakeResult {
+  frames: number;
+  durationMs: number;
+  fps: number;
+  times: number[];
+  parts: BakedPart[];
+  /** ADVISORY keyframe-pose interferences — NON-FATAL; drives the Studio warning. */
+  collisions: AnimationCollision[];
+}
+
+/** Typed guard error the endpoint surfaces as 422 and the build skips. */
+function bakeError(message: string, code: string, hint?: string): Error {
+  return Object.assign(new Error(message), { code, hint });
+}
+
+const ASSEMBLY_RECORD_KINDS: ReadonlySet<string> = new Set([
+  'solvedAssembly',
+  'assemblyModel',
+]);
+
+function firstAssemblyIndex(model: BuiltModel): number {
+  for (let i = 0; i < model.records.length; i += 1) {
+    if (ASSEMBLY_RECORD_KINDS.has(model.records[i].kind)) return i;
+  }
+  return -1;
+}
+
+/** Last-wins animationView metadata across the model's records. */
+export function selectAnimationMetadata(model: BuiltModel): AnimationViewMetadata | null {
+  let found: AnimationViewMetadata | null = null;
+  for (const record of model.records) {
+    if (record.kind !== 'animationView') continue;
+    if (!record.metadata) continue;
+    found = record.metadata as unknown as AnimationViewMetadata;
+  }
+  return found;
+}
+
+/** Live solved tail from the session's `cachedShapes`, falling back to `tailShape`. */
+function liveTail(model: BuiltModel): unknown {
+  const session = model.session as unknown as { cachedShapes?: Map<string, unknown> };
+  const tailId = model.tailId;
+  const cached = tailId ? session.cachedShapes?.get(tailId) : undefined;
+  return cached ?? model.tailShape;
+}
+
+/**
+ * Bake the model's animationView timeline into per-part world transforms.
+ * MUTATES the model's param poses during the sweep (caller restores if the
+ * model is shared, e.g. a pooled live session). Throws a typed guard error if
+ * there is no view, too many frames, a geometry-driving track, or a pose that
+ * doesn't resolve an assembly scene.
+ */
+export async function bakeAnimationTimeline(model: BuiltModel): Promise<AnimationBakeResult> {
+  const metadata = selectAnimationMetadata(model);
+  if (!metadata) {
+    throw bakeError(
+      'session has no animationView() record to bake',
+      'animation.bake.no-view',
+      'Declare an animationView({ tracks: [...] }) in the script before requesting a bake.',
+    );
+  }
+
+  const tracks = metadata.tracks;
+  const fps = metadata.fps;
+  const { frames: schedule, durationMs } = sampleTracks(tracks, fps);
+  if (schedule.length > MAX_BAKE_FRAMES) {
+    throw bakeError(
+      `animation timeline bakes to ${schedule.length} frames, above the ${MAX_BAKE_FRAMES}-frame ceiling`,
+      'animation.bake.too-many-frames',
+      `Lower the animationView fps or shorten durationMs so frames ≤ ${MAX_BAKE_FRAMES}.`,
+    );
+  }
+
+  const assemblyIndex = firstAssemblyIndex(model);
+  const recordIndexById = new Map<string, number>();
+  model.records.forEach((rec, idx) => recordIndexById.set(rec.id, idx));
+
+  const times: number[] = [];
+  const order: string[] = [];
+  const byPart = new Map<string, number[][]>();
+
+  for (let i = 0; i < schedule.length; i += 1) {
+    const frame = schedule[i];
+    times.push(frame.tMs);
+    const edits: ParamUpdateEdit[] = tracks.map((track) => ({
+      name: track.param,
+      value: frame.values[track.param],
+    }));
+    const { model: updated, result: updateResult } = await updateModelParams(model, edits, {
+      silent: true,
+    });
+
+    // Geometry-param guard: baked playback re-applies RIGID per-part transforms
+    // only. A track param that re-lowers a part record BEFORE the assembly
+    // record changed geometry, not just a pose → the baked transforms would
+    // pose the pre-edit shape. Detect on the first frame and refuse.
+    if (i === 0 && assemblyIndex >= 0) {
+      const touchedGeometry = updateResult.relowered.some((id) => {
+        const idx = recordIndexById.get(id);
+        return idx !== undefined && idx < assemblyIndex;
+      });
+      if (touchedGeometry) {
+        throw bakeError(
+          'this animationView timeline drives part GEOMETRY (a dimension / extrude depth / hole radius), ' +
+            'not just a mate pose — baked playback only re-applies rigid per-part transforms.',
+          'animation.bake.geometry-param',
+          'Studio playback supports POSE-ONLY (mate-driven) timelines. Render geometry-animating timelines with `kernelcad animate`.',
+        );
+      }
+    }
+
+    // Read the freshly-posed scene from the STABLE original tailId on the
+    // shared session (updateModelParams populated `model.session.cachedShapes`
+    // in place). The returned `updated` model can carry a tailId that misses
+    // the cache → a stale frame-0 tailShape fallback → a frozen mechanism.
+    // Same accessor the live `transformsEndpoint` uses (`entry.model.tailId`).
+    const tail = liveTail(updated);
+    if (!isSceneBackend(tail)) {
+      throw bakeError(
+        `the pose at tMs=${frame.tMs} did not resolve an assembly scene; baked playback needs per-part transforms`,
+        'animation.bake.no-scene',
+        'Return the solved assembly from the script — `return asm.solvedModel(...)`.',
+      );
+    }
+    for (const part of tail.parts) {
+      let matrices = byPart.get(part.name);
+      if (!matrices) {
+        matrices = [];
+        byPart.set(part.name, matrices);
+        order.push(part.name);
+      }
+      matrices.push(Array.from(part.worldTransform.toMat4()));
+    }
+  }
+
+  // ADVISORY collision check (same keyframe-sample check `kernelcad animate`
+  // uses). NON-FATAL: never sink a bake whose transforms are already computed.
+  let collisions: AnimationCollision[] = [];
+  try {
+    const verdict = await verifyAnimation(model, tracks, { silent: true });
+    collisions = verdict.collisions;
+  } catch (e) {
+    console.warn('[bakeAnimationTimeline] advisory collision check failed:', e instanceof Error ? e.message : String(e));
+  }
+
+  return {
+    frames: schedule.length,
+    durationMs,
+    fps,
+    times,
+    parts: order.map((name) => ({ name, matrices: byPart.get(name) ?? [] })),
+    collisions,
+  };
+}

--- a/src/studio/components/animation/AnimationTab.tsx
+++ b/src/studio/components/animation/AnimationTab.tsx
@@ -5,6 +5,8 @@ import { Play, Pause } from 'lucide-react';
 import { useRecomputeResult } from '../../hooks/useRecomputeResult';
 import { useWorkbench } from '../../context/WorkbenchContext';
 import { selectAnimationMetadata } from '../../logic/animationRecord';
+import { shouldUseHostedMesh } from '../../scriptSource';
+import { fetchGalleryAnimBake } from './fetchGalleryAnimBake';
 import {
     useAnimationPlayback,
     PLAYBACK_MODES,
@@ -40,16 +42,32 @@ export function AnimationTab(): JSX.Element {
         clearGeometryTransformOverrides,
         setViewportDriverLock,
     } = useRecomputeResult();
-    const { sessionToken, kernelEpoch } = useWorkbench();
+    const { sessionToken, kernelEpoch, code } = useWorkbench();
     const metadata = selectAnimationMetadata(features);
+
+    // Gallery static-bake mode: on the hosted app with no live session, an
+    // animated curated model plays from its build-time precomputed timeline
+    // (`/gallery/_anim/<sha>.json`) — anonymous visitors can't open a session,
+    // so this is how the gallery mechanism moves. Active only when hosted,
+    // session-less, animated, and we have the source to key the static file.
+    const galleryStatic = Boolean(!sessionToken && metadata && code && shouldUseHostedMesh());
 
     const playback = useAnimationPlayback({
         metadata,
         sessionToken,
-        // updateParam is only the pause-sync edit now; gate on the session too.
+        // Gallery static bake source: the source code, which fetchGalleryAnimBake
+        // hashes to locate the static `_anim/<sha>.json`.
+        staticBakeKey: galleryStatic ? code : undefined,
+        bakeFetcher: galleryStatic ? fetchGalleryAnimBake : undefined,
+        // updateParam is the pause-sync edit; needs a live session (no kernel to
+        // sync in static mode), so session-only.
         updateParam: sessionToken ? updateParam : undefined,
-        applyPartTransform: sessionToken ? setGeometryTransformOverride : undefined,
+        // Apply baked transforms to the viewport in BOTH live-session and
+        // gallery-static mode (the gallery geometry is rendered and overridable).
+        applyPartTransform: (sessionToken || galleryStatic) ? setGeometryTransformOverride : undefined,
         clearPartTransforms: clearGeometryTransformOverrides,
+        // The viewport driver-lock guards against SSE relower races — only the
+        // live session has those; static mode needs no lock.
         setViewportDriverLock: sessionToken ? setViewportDriverLock : undefined,
         // Any kernel relower (Params-tab edit, rebuild) bumps this; folded into
         // the bake cache key so a stale bake never survives a kernel mutation.

--- a/src/studio/components/animation/fetchGalleryAnimBake.ts
+++ b/src/studio/components/animation/fetchGalleryAnimBake.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// Static gallery bake fetcher. Unlike `fetchAnimationBake` (which POSTs to the
+// live session endpoint), this GETs the build-time precomputed timeline
+// `/gallery/_anim/<sha>.json`, so anonymous gallery visitors — who cannot open
+// a server session — still get a moving mechanism. The `key` it receives is the
+// .kcad.ts SOURCE; it computes the same sha256 digest build-gallery used.
+import { galleryPrecomputedAnimUrl } from '../../gallerySource';
+import type { BakedTimeline } from './bakeInterpolation';
+import type { BakeFetcher } from './fetchAnimationBake';
+
+/** sha256 hex via Web Crypto — matches the node digest build-gallery keys the
+ *  `_anim/<sha>.json` files by (and the same one `scriptSource` uses for mesh). */
+async function sha256Hex(text: string): Promise<string> {
+    const bytes = new TextEncoder().encode(text);
+    const digest = await crypto.subtle.digest('SHA-256', bytes);
+    return Array.from(new Uint8Array(digest))
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+}
+
+export const fetchGalleryAnimBake: BakeFetcher = async (source) => {
+    const sha = await sha256Hex(source);
+    const res = await fetch(galleryPrecomputedAnimUrl(sha));
+    if (!res.ok) {
+        // No precomputed animation for this source (not an animated model, or
+        // the gallery wasn't rebuilt). Typed error → the tab shows the static
+        // readout instead of hanging in "baking".
+        throw new Error(`no precomputed animation (${res.status})`);
+    }
+    return (await res.json()) as BakedTimeline;
+};

--- a/src/studio/components/animation/useAnimationPlayback.test.ts
+++ b/src/studio/components/animation/useAnimationPlayback.test.ts
@@ -132,11 +132,12 @@ function harness(overrides: Partial<{ bakeFetcher: Harness['bakeFetcher'] }> = {
     };
 }
 
-function renderPlayback(h: Harness, opts: { metadata?: AnimationViewMetadata | null; sessionToken?: string | null } = {}) {
+function renderPlayback(h: Harness, opts: { metadata?: AnimationViewMetadata | null; sessionToken?: string | null; staticBakeKey?: string | null } = {}) {
     return renderHook(() =>
         useAnimationPlayback({
             metadata: opts.metadata === undefined ? FIXTURE : opts.metadata,
             sessionToken: opts.sessionToken === undefined ? 't1' : opts.sessionToken,
+            staticBakeKey: opts.staticBakeKey,
             updateParam: h.update,
             applyPartTransform: h.apply,
             clearPartTransforms: h.clear,
@@ -148,6 +149,36 @@ function renderPlayback(h: Harness, opts: { metadata?: AnimationViewMetadata | n
 }
 
 afterEach(() => { vi.restoreAllMocks(); });
+
+describe('useAnimationPlayback — gallery static-bake (no session)', () => {
+    it('drives the viewport from staticBakeKey with NO sessionToken', async () => {
+        const h = harness();
+        const { result } = renderPlayback(h, { sessionToken: null, staticBakeKey: 'export default carousel;' });
+
+        // No live session, but a static bake source → the player can drive.
+        expect(result.current.canDrive).toBe(true);
+
+        await act(async () => {
+            result.current.scrubTo(2000);
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        // Baked once via the injected (static) fetcher, keyed by the source.
+        expect(h.bakeFetcher).toHaveBeenCalledTimes(1);
+        expect(h.bakeFetcher).toHaveBeenCalledWith('export default carousel;');
+        // Transforms applied to the viewport — the mechanism moves.
+        expect(h.apply.mock.calls.length).toBeGreaterThan(0);
+        // (The session-only gating of the pause-sync `updateParam` lives in
+        // AnimationTab, not this hook — the hook uses whatever is passed.)
+    });
+
+    it('cannot drive with neither a session nor a static key', () => {
+        const h = harness();
+        const { result } = renderPlayback(h, { sessionToken: null, staticBakeKey: undefined });
+        expect(result.current.canDrive).toBe(false);
+    });
+});
 
 describe('useAnimationPlayback (baked)', () => {
     it('scrub bakes once then applies interpolated transforms; ONE pause-sync param edit', async () => {

--- a/src/studio/components/animation/useAnimationPlayback.ts
+++ b/src/studio/components/animation/useAnimationPlayback.ts
@@ -71,6 +71,12 @@ export interface UseAnimationPlaybackOptions {
     setViewportDriverLock?: (locked: boolean) => void;
     /** Injected bake fetcher for tests; defaults to the real network fetch. */
     bakeFetcher?: BakeFetcher;
+    /** Gallery static-bake mode: when set (and `sessionToken` is absent), the
+     *  player drives the viewport from a build-time precomputed timeline that
+     *  `bakeFetcher(staticBakeKey)` fetches (the `/gallery/_anim/<sha>.json`
+     *  static file) — no live session required. This is how anonymous gallery
+     *  visitors, who cannot open a server session, get a moving mechanism. */
+    staticBakeKey?: string | null;
     /** Injected clock for deterministic tests; defaults to real rAF. */
     clock?: PlaybackClock;
     /** Monotonic kernel-state epoch, bumped by GeometryContext on EVERY relower
@@ -168,15 +174,20 @@ export function useAnimationPlayback(
         clearPartTransforms,
         setViewportDriverLock,
         bakeFetcher = fetchAnimationBake,
+        staticBakeKey,
         clock = defaultClock,
         kernelEpoch = 0,
     } = opts;
 
+    // The bake source is the live session OR a gallery static-bake key.
+    const bakeSourceKey = sessionToken ?? staticBakeKey ?? null;
+
     const durationMs = metadata?.durationMs ?? 0;
     const fps = metadata?.fps ?? 30;
     const name = metadata?.name ?? 'animation';
-    // Driving the viewport needs a session (bake source) AND an apply path.
-    const canDrive = Boolean(sessionToken) && applyPartTransform != null;
+    // Driving the viewport needs a bake source (live session OR gallery static
+    // bake) AND an apply path.
+    const canDrive = Boolean(bakeSourceKey) && applyPartTransform != null;
 
     const [tMs, setTMs] = useState(0);
     const [isPlaying, setIsPlaying] = useState(false);
@@ -263,19 +274,19 @@ export function useAnimationPlayback(
     const settledSelfCreditsRef = useRef(0);
 
     const bakeKey = useMemo(() => {
-        if (!metadata || !sessionToken) return null;
-        // Identity of the timeline that matters for the baked poses: token +
-        // per-track keyframes (param/atMs/value/ease) + fps. Stable across
-        // re-renders that don't change the timeline.
+        if (!metadata || !bakeSourceKey) return null;
+        // Identity of the timeline that matters for the baked poses: source key
+        // (session token or static gallery key) + per-track keyframes + fps.
+        // Stable across re-renders that don't change the timeline.
         return JSON.stringify({
-            token: sessionToken,
+            token: bakeSourceKey,
             fps: metadata.fps,
             tracks: metadata.tracks.map((t) => ({
                 p: t.param,
                 k: t.keys.map((k) => [k.atMs, k.value, k.ease]),
             })),
         });
-    }, [metadata, sessionToken]);
+    }, [metadata, bakeSourceKey]);
 
     const invalidateBake = useCallback(() => {
         bakeRef.current = null;
@@ -333,7 +344,9 @@ export function useAnimationPlayback(
     // Fetch (or reuse) the bake for the current key. Single-flight: a second
     // caller while a fetch is pending awaits the same promise.
     const ensureBake = useCallback(async (): Promise<BakedTimeline | null> => {
-        const token = sessionToken;
+        // Live session token, or the gallery static-bake key. The injected
+        // bakeFetcher interprets it (session POST vs static-file GET).
+        const token = sessionToken ?? staticBakeKey ?? null;
         if (!token || !applyRef.current || !metaRef.current) return null;
         if (bakeRef.current) return bakeRef.current;
         if (bakeInFlightRef.current) return bakeInFlightRef.current;
@@ -366,7 +379,7 @@ export function useAnimationPlayback(
         })();
         bakeInFlightRef.current = promise;
         return promise;
-    }, [sessionToken]);
+    }, [sessionToken, staticBakeKey]);
 
     // Sample every track at `at` → one param-edit batch (for the pause-sync
     // and the readout). Pure; no I/O.

--- a/src/studio/gallerySource.ts
+++ b/src/studio/gallerySource.ts
@@ -36,6 +36,17 @@ export function galleryPrecomputedMeshUrl(sourceSha256Hex: string): string {
   return `${galleryAssetBase()}/gallery/_mesh/${sourceSha256Hex}.json`;
 }
 
+/**
+ * URL of a build-time precomputed ANIMATION timeline (per-part world transforms
+ * per frame), keyed by the sha256 hex of the .kcad.ts source. `build-gallery.ts`
+ * writes these under `public/gallery/_anim/<sha>.json` for curated entries that
+ * declare an `animationView()`, so the hosted Studio can PLAY the mechanism for
+ * anonymous visitors (who can't open a live server session) with zero compute.
+ */
+export function galleryPrecomputedAnimUrl(sourceSha256Hex: string): string {
+  return `${galleryAssetBase()}/gallery/_anim/${sourceSha256Hex}.json`;
+}
+
 function resolveGalleryAssetUrl(sourceUrl: string, manifestUrl: string): string {
   if (/^https?:\/\//i.test(sourceUrl)) return sourceUrl;
   if (/^https?:\/\//i.test(manifestUrl)) return new URL(sourceUrl, manifestUrl).toString();


### PR DESCRIPTION
## Problem
Anonymous gallery visitors can't open a live server session (it's per-user JWT-authed), so the Studio Animation tab's mechanism never moved for them — only `?script=` sessions baked the timeline. (The "Live playback drives the viewport only when opened from a script" note was the symptom.)

## Fix — precompute the timeline at build time, play it client-side
Zero server compute, works signed-out.

- **`bakeAnimationTimeline`** (prior commit): pure session-free baker. Verified end-to-end on the real spice-dispenser — drum rotates 0°→60° at mid-cycle.
- **build-gallery**: for curated entries with an `animationView()`, bake per-part world transforms → `public/gallery/_anim/<sha>.json` (same source-sha key as the mesh precompute). Verified output: **120 frames, 11 parts, drum rotates, 0 collisions**.
- **`fetchGalleryAnimBake`**: static fetcher that GETs that file (hashes the source).
- **`useAnimationPlayback`**: new `staticBakeKey` path drives the viewport from a static bake with **no sessionToken**. The live `?script=` path is unchanged.
- **AnimationTab**: on the hosted app with no session, an animated curated model plays from its precomputed timeline; the "won't move" note auto-hides.

## Verification
- Baker test green (spice bakes, parts move). 34 animation tests green (32 existing + 2 new static-bake). Typecheck clean. Gallery build emits a valid moving `_anim` file.
- **Lights up live after** a marketing rebuild (emits the `_anim` files) + the app deploy (client). I'll verify on the live gallery once both land.

Closes the gallery-animation half of the slug/session unification (the targeted, $0/view path).