### PR TITLE
Studio: owner privacy toggle on /p/:slug

### DIFF
--- a/src/funnel/lib/apiClient.test.ts
+++ b/src/funnel/lib/apiClient.test.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getSessionMock = vi.fn();
+const getSupabaseMock = vi.fn(() => ({ auth: { getSession: getSessionMock } }));
+
+vi.mock('./supabaseClient', () => ({ getSupabase: () => getSupabaseMock() }));
+
+import { setProjectPrivacy, PRIVATE_REQUIRES_PAID } from './apiClient';
+
+describe('setProjectPrivacy', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    getSessionMock.mockReset();
+    getSupabaseMock.mockReturnValue({ auth: { getSession: getSessionMock } });
+    getSessionMock.mockResolvedValue({ data: { session: { access_token: 'tok-1' } } });
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.kernelcad.com');
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('PATCHes the privacy endpoint with a bearer token and returns the new privacy', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ privacy: 'private' }),
+    });
+
+    await expect(setProjectPrivacy('slug-1', 'private')).resolves.toEqual({ privacy: 'private' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.kernelcad.com/api/v1/projects/slug-1/privacy');
+    expect(init.method).toBe('PATCH');
+    expect(init.headers.Authorization).toBe('Bearer tok-1');
+    expect(JSON.parse(init.body)).toEqual({ privacy: 'private' });
+  });
+
+  it('url-encodes the slug', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ privacy: 'public_unlisted' }) });
+    await setProjectPrivacy('a/b', 'public_unlisted');
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://api.kernelcad.com/api/v1/projects/a%2Fb/privacy');
+  });
+
+  it('surfaces the PRIVATE_REQUIRES_PAID code in the thrown error on 403', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      text: async () => JSON.stringify({ error: PRIVATE_REQUIRES_PAID }),
+    });
+
+    await expect(setProjectPrivacy('slug-1', 'private')).rejects.toThrow(PRIVATE_REQUIRES_PAID);
+  });
+});

