### PR TITLE
Remove Clone-to-my-projects button from /p/:slug

### DIFF
--- a/src/funnel/lib/apiClient.test.ts
+++ b/src/funnel/lib/apiClient.test.ts
@@ -7,54 +7,7 @@ const getSupabaseMock = vi.fn(() => ({ auth: { getSession: getSessionMock } }));
 
 vi.mock('./supabaseClient', () => ({ getSupabase: () => getSupabaseMock() }));
 
-import { setProjectPrivacy, cloneProject, PRIVATE_REQUIRES_PAID } from './apiClient';
-
-describe('cloneProject', () => {
-  const fetchMock = vi.fn();
-
-  beforeEach(() => {
-    getSessionMock.mockReset();
-    getSupabaseMock.mockReturnValue({ auth: { getSession: getSessionMock } });
-    getSessionMock.mockResolvedValue({ data: { session: { access_token: 'tok-1' } } });
-    vi.stubEnv('VITE_API_BASE_URL', 'https://api.kernelcad.com');
-    vi.stubGlobal('fetch', fetchMock);
-    fetchMock.mockReset();
-  });
-
-  afterEach(() => {
-    vi.unstubAllEnvs();
-    vi.unstubAllGlobals();
-  });
-
-  it('POSTs the clone endpoint with a bearer token and returns the parsed body', async () => {
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ slug: 'cloned-slug', projectId: 'proj-9' }),
-    });
-
-    await expect(cloneProject('slug-1')).resolves.toEqual({
-      slug: 'cloned-slug',
-      projectId: 'proj-9',
-    });
-
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0]!;
-    expect(url).toBe('https://api.kernelcad.com/api/v1/projects/slug-1/clone');
-    expect(init.method).toBe('POST');
-    expect(init.headers.Authorization).toBe('Bearer tok-1');
-  });
-
-  it('url-encodes the slug', async () => {
-    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ slug: 'x', projectId: 'y' }) });
-    await cloneProject('a/b');
-    expect(fetchMock.mock.calls[0]![0]).toBe('https://api.kernelcad.com/api/v1/projects/a%2Fb/clone');
-  });
-
-  it('throws the response body on a non-2xx', async () => {
-    fetchMock.mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'boom' });
-    await expect(cloneProject('slug-1')).rejects.toThrow('boom');
-  });
-});
+import { setProjectPrivacy, PRIVATE_REQUIRES_PAID } from './apiClient';
 
 describe('setProjectPrivacy', () => {
   const fetchMock = vi.fn();

--- a/src/funnel/lib/apiClient.ts
+++ b/src/funnel/lib/apiClient.ts
@@ -92,13 +92,6 @@ export async function claimProject(slug: string): Promise<{ claimed: boolean }> 
   return authedFetch<{ claimed: boolean }>('POST', `/api/v1/projects/${encodeURIComponent(slug)}/claim`, {});
 }
 
-/** "Clone to my projects": copy a public project into a new project owned by
- *  the signed-in user. Returns the new project's slug + id so the caller can
- *  navigate to it. */
-export async function cloneProject(slug: string): Promise<{ slug: string; projectId: string }> {
-  return authedFetch('POST', `/api/v1/projects/${encodeURIComponent(slug)}/clone`);
-}
-
 /** Thrown when a free user tries to make a project private — the body text
  *  authedFetch surfaces on a 403 carries this code. Lets the UI show an
  *  upgrade CTA instead of a generic failure. */

--- a/src/studio/__tests__/ProjectViewerActions.test.tsx
+++ b/src/studio/__tests__/ProjectViewerActions.test.tsx
@@ -3,26 +3,9 @@
 /** @vitest-environment happy-dom */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type { Session } from '@supabase/supabase-js';
 import type { ProjectRow } from '../../funnel/lib/apiClient';
 
-const cloneProjectMock = vi.fn();
-
-vi.mock('../../funnel/lib/apiClient', () => ({
-  cloneProject: (slug: string) => cloneProjectMock(slug),
-}));
-
-// SignInButton pulls in the Supabase client; stub it to a plain button so the
-// anonymous affordance is renderable without auth wiring.
-vi.mock('../../funnel/components/SignInButton', () => ({
-  SignInButton: ({ children }: { children?: React.ReactNode }) => (
-    <button type="button">{children}</button>
-  ),
-}));
-
 import { ProjectViewerActions } from '../../studio/routes/-ProjectViewerActions';
-
-const fakeSession = { user: { id: 'u-1' } } as unknown as Session;
 
 function makeProject(overrides: Partial<ProjectRow> = {}): ProjectRow {
   return {
@@ -42,7 +25,6 @@ function makeProject(overrides: Partial<ProjectRow> = {}): ProjectRow {
 const writeText = vi.fn();
 
 beforeEach(() => {
-  cloneProjectMock.mockReset();
   writeText.mockReset();
   writeText.mockResolvedValue(undefined);
   Object.defineProperty(navigator, 'clipboard', {
@@ -55,14 +37,7 @@ afterEach(() => cleanup());
 
 describe('ProjectViewerActions', () => {
   it('writes the public /p/<slug> URL to the clipboard when Share is clicked', async () => {
-    render(
-      <ProjectViewerActions
-        slug="demo"
-        project={makeProject()}
-        session={null}
-        onNavigateToSlug={vi.fn()}
-      />,
-    );
+    render(<ProjectViewerActions slug="demo" project={makeProject()} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Share' }));
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
@@ -71,61 +46,9 @@ describe('ProjectViewerActions', () => {
   });
 
   it('disables Share for private projects with a make-public hint', () => {
-    render(
-      <ProjectViewerActions
-        slug="demo"
-        project={makeProject({ privacy: 'private' })}
-        session={fakeSession}
-        onNavigateToSlug={vi.fn()}
-      />,
-    );
+    render(<ProjectViewerActions slug="demo" project={makeProject({ privacy: 'private' })} />);
     const share = screen.getByRole('button', { name: 'Share' }) as HTMLButtonElement;
     expect(share.disabled).toBe(true);
     expect(share.title).toBe('Make this project public to share a link');
-  });
-
-  it('clones and navigates to the new slug when logged in', async () => {
-    cloneProjectMock.mockResolvedValue({ slug: 'demo-copy', projectId: 'p-2' });
-    const onNavigate = vi.fn();
-    render(
-      <ProjectViewerActions
-        slug="demo"
-        project={makeProject()}
-        session={fakeSession}
-        onNavigateToSlug={onNavigate}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole('button', { name: 'Clone to my projects' }));
-    await waitFor(() => expect(cloneProjectMock).toHaveBeenCalledWith('demo'));
-    await waitFor(() => expect(onNavigate).toHaveBeenCalledWith('demo-copy'));
-  });
-
-  it('shows "Sign in to clone" and does not clone when anonymous', () => {
-    render(
-      <ProjectViewerActions
-        slug="demo"
-        project={makeProject()}
-        session={null}
-        onNavigateToSlug={vi.fn()}
-      />,
-    );
-    expect(screen.getByText('Sign in to clone')).toBeTruthy();
-    expect(screen.queryByRole('button', { name: 'Clone to my projects' })).toBeNull();
-    expect(cloneProjectMock).not.toHaveBeenCalled();
-  });
-
-  it('surfaces an inline error when the clone call fails', async () => {
-    cloneProjectMock.mockRejectedValue(new Error('nope'));
-    render(
-      <ProjectViewerActions
-        slug="demo"
-        project={makeProject()}
-        session={fakeSession}
-        onNavigateToSlug={vi.fn()}
-      />,
-    );
-    fireEvent.click(screen.getByRole('button', { name: 'Clone to my projects' }));
-    await waitFor(() => expect(screen.getByText('Clone failed')).toBeTruthy());
   });
 });

--- a/src/studio/routes/-ProjectViewerActions.tsx
+++ b/src/studio/routes/-ProjectViewerActions.tsx
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import { useCallback, useState, type ReactNode } from 'react';
-import type { Session } from '@supabase/supabase-js';
-import { SignInButton } from '../../funnel/components/SignInButton';
-import { cloneProject, type ProjectRow } from '../../funnel/lib/apiClient';
+import type { ProjectRow } from '../../funnel/lib/apiClient';
 
 const BTN_CLASS =
   'inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap px-2.5 py-0.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50 transition-colors';
@@ -11,9 +9,6 @@ const BTN_CLASS =
 export interface ProjectViewerActionsProps {
   slug: string;
   project: ProjectRow;
-  session: Session | null;
-  /** Navigate to a project page by slug — wraps the router's navigate. */
-  onNavigateToSlug: (slug: string) => void;
 }
 
 function isPublic(privacy: ProjectRow['privacy']): boolean {
@@ -24,17 +19,13 @@ function isPublic(privacy: ProjectRow['privacy']): boolean {
   );
 }
 
-/** Share + Clone affordances rendered in the /p/:slug header's right slot,
- *  alongside the existing claim/save/privacy buttons. */
+/** Share affordance rendered in the /p/:slug header's right slot, alongside the
+ *  existing claim/save/privacy buttons. */
 export function ProjectViewerActions({
   slug,
   project,
-  session,
-  onNavigateToSlug,
 }: ProjectViewerActionsProps): ReactNode {
   const [copied, setCopied] = useState(false);
-  const [cloning, setCloning] = useState(false);
-  const [cloneErr, setCloneErr] = useState<string | null>(null);
 
   const sharePublic = isPublic(project.privacy);
 
@@ -49,18 +40,6 @@ export function ProjectViewerActions({
       // Clipboard blocked (permissions / insecure context) — leave label as-is.
     }
   }, [slug]);
-
-  const handleClone = useCallback(async () => {
-    setCloning(true);
-    setCloneErr(null);
-    try {
-      const result = await cloneProject(slug);
-      onNavigateToSlug(result.slug);
-    } catch (e) {
-      setCloneErr(e instanceof Error ? e.message : String(e));
-      setCloning(false);
-    }
-  }, [slug, onNavigateToSlug]);
 
   return (
     <div className="flex items-center gap-2 min-w-0">
@@ -77,25 +56,6 @@ export function ProjectViewerActions({
         >
           Share
         </button>
-      )}
-
-      {session ? (
-        <button type="button" onClick={handleClone} disabled={cloning} className={BTN_CLASS}>
-          {cloning ? 'Cloning…' : 'Clone to my projects'}
-        </button>
-      ) : (
-        <SignInButton
-          redirectTo={typeof window !== 'undefined' ? window.location.href : undefined}
-          className={BTN_CLASS}
-        >
-          Sign in to clone
-        </SignInButton>
-      )}
-
-      {cloneErr && (
-        <span className="text-[11px] text-copper font-mono whitespace-nowrap">
-          Clone failed
-        </span>
       )}
     </div>
   );

--- a/src/studio/routes/p.$slug.tsx
+++ b/src/studio/routes/p.$slug.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
-import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router';
 import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import App from '../App';
 import { SignInButton } from '../../funnel/components/SignInButton';
@@ -29,7 +29,6 @@ function formatPrivacyLabel(privacy: ProjectRow['privacy']): string {
 function ProjectPage() {
   const { slug } = Route.useParams();
   const { session } = useSession();
-  const navigate = useNavigate();
   const [project, setProject] = useState<ProjectRow | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [claimed, setClaimed] = useState(false);
@@ -110,13 +109,6 @@ function ProjectPage() {
       setPrivacyBusy(false);
     }
   }, [slug, project?.privacy]);
-
-  const handleNavigateToSlug = useCallback(
-    (target: string) => {
-      navigate({ to: '/p/$slug', params: { slug: target } });
-    },
-    [navigate],
-  );
 
   const handleUpgrade = useCallback(async () => {
     try {
@@ -202,8 +194,6 @@ function ProjectPage() {
       <ProjectViewerActions
         slug={slug}
         project={project}
-        session={session}
-        onNavigateToSlug={handleNavigateToSlug}
       />
     </div>
   );


### PR DESCRIPTION
## What

The `/p/:slug` viewer header was showing two redundant affordances — **Save to my projects** (claim, for anonymous projects) next to **Clone to my projects** — which do nearly the same thing. This removes the Clone affordance.

- `-ProjectViewerActions.tsx`: drop the Clone button + "Sign in to clone" fallback, `handleClone`, `cloning`/`cloneErr` state, and the now-unused `session` / `onNavigateToSlug` props and `SignInButton`/`cloneProject` imports. **Share button kept.**
- `p.$slug.tsx`: drop `useNavigate` + `handleNavigateToSlug` and the two removed props.
- `apiClient.ts`: remove the now-unused `cloneProject` client function.
- Tests: drop clone cases from `ProjectViewerActions.test.tsx` and `apiClient.test.ts` (Share + privacy tests kept).

Backend `POST /api/v1/projects/:slug/clone` is left intact (harmless, out of scope).

## Verification
typecheck clean; `ProjectViewerActions` + `apiClient` tests green (5); lint clean; no leftover clone references in `src/`.