### PR TITLE
Camera-fit tween yields to user input (fix unrotatable-on-load)

### DIFF
--- a/src/studio/components/viewer/controllers/CameraHandler.tsx
+++ b/src/studio/components/viewer/controllers/CameraHandler.tsx
@@ -124,6 +124,23 @@ export function CameraHandler({
         }
     }, [sketchMode, selectedFace, geometries, camera, controls]);
 
+    // Hand control to the user the instant they grab the camera. The fit/
+    // navigation tween below lerps the camera every frame until it converges
+    // (~seconds); without this, an orbit/pan/zoom during that window is fought
+    // by the lerp and feels unresponsive on first load. OrbitControls fires
+    // 'start' on pointer/touch down (user-initiated, not on programmatic
+    // update()), so cancelling the tween there yields immediately.
+    useEffect(() => {
+        const ctrl = controls as unknown as {
+            addEventListener?: (type: string, fn: () => void) => void;
+            removeEventListener?: (type: string, fn: () => void) => void;
+        } | null;
+        if (!ctrl?.addEventListener) return;
+        const onUserInteractStart = () => { targetState.current = null; };
+        ctrl.addEventListener('start', onUserInteractStart);
+        return () => ctrl.removeEventListener?.('start', onUserInteractStart);
+    }, [controls]);
+
     useFrame((_state, delta) => {
         if (!targetState.current) return;
         const dampFactor = 5.0 * delta;


### PR DESCRIPTION
## Problem

Right after opening a model in the viewer, you can't rotate it for a few seconds; then it suddenly becomes responsive.

## Root cause

`CameraHandler.tsx` runs a camera-fit (and view-navigation) tween: on geometry load it sets a target pose and `lerp`s `camera.position` + the OrbitControls target toward it **every frame** in `useFrame` until it converges (`dampFactor = 5.0`, ~3-5s on large bounds). Controls are technically enabled, but any user orbit during that window is overwritten by the lerp on the next frame — so it feels locked until the tween finishes (`targetState.current = null`).

## Fix

Cancel the in-flight tween the instant the user grabs the camera. OrbitControls fires `'start'` on pointer/touch down (user-initiated — not on the programmatic `update()` we call each frame), so a listener that clears `targetState.current` hands control to OrbitControls immediately. The auto-fit still runs normally when the user doesn't touch it — no regression to framing-on-load. Minimal, localized change (one `useEffect`).

## Verification

typecheck clean; lint clean; existing `CameraHandler`/`cameraPose` tests pass (5). The r3f component isn't unit-tested in this repo (useThree/useFrame), so the behavioral proof is interacting with the viewer — verify on the Pages preview: open a model and immediately drag; it should orbit with no dead window.