--- a/src/funnel/lib/apiClient.ts
+++ b/src/funnel/lib/apiClient.ts
@@ -39,7 +39,7 @@ export async function fetchGeneration(genId: string): Promise<GenerationRow | nu
 // ---------------------------------------------------------------------------
 
 export async function authedFetch<T>(
-  method: 'GET' | 'POST',
+  method: 'GET' | 'POST' | 'PATCH',
   path: string,
   body?: unknown,
 ): Promise<T> {
@@ -90,6 +90,21 @@ export async function saveProject(input: SaveProjectInput): Promise<SaveProjectR
  *  user. `claimed` is false if it was already owned. */
 export async function claimProject(slug: string): Promise<{ claimed: boolean }> {
   return authedFetch<{ claimed: boolean }>('POST', `/api/v1/projects/${encodeURIComponent(slug)}/claim`, {});
+}
+
+/** Thrown when a free user tries to make a project private — the body text
+ *  authedFetch surfaces on a 403 carries this code. Lets the UI show an
+ *  upgrade CTA instead of a generic failure. */
+export const PRIVATE_REQUIRES_PAID = 'private_requires_paid_account';
+
+/** Owner-only privacy toggle (public_unlisted <-> private). Making a project
+ *  private is Pro-gated server-side; a 403 carrying PRIVATE_REQUIRES_PAID means
+ *  the caller needs to upgrade. */
+export async function setProjectPrivacy(
+  slug: string,
+  privacy: Extract<ProjectPrivacy, 'public_unlisted' | 'private'>,
+): Promise<{ privacy: Extract<ProjectPrivacy, 'public_unlisted' | 'private'> }> {
+  return authedFetch('PATCH', `/api/v1/projects/${encodeURIComponent(slug)}/privacy`, { privacy });
 }
 
 export interface ProjectRow {

--- a/src/studio/routes/p.$slug.tsx
+++ b/src/studio/routes/p.$slug.tsx
@@ -5,7 +5,14 @@ import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import App from '../App';
 import { SignInButton } from '../../funnel/components/SignInButton';
 import { useSession } from '../../funnel/hooks/useSession';
-import { fetchProjectBySlug, claimProject, type ProjectRow } from '../../funnel/lib/apiClient';
+import {
+  fetchProjectBySlug,
+  claimProject,
+  setProjectPrivacy,
+  createCheckoutSession,
+  PRIVATE_REQUIRES_PAID,
+  type ProjectRow,
+} from '../../funnel/lib/apiClient';
 import { shouldApplyProjectUpdate } from '../../funnel/lib/liveProject';
 
 export const Route = createFileRoute('/p/$slug')({
@@ -25,6 +32,8 @@ function ProjectPage() {
   const [err, setErr] = useState<string | null>(null);
   const [claimed, setClaimed] = useState(false);
   const [claiming, setClaiming] = useState(false);
+  const [privacyBusy, setPrivacyBusy] = useState(false);
+  const [upgradeNeeded, setUpgradeNeeded] = useState(false);
   const [liveCode, setLiveCode] = useState<string | undefined>();
   const [lastLiveUpdate, setLastLiveUpdate] = useState<Date | null>(null);
   const versionRef = useRef<number | null>(null);
@@ -83,6 +92,32 @@ function ProjectPage() {
     }
   }, [slug]);
 
+  // Owner-only privacy toggle: public_unlisted <-> private. Making a project
+  // private is Pro-gated server-side; a 403 surfaces the upgrade CTA instead.
+  const handleTogglePrivacy = useCallback(async () => {
+    setPrivacyBusy(true);
+    setUpgradeNeeded(false);
+    try {
+      const next = project?.privacy === 'private' ? 'public_unlisted' : 'private';
+      const { privacy } = await setProjectPrivacy(slug, next);
+      setProject(p => (p ? { ...p, privacy } : p));
+    } catch (e) {
+      if (String(e).includes(PRIVATE_REQUIRES_PAID)) setUpgradeNeeded(true);
+      // else: transient — leave the button available to retry.
+    } finally {
+      setPrivacyBusy(false);
+    }
+  }, [slug, project?.privacy]);
+
+  const handleUpgrade = useCallback(async () => {
+    try {
+      const { url } = await createCheckoutSession();
+      if (typeof window !== 'undefined') window.location.href = url;
+    } catch {
+      // Leave the button available to retry.
+    }
+  }, []);
+
   if (err) {
     return (
       <main className="min-h-screen bg-vellum font-sans p-8">
@@ -118,6 +153,8 @@ function ProjectPage() {
   // Anonymous (owner-less) projects — e.g. built by a web-Claude session via
   // open_in_studio — can be claimed: "sign in to save" → claim into your account.
   const isAnonymous = project.owner_id == null && !claimed;
+  const isOwner = !!session && project.owner_id != null && project.owner_id === session.user.id;
+  const isPrivate = project.privacy === 'private';
   const btnClass = 'inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap px-2.5 py-0.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 transition-colors';
 
   let headerRight: ReactNode = null;
@@ -136,6 +173,16 @@ function ProjectPage() {
     headerRight = (
       <button type="button" onClick={handleClaim} disabled={claiming} className={btnClass}>
         {claiming ? 'Saving…' : 'Save to my projects'}
+      </button>
+    );
+  } else if (isOwner) {
+    headerRight = upgradeNeeded ? (
+      <button type="button" onClick={handleUpgrade} className={btnClass} title="Private projects require Pro">
+        Upgrade to keep private
+      </button>
+    ) : (
+      <button type="button" onClick={handleTogglePrivacy} disabled={privacyBusy} className={btnClass}>
+        {privacyBusy ? '…' : isPrivate ? 'Make public' : 'Make private'}
       </button>
     );
   }


### PR DESCRIPTION
## What

Adds an owner-only privacy toggle to the project page, pairing with the server's new `PATCH /api/v1/projects/:slug/privacy` endpoint.

- `setProjectPrivacy()` API client (`PATCH`) + `PRIVATE_REQUIRES_PAID` export in `apiClient.ts`; widened `authedFetch` to allow `PATCH`.
- `/p/:slug`: when the signed-in user owns the project, a **Make private** / **Make public** button next to the privacy label. A free user's `403` swaps the button for an **Upgrade to keep private** CTA that opens Stripe checkout, rather than a dead error.

## Notes

- Owner detection: `session.user.id === project.owner_id`. The existing anonymous "Sign in to save" / "Save to my projects" flow is unchanged (owner and anonymous are mutually exclusive).
- Depends on the server PR (`kernelCAD-server` → `main`) for the endpoint.

## Tests

`src/funnel/lib/apiClient.test.ts` (3 cases): PATCHes the right URL with a bearer token + body, url-encodes the slug, surfaces `PRIVATE_REQUIRES_PAID` on 403. All passing; typecheck + lint clean.