### PR TITLE
feat(parts): ingestion-at-scale pipeline + fetch-by-URL (Phase 1)

### DIFF
--- a/scripts/ingestParts.ts
+++ b/scripts/ingestParts.ts
@@ -36,6 +36,7 @@ import { join, relative, basename, extname, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
 import { inspectStepFile } from '../src/agent/inspect/inspectStep';
 import { synthesizeConnectorsFromReport } from '../src/modeling/parts/synthesizeConnectors';
+import { PAGES_WORKER } from './parts/workerTemplate';
 
 // -----------------------------------------------------------------------------
 // Types — the served record matches the remote adapter's StepPartsRecord shape.
@@ -217,47 +218,11 @@ export async function ingestDirectory(
   return records;
 }
 
-// A single advanced-mode Cloudflare Pages Worker (`_worker.js` at the deploy
-// root) implementing the two endpoints the remote adapter calls, over the
-// bundled static index. Advanced mode is used instead of a `functions/` route
-// because a `[[path]]` catch-all sharing the `/v1/parts` prefix with the static
-// per-part `.json` assets does not route reliably (static-asset precedence +
-// zero-segment catch-all both 404). The Worker intercepts `/v1/parts` itself and
-// passes everything else through to `env.ASSETS` (the .step / .json / index).
-// See remoteClient.ts for the contract.
-const PAGES_WORKER = `// SPDX-License-Identifier: MIT
-// Serves /v1/parts?q=... (search) and /v1/parts/{id} (detail) from the static
-// /v1/catalog/parts.index.json asset; all other paths fall through to static
-// assets. Deploy this directory to Cloudflare Pages and point
-// KERNELCAD_PARTS_BASE_URL at it.
-export default {
-  async fetch(request, env) {
-    const url = new URL(request.url);
-    const m = url.pathname.match(/^\\/v1\\/parts(?:\\/(.+))?$/);
-    if (!m) return env.ASSETS.fetch(request);
-
-    const idxReq = new Request(url.origin + '/v1/catalog/parts.index.json');
-    const res = await env.ASSETS.fetch(idxReq);
-    if (!res.ok) return new Response('catalog index unavailable', { status: 502 });
-    const items = (await res.json()).items;
-
-    const id = m[1] ? m[1].replace(/\\.json$/, '') : '';
-    if (id) {
-      const rec = items.find((r) => r.id === id);
-      return rec
-        ? Response.json(rec)
-        : new Response('not found', { status: 404 });
-    }
-    const q = (url.searchParams.get('q') || '').toLowerCase();
-    const hits = q
-      ? items.filter((r) =>
-          [r.id, r.name, ...(r.tags || [])].join(' ').toLowerCase().includes(q),
-        )
-      : items;
-    return Response.json({ items: hits, total: hits.length });
-  },
-};
-`;
+// The advanced-mode Cloudflare Pages Worker (`_worker.js`) is factored into
+// scripts/parts/workerTemplate.ts (PAGES_WORKER) so the registry-driven engine
+// and this directory-ingest CLI emit the same serving shim. It intercepts
+// `/v1/parts` itself and passes everything else (the .step / .json / index)
+// through to `env.ASSETS`. See remoteClient.ts for the contract.
 
 // -----------------------------------------------------------------------------
 // CLI

--- a/scripts/parts/contracts.ts
+++ b/scripts/parts/contracts.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/contracts.ts
+//
+// Shared seams for the parts ingestion-at-scale pipeline. The source registry,
+// the ingestion engine, the step.parts adapter, and the mirror store all build
+// against these interfaces so the pieces compose without coupling.
+
+import type {
+  LicenseClass,
+  RedistributionMode,
+  PartRecord,
+  UpstreamProvenance,
+} from '../../src/shared/parts/types';
+import type { PartCategory } from '../../src/shared/parts/taxonomy';
+
+/** Which ingest path a source uses. */
+export type IngestAdapter = 'step-passthrough' | 'step-parts' | 'github-glob';
+
+/** How a source's per-part license is resolved (when not uniform across the source). */
+export type PerPartLicenseMode = 'third-party-notices' | 'spdx-header';
+
+/** One entry in the source registry (the machine-readable form of the sweep). */
+export interface PartSourceEntry {
+  /** Stable id, e.g. 'step-parts', 'freecad-library', 'adafruit-cad'. */
+  id: string;
+  /** Canonical upstream URL. */
+  repo: string;
+  /** Pinned SHA / tag for reproducible ingest. */
+  commit: string;
+  licenseClass: LicenseClass;
+  redistribution: RedistributionMode;
+  /** SPDX id, or 'mixed-per-part' when resolved via perPartLicense. */
+  license: string;
+  /** Attribution applied to every part unless a per-part override exists. */
+  attribution: string;
+  adapter: IngestAdapter;
+  /** Path globs for STEP files within the source. */
+  include: string[];
+  exclude?: string[];
+  /** Upstream-dir → kernelCAD category hint; unmapped parts use keyword heuristics. */
+  categoryMap?: Record<string, PartCategory>;
+  /** How to resolve per-part licenses; null/undefined ⇒ use the source-level license. */
+  perPartLicense?: PerPartLicenseMode | null;
+  /** Requires legal sign-off before being served live (e.g. CC-BY-SA collections). */
+  legalHold?: boolean;
+}
+
+/**
+ * A part discovered by an adapter, BEFORE geometry-derived fields (sha256,
+ * connectors) are computed. The engine turns candidates into IngestedParts by
+ * fetching the STEP bytes, inspecting, synthesizing connectors, and mirroring.
+ * The bytes come from `stepUrl` (remote: step.parts / github-raw) or `stepPath`
+ * (a locally-cloned file).
+ */
+export interface PartCandidate {
+  id: string;
+  name: string;
+  category: PartCategory | string;
+  family: string;
+  standard?: string;
+  tags: string[];
+  attributes: Record<string, number | string>;
+  license: string;
+  licenseClass: LicenseClass;
+  attribution?: string;
+  redistribution: RedistributionMode;
+  upstream: UpstreamProvenance;
+  stepUrl?: string;
+  stepPath?: string;
+}
+
+/** A part produced by the ingestion engine: record + (for mirrored parts) STEP bytes. */
+export interface IngestedPart {
+  record: PartRecord;
+  /** Present only for redistribution:'mirror'; absent for fetch-only. */
+  stepBytes?: Uint8Array;
+}
+
+/**
+ * Pluggable, content-addressed mirror store. Local-fs impl for tests/dev,
+ * Cloudflare R2 impl for prod. Keyed by sha256 ⇒ automatic global dedup.
+ */
+export interface MirrorStore {
+  /** Idempotently store STEP bytes under the sha256 key; returns the public URL/key. */
+  put(sha256: string, bytes: Uint8Array): Promise<string>;
+  has(sha256: string): Promise<boolean>;
+}
+
+/** Per-source ingest accounting — surfaced in the run report, never silently dropped. */
+export interface IngestRunReport {
+  source: string;
+  ingested: number;
+  skippedUnparseable: number;
+  droppedForLicense: number;
+  deduped: number;
+  connectorless: number;
+  errors: string[];
+}

--- a/scripts/parts/engine.test.ts
+++ b/scripts/parts/engine.test.ts
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/engine.test.ts
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  candidatesFromSource,
+  ingestCandidate,
+  ingestFromRegistry,
+  verifyCatalog,
+  type IngestDeps,
+} from './engine';
+import type { PartSourceEntry, PartCandidate, MirrorStore } from './contracts';
+import type { StepInspectReport } from '../../src/agent/inspect/inspectStep';
+import type { AutoConnector } from '../../src/modeling/parts/holeAutoConnectors';
+import type { PartRecord } from '../../src/shared/parts/types';
+
+// --- In-memory mirror store ---------------------------------------------------
+
+class MemStore implements MirrorStore {
+  objects = new Map<string, Uint8Array>();
+  putCount = 0;
+  async put(sha256: string, bytes: Uint8Array): Promise<string> {
+    this.putCount++;
+    if (!this.objects.has(sha256)) this.objects.set(sha256, bytes);
+    return `mem://step/${sha256}.step`;
+  }
+  async has(sha256: string): Promise<boolean> {
+    return this.objects.has(sha256);
+  }
+}
+
+// --- Mocked geometry deps -----------------------------------------------------
+
+function reportWithSolids(n: number): StepInspectReport {
+  const solids = Array.from({ length: n }, (_, i) => ({
+    index: i,
+    name: null,
+    bboxExact: { min: [0, 0, 0] as [number, number, number], max: [10, 10, 10] as [number, number, number] },
+    volumeMm3: 1000,
+    faceCount: 6,
+    holes: [],
+  }));
+  return { file: 'mem', solidCount: n, solids };
+}
+
+const conn = (name: string): AutoConnector => ({
+  name,
+  ref: `ref:${name}`,
+  origin: [0, 0, 0],
+  axis: [0, 0, 1],
+  type: 'frame',
+});
+
+/** A deps that decides parse/connector behavior from the candidate id substring. */
+function makeDeps(): IngestDeps {
+  return {
+    inspectStep: async (_bytes, hint) => {
+      if (hint.includes('unparseable')) return reportWithSolids(0);
+      return reportWithSolids(2);
+    },
+    synthesizeConnectors: (_report, partName) => {
+      if (partName.includes('connectorless')) return [];
+      return [conn('mating-face'), conn('top-face')];
+    },
+  };
+}
+
+// --- Fixtures -----------------------------------------------------------------
+
+function makeCheckout(): { dir: string; source: PartSourceEntry } {
+  const dir = mkdtempSync(join(tmpdir(), 'kc-engine-'));
+  // gears/spur.step  → categoryMap should pick 'gear'
+  mkdirSync(join(dir, 'gears'), { recursive: true });
+  writeFileSync(join(dir, 'gears', 'spur-gear.step'), 'ISO-10303-21; gear');
+  // misc/widget.stp → no categoryMap match → guessCategory fallback
+  mkdirSync(join(dir, 'misc'), { recursive: true });
+  writeFileSync(join(dir, 'misc', 'mystery-widget.stp'), 'ISO-10303-21; widget');
+  // a non-STEP file that must be ignored
+  writeFileSync(join(dir, 'README.md'), '# readme');
+
+  const source: PartSourceEntry = {
+    id: 'fixture-src',
+    repo: 'github.com/example/fixture',
+    commit: 'deadbeef',
+    licenseClass: 'permissive',
+    redistribution: 'mirror',
+    license: 'MIT',
+    attribution: 'Example contributors',
+    adapter: 'github-glob',
+    include: ['**/*.step', '**/*.stp'],
+    categoryMap: { gears: 'gear' },
+  };
+  return { dir, source };
+}
+
+// --- Tests --------------------------------------------------------------------
+
+describe('candidatesFromSource (github-glob)', () => {
+  it('finds both STEP files with correct category/upstream/license', async () => {
+    const { dir, source } = makeCheckout();
+    const { candidates } = await candidatesFromSource(source, { checkoutDir: dir });
+
+    expect(candidates).toHaveLength(2);
+    const byPath = new Map(candidates.map((c) => [c.upstream.path, c]));
+
+    const gear = byPath.get('gears/spur-gear.step')!;
+    expect(gear.category).toBe('gear'); // from categoryMap top dir
+    expect(gear.license).toBe('MIT');
+    expect(gear.licenseClass).toBe('permissive');
+    expect(gear.upstream).toEqual({ repo: 'github.com/example/fixture', commit: 'deadbeef', path: 'gears/spur-gear.step' });
+    expect(gear.stepPath).toContain('spur-gear.step');
+
+    const widget = byPath.get('misc/mystery-widget.stp')!;
+    // 'widget' has no keyword → uncategorized fallback.
+    expect(widget.category).toBe('uncategorized');
+    expect(widget.attribution).toBe('Example contributors');
+  });
+
+  it('respects exclude globs', async () => {
+    const { dir, source } = makeCheckout();
+    const { candidates } = await candidatesFromSource(
+      { ...source, exclude: ['misc/**'] },
+      { checkoutDir: dir },
+    );
+    expect(candidates.map((c) => c.upstream.path)).toEqual(['gears/spur-gear.step']);
+  });
+});
+
+describe('ingestCandidate gates', () => {
+  const deps = makeDeps();
+  const base: PartCandidate = {
+    id: 'p1',
+    name: 'P1',
+    category: 'gear',
+    family: 'p1',
+    tags: ['fixture'],
+    attributes: {},
+    license: 'MIT',
+    licenseClass: 'permissive',
+    redistribution: 'mirror',
+    upstream: { repo: 'r', commit: 'c', path: 'p1.step' },
+    stepUrl: 'mem://p1',
+  };
+  const fetchBytes = (s: string): IngestDeps =>
+    ({ ...deps, fetchImpl: (async () => new Response(s)) as unknown as typeof fetch });
+
+  it('G3: drops a fetch-only candidate without mirroring', async () => {
+    const store = new MemStore();
+    const res = await ingestCandidate(
+      { ...base, licenseClass: 'fetch-only' },
+      store,
+      fetchBytes('bytes-a'),
+    );
+    expect(res.outcome).toBe('dropped-license');
+    expect(res.part).toBeUndefined();
+    expect(store.putCount).toBe(0);
+  });
+
+  it('G3: drops a candidate with empty license', async () => {
+    const store = new MemStore();
+    const res = await ingestCandidate({ ...base, license: '' }, store, fetchBytes('bytes-a'));
+    expect(res.outcome).toBe('dropped-license');
+    expect(store.putCount).toBe(0);
+  });
+
+  it('G1: skips an unparseable candidate (0 solids)', async () => {
+    const store = new MemStore();
+    const res = await ingestCandidate(
+      { ...base, id: 'p-unparseable' },
+      store,
+      fetchBytes('bytes-bad'),
+    );
+    expect(res.outcome).toBe('skipped-unparseable');
+    expect(store.putCount).toBe(0);
+  });
+
+  it('mirrors a clean candidate with connectors', async () => {
+    const store = new MemStore();
+    const res = await ingestCandidate(base, store, fetchBytes('bytes-clean'));
+    expect(res.outcome).toBe('mirrored');
+    expect(res.part?.connectors).toEqual(['mating-face', 'top-face']);
+    expect(res.part?.redistribution).toBe('mirror');
+    expect(res.part?.source).toBe('remote');
+    expect(res.part?.stepUrl).toMatch(/^mem:\/\/step\//);
+    expect(store.putCount).toBe(1);
+  });
+
+  it('G4: marks a connectorless candidate, still mirrors, adds tag', async () => {
+    const store = new MemStore();
+    const res = await ingestCandidate(
+      { ...base, id: 'p-connectorless' },
+      store,
+      fetchBytes('bytes-cl'),
+    );
+    expect(res.outcome).toBe('connectorless');
+    expect(res.part?.connectors).toEqual([]);
+    expect(res.part?.tags).toContain('connectorless');
+    expect(store.putCount).toBe(1);
+  });
+
+  it('dedups identical sha256 seen in the same run', async () => {
+    const store = new MemStore();
+    const seen = new Set<string>();
+    const first = await ingestCandidate(base, store, fetchBytes('same-bytes'), { seen });
+    expect(first.outcome).toBe('mirrored');
+    const second = await ingestCandidate(
+      { ...base, id: 'p2' },
+      store,
+      fetchBytes('same-bytes'),
+      { seen },
+    );
+    expect(second.outcome).toBe('deduped');
+    expect(store.putCount).toBe(1);
+  });
+
+  it('adds legal-hold tag when the source is on legal hold', async () => {
+    const store = new MemStore();
+    const res = await ingestCandidate(base, store, fetchBytes('lh-bytes'), { legalHold: true });
+    expect(res.part?.tags).toContain('legal-hold');
+  });
+});
+
+describe('ingestFromRegistry', () => {
+  it('merges parts and reports per-source accounting', async () => {
+    const { dir, source } = makeCheckout();
+    const store = new MemStore();
+    const logs: string[] = [];
+    const { index, reports } = await ingestFromRegistry([source], store, {
+      deps: makeDeps(),
+      candidatesOptions: () => ({ checkoutDir: dir }),
+      log: (l) => logs.push(l),
+    });
+
+    expect(index).toHaveLength(2);
+    expect(reports).toHaveLength(1);
+    expect(reports[0].ingested).toBe(2);
+    expect(reports[0].droppedForLicense).toBe(0);
+    expect(logs[0]).toContain('[fixture-src]');
+    expect(logs[0]).toContain('ingested=2');
+  });
+});
+
+describe('verifyCatalog', () => {
+  function rec(over: Partial<PartRecord>): PartRecord {
+    return {
+      id: 'r',
+      name: 'R',
+      category: 'gear',
+      family: 'r',
+      tags: [],
+      attributes: {},
+      sha256: 'sha-present',
+      source: 'remote',
+      license: 'MIT',
+      connectors: ['mating-face'],
+      licenseClass: 'permissive',
+      redistribution: 'mirror',
+      ...over,
+    };
+  }
+
+  it('passes a clean catalog whose objects are all present', async () => {
+    const store = new MemStore();
+    store.objects.set('sha-present', new Uint8Array([1]));
+    const { ok, problems } = await verifyCatalog([rec({})], store);
+    expect(ok).toBe(true);
+    expect(problems).toHaveLength(0);
+  });
+
+  it('flags a record with empty license (G3)', async () => {
+    const store = new MemStore();
+    store.objects.set('sha-present', new Uint8Array([1]));
+    const { ok, problems } = await verifyCatalog([rec({ license: '' })], store);
+    expect(ok).toBe(false);
+    expect(problems.some((p) => p.startsWith('G3') && p.includes('empty license'))).toBe(true);
+  });
+
+  it('flags a mirror record missing from the store (G2)', async () => {
+    const store = new MemStore(); // object NOT added
+    const { ok, problems } = await verifyCatalog([rec({})], store);
+    expect(ok).toBe(false);
+    expect(problems.some((p) => p.startsWith('G2'))).toBe(true);
+  });
+
+  it('flags a fetch-only mirror record (G3) and connectorless (G4)', async () => {
+    const store = new MemStore();
+    store.objects.set('sha-present', new Uint8Array([1]));
+    const { ok, problems } = await verifyCatalog(
+      [rec({ licenseClass: 'fetch-only', connectors: [], tags: ['connectorless'] })],
+      store,
+    );
+    expect(ok).toBe(false);
+    expect(problems.some((p) => p.startsWith('G3') && p.includes('fetch-only'))).toBe(true);
+    expect(problems.some((p) => p.startsWith('G4'))).toBe(true);
+  });
+});

--- a/scripts/parts/engine.ts
+++ b/scripts/parts/engine.ts
@@ -1,0 +1,559 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/engine.ts
+//
+// The registry-driven parts ingestion engine. Turns the SOURCE registry into a
+// mirrored, content-addressed catalog of PartRecords, enforcing four gates:
+//
+//   G1 (parse)    — a candidate's STEP must inspect to ≥1 solid, else it's
+//                   skipped-unparseable (real catalogs ship surface-only exports).
+//   G2 (mirror)   — verifyCatalog asserts every mirror record's sha256 object is
+//                   actually present in the store (no dangling index entry).
+//   G3 (license)  — fetch-only / license-less candidates are dropped, never
+//                   mirrored; verifyCatalog re-asserts the invariant on the index.
+//   G4 (connector)— zero synthesized connectors still mirrors (the geometry is
+//                   useful) but is tagged 'connectorless' and counted, never
+//                   silently shipped as a fully-mateable part.
+//
+// Geometry deps (inspectStep / synthesizeConnectors) and byte fetch are injected
+// via `deps`, so the unit tests run without OCCT or the network. The mass run is
+// OPERATOR-TRIGGERED (see the `import.meta` main guard at the bottom): importing
+// this module never clones a repo or writes a catalog.
+
+import { readFileSync, readdirSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join, relative, basename, sep } from 'node:path';
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import type {
+  PartSourceEntry,
+  PartCandidate,
+  IngestRunReport,
+  MirrorStore,
+} from './contracts';
+import type { PartRecord } from '../../src/shared/parts/types';
+import type { StepInspectReport } from '../../src/agent/inspect/inspectStep';
+import type { AutoConnector } from '../../src/modeling/parts/holeAutoConnectors';
+import { guessCategory } from '../../src/shared/parts/taxonomy';
+import { ingestStepParts } from './stepPartsIngest';
+import { PAGES_WORKER } from './workerTemplate';
+
+// -----------------------------------------------------------------------------
+// Injectable geometry/network deps
+// -----------------------------------------------------------------------------
+
+export interface IngestDeps {
+  /** Inspect STEP bytes → solid report. Injected so tests need no OCCT. */
+  inspectStep: (bytes: Uint8Array, hint: string) => Promise<StepInspectReport>;
+  /** Synthesize connectors from a report. */
+  synthesizeConnectors: (report: StepInspectReport, partName: string) => AutoConnector[];
+  /** Fetch impl for candidates that carry only a `stepUrl`. */
+  fetchImpl?: typeof fetch;
+}
+
+// -----------------------------------------------------------------------------
+// Minimal glob (Node 20 has no fs.glob). Supports `**`, `*`, and `?`.
+// -----------------------------------------------------------------------------
+
+function globToRegExp(glob: string): RegExp {
+  // Tokenize so `**` is handled before single `*`.
+  let re = '';
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === '*') {
+      if (glob[i + 1] === '*') {
+        // `**` matches any number of path segments (incl. none).
+        re += '.*';
+        i++;
+        // consume a trailing slash after ** so `**/x` matches `x`.
+        if (glob[i + 1] === '/') i++;
+      } else {
+        re += '[^/]*';
+      }
+    } else if (c === '?') {
+      re += '[^/]';
+    } else if ('.+^${}()|[]\\'.includes(c)) {
+      re += `\\${c}`;
+    } else {
+      re += c;
+    }
+  }
+  return new RegExp(`^${re}$`, 'i');
+}
+
+function matchesAny(relPath: string, patterns: string[]): boolean {
+  const p = relPath.split(sep).join('/');
+  return patterns.some((g) => globToRegExp(g).test(p));
+}
+
+/** All files under `dir`, returned as POSIX-style paths relative to `dir`. */
+function walkFiles(dir: string): string[] {
+  const out: string[] = [];
+  let entries: ReturnType<typeof readdirSync>;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const abs = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkFiles(abs));
+    else out.push(abs);
+  }
+  return out;
+}
+
+// -----------------------------------------------------------------------------
+// Discovery: source → candidates
+// -----------------------------------------------------------------------------
+
+export interface CandidatesOptions {
+  /** Local checkout root for 'github-glob' / 'step-passthrough' adapters. */
+  checkoutDir?: string;
+  /** Forwarded to the step.parts adapter (baseUrl / fetchImpl / limit). */
+  stepParts?: Parameters<typeof ingestStepParts>[0];
+}
+
+function slugify(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+function humanize(s: string): string {
+  return s.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()).trim();
+}
+
+/** Resolve a category from the source's categoryMap (by top dir), else heuristic. */
+function categoryForFile(source: PartSourceEntry, relPath: string, fileName: string): string {
+  const topDir = relPath.split('/')[0]?.toLowerCase() ?? '';
+  if (source.categoryMap) {
+    for (const [key, cat] of Object.entries(source.categoryMap)) {
+      if (topDir === key.toLowerCase() || topDir.includes(key.toLowerCase())) return cat;
+    }
+  }
+  return guessCategory(`${fileName} ${relPath}`);
+}
+
+/**
+ * Discover candidates for one source.
+ *   - 'step-parts'   → delegate to the step.parts adapter.
+ *   - 'github-glob' | 'step-passthrough' → glob a LOCAL checkout (opts.checkoutDir)
+ *     for STEP files; this does NOT clone (the caller provides the checkout).
+ */
+export async function candidatesFromSource(
+  source: PartSourceEntry,
+  opts: CandidatesOptions = {},
+): Promise<{ candidates: PartCandidate[]; report: IngestRunReport }> {
+  if (source.adapter === 'step-parts') {
+    return ingestStepParts(opts.stepParts ?? {});
+  }
+
+  const report: IngestRunReport = {
+    source: source.id,
+    ingested: 0,
+    skippedUnparseable: 0,
+    droppedForLicense: 0,
+    deduped: 0,
+    connectorless: 0,
+    errors: [],
+  };
+  const candidates: PartCandidate[] = [];
+
+  const checkoutDir = opts.checkoutDir;
+  if (!checkoutDir) {
+    report.errors.push(`no checkoutDir provided for source ${source.id}`);
+    return { candidates, report };
+  }
+
+  const include = source.include.length > 0 ? source.include : ['**/*.step', '**/*.stp'];
+  const exclude = source.exclude ?? [];
+
+  for (const abs of walkFiles(checkoutDir)) {
+    const relPath = relative(checkoutDir, abs).split(sep).join('/');
+    if (!matchesAny(relPath, include)) continue;
+    if (exclude.length > 0 && matchesAny(relPath, exclude)) continue;
+
+    const fileName = basename(abs);
+    const baseName = fileName.replace(/\.(step|stp)$/i, '');
+    const category = categoryForFile(source, relPath, fileName);
+    const id = `${source.id}--${slugify(baseName)}`;
+
+    candidates.push({
+      id,
+      name: humanize(baseName),
+      category,
+      family: slugify(baseName),
+      tags: [source.id, category],
+      attributes: {},
+      license: source.license,
+      licenseClass: source.licenseClass,
+      attribution: source.attribution,
+      redistribution: source.redistribution,
+      upstream: {
+        repo: source.repo,
+        commit: source.commit,
+        path: relPath,
+      },
+      stepPath: abs,
+    });
+  }
+
+  return { candidates, report };
+}
+
+/**
+ * Shallow-clone a source into `destDir` at its pinned commit. Used by the
+ * operator CLI run, NOT by unit tests (which provide a pre-built checkoutDir).
+ */
+export function shallowCloneSource(source: PartSourceEntry, destDir: string): string {
+  const url = source.repo.startsWith('http') ? source.repo : `https://${source.repo}`;
+  mkdirSync(destDir, { recursive: true });
+  // Fetch just the pinned commit when possible; fall back to a depth-1 clone.
+  try {
+    execFileSync('git', ['init', '-q'], { cwd: destDir });
+    execFileSync('git', ['remote', 'add', 'origin', url], { cwd: destDir });
+    execFileSync('git', ['fetch', '--depth', '1', 'origin', source.commit], { cwd: destDir });
+    execFileSync('git', ['checkout', '-q', 'FETCH_HEAD'], { cwd: destDir });
+  } catch {
+    // Some hosts disallow fetch-by-sha; depth-1 clone then checkout the commit.
+    execFileSync('git', ['clone', '--depth', '1', url, destDir]);
+    try {
+      execFileSync('git', ['fetch', '--depth', '1', 'origin', source.commit], { cwd: destDir });
+      execFileSync('git', ['checkout', '-q', source.commit], { cwd: destDir });
+    } catch {
+      // Leave HEAD at the default branch; the commit pin couldn't be resolved.
+    }
+  }
+  return destDir;
+}
+
+// -----------------------------------------------------------------------------
+// Ingest a single candidate (the gate gauntlet)
+// -----------------------------------------------------------------------------
+
+export type IngestOutcome =
+  | 'mirrored'
+  | 'deduped'
+  | 'skipped-unparseable'
+  | 'dropped-license'
+  | 'connectorless';
+
+export interface IngestCandidateOptions {
+  /** sha256s already mirrored in this run, for cross-source dedup. */
+  seen?: Set<string>;
+  /** Source-level legalHold flag → 'legal-hold' tag on the record. */
+  legalHold?: boolean;
+}
+
+async function bytesForCandidate(
+  c: PartCandidate,
+  deps: IngestDeps,
+): Promise<Uint8Array> {
+  if (c.stepPath) {
+    return readFileSync(c.stepPath);
+  }
+  if (c.stepUrl) {
+    const doFetch = deps.fetchImpl ?? fetch;
+    const res = await doFetch(c.stepUrl);
+    if (!res.ok) throw new Error(`fetch ${c.stepUrl} → HTTP ${res.status}`);
+    return new Uint8Array(await res.arrayBuffer());
+  }
+  throw new Error(`candidate ${c.id} has neither stepPath nor stepUrl`);
+}
+
+export async function ingestCandidate(
+  c: PartCandidate,
+  store: MirrorStore,
+  deps: IngestDeps,
+  opts: IngestCandidateOptions = {},
+): Promise<{ part?: PartRecord; outcome: IngestOutcome }> {
+  // GATE G3 (license): never mirror fetch-only or license-less geometry.
+  if (c.licenseClass === 'fetch-only' || !c.license) {
+    return { outcome: 'dropped-license' };
+  }
+
+  // Materialize bytes (local file or remote fetch).
+  let bytes: Uint8Array;
+  try {
+    bytes = await bytesForCandidate(c, deps);
+  } catch {
+    return { outcome: 'skipped-unparseable' };
+  }
+
+  const sha256 = createHash('sha256').update(bytes).digest('hex');
+
+  // Dedup: identical content already mirrored in this run. (store.put is itself
+  // idempotent on the content-addressed key, so a cross-RUN re-mirror is a
+  // harmless no-op; we only short-circuit the in-run duplicate here.)
+  const seen = opts.seen;
+  if (seen?.has(sha256) && (await store.has(sha256))) {
+    return { outcome: 'deduped' };
+  }
+
+  // GATE G1 (parse): must yield ≥1 solid.
+  let report: StepInspectReport;
+  try {
+    report = await deps.inspectStep(bytes, c.id);
+  } catch {
+    return { outcome: 'skipped-unparseable' };
+  }
+  if (!report || report.solidCount < 1 || report.solids.length < 1) {
+    return { outcome: 'skipped-unparseable' };
+  }
+
+  // GATE G4 (connectors): zero ⇒ still mirror, but tag + count.
+  const connectors = deps.synthesizeConnectors(report, c.id);
+  const connectorless = connectors.length === 0;
+
+  const mirrorUrl = await store.put(sha256, bytes);
+  seen?.add(sha256);
+
+  const tags = [...c.tags];
+  if (connectorless && !tags.includes('connectorless')) tags.push('connectorless');
+  if (opts.legalHold && !tags.includes('legal-hold')) tags.push('legal-hold');
+
+  const part: PartRecord = {
+    id: c.id,
+    name: c.name,
+    category: c.category,
+    family: c.family,
+    tags,
+    attributes: c.attributes,
+    sha256,
+    source: 'remote',
+    license: c.license,
+    connectors: connectors.map((conn) => conn.name),
+    stepUrl: mirrorUrl,
+    licenseClass: c.licenseClass,
+    redistribution: 'mirror',
+    upstream: c.upstream,
+  };
+  if (c.standard !== undefined) part.standard = c.standard;
+  if (c.attribution !== undefined) part.attribution = c.attribution;
+
+  return { part, outcome: connectorless ? 'connectorless' : 'mirrored' };
+}
+
+// -----------------------------------------------------------------------------
+// Orchestrate across the whole registry
+// -----------------------------------------------------------------------------
+
+export interface RegistryIngestOptions {
+  deps: IngestDeps;
+  candidatesOptions?: (source: PartSourceEntry) => CandidatesOptions;
+  /** Sink for per-source summary lines (defaults to console.log). */
+  log?: (line: string) => void;
+}
+
+export async function ingestFromRegistry(
+  sources: PartSourceEntry[],
+  store: MirrorStore,
+  opts: RegistryIngestOptions,
+): Promise<{ index: PartRecord[]; reports: IngestRunReport[] }> {
+  const log = opts.log ?? ((l: string) => console.log(l));
+  const index: PartRecord[] = [];
+  const reports: IngestRunReport[] = [];
+  const seen = new Set<string>(); // cross-source dedup by sha256
+
+  for (const source of sources) {
+    const { candidates, report } = await candidatesFromSource(
+      source,
+      opts.candidatesOptions ? opts.candidatesOptions(source) : {},
+    );
+
+    for (const c of candidates) {
+      try {
+        const { part, outcome } = await ingestCandidate(c, store, opts.deps, {
+          seen,
+          legalHold: source.legalHold,
+        });
+        switch (outcome) {
+          case 'mirrored':
+            report.ingested++;
+            if (part) index.push(part);
+            break;
+          case 'connectorless':
+            report.ingested++;
+            report.connectorless++;
+            if (part) index.push(part);
+            break;
+          case 'deduped':
+            report.deduped++;
+            break;
+          case 'skipped-unparseable':
+            report.skippedUnparseable++;
+            break;
+          case 'dropped-license':
+            report.droppedForLicense++;
+            break;
+        }
+      } catch (err) {
+        report.errors.push(`${c.id}: ${String(err)}`);
+      }
+    }
+
+    reports.push(report);
+    // No silent truncation — every source's accounting is logged.
+    log(
+      `[${report.source}] ingested=${report.ingested} ` +
+        `skipped=${report.skippedUnparseable} dropped=${report.droppedForLicense} ` +
+        `deduped=${report.deduped} connectorless=${report.connectorless}` +
+        (report.errors.length ? ` errors=${report.errors.length}` : ''),
+    );
+  }
+
+  return { index, reports };
+}
+
+// -----------------------------------------------------------------------------
+// Catalog verification gates (post-ingest invariants)
+// -----------------------------------------------------------------------------
+
+export async function verifyCatalog(
+  index: PartRecord[],
+  store: MirrorStore,
+): Promise<{ ok: boolean; problems: string[] }> {
+  const problems: string[] = [];
+  let connectorlessCount = 0;
+
+  for (const rec of index) {
+    // GATE G3: every record must carry a non-empty license.
+    if (!rec.license || rec.license.trim().length === 0) {
+      problems.push(`G3: record ${rec.id} has empty license`);
+    }
+    // GATE G3: no mirror record may be fetch-only class.
+    if (rec.redistribution === 'mirror' && rec.licenseClass === 'fetch-only') {
+      problems.push(`G3: mirror record ${rec.id} is licenseClass:'fetch-only'`);
+    }
+    // GATE G2: every mirror record's sha256 object must be present.
+    if (rec.redistribution === 'mirror') {
+      const present = await store.has(rec.sha256);
+      if (!present) {
+        problems.push(`G2: mirror record ${rec.id} sha256 ${rec.sha256} missing from store`);
+      }
+    }
+    // GATE G4: flag connectorless records.
+    if ((rec.tags ?? []).includes('connectorless') || rec.connectors.length === 0) {
+      connectorlessCount++;
+    }
+  }
+
+  if (connectorlessCount > 0) {
+    problems.push(`G4: ${connectorlessCount} connectorless record(s) (mirrored but un-mateable)`);
+  }
+
+  // G4 is a flag, not a hard failure — `ok` reflects G2/G3 (mirror integrity +
+  // license). Connectorless parts are still served; the count is surfaced.
+  const hardProblems = problems.filter((p) => p.startsWith('G2') || p.startsWith('G3'));
+  return { ok: hardProblems.length === 0, problems };
+}
+
+// -----------------------------------------------------------------------------
+// Catalog writer (shared output tree shape with scripts/ingestParts.ts)
+// -----------------------------------------------------------------------------
+
+/** Write a deployable /v1/parts catalog tree from an in-memory index. */
+export function writeCatalog(outDir: string, index: PartRecord[]): void {
+  mkdirSync(join(outDir, 'v1', 'parts'), { recursive: true });
+  mkdirSync(join(outDir, 'v1', 'catalog'), { recursive: true });
+
+  const shaManifest: Record<string, string> = {};
+  for (const rec of index) {
+    writeFileSync(join(outDir, 'v1', 'parts', `${rec.id}.json`), JSON.stringify(rec, null, 2));
+    shaManifest[rec.id] = rec.sha256;
+  }
+  writeFileSync(
+    join(outDir, 'v1', 'catalog', 'parts.index.json'),
+    JSON.stringify({ catalog: { partCount: index.length }, items: index }, null, 2),
+  );
+  writeFileSync(join(outDir, 'sha256-manifest.json'), JSON.stringify(shaManifest, null, 2));
+  writeFileSync(join(outDir, '_worker.js'), PAGES_WORKER, { flag: 'w' });
+}
+
+// -----------------------------------------------------------------------------
+// CLI — OPERATOR-TRIGGERED mass run only. Importing this module never runs it.
+// -----------------------------------------------------------------------------
+//
+// The real mass-run clones every SOURCE at its pinned commit into a temp dir and
+// ingests into a LocalFsMirrorStore (or R2 when R2_* env is set), writing the
+// catalog tree. It loads OCCT (inspectStepFile) and hits the network, so it is
+// guarded behind the import.meta main check and intended to be operator-run:
+//
+//   npx tsx scripts/parts/engine.ts <outDir> [--mirror-root DIR]
+
+async function runCli(argv: string[]): Promise<void> {
+  const { mkdtempSync } = await import('node:fs');
+  const { tmpdir } = await import('node:os');
+  const { SOURCES } = await import('./sources');
+  const { inspectStepFile } = await import('../../src/agent/inspect/inspectStep');
+  const { synthesizeConnectorsFromReport } = await import(
+    '../../src/modeling/parts/synthesizeConnectors'
+  );
+  const { LocalFsMirrorStore, R2MirrorStore } = await import('./mirrorStore');
+  const { writeFile, rm } = await import('node:fs/promises');
+
+  const pos: string[] = [];
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i].startsWith('--')) flags[argv[i].slice(2)] = argv[++i];
+    else pos.push(argv[i]);
+  }
+  const outDir = pos[0];
+  if (!outDir) {
+    console.error('usage: engine <outDir> [--mirror-root DIR]');
+    process.exit(2);
+    return;
+  }
+
+  // inspectStepFile reads a path; the engine injects bytes — bridge via a temp file.
+  const inspectStep = async (bytes: Uint8Array, hint: string) => {
+    const tmp = join(mkdtempSync(join(tmpdir(), 'kc-step-')), `${slugify(hint)}.step`);
+    await writeFile(tmp, bytes);
+    try {
+      return await inspectStepFile(tmp);
+    } finally {
+      await rm(tmp, { force: true }).catch(() => {});
+    }
+  };
+
+  const deps: IngestDeps = {
+    inspectStep,
+    synthesizeConnectors: synthesizeConnectorsFromReport,
+  };
+
+  const store: MirrorStore =
+    process.env.R2_BUCKET && process.env.R2_ACCOUNT_ID
+      ? new R2MirrorStore({
+          bucket: process.env.R2_BUCKET,
+          accountId: process.env.R2_ACCOUNT_ID,
+          accessKeyId: process.env.R2_ACCESS_KEY_ID ?? '',
+          secretAccessKey: process.env.R2_SECRET_ACCESS_KEY ?? '',
+          publicBaseUrl: process.env.R2_PUBLIC_BASE_URL ?? '',
+        })
+      : new LocalFsMirrorStore(flags['mirror-root'] ?? outDir);
+
+  const checkoutRoot = mkdtempSync(join(tmpdir(), 'kc-parts-'));
+  const { index } = await ingestFromRegistry(SOURCES, store, {
+    deps,
+    candidatesOptions: (source) => {
+      if (source.adapter === 'step-parts') return {};
+      const dir = join(checkoutRoot, source.id);
+      shallowCloneSource(source, dir);
+      return { checkoutDir: dir };
+    },
+  });
+
+  writeCatalog(outDir, index);
+  console.log(`ingested ${index.length} parts into ${outDir}`);
+}
+
+const isMain =
+  typeof process !== 'undefined' &&
+  Array.isArray(process.argv) &&
+  process.argv[1] !== undefined &&
+  /parts[/\\]engine\.(ts|js)$/.test(process.argv[1]);
+
+if (isMain) {
+  runCli(process.argv.slice(2)).catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/scripts/parts/mirrorStore.test.ts
+++ b/scripts/parts/mirrorStore.test.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/mirrorStore.test.ts
+
+import { describe, it, expect, vi } from 'vitest';
+import { mkdtempSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { LocalFsMirrorStore, R2MirrorStore, stepKey } from './mirrorStore';
+
+const SHA = 'a'.repeat(64);
+const BYTES = new TextEncoder().encode('ISO-10303-21; fake step');
+
+describe('LocalFsMirrorStore', () => {
+  it('round-trips: has() false before put, true after, returns the step key', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'kc-mirror-'));
+    const store = new LocalFsMirrorStore(root);
+
+    expect(await store.has(SHA)).toBe(false);
+    const url = await store.put(SHA, BYTES);
+    expect(url).toBe(stepKey(SHA));
+    expect(url).toBe(`step/${SHA}.step`);
+    expect(await store.has(SHA)).toBe(true);
+    expect(existsSync(join(root, 'step', `${SHA}.step`))).toBe(true);
+    expect(readFileSync(join(root, 'step', `${SHA}.step`))).toEqual(Buffer.from(BYTES));
+  });
+
+  it('is idempotent: re-put of identical content does not error and keeps content', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'kc-mirror-'));
+    const store = new LocalFsMirrorStore(root);
+    await store.put(SHA, BYTES);
+    const url2 = await store.put(SHA, BYTES);
+    expect(url2).toBe(stepKey(SHA));
+    expect(readFileSync(join(root, 'step', `${SHA}.step`))).toEqual(Buffer.from(BYTES));
+  });
+});
+
+describe('R2MirrorStore', () => {
+  const cfg = {
+    bucket: 'kc-parts',
+    accountId: 'acct123',
+    accessKeyId: 'AKIAEXAMPLE',
+    secretAccessKey: 'secretEXAMPLE',
+    publicBaseUrl: 'https://parts.example.com/',
+    now: () => new Date('2026-06-13T12:00:00.000Z'),
+  };
+
+  it('put() PUTs to the content-addressed key and returns the public URL', async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    const store = new R2MirrorStore({ ...cfg, fetchImpl: fetchMock as unknown as typeof fetch });
+
+    const url = await store.put(SHA, BYTES);
+    expect(url).toBe(`https://parts.example.com/step/${SHA}.step`);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [calledUrl, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(calledUrl).toBe(
+      `https://acct123.r2.cloudflarestorage.com/kc-parts/step/${SHA}.step`,
+    );
+    expect(init.method).toBe('PUT');
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toMatch(/^AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE\//);
+    expect(headers['x-amz-date']).toBe('20260613T120000Z');
+    expect(headers['x-amz-content-sha256']).toMatch(/^[0-9a-f]{64}$/);
+    expect(init.body).toBe(BYTES);
+  });
+
+  it('has() issues a HEAD: 200 → true, 404 → false', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 404 }));
+    const store = new R2MirrorStore({ ...cfg, fetchImpl: fetchMock as unknown as typeof fetch });
+
+    expect(await store.has(SHA)).toBe(true);
+    expect(await store.has(SHA)).toBe(false);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.method).toBe('HEAD');
+  });
+
+  it('put() throws on a non-2xx response', async () => {
+    const fetchMock = vi.fn(async () => new Response('denied', { status: 403 }));
+    const store = new R2MirrorStore({ ...cfg, fetchImpl: fetchMock as unknown as typeof fetch });
+    await expect(store.put(SHA, BYTES)).rejects.toThrow(/HTTP 403/);
+  });
+});

--- a/scripts/parts/mirrorStore.ts
+++ b/scripts/parts/mirrorStore.ts
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/mirrorStore.ts
+//
+// Content-addressed mirror stores for the parts ingestion engine. Keyed by
+// sha256 ⇒ identical STEP bytes from any source mirror to the same object, so
+// dedup is automatic and global. Two impls behind the `MirrorStore` seam:
+//
+//   LocalFsMirrorStore — writes `<rootDir>/step/<sha256>.step` on the local
+//     filesystem. Used by tests, dev, and the operator's local catalog build.
+//   R2MirrorStore — PUT/HEAD against Cloudflare R2's S3-compatible API using a
+//     minimal SigV4 signer (no AWS SDK dependency). Runs in prod only; it must
+//     typecheck and is unit-tested with a mocked fetch — it never touches real
+//     R2 from the test suite.
+
+import { mkdirSync, existsSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash, createHmac } from 'node:crypto';
+import type { MirrorStore } from './contracts';
+
+/** Content-addressed object key for a STEP blob. */
+export function stepKey(sha256: string): string {
+  return `step/${sha256}.step`;
+}
+
+// -----------------------------------------------------------------------------
+// Local filesystem store
+// -----------------------------------------------------------------------------
+
+export class LocalFsMirrorStore implements MirrorStore {
+  private readonly rootDir: string;
+
+  constructor(rootDir: string) {
+    this.rootDir = rootDir;
+  }
+
+  private pathFor(sha256: string): string {
+    return join(this.rootDir, 'step', `${sha256}.step`);
+  }
+
+  async put(sha256: string, bytes: Uint8Array): Promise<string> {
+    const dest = this.pathFor(sha256);
+    // Idempotent: identical content under a content-addressed key — skip the
+    // write if it already exists.
+    if (!existsSync(dest)) {
+      mkdirSync(join(this.rootDir, 'step'), { recursive: true });
+      writeFileSync(dest, bytes);
+    }
+    return stepKey(sha256);
+  }
+
+  async has(sha256: string): Promise<boolean> {
+    return existsSync(this.pathFor(sha256));
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Cloudflare R2 store (S3-compatible, minimal SigV4 — no AWS SDK dependency)
+// -----------------------------------------------------------------------------
+
+export interface R2MirrorStoreConfig {
+  bucket: string;
+  accountId: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  /** Public base URL the mirrored object is served from, e.g. a Pages/CDN host. */
+  publicBaseUrl: string;
+  /** R2 region label; R2 uses 'auto'. Injectable for testing. */
+  region?: string;
+  /** Injectable fetch for unit tests; defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Injectable clock for deterministic SigV4 test assertions. */
+  now?: () => Date;
+}
+
+const EMPTY_SHA256 = createHash('sha256').update('').digest('hex');
+
+export class R2MirrorStore implements MirrorStore {
+  private readonly cfg: Required<Omit<R2MirrorStoreConfig, 'fetchImpl' | 'now'>>;
+  private readonly doFetch: typeof fetch;
+  private readonly now: () => Date;
+
+  constructor(config: R2MirrorStoreConfig) {
+    this.cfg = {
+      bucket: config.bucket,
+      accountId: config.accountId,
+      accessKeyId: config.accessKeyId,
+      secretAccessKey: config.secretAccessKey,
+      publicBaseUrl: config.publicBaseUrl.replace(/\/$/, ''),
+      region: config.region ?? 'auto',
+    };
+    this.doFetch = config.fetchImpl ?? fetch;
+    this.now = config.now ?? (() => new Date());
+  }
+
+  /** S3-compatible endpoint host for this R2 account. */
+  private endpointHost(): string {
+    return `${this.cfg.accountId}.r2.cloudflarestorage.com`;
+  }
+
+  private objectUrl(sha256: string): string {
+    return `https://${this.endpointHost()}/${this.cfg.bucket}/${stepKey(sha256)}`;
+  }
+
+  async has(sha256: string): Promise<boolean> {
+    const res = await this.signedRequest('HEAD', sha256, undefined);
+    if (res.status === 200) return true;
+    if (res.status === 404) return false;
+    // 403 on a missing key is also possible depending on bucket policy; treat
+    // anything non-200 that isn't a hard error as "not present".
+    if (res.status >= 500) {
+      throw new Error(`R2 HEAD ${stepKey(sha256)} failed: HTTP ${res.status}`);
+    }
+    return false;
+  }
+
+  async put(sha256: string, bytes: Uint8Array): Promise<string> {
+    const res = await this.signedRequest('PUT', sha256, bytes);
+    if (res.status !== 200 && res.status !== 201) {
+      throw new Error(`R2 PUT ${stepKey(sha256)} failed: HTTP ${res.status}`);
+    }
+    return `${this.cfg.publicBaseUrl}/${stepKey(sha256)}`;
+  }
+
+  /** Sign + dispatch a single S3 request with AWS SigV4 (service 's3'). */
+  private async signedRequest(
+    method: 'PUT' | 'HEAD',
+    sha256: string,
+    body: Uint8Array | undefined,
+  ): Promise<Response> {
+    const url = this.objectUrl(sha256);
+    const host = this.endpointHost();
+    const date = this.now();
+    const amzDate = toAmzDate(date); // YYYYMMDDTHHMMSSZ
+    const dateStamp = amzDate.slice(0, 8); // YYYYMMDD
+    const region = this.cfg.region;
+    const service = 's3';
+    const payloadHash =
+      body && body.length > 0
+        ? createHash('sha256').update(body).digest('hex')
+        : EMPTY_SHA256;
+
+    const canonicalUri = `/${this.cfg.bucket}/${stepKey(sha256)}`;
+    const canonicalQuery = '';
+    const signedHeaders = 'host;x-amz-content-sha256;x-amz-date';
+    const canonicalHeaders =
+      `host:${host}\n` +
+      `x-amz-content-sha256:${payloadHash}\n` +
+      `x-amz-date:${amzDate}\n`;
+    const canonicalRequest = [
+      method,
+      canonicalUri,
+      canonicalQuery,
+      canonicalHeaders,
+      signedHeaders,
+      payloadHash,
+    ].join('\n');
+
+    const scope = `${dateStamp}/${region}/${service}/aws4_request`;
+    const stringToSign = [
+      'AWS4-HMAC-SHA256',
+      amzDate,
+      scope,
+      createHash('sha256').update(canonicalRequest).digest('hex'),
+    ].join('\n');
+
+    const signingKey = sigV4Key(this.cfg.secretAccessKey, dateStamp, region, service);
+    const signature = createHmac('sha256', signingKey).update(stringToSign).digest('hex');
+
+    const authorization =
+      `AWS4-HMAC-SHA256 Credential=${this.cfg.accessKeyId}/${scope}, ` +
+      `SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+    const headers: Record<string, string> = {
+      host,
+      'x-amz-date': amzDate,
+      'x-amz-content-sha256': payloadHash,
+      Authorization: authorization,
+    };
+    if (method === 'PUT') headers['Content-Type'] = 'application/step';
+
+    const init: RequestInit = { method, headers };
+    if (body !== undefined) {
+      init.body = body;
+    }
+    return this.doFetch(url, init);
+  }
+}
+
+/** AWS SigV4 date format: YYYYMMDDTHHMMSSZ. */
+function toAmzDate(d: Date): string {
+  return d.toISOString().replace(/[:-]/g, '').replace(/\.\d{3}/, '');
+}
+
+/** Derive the SigV4 signing key chain. */
+function sigV4Key(
+  secretAccessKey: string,
+  dateStamp: string,
+  region: string,
+  service: string,
+): Buffer {
+  const kDate = createHmac('sha256', `AWS4${secretAccessKey}`).update(dateStamp).digest();
+  const kRegion = createHmac('sha256', kDate).update(region).digest();
+  const kService = createHmac('sha256', kRegion).update(service).digest();
+  return createHmac('sha256', kService).update('aws4_request').digest();
+}

--- a/scripts/parts/sources.test.ts
+++ b/scripts/parts/sources.test.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/sources.test.ts
+
+import { describe, it, expect } from 'vitest';
+import { SOURCES } from './sources';
+import { isPartCategory } from '../../src/shared/parts/taxonomy';
+
+const ADAPTERS = new Set(['step-passthrough', 'step-parts', 'github-glob']);
+const LICENSE_CLASSES = new Set(['permissive', 'share-alike', 'fetch-only']);
+const REDISTRIBUTION = new Set(['mirror', 'fetch-only']);
+
+describe('SOURCES registry', () => {
+  it('is non-empty', () => {
+    expect(SOURCES.length).toBeGreaterThan(0);
+  });
+
+  it('every entry has the required fields with valid values', () => {
+    for (const s of SOURCES) {
+      expect(typeof s.id, s.id).toBe('string');
+      expect(s.id.length, s.id).toBeGreaterThan(0);
+      expect(typeof s.repo, s.id).toBe('string');
+      expect(s.repo.length, s.id).toBeGreaterThan(0);
+      expect(typeof s.commit, s.id).toBe('string');
+      expect(s.commit.length, s.id).toBeGreaterThan(0);
+      expect(typeof s.license, s.id).toBe('string');
+      expect(s.license.length, s.id).toBeGreaterThan(0);
+      expect(typeof s.attribution, s.id).toBe('string');
+      expect(s.attribution.length, s.id).toBeGreaterThan(0);
+      expect(ADAPTERS.has(s.adapter), `${s.id} adapter=${s.adapter}`).toBe(true);
+      expect(LICENSE_CLASSES.has(s.licenseClass), `${s.id} licenseClass`).toBe(true);
+      expect(REDISTRIBUTION.has(s.redistribution), `${s.id} redistribution`).toBe(true);
+      expect(Array.isArray(s.include), s.id).toBe(true);
+      expect(s.include.length, s.id).toBeGreaterThan(0);
+    }
+  });
+
+  it('has unique ids', () => {
+    const ids = SOURCES.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every mirror entry is permissive or share-alike (never fetch-only)", () => {
+    for (const s of SOURCES) {
+      if (s.redistribution === 'mirror') {
+        expect(s.licenseClass, s.id).not.toBe('fetch-only');
+        expect(['permissive', 'share-alike']).toContain(s.licenseClass);
+      }
+    }
+  });
+
+  it('every share-alike entry sits behind a legal hold', () => {
+    for (const s of SOURCES) {
+      if (s.licenseClass === 'share-alike') {
+        expect(s.legalHold, s.id).toBe(true);
+      }
+    }
+  });
+
+  it('categoryMap values (when present) are valid taxonomy categories', () => {
+    for (const s of SOURCES) {
+      if (!s.categoryMap) continue;
+      for (const [dir, cat] of Object.entries(s.categoryMap)) {
+        expect(isPartCategory(cat), `${s.id}.${dir} -> ${cat}`).toBe(true);
+      }
+    }
+  });
+
+  it('pins a 40-char SHA for every entry (or flags a branch fallback)', () => {
+    for (const s of SOURCES) {
+      const isSha = /^[0-9a-f]{40}$/.test(s.commit);
+      const isBranch = /^[a-z][\w.\-/]*$/i.test(s.commit);
+      expect(isSha || isBranch, `${s.id} commit=${s.commit}`).toBe(true);
+    }
+  });
+});

--- a/scripts/parts/sources.ts
+++ b/scripts/parts/sources.ts
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/sources.ts
+//
+// The Phase-1 parts-ingestion SOURCE REGISTRY: the machine-readable form of the
+// open-STEP source sweep. Each entry is an upstream collection kernelCAD can
+// ingest at scale, pinned to a real commit for reproducible runs.
+//
+// Only MIRRORABLE sources live here:
+//   - redistribution:'mirror' + licenseClass:'permissive'  — re-hosted freely
+//     (attribution kept).
+//   - redistribution:'mirror' + licenseClass:'share-alike'  — re-hosted with
+//     copyleft obligations; kept in an attributed partition, served behind a
+//     legal gate (legalHold:true).
+//
+// Sources whose license forbids re-hosting (NC/ND/unlicensed/vendor-ToS, i.e.
+// licenseClass:'fetch-only') are NOT registered here — they are reached on
+// demand through the `fetch_part` MCP tool (fetch-by-URL only, never mirrored).
+//
+// The `commit` field is pinned to the upstream HEAD SHA at sweep time
+// (resolved via `git ls-remote <repo> HEAD`). A `// TODO: pin` comment marks
+// any entry whose SHA could not be resolved and fell back to a branch name.
+
+import type { PartSourceEntry } from './contracts';
+
+export const SOURCES: PartSourceEntry[] = [
+  // ── PERMISSIVE / mirror ────────────────────────────────────────────────
+  {
+    id: 'step-parts',
+    repo: 'github.com/earthtojake/step.parts',
+    commit: 'c6113328a5695b976a010a203a90fe86191769bf',
+    licenseClass: 'permissive',
+    redistribution: 'mirror',
+    license: 'mixed-per-part',
+    attribution: 'step.parts catalog (earthtojake/step.parts) + per-part upstream notices',
+    adapter: 'step-parts',
+    include: ['**/*.step', '**/*.stp'],
+    perPartLicense: 'third-party-notices',
+  },
+  {
+    id: 'freecad-library',
+    repo: 'github.com/FreeCAD/FreeCAD-library',
+    commit: '27c1d48e2b33a29d11ac7cfb323294b295cd20a2',
+    licenseClass: 'permissive',
+    redistribution: 'mirror',
+    license: 'CC-BY-3.0',
+    attribution: 'FreeCAD parts_library contributors',
+    adapter: 'github-glob',
+    include: ['**/*.stp', '**/*.step'],
+  },
+  {
+    id: 'adafruit-cad',
+    repo: 'github.com/adafruit/Adafruit_CAD_Parts',
+    commit: '73a62d82d74c7d089ab5f6234f503a6bdb67d2c4',
+    licenseClass: 'permissive',
+    redistribution: 'mirror',
+    license: 'MIT',
+    attribution: 'Adafruit Industries',
+    adapter: 'github-glob',
+    include: ['**/*.step', '**/*.stp'],
+  },
+  {
+    id: 'geez0x1-cycloidal-2022',
+    repo: 'github.com/geez0x1/2022-cycloidal-drive',
+    commit: '5867f4673b544a0b0c721aea170dc02019e066bc',
+    licenseClass: 'permissive',
+    redistribution: 'mirror',
+    license: 'MIT',
+    attribution: 'geez0x1 — 2022 cycloidal drive',
+    adapter: 'github-glob',
+    include: ['**/*.step', '**/*.stp'],
+    categoryMap: {
+      actuator: 'actuator',
+      motor: 'actuator',
+      drive: 'actuator',
+      gears: 'gear',
+      gear: 'gear',
+    },
+  },
+  {
+    id: 'geez0x1-cycloidal-2023',
+    repo: 'github.com/geez0x1/2023-cycloidal-drive-nonpinwheel',
+    commit: '841a92efa222cc1516e224704f9dd6606b64f9c7',
+    licenseClass: 'permissive',
+    redistribution: 'mirror',
+    license: 'MIT',
+    attribution: 'geez0x1 — 2023 cycloidal drive (non-pinwheel)',
+    adapter: 'github-glob',
+    include: ['**/*.step', '**/*.stp'],
+  },
+  {
+    id: 'xrobots-opendog-v3',
+    repo: 'github.com/XRobots/openDogV3',
+    commit: '537aa0db8539bf255b072e4a1d7da38d08084ba8',
+    licenseClass: 'permissive',
+    redistribution: 'mirror',
+    license: 'MIT',
+    attribution: 'XRobots — openDog V3',
+    adapter: 'github-glob',
+    include: ['**/*.step', '**/*.stp'],
+    categoryMap: {
+      frame: 'structural-frame',
+      chassis: 'structural-frame',
+      body: 'structural-frame',
+    },
+  },
+  {
+    id: 'xrobots-cycloidal',
+    repo: 'github.com/XRobots/CycloidalDrive',
+    commit: '9a63c95a69e1a59809ac7a033b4f1fc796f0a157',
+    licenseClass: 'permissive',
+    redistribution: 'mirror',
+    license: 'MIT',
+    attribution: 'XRobots — Cycloidal Drive',
+    adapter: 'github-glob',
+    include: ['**/*.step', '**/*.stp'],
+    categoryMap: {
+      drive: 'actuator',
+      actuator: 'actuator',
+      motor: 'actuator',
+    },
+  },
+  {
+    id: 'jetbot',
+    repo: 'github.com/NVIDIA-AI-IOT/jetbot',
+    commit: 'ecf840baf644412771524a7806e6bbb7e0219509',
+    licenseClass: 'permissive',
+    redistribution: 'mirror',
+    license: 'MIT',
+    attribution: 'NVIDIA AI-IOT — JetBot',
+    adapter: 'github-glob',
+    include: ['**/*.step', '**/*.stp'],
+  },
+  {
+    id: 'so-arm100',
+    repo: 'github.com/TheRobotStudio/SO-ARM100',
+    commit: 'fda892cba81032c46c40976a48c9ceadbf40a9ca',
+    licenseClass: 'permissive',
+    redistribution: 'mirror',
+    license: 'Apache-2.0',
+    attribution: 'The Robot Studio — SO-ARM100',
+    adapter: 'github-glob',
+    include: ['**/*.step', '**/*.stp'],
+    categoryMap: {
+      frame: 'structural-frame',
+      arm: 'structural-frame',
+      link: 'structural-frame',
+      base: 'structural-frame',
+    },
+  },
+  {
+    id: 'koch-v1-1',
+    repo: 'github.com/jess-moss/koch-v1-1',
+    commit: '1a553e1fa7d5404b51bbd83b99b0f7eba54888e0',
+    licenseClass: 'permissive',
+    redistribution: 'mirror',
+    license: 'Apache-2.0',
+    attribution: 'Jess Moss — Koch v1.1',
+    adapter: 'github-glob',
+    include: ['**/*.step', '**/*.stp'],
+    // SLDPRT is a Phase-2 (proprietary CAD) ingest path; STEP only for now.
+    exclude: ['**/*.SLDPRT', '**/*.sldprt'],
+  },
+  {
+    id: 'niryo-ned2',
+    repo: 'github.com/NiryoRobotics/ned2',
+    commit: '2814a5c9141b3e013b67bf1c2f165dc006a5aa28',
+    licenseClass: 'permissive',
+    redistribution: 'mirror',
+    license: 'CC0-1.0',
+    attribution: 'Niryo — Ned2',
+    adapter: 'github-glob',
+    include: ['**/*.step', '**/*.stp'],
+    // 'needs-decomposition': ships as a monolithic arm STEP — the ingest engine
+    // should split it into per-link parts before cataloging.
+  },
+  {
+    id: 'compliantfinray',
+    repo: 'github.com/richardhartisch/compliantfinray',
+    commit: 'b9e5a0bdb31f63e706849e120c61c500e31f80a5',
+    licenseClass: 'permissive',
+    redistribution: 'mirror',
+    license: 'BSD-3-Clause',
+    attribution: 'Richard Hartisch — compliant Fin Ray',
+    adapter: 'github-glob',
+    include: ['**/*.step', '**/*.stp'],
+    categoryMap: {
+      finger: 'gripper',
+      finray: 'gripper',
+      gripper: 'gripper',
+    },
+  },
+  {
+    id: 'ssg-48',
+    repo: 'github.com/PCrnjak/SSG-48-adaptive-electric-gripper',
+    commit: 'fc4433fb178058b2020d5c6f90e7941439830a30',
+    licenseClass: 'permissive',
+    redistribution: 'mirror',
+    license: 'Apache-2.0',
+    attribution: 'Petar Crnjak — SSG-48 adaptive electric gripper',
+    adapter: 'github-glob',
+    include: ['**/*.step', '**/*.stp'],
+    categoryMap: {
+      gripper: 'gripper',
+      finger: 'gripper',
+      jaw: 'gripper',
+    },
+  },
+
+  // ── SHARE-ALIKE / mirror / legalHold ───────────────────────────────────
+  // CC-BY-SA / GPL collections: re-hosted only behind the legal gate.
+  {
+    id: 'kicad-packages3d',
+    repo: 'gitlab.com/kicad/libraries/kicad-packages3D',
+    commit: '0bc64e922178140eb6890377646efd45e15011bd',
+    licenseClass: 'share-alike',
+    redistribution: 'mirror',
+    license: 'CC-BY-SA-4.0',
+    attribution: 'KiCad Libraries — kicad-packages3D contributors',
+    adapter: 'github-glob',
+    include: ['**/*.step', '**/*.stp'],
+    exclude: ['**/*.wrl'],
+    legalHold: true,
+  },
+  {
+    id: 'sparkfun-3d-models',
+    repo: 'github.com/sparkfun/3D_Models',
+    commit: '53d298c3b8202cf8fce9ab61885855720c84c012',
+    licenseClass: 'share-alike',
+    redistribution: 'mirror',
+    license: 'CC-BY-SA-4.0',
+    attribution: 'SparkFun Electronics — 3D_Models',
+    adapter: 'github-glob',
+    include: ['**/*.step', '**/*.stp'],
+    legalHold: true,
+  },
+  {
+    id: 'thor',
+    repo: 'github.com/AngelLM/Thor',
+    commit: '286b081fe6f056d87c379b884781ef77ff6a0159',
+    licenseClass: 'share-alike',
+    redistribution: 'mirror',
+    license: 'CC-BY-SA-4.0',
+    attribution: 'Ángel L. M. — Thor open-source robotic arm',
+    adapter: 'github-glob',
+    include: ['**/*.step', '**/*.stp'],
+    legalHold: true,
+  },
+  {
+    id: 'e3d-toolchanger',
+    repo: 'github.com/e3donline/ToolChanger',
+    commit: 'd36e0c769d69dac384e7e89e62ec0254aefb45b1',
+    licenseClass: 'share-alike',
+    redistribution: 'mirror',
+    license: 'GPL-3.0',
+    attribution: 'E3D Online — ToolChanger',
+    adapter: 'github-glob',
+    include: ['**/*.step', '**/*.stp'],
+    legalHold: true,
+  },
+];

--- a/scripts/parts/stepPartsIngest.test.ts
+++ b/scripts/parts/stepPartsIngest.test.ts
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/stepPartsIngest.test.ts
+
+import { describe, it, expect } from 'vitest';
+import {
+  ingestStepParts,
+  classifyLicense,
+  parseThirdPartyNotices,
+} from './stepPartsIngest';
+
+const BASE = 'https://api.step.parts';
+
+// Fixture catalog: one part per source/license shape. `license` is inlined on
+// the item so the resolver has a deterministic per-part value to classify
+// (the real index has no license field; this exercises the classify+map path).
+const FIXTURE_INDEX = {
+  catalog: { version: 'test-v1', sha256: 'deadbeef' },
+  fields: ['id', 'name', 'category', 'family'],
+  items: [
+    {
+      id: 'din913_set_screw_m3x3',
+      name: 'DIN 913 set screw, M3 x 3',
+      category: 'fastener',
+      family: 'set-screw',
+      standard: 'DIN 913',
+      tags: ['screw', 'metric'],
+      aliases: ['M3 set screw'],
+      pageUrl: 'https://www.step.parts/parts/din913_set_screw_m3x3',
+      stepUrl: 'https://media.example/din913.step',
+      sha256: 'aaa',
+      license: 'MIT',
+    },
+    {
+      id: 'nema17_stepper',
+      name: 'NEMA 17 stepper motor',
+      category: 'unknown-source-category', // not a taxonomy cat -> guessCategory
+      family: 'stepper',
+      tags: ['motor', 'nema'],
+      pageUrl: 'https://www.step.parts/parts/nema17_stepper',
+      stepUrl: 'https://media.example/nema17.step',
+      license: 'BSD-3-Clause',
+    },
+    {
+      id: 'kicad_R_0805',
+      name: 'Resistor 0805 (KiCad)',
+      category: 'electronics-module',
+      family: 'resistor',
+      tags: ['kicad', 'smd'],
+      pageUrl: 'https://www.step.parts/parts/kicad_R_0805',
+      stepUrl: 'https://media.example/r0805.step',
+      license: 'CC-BY-SA-4.0',
+    },
+    {
+      id: 'nc_only_widget',
+      name: 'NonCommercial widget',
+      category: 'uncategorized',
+      family: 'widget',
+      tags: [],
+      pageUrl: 'https://www.step.parts/parts/nc_only_widget',
+      stepUrl: 'https://media.example/nc.step',
+      license: 'CC-BY-NC-4.0',
+    },
+    {
+      id: 'nd_only_widget',
+      name: 'NoDerivatives widget',
+      category: 'uncategorized',
+      family: 'widget',
+      tags: [],
+      pageUrl: 'https://www.step.parts/parts/nd_only_widget',
+      stepUrl: 'https://media.example/nd.step',
+      license: 'CC-BY-ND-4.0',
+    },
+    {
+      id: 'mystery_part',
+      name: 'Mystery part with no license',
+      category: 'uncategorized',
+      family: 'mystery',
+      tags: [],
+      pageUrl: 'https://www.step.parts/parts/mystery_part',
+      stepUrl: 'https://media.example/mystery.step',
+      // no license field, no notices entry -> unknown -> fetch-only -> dropped
+    },
+  ],
+};
+
+const FIXTURE_NOTICES = `# Third Party Notices
+
+This project's original material is licensed under the MIT License.
+
+## License summary
+
+### KiCad kicad-packages3D
+https://gitlab.com/kicad/libraries/kicad-packages3D
+SPDX: CC-BY-SA-4.0 WITH KiCad-libraries-exception
+
+### Per-part overrides
+| nema17_stepper | BSD-3-Clause |
+`;
+
+function makeFetch() {
+  return async (input: RequestInfo | URL): Promise<Response> => {
+    const url = String(input);
+    if (url.endsWith('/v1/catalog/parts.index.json')) {
+      return new Response(JSON.stringify(FIXTURE_INDEX), { status: 200 });
+    }
+    if (url.includes('THIRD_PARTY_NOTICES.md')) {
+      return new Response(FIXTURE_NOTICES, { status: 200 });
+    }
+    return new Response('not found', { status: 404 });
+  };
+}
+
+describe('classifyLicense', () => {
+  it('maps permissive licenses', () => {
+    for (const l of ['MIT', 'BSD-3-Clause', 'Apache-2.0', 'CC0-1.0', 'CC-BY-3.0', 'ISC', 'Unlicense']) {
+      expect(classifyLicense(l), l).toBe('permissive');
+    }
+  });
+  it('maps share-alike / copyleft licenses', () => {
+    for (const l of ['CC-BY-SA-4.0', 'GPL-3.0', 'LGPL-2.1', 'MPL-2.0', 'CERN-OHL-S-2.0']) {
+      expect(classifyLicense(l), l).toBe('share-alike');
+    }
+  });
+  it('maps NC / ND / unknown / empty to fetch-only', () => {
+    for (const l of ['CC-BY-NC-4.0', 'CC-BY-ND-4.0', 'CC-BY-NC-SA-4.0', 'unknown', '', undefined, null]) {
+      expect(classifyLicense(l as string | undefined), String(l)).toBe('fetch-only');
+    }
+  });
+});
+
+describe('parseThirdPartyNotices', () => {
+  it('records a default MIT and a per-source SA entry', () => {
+    const t = parseThirdPartyNotices(FIXTURE_NOTICES);
+    expect(t.defaultSpdx?.toUpperCase()).toContain('MIT');
+    const kicad = t.bySource.get('kicad-kicad-packages3d');
+    expect(kicad).toBeTruthy();
+    expect(classifyLicense(kicad)).toBe('share-alike');
+  });
+});
+
+describe('ingestStepParts', () => {
+  it('drops NC/ND/unknown and keeps permissive + share-alike', async () => {
+    const { candidates, report } = await ingestStepParts({
+      baseUrl: BASE,
+      fetchImpl: makeFetch(),
+    });
+
+    const keptIds = candidates.map((c) => c.id);
+
+    // 3 redistributable, 3 dropped (NC, ND, unknown).
+    expect(report.ingested).toBe(3);
+    expect(report.droppedForLicense).toBe(3);
+    expect(candidates).toHaveLength(3);
+
+    expect(keptIds).toContain('din913_set_screw_m3x3');
+    expect(keptIds).toContain('nema17_stepper');
+    expect(keptIds).toContain('kicad_R_0805');
+
+    expect(keptIds).not.toContain('nc_only_widget');
+    expect(keptIds).not.toContain('nd_only_widget');
+    expect(keptIds).not.toContain('mystery_part');
+  });
+
+  it('stamps permissive parts with class, mirror, stepUrl, upstream', async () => {
+    const { candidates } = await ingestStepParts({ baseUrl: BASE, fetchImpl: makeFetch() });
+    const mit = candidates.find((c) => c.id === 'din913_set_screw_m3x3')!;
+    expect(mit.licenseClass).toBe('permissive');
+    expect(mit.redistribution).toBe('mirror');
+    expect(mit.stepUrl).toBe('https://media.example/din913.step');
+    expect(mit.upstream).toMatchObject({
+      repo: 'github.com/earthtojake/step.parts',
+      commit: 'test-v1',
+      path: 'din913_set_screw_m3x3',
+    });
+    expect(mit.attribution).toBeTruthy();
+    expect(mit.standard).toBe('DIN 913');
+    expect(mit.category).toBe('fastener');
+  });
+
+  it('classifies share-alike parts as share-alike', async () => {
+    const { candidates } = await ingestStepParts({ baseUrl: BASE, fetchImpl: makeFetch() });
+    const sa = candidates.find((c) => c.id === 'kicad_R_0805')!;
+    expect(sa.licenseClass).toBe('share-alike');
+    expect(sa.redistribution).toBe('mirror');
+  });
+
+  it('maps non-taxonomy source categories via guessCategory', async () => {
+    const { candidates } = await ingestStepParts({ baseUrl: BASE, fetchImpl: makeFetch() });
+    const motor = candidates.find((c) => c.id === 'nema17_stepper')!;
+    // 'unknown-source-category' is not a taxonomy cat -> guessed from name/tags.
+    expect(motor.category).toBe('actuator');
+  });
+
+  it('report counts add up to the index size', async () => {
+    const { report } = await ingestStepParts({ baseUrl: BASE, fetchImpl: makeFetch() });
+    const accounted =
+      report.ingested +
+      report.droppedForLicense +
+      report.skippedUnparseable +
+      report.deduped;
+    expect(accounted).toBe(FIXTURE_INDEX.items.length);
+  });
+
+  it('respects the limit option', async () => {
+    const { candidates } = await ingestStepParts({
+      baseUrl: BASE,
+      fetchImpl: makeFetch(),
+      limit: 1,
+    });
+    expect(candidates).toHaveLength(1);
+  });
+});

--- a/scripts/parts/stepPartsIngest.ts
+++ b/scripts/parts/stepPartsIngest.ts
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/stepPartsIngest.ts
+//
+// step.parts ingestion adapter. Reads the public step.parts catalog index and
+// the catalog repo's THIRD_PARTY_NOTICES.md, resolves a per-part license,
+// classifies it, and emits PartCandidate[] for the REDISTRIBUTABLE subset
+// (permissive + share-alike); fetch-only parts (NC/ND/unknown) are dropped and
+// accounted for in the run report.
+//
+// Reality note (vs the original brief): step.parts' THIRD_PARTY_NOTICES.md is a
+// per-SOURCE license table (KiCad / FreeCAD-library / Adafruit / SparkFun /
+// original-MIT), NOT a per-part id→license map. The catalog index items also
+// carry no per-part license field. So we parse the notices file defensively for
+// BOTH shapes — explicit `id: SPDX` lines if a future version adds them, AND the
+// per-source `### Section … SPDX-expression` table — and map a part to a license
+// by (1) an exact id match, then (2) its source section inferred from the part's
+// family/category/id provenance, then (3) UNKNOWN ⇒ fetch-only (dropped).
+
+import type {
+  PartCandidate,
+  IngestRunReport,
+} from './contracts';
+import type { LicenseClass } from '../../src/shared/parts/types';
+import {
+  guessCategory,
+  isPartCategory,
+} from '../../src/shared/parts/taxonomy';
+import {
+  STEP_PARTS_BASE_URL,
+  mapStepPartsRecord,
+  type StepPartsRecord,
+} from '../../src/modeling/parts/stepPartsAdapter';
+
+const NOTICES_URL =
+  'https://raw.githubusercontent.com/earthtojake/step.parts/main/THIRD_PARTY_NOTICES.md';
+
+const STEP_PARTS_REPO = 'github.com/earthtojake/step.parts';
+
+/** A catalog index item (the per-part summary in parts.index.json `items`). */
+interface CatalogIndexItem extends StepPartsRecord {
+  // index items carry id/name/category/family/standard/tags/aliases/pageUrl;
+  // stepUrl + sha256 may be supplied (e.g. in fixtures / future index versions)
+  // and are passed straight through if present.
+  sourceKey?: string;
+}
+
+interface CatalogIndex {
+  catalog?: { version?: string; sha256?: string; lastModified?: string };
+  fields?: string[];
+  items: CatalogIndexItem[];
+}
+
+/**
+ * Classify an SPDX-ish license string into a redistribution LicenseClass.
+ *   permissive  — MIT / BSD / Apache / CC0 / CC-BY (no SA/NC/ND) / ISC / Unlicense
+ *   share-alike — CC-BY-SA / CERN-OHL / GPL / LGPL / MPL
+ *   fetch-only  — CC*NC* / CC*ND* / 'unknown' / empty
+ */
+export function classifyLicense(spdx: string | undefined | null): LicenseClass {
+  const s = (spdx ?? '').trim().toUpperCase();
+  if (s.length === 0 || s === 'UNKNOWN' || s === 'NONE' || s === 'NOASSERTION') {
+    return 'fetch-only';
+  }
+  // Non-commercial / no-derivatives are never mirrorable, regardless of base.
+  if (/\bNC\b/.test(s) || s.includes('-NC') || s.includes('NONCOMMERCIAL')) {
+    return 'fetch-only';
+  }
+  if (/\bND\b/.test(s) || s.includes('-ND') || s.includes('NODERIV')) {
+    return 'fetch-only';
+  }
+  // Share-alike / copyleft.
+  if (
+    s.includes('-SA') ||
+    s.includes('SHAREALIKE') ||
+    s.includes('CERN-OHL') ||
+    s.includes('GPL') || // covers GPL / LGPL / AGPL
+    s.includes('MPL') ||
+    s.includes('EPL')
+  ) {
+    return 'share-alike';
+  }
+  // Permissive.
+  if (
+    s.includes('MIT') ||
+    s.includes('BSD') ||
+    s.includes('APACHE') ||
+    s.includes('CC0') ||
+    s.includes('CC-BY') || // BY without SA/NC/ND fell through to here ⇒ permissive
+    s.includes('CC BY') ||
+    s.includes('ISC') ||
+    s.includes('UNLICENSE') ||
+    s.includes('ZLIB') ||
+    s.includes('PUBLIC DOMAIN')
+  ) {
+    return 'permissive';
+  }
+  // Anything unrecognized is treated as not-known-safe to mirror.
+  return 'fetch-only';
+}
+
+/**
+ * Parse THIRD_PARTY_NOTICES.md into license-resolution tables.
+ *
+ * Returns two maps:
+ *   byId     — explicit `partId: SPDX` lines (rare/future; matched first).
+ *   bySource — per-source-section SPDX, keyed by a normalized source token
+ *              ('kicad', 'freecad-library', 'adafruit', 'sparkfun', ...).
+ * Also returns `defaultSpdx` — the repo-level/original-material license (MIT)
+ * used as the last resort before UNKNOWN.
+ *
+ * Parsing is intentionally tolerant: it scans line-by-line, tracks the current
+ * `###`/`##` section heading, and records the first SPDX-looking token within
+ * that section. Unknown shapes simply yield empty maps (everything → fetch-only).
+ */
+export function parseThirdPartyNotices(md: string): {
+  byId: Map<string, string>;
+  bySource: Map<string, string>;
+  defaultSpdx: string | undefined;
+} {
+  const byId = new Map<string, string>();
+  const bySource = new Map<string, string>();
+  let defaultSpdx: string | undefined;
+
+  // SPDX expression: letters/digits and . - + with optional `WITH exception`.
+  const spdxRe =
+    /\b((?:CC0|CC[\s-]?BY(?:[\s-]?SA|[\s-]?NC|[\s-]?ND)*(?:[\s-]?\d(?:\.\d)?)?|MIT|BSD-[0-9]-Clause|BSD|Apache-2\.0|Apache|GPL-[0-9]\.[0-9](?:-or-later|-only)?|LGPL-[0-9]\.[0-9]|AGPL-[0-9]\.[0-9]|MPL-[0-9]\.[0-9]|MPL|CERN-OHL(?:-[A-Z])?-[0-9]\.[0-9]|ISC|Unlicense|Zlib)(?:\s+WITH\s+[\w.-]+)?)\b/i;
+
+  let currentSection: string | null = null;
+  for (const rawLine of md.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.length === 0) continue;
+
+    // Section heading (## or ###). Normalize to a lowercase source token.
+    const heading = line.match(/^#{2,4}\s+(.*)$/);
+    if (heading) {
+      currentSection = normalizeSourceToken(heading[1]);
+      continue;
+    }
+
+    const spdxMatch = line.match(spdxRe);
+    const spdx = spdxMatch ? spdxMatch[1].replace(/\s+/g, '-') : undefined;
+
+    // Explicit per-part line: `someId: SPDX` or `| someId | SPDX |`.
+    const idLine = line.match(/^[|\s]*([a-z0-9][a-z0-9._-]{2,})\s*[:|]\s*(.+)$/i);
+    if (idLine && spdx && looksLikePartId(idLine[1])) {
+      byId.set(idLine[1].toLowerCase(), spdx);
+      continue;
+    }
+
+    // Per-source SPDX inside a known section (first SPDX in the section wins).
+    if (spdx && currentSection) {
+      if (!bySource.has(currentSection)) bySource.set(currentSection, spdx);
+      // The "original / not based on third-party" section defines the default.
+      if (
+        defaultSpdx === undefined &&
+        (currentSection.includes('original') ||
+          currentSection.includes('project-material') ||
+          currentSection.includes('first-party'))
+      ) {
+        defaultSpdx = spdx;
+      }
+    } else if (spdx && currentSection === null && defaultSpdx === undefined) {
+      // Top-of-file MIT statement before any section.
+      if (/license/i.test(line) && spdx.toUpperCase().includes('MIT')) {
+        defaultSpdx = spdx;
+      }
+    }
+  }
+
+  return { byId, bySource, defaultSpdx };
+}
+
+function normalizeSourceToken(heading: string): string {
+  return heading
+    .toLowerCase()
+    .replace(/[`*]/g, '')
+    .replace(/https?:\/\/\S+/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function looksLikePartId(s: string): boolean {
+  // Part ids are snake/kebab tokens, not prose words like "License" or "Source".
+  return /[_-]/.test(s) || /\d/.test(s);
+}
+
+/** Source tokens we can infer for a step.parts item, used to hit bySource. */
+function inferSourceTokens(item: CatalogIndexItem): string[] {
+  const tokens: string[] = [];
+  if (item.sourceKey) tokens.push(normalizeSourceToken(item.sourceKey));
+  const blob = `${item.id} ${item.family} ${item.category} ${(item.tags ?? []).join(' ')}`.toLowerCase();
+  // Heuristic source attribution from the part's provenance fingerprint.
+  if (/kicad/.test(blob)) tokens.push('kicad', 'kicad-packages3d');
+  if (/freecad/.test(blob)) tokens.push('freecad', 'freecad-library');
+  if (/adafruit/.test(blob)) tokens.push('adafruit', 'adafruit-cad-parts');
+  if (/sparkfun/.test(blob)) tokens.push('sparkfun');
+  return tokens;
+}
+
+function resolveSpdx(
+  item: CatalogIndexItem,
+  tables: ReturnType<typeof parseThirdPartyNotices>,
+): string | undefined {
+  // 1. Explicit per-part override.
+  const direct = tables.byId.get(item.id.toLowerCase());
+  if (direct) return direct;
+  // 2. An inline per-item license field (fixtures / future index versions).
+  const inline = (item as unknown as { license?: string }).license;
+  if (typeof inline === 'string' && inline.length > 0) return inline;
+  // 3. Per-source section.
+  for (const tok of inferSourceTokens(item)) {
+    const hit = tables.bySource.get(tok);
+    if (hit) return hit;
+  }
+  // No positive license signal. The repo-level default (`tables.defaultSpdx`,
+  // MIT) covers only step.parts' OWN original material — it must NOT blanket
+  // every unattributed part, or we'd mirror geometry whose provenance we can't
+  // prove. So an unresolved part is UNKNOWN ⇒ fetch-only ⇒ dropped.
+  return undefined;
+}
+
+/** Pick a robotics-taxonomy category, preferring the source's own when valid. */
+function resolveCategory(item: CatalogIndexItem): string {
+  if (isPartCategory(item.category)) return item.category;
+  const hint = `${item.name} ${item.family} ${(item.tags ?? []).join(' ')} ${item.id}`;
+  return guessCategory(hint);
+}
+
+export interface IngestStepPartsOptions {
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+  limit?: number;
+}
+
+/**
+ * Ingest the step.parts catalog into PartCandidate[] (redistributable subset).
+ *
+ * 1. GET `${baseUrl}/v1/catalog/parts.index.json`.
+ * 2. GET THIRD_PARTY_NOTICES.md → license-resolution tables.
+ * 3. Classify each part; drop fetch-only (NC/ND/unknown), count them.
+ * 4. Map the kept parts via `mapStepPartsRecord`, stamping licenseClass,
+ *    redistribution:'mirror', upstream provenance, stepUrl, attribution, and
+ *    a robotics-taxonomy category.
+ * 5. Fill the IngestRunReport.
+ */
+export async function ingestStepParts(opts: IngestStepPartsOptions = {}): Promise<{
+  candidates: PartCandidate[];
+  report: IngestRunReport;
+}> {
+  const baseUrl = opts.baseUrl ?? STEP_PARTS_BASE_URL;
+  const doFetch = opts.fetchImpl ?? fetch;
+
+  const report: IngestRunReport = {
+    source: 'step-parts',
+    ingested: 0,
+    skippedUnparseable: 0,
+    droppedForLicense: 0,
+    deduped: 0,
+    connectorless: 0,
+    errors: [],
+  };
+  const candidates: PartCandidate[] = [];
+
+  // 1. Catalog index.
+  let index: CatalogIndex;
+  try {
+    const res = await doFetch(`${baseUrl}/v1/catalog/parts.index.json`);
+    if (!res.ok) {
+      report.errors.push(`catalog index HTTP ${res.status}`);
+      return { candidates, report };
+    }
+    index = (await res.json()) as CatalogIndex;
+  } catch (err) {
+    report.errors.push(`catalog index fetch failed: ${String(err)}`);
+    return { candidates, report };
+  }
+
+  const items = Array.isArray(index?.items) ? index.items : [];
+  if (items.length === 0) {
+    report.errors.push('catalog index had no items');
+    return { candidates, report };
+  }
+
+  // 2. License tables.
+  let tables: ReturnType<typeof parseThirdPartyNotices> = {
+    byId: new Map(),
+    bySource: new Map(),
+    defaultSpdx: undefined,
+  };
+  try {
+    const res = await doFetch(NOTICES_URL);
+    if (res.ok) {
+      tables = parseThirdPartyNotices(await res.text());
+    } else {
+      report.errors.push(`THIRD_PARTY_NOTICES HTTP ${res.status} (licenses → unknown)`);
+    }
+  } catch (err) {
+    report.errors.push(`THIRD_PARTY_NOTICES fetch failed: ${String(err)}`);
+  }
+
+  const upstreamCommit = index.catalog?.version ?? index.catalog?.sha256 ?? 'main';
+  const limit = opts.limit;
+  const seen = new Set<string>();
+
+  for (const item of items) {
+    if (limit !== undefined && candidates.length >= limit) break;
+    if (!item || typeof item.id !== 'string' || item.id.length === 0) {
+      report.skippedUnparseable++;
+      continue;
+    }
+
+    const spdx = resolveSpdx(item, tables);
+    const licenseClass = classifyLicense(spdx);
+
+    // Drop the non-redistributable subset.
+    if (licenseClass === 'fetch-only') {
+      report.droppedForLicense++;
+      continue;
+    }
+
+    if (seen.has(item.id)) {
+      report.deduped++;
+      continue;
+    }
+    seen.add(item.id);
+
+    const base = mapStepPartsRecord(item);
+    const category = resolveCategory(item);
+    const stepUrl =
+      item.stepUrl ?? base.stepUrl ?? `${baseUrl}/v1/parts/${item.id}/step`;
+    const attribution =
+      base.attribution ?? item.pageUrl ?? `https://www.step.parts/parts/${item.id}`;
+
+    const candidate: PartCandidate = {
+      id: base.id,
+      name: base.name,
+      category,
+      family: base.family,
+      tags: base.tags,
+      attributes: base.attributes,
+      license: spdx ?? base.license,
+      licenseClass,
+      attribution,
+      redistribution: 'mirror',
+      upstream: {
+        repo: STEP_PARTS_REPO,
+        commit: upstreamCommit,
+        path: item.id,
+      },
+      stepUrl,
+    };
+    if (base.standard !== undefined) candidate.standard = base.standard;
+
+    candidates.push(candidate);
+    report.ingested++;
+    report.connectorless++; // connectors are synthesized later, at fetch time
+  }
+
+  return { candidates, report };
+}

--- a/scripts/parts/workerTemplate.ts
+++ b/scripts/parts/workerTemplate.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/workerTemplate.ts
+//
+// The Cloudflare Pages advanced-mode `_worker.js` served from a deployed parts
+// catalog. Serves `/v1/parts?q=...` (search) and `/v1/parts/{id}` (detail) over
+// the static `/v1/catalog/parts.index.json` asset; everything else (the .step
+// blobs, per-part .json) falls through to `env.ASSETS`.
+//
+// Ingestion-engine extensions over the original ingestParts.ts shim:
+//   - GATE G4 / legal-hold: records tagged 'legal-hold' (share-alike collections
+//     pending sign-off) are EXCLUDED from `/v1/parts` search results by default.
+//     Pass `?includeLegalHold=1` to include them. Direct `/v1/parts/{id}` detail
+//     is NOT filtered (an explicit id lookup is an intentional fetch).
+//   - `?licenseClass=` filter passthrough on search.
+//
+// Exported as a string so both ingestParts.ts and the engine write the same
+// `_worker.js`.
+
+export const PAGES_WORKER = `// SPDX-License-Identifier: MIT
+// Serves /v1/parts?q=... (search) and /v1/parts/{id} (detail) from the static
+// /v1/catalog/parts.index.json asset; all other paths fall through to static
+// assets. Deploy this directory to Cloudflare Pages and point
+// KERNELCAD_PARTS_BASE_URL at it.
+//
+// Legal-hold records (share-alike collections behind a sign-off gate) are tagged
+// 'legal-hold' and excluded from search by default. Pass ?includeLegalHold=1 to
+// include them; an explicit /v1/parts/{id} lookup is never filtered.
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const m = url.pathname.match(/^\\/v1\\/parts(?:\\/(.+))?$/);
+    if (!m) return env.ASSETS.fetch(request);
+
+    const idxReq = new Request(url.origin + '/v1/catalog/parts.index.json');
+    const res = await env.ASSETS.fetch(idxReq);
+    if (!res.ok) return new Response('catalog index unavailable', { status: 502 });
+    const items = (await res.json()).items;
+
+    const id = m[1] ? m[1].replace(/\\.json$/, '') : '';
+    if (id) {
+      // Explicit id lookup: intentional fetch, not filtered by legal-hold.
+      const rec = items.find((r) => r.id === id);
+      return rec
+        ? Response.json(rec)
+        : new Response('not found', { status: 404 });
+    }
+
+    const includeLegalHold = url.searchParams.get('includeLegalHold') === '1';
+    const licenseClass = (url.searchParams.get('licenseClass') || '').toLowerCase();
+    const q = (url.searchParams.get('q') || '').toLowerCase();
+
+    const isLegalHold = (r) => (r.tags || []).includes('legal-hold');
+
+    let hits = items;
+    if (!includeLegalHold) hits = hits.filter((r) => !isLegalHold(r));
+    if (licenseClass) hits = hits.filter((r) => (r.licenseClass || '').toLowerCase() === licenseClass);
+    if (q) {
+      hits = hits.filter((r) =>
+        [r.id, r.name, ...(r.tags || [])].join(' ').toLowerCase().includes(q),
+      );
+    }
+    return Response.json({ items: hits, total: hits.length });
+  },
+};
+`;

--- a/src/agent/mcp/tools/fetchPart.ts
+++ b/src/agent/mcp/tools/fetchPart.ts
@@ -5,7 +5,10 @@
 // MCP tool: resolve a bundled (or remote) part id to a record + cache path.
 
 import { CaptureSession } from '../../../modeling/capture/captureSession';
-import { fetchPartHost } from '../../../modeling/parts/fetchPart';
+import {
+  fetchPartHost,
+  fetchPartFromUrlHost,
+} from '../../../modeling/parts/fetchPart';
 import { KernelError } from '../../../shared/intent/kernelError';
 import {
   loadCatalog,
@@ -16,6 +19,8 @@ import type { PartRecord } from '../../../shared/parts/types';
 export interface FetchPartInput {
   id?: string;
   query?: string;
+  /** Direct geometry URL (FETCH-BY-URL mode). Trusted hosts only; never re-hosted. */
+  url?: string;
   category?: string;
   family?: string;
   standard?: string;
@@ -30,18 +35,64 @@ export type FetchPartOutput =
       sha256: string;
       source: 'local' | 'remote';
     }
+  | {
+      // FETCH-BY-URL vendor configurator: the agent must download + ingest locally.
+      ok: true;
+      kind: 'link_out';
+      url: string;
+      instruction: string;
+    }
+  | { ok: false; error: 'url_host_not_allowed'; host: string | null }
   | { ok: false; error: string; errorCode: string; errorHint: string };
 
 export async function fetchPartTool(
   input: FetchPartInput,
 ): Promise<FetchPartOutput> {
+  // FETCH-BY-URL mode takes precedence when a url is supplied.
+  if (typeof input.url === 'string' && input.url.length > 0) {
+    const session = new CaptureSession();
+    try {
+      const outcome = await fetchPartFromUrlHost({ session }, input.url);
+      if (!outcome.ok) {
+        return { ok: false, error: outcome.error, host: outcome.host };
+      }
+      if (outcome.kind === 'link_out') {
+        return {
+          ok: true,
+          kind: 'link_out',
+          url: outcome.url,
+          instruction: outcome.instruction,
+        };
+      }
+      const { record } = outcome.result;
+      const cachePath = String(record.attributes.cachePath ?? '');
+      return {
+        ok: true,
+        record,
+        cachePath,
+        sha256: record.sha256,
+        source: 'remote',
+      };
+    } catch (e) {
+      if (e instanceof KernelError) {
+        return {
+          ok: false,
+          error: e.message,
+          errorCode: e.code,
+          errorHint: e.hint ?? '',
+        };
+      }
+      throw e;
+    }
+  }
+
   if (!input.id && !input.query) {
     return {
       ok: false,
-      error: 'fetch_part requires id or query.',
+      error: 'fetch_part requires id, query, or url.',
       errorCode: 'parts.input.id-or-query-required',
       errorHint:
-        'Pass either an id (exact bundled record) or a query (fuzzy search).',
+        'Pass an id (exact bundled record), a query (fuzzy search), or a url (direct geometry URL).',
     };
   }
   const idOrQuery = input.id ?? input.query!;

--- a/src/agent/mcp/tools/findPart.ts
+++ b/src/agent/mcp/tools/findPart.ts
@@ -9,7 +9,7 @@ import {
   type FindPartOpts,
 } from '../../../modeling/parts/findPart';
 import { KernelError } from '../../../shared/intent/kernelError';
-import type { PartRecord } from '../../../shared/parts/types';
+import type { LicenseClass, PartRecord } from '../../../shared/parts/types';
 
 export interface FindPartInput {
   query?: string;
@@ -20,6 +20,8 @@ export interface FindPartInput {
   limit?: number;
   source?: 'local' | 'remote' | 'auto';
   partsBaseUrl?: string;
+  /** Restrict to a redistribution license class ('permissive' | 'share-alike' | 'fetch-only'). */
+  licenseClass?: LicenseClass;
 }
 
 export interface FindPartOk {
@@ -68,6 +70,9 @@ export async function findPartTool(
       ...(input.source !== undefined ? { source: input.source } : {}),
       ...(input.partsBaseUrl !== undefined
         ? { partsBaseUrl: input.partsBaseUrl }
+        : {}),
+      ...(input.licenseClass !== undefined
+        ? { licenseClass: input.licenseClass }
         : {}),
     };
     const r = await findPartHost(input.query ?? '', opts);

--- a/src/agent/skills/kernelcad-parts/SKILL.md
+++ b/src/agent/skills/kernelcad-parts/SKILL.md
@@ -24,14 +24,31 @@ chain. Each step narrows the search:
    `motor`, `connector`, `shaft`).
 2. `inspect({ of: 'part-families', category })` → families within the bucket
    (e.g. `socket-head-cap-screw`, `deep-groove-ball-bearing`).
-3. `find_part` `{ query, family?, standard?, tag? }` → ranked records that
-   match the fuzzy query plus filters. Tokens AND-combine; cross-facet
-   filters AND-combine.
+3. `find_part` `{ query, family?, standard?, tag?, licenseClass? }` → ranked
+   records that match the fuzzy query plus filters. Tokens AND-combine;
+   cross-facet filters AND-combine. `licenseClass` (`'permissive'` |
+   `'share-alike'` | `'fetch-only'`) filters by redistribution license; records
+   with no class are treated as `permissive` (the bundled catalog).
 4. `fetch_part` `{ id }` → resolves the id to a record, writes the STEP into
    the cache, returns the cache path + sha256.
 
 For tasks where the id is already known, skip straight to `fetch_part` or
 use the typed `lib.standard.*` shortcuts.
+
+### Fetch-by-URL (parts not in the catalog)
+
+`fetch_part { url }` pulls geometry on demand from an **allowlisted** host
+(`raw.githubusercontent.com`, `objects.githubusercontent.com`, `github.com`,
+`gitlab.com`, `api.step.parts`) — it is cached locally, never re-hosted
+(`redistribution: 'fetch-only'`):
+
+- A `.step`/`.stp` URL → inspected, connectors synthesized, returned as a record.
+- A `.stl`/`.dae`/`.obj` URL → returned as a `mesh-import` handle (non-BREP,
+  `attributes.geometryKind = 'mesh'`) for blockout/reference.
+- A **vendor configurator** URL (igus/MISUMI/Pololu/TraceParts) → NOT fetched;
+  returns `{ kind: 'link_out', url, instruction }`. Download the STEP from the
+  configurator and ingest it locally with `fetch_part { file }`.
+- A disallowed host → `{ error: 'url_host_not_allowed' }`.
 
 ## Authoring surface
 

--- a/src/agent/skills/kernelcad-parts/SKILL.md
+++ b/src/agent/skills/kernelcad-parts/SKILL.md
@@ -38,9 +38,8 @@ use the typed `lib.standard.*` shortcuts.
 ### Fetch-by-URL (parts not in the catalog)
 
 `fetch_part { url }` pulls geometry on demand from an **allowlisted** host
-(`raw.githubusercontent.com`, `objects.githubusercontent.com`, `github.com`,
-`gitlab.com`, `api.step.parts`) — it is cached locally, never re-hosted
-(`redistribution: 'fetch-only'`):
+(GitHub/GitLab raw + release-asset hosts and the kernelCAD parts host) — it is
+cached locally, never re-hosted (`redistribution: 'fetch-only'`):
 
 - A `.step`/`.stp` URL → inspected, connectors synthesized, returned as a record.
 - A `.stl`/`.dae`/`.obj` URL → returned as a `mesh-import` handle (non-BREP,

--- a/src/modeling/parts/fetchPart.ts
+++ b/src/modeling/parts/fetchPart.ts
@@ -9,6 +9,7 @@
 //   4. Throw `parts.fetch.remote-disabled` when no partsBaseUrl is set.
 
 import { existsSync, readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import type { CaptureSession } from '../capture/captureSession';
 import { fromStepBytes } from './fromSTEP';
 import type { Shape } from '../capture/proxy';
@@ -43,6 +44,243 @@ export interface FetchPartOpts {
 export interface FetchPartResult {
   shape: Shape;
   record: PartRecord;
+}
+
+// ---------------------------------------------------------------------------
+// FETCH-BY-URL mode
+//
+// An agent may hand fetch_part a direct geometry URL instead of a catalog id.
+// We never re-host these bytes (redistribution:'fetch-only') and we only ever
+// touch the network for a small allowlist of trusted code-hosting hosts. Vendor
+// *configurators* (igus, misumi, …) are detected and turned into a `link_out`
+// instruction — those need a human to drive a parametric download UI, so the
+// agent is told to ingest the resulting STEP locally with fetch_part({ file }).
+// ---------------------------------------------------------------------------
+
+/** Hosts we are willing to fetch raw geometry bytes from. */
+const ALLOWED_PART_URL_HOSTS = [
+  'raw.githubusercontent.com',
+  'objects.githubusercontent.com',
+  'github.com',
+  'gitlab.com',
+  'api.step.parts',
+];
+
+/**
+ * Vendor configurator hosts. These serve parametric part *UIs*, not direct
+ * geometry, so we never fetch them — we return a `link_out` telling the agent
+ * to download the STEP by hand and ingest it locally.
+ */
+const VENDOR_CONFIGURATOR_HOSTS: RegExp[] = [
+  /(^|\.)partcommunity\.com$/i, // igus.partcommunity.com and friends
+  /(^|\.)misumi([.-]|$)/i, // misumi*, e.g. us.misumi-ec.com / misumi.com
+  /(^|\.)pololu\.com$/i,
+  /(^|\.)traceparts/i, // traceparts.com / traceparts*
+];
+
+function parseUrlHost(url: string): string | null {
+  try {
+    return new URL(url).host.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/** True when `url` parses and its host is on the trusted fetch allowlist. */
+export function isAllowedPartUrl(url: string): boolean {
+  const host = parseUrlHost(url);
+  if (host === null) return false;
+  // `host` includes a :port; compare on hostname (strip the port) too.
+  const hostname = host.replace(/:\d+$/, '');
+  return ALLOWED_PART_URL_HOSTS.includes(hostname);
+}
+
+function isVendorConfiguratorUrl(url: string): boolean {
+  const host = parseUrlHost(url);
+  if (host === null) return false;
+  const hostname = host.replace(/:\d+$/, '');
+  return VENDOR_CONFIGURATOR_HOSTS.some((re) => re.test(hostname));
+}
+
+/**
+ * Classify a part URL into one of three handling modes:
+ *  - 'link_out' — a vendor configurator; the agent must download the STEP by
+ *                 hand and ingest it locally (never fetched here).
+ *  - 'fetch'    — an allowed host; bytes may be fetched.
+ *  - 'blocked'  — anything else (unknown / untrusted host, or unparseable).
+ *
+ * Vendor detection wins over the allowlist so a configurator can never be
+ * fetched even if it were also allowlisted.
+ */
+export function classifyPartUrl(url: string): 'fetch' | 'link_out' | 'blocked' {
+  if (isVendorConfiguratorUrl(url)) return 'link_out';
+  if (isAllowedPartUrl(url)) return 'fetch';
+  return 'blocked';
+}
+
+/** Structured outcomes of the fetch-by-URL path (host-level, pre-Shape). */
+export type FetchPartUrlOutcome =
+  | { ok: false; error: 'url_host_not_allowed'; host: string | null }
+  | {
+      ok: true;
+      kind: 'link_out';
+      url: string;
+      instruction: string;
+    }
+  | { ok: true; kind: 'part'; result: FetchPartResult };
+
+export interface FetchPartUrlOpts {
+  /** Injectable network fetch so tests never hit the wire. Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+const STEP_EXT_RE = /\.(step|stp)(\?.*)?$/i;
+const MESH_EXT_RE = /\.(stl|dae|obj)(\?.*)?$/i;
+
+function sha256Hex(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+/**
+ * FETCH-BY-URL entrypoint. Resolves a direct geometry URL on a trusted host to
+ * a fetch-only PartRecord (STEP → inspected + connector-synthesized; mesh →
+ * cached, flagged non-BREP). Never re-hosts. See classifyPartUrl for routing.
+ */
+export async function fetchPartFromUrlHost(
+  ctx: FetchPartCtx,
+  url: string,
+  opts: FetchPartUrlOpts = {},
+): Promise<FetchPartUrlOutcome> {
+  const mode = classifyPartUrl(url);
+  if (mode === 'link_out') {
+    return {
+      ok: true,
+      kind: 'link_out',
+      url,
+      instruction:
+        'Download the STEP from this configurator and ingest it locally with fetch_part({ file })',
+    };
+  }
+  if (mode === 'blocked') {
+    return { ok: false, error: 'url_host_not_allowed', host: parseUrlHost(url) };
+  }
+
+  const doFetch = opts.fetchImpl ?? fetch;
+  const fetcher = async (u: string): Promise<Buffer> => {
+    const resp = await doFetch(u);
+    if (!resp.ok) {
+      throw new KernelError(
+        'parts.fetch.api-error',
+        `fetch_part(url): HTTP ${resp.status} fetching ${u}.`,
+        undefined,
+        'parts.fetch.url.http-error — the geometry URL returned a non-2xx status; verify the link is a direct file URL.',
+      );
+    }
+    return Buffer.from(await resp.arrayBuffer());
+  };
+
+  const isMesh = MESH_EXT_RE.test(url);
+  const isStep = STEP_EXT_RE.test(url);
+  if (!isMesh && !isStep) {
+    throw new KernelError(
+      'feature.invalid-args',
+      `fetch_part(url): ${url} is not a recognized geometry URL (.step/.stp or .stl/.dae/.obj).`,
+      undefined,
+      'parts.fetch.url.unsupported-ext — point at a direct .step/.stp (BREP) or .stl/.dae/.obj (mesh) URL.',
+    );
+  }
+
+  const ext = isMesh ? meshExt(url) : '.step';
+  // Cache under the same ~/.cache/kernelcad/parts/<sha256(url)><ext> path the
+  // remote tier uses. No expectedSha256: the URL is the trust anchor here, and
+  // we hash the bytes ourselves for the record's provenance field.
+  const path = await getOrFetchAsync({
+    consumer: 'parts',
+    url,
+    ext,
+    ttlMs: null,
+    fetcher,
+  });
+  const bytes = readFileSync(path);
+  const sha256 = sha256Hex(bytes);
+  const baseName = urlBaseName(url);
+
+  if (isMesh) {
+    // Mesh import: we do NOT have a BREP path here, so return a usable cached
+    // handle flagged as a mesh. The cache path is exposed via metadata so the
+    // mesh-import escape hatch can pick it up.
+    const record: PartRecord = {
+      id: `url:${sha256.slice(0, 16)}`,
+      name: baseName,
+      category: 'imported',
+      family: 'url-import',
+      tags: ['url-import', 'mesh-import'],
+      attributes: { geometryKind: 'mesh', cachePath: path },
+      sha256,
+      source: 'remote',
+      license: 'unknown',
+      connectors: [],
+      stepUrl: url,
+      redistribution: 'fetch-only',
+    };
+    // Mesh imports have no Shape (no BREP); surface the cached path on a stub
+    // shape so callers keep a uniform { shape, record } contract. We park no
+    // geometry — the lowerer treats this as a mesh-import escape hatch.
+    const shape = ctx.session.createShape({
+      kind: 'importedMesh',
+      params: {},
+      inputs: {},
+      metadata: { sourcePath: path, geometryKind: 'mesh' },
+    });
+    return { ok: true, kind: 'part', result: { shape, record } };
+  }
+
+  // STEP path: import → inspect → synthesize connectors (same flow the remote
+  // tier uses for catalog STEP).
+  const shape = await fromStepBytes(ctx, bytes, url);
+  let connectors: string[] = [];
+  try {
+    const report = await inspectStepFile(path);
+    const conns = synthesizeConnectorsFromReport(report, shape.id);
+    if (conns.length > 0) {
+      ctx.session.attachAutoConnectors(shape.id, conns);
+      connectors = conns.map((c) => c.name);
+    }
+  } catch {
+    // Defensive: a STEP that resists inspection still imports, just without
+    // synthesized connectors.
+  }
+
+  const record: PartRecord = {
+    id: `url:${sha256.slice(0, 16)}`,
+    name: baseName,
+    category: 'imported',
+    family: 'url-import',
+    tags: ['url-import'],
+    attributes: {},
+    sha256,
+    source: 'remote',
+    license: 'unknown',
+    connectors,
+    stepUrl: url,
+    redistribution: 'fetch-only',
+  };
+  return { ok: true, kind: 'part', result: { shape, record } };
+}
+
+function meshExt(url: string): string {
+  const m = MESH_EXT_RE.exec(url);
+  return m ? `.${m[1].toLowerCase()}` : '.stl';
+}
+
+function urlBaseName(url: string): string {
+  try {
+    const p = new URL(url).pathname;
+    const last = p.split('/').filter(Boolean).pop();
+    return last ? decodeURIComponent(last) : url;
+  } catch {
+    return url;
+  }
 }
 
 export async function fetchPartHost(

--- a/src/modeling/parts/fetchPartUrl.test.ts
+++ b/src/modeling/parts/fetchPartUrl.test.ts
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/modeling/parts/fetchPartUrl.test.ts
+//
+// FETCH-BY-URL mode: allowlist + vendor-configurator classification (pure),
+// and the host fetch path with an injected fetchImpl so no network / OCCT is
+// touched. The geometry modules (fromStepBytes / inspectStepFile /
+// synthesizeConnectorsFromReport) are mocked so the STEP path stays
+// deterministic without an OCCT init — mirroring how the catalog STEP flow is
+// kept offline elsewhere.
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// --- Mock the geometry dependencies of fetchPart's URL STEP path. ----------
+// fromStepBytes registers a real Shape on the passed session so connector
+// attachment + the { shape, record } contract work without importing STEP.
+vi.mock('./fromSTEP', () => ({
+  fromStepBytes: vi.fn(
+    async (
+      ctx: { session: { createShape: (s: unknown) => { id: string } } },
+      _bytes: Buffer,
+      sourceLabel: string,
+    ) =>
+      ctx.session.createShape({
+        kind: 'importedStep',
+        params: {},
+        inputs: {},
+        metadata: { sourcePath: sourceLabel },
+      }),
+  ),
+}));
+
+vi.mock('../../agent/inspect/inspectStep', () => ({
+  inspectStepFile: vi.fn(async (path: string) => ({
+    file: path,
+    solidCount: 1,
+    solids: [],
+  })),
+}));
+
+vi.mock('./synthesizeConnectors', () => ({
+  synthesizeConnectorsFromReport: vi.fn(
+    (_report: unknown, partName: string) => [
+      {
+        name: 'mating-face',
+        ref: `${partName}#connector:mating-face`,
+        origin: [0, 0, 0],
+        axis: [0, 0, -1],
+        type: 'frame' as const,
+      },
+    ],
+  ),
+}));
+
+import {
+  isAllowedPartUrl,
+  classifyPartUrl,
+  fetchPartFromUrlHost,
+} from './fetchPart';
+import { __resetUserCacheForTests } from '../../shared/cache/userCache';
+import { CaptureSession } from '../capture/captureSession';
+
+const STEP_FIXTURE = Buffer.from(
+  "ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\nENDSEC;\nEND-ISO-10303-21;\n",
+  'utf8',
+);
+const MESH_FIXTURE = Buffer.from('solid x\nendsolid x\n', 'utf8');
+
+function fetchOf(bytes: Buffer, ok = true, status = 200): typeof fetch {
+  return vi.fn(async () => ({
+    ok,
+    status,
+    arrayBuffer: async () =>
+      bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  })) as unknown as typeof fetch;
+}
+
+describe('isAllowedPartUrl', () => {
+  it('accepts the trusted host allowlist', () => {
+    expect(
+      isAllowedPartUrl('https://raw.githubusercontent.com/o/r/main/p.step'),
+    ).toBe(true);
+    expect(
+      isAllowedPartUrl('https://objects.githubusercontent.com/x/p.step'),
+    ).toBe(true);
+    expect(
+      isAllowedPartUrl('https://github.com/o/r/releases/download/v1/p.step'),
+    ).toBe(true);
+    expect(isAllowedPartUrl('https://gitlab.com/o/r/-/raw/main/p.step')).toBe(
+      true,
+    );
+    expect(isAllowedPartUrl('https://api.step.parts/v1/p.step')).toBe(true);
+  });
+
+  it('rejects unknown / untrusted hosts and garbage', () => {
+    expect(isAllowedPartUrl('https://evil.example.com/p.step')).toBe(false);
+    expect(isAllowedPartUrl('https://igus.partcommunity.com/p.step')).toBe(
+      false,
+    );
+    // host-suffix spoofing must not pass.
+    expect(
+      isAllowedPartUrl('https://raw.githubusercontent.com.evil.com/p.step'),
+    ).toBe(false);
+    expect(isAllowedPartUrl('not a url')).toBe(false);
+  });
+});
+
+describe('classifyPartUrl', () => {
+  it("returns 'link_out' for vendor configurators", () => {
+    expect(classifyPartUrl('https://igus.partcommunity.com/x')).toBe(
+      'link_out',
+    );
+    expect(classifyPartUrl('https://us.misumi-ec.com/x')).toBe('link_out');
+    expect(classifyPartUrl('https://www.pololu.com/product/1/cad')).toBe(
+      'link_out',
+    );
+    expect(classifyPartUrl('https://www.traceparts.com/x')).toBe('link_out');
+  });
+
+  it("returns 'fetch' for an allowed-host STEP url", () => {
+    expect(
+      classifyPartUrl('https://raw.githubusercontent.com/o/r/main/p.step'),
+    ).toBe('fetch');
+  });
+
+  it("returns 'blocked' for disallowed hosts", () => {
+    expect(classifyPartUrl('https://evil.example.com/p.step')).toBe('blocked');
+    expect(classifyPartUrl('garbage')).toBe('blocked');
+  });
+});
+
+describe('fetchPartFromUrlHost', () => {
+  let cacheDir: string;
+  let prevCacheDir: string | undefined;
+
+  beforeEach(() => {
+    prevCacheDir = process.env.KERNELCAD_CACHE_DIR;
+    cacheDir = mkdtempSync(join(tmpdir(), 'kc-parts-url-'));
+    process.env.KERNELCAD_CACHE_DIR = cacheDir;
+    __resetUserCacheForTests();
+  });
+  afterEach(() => {
+    if (prevCacheDir === undefined) delete process.env.KERNELCAD_CACHE_DIR;
+    else process.env.KERNELCAD_CACHE_DIR = prevCacheDir;
+    rmSync(cacheDir, { recursive: true, force: true });
+    __resetUserCacheForTests();
+  });
+
+  it('STEP url on an allowed host → fetch-only PartRecord with stepUrl + connectors', async () => {
+    const session = new CaptureSession();
+    const url = 'https://raw.githubusercontent.com/o/r/main/bracket.step';
+    const outcome = await fetchPartFromUrlHost({ session }, url, {
+      fetchImpl: fetchOf(STEP_FIXTURE),
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok || outcome.kind !== 'part') throw new Error('expected part');
+    const { record, shape } = outcome.result;
+    expect(shape).toBeDefined();
+    expect(record.redistribution).toBe('fetch-only');
+    expect(record.source).toBe('remote');
+    expect(record.stepUrl).toBe(url);
+    expect(record.connectors).toContain('mating-face');
+    expect(record.sha256.length).toBeGreaterThan(0);
+    expect(record.license).toBe('unknown');
+  });
+
+  it('mesh url → mesh-flagged fetch-only record (non-BREP)', async () => {
+    const session = new CaptureSession();
+    const url = 'https://raw.githubusercontent.com/o/r/main/gizmo.stl';
+    const outcome = await fetchPartFromUrlHost({ session }, url, {
+      fetchImpl: fetchOf(MESH_FIXTURE),
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok || outcome.kind !== 'part') throw new Error('expected part');
+    const { record } = outcome.result;
+    expect(record.redistribution).toBe('fetch-only');
+    expect(record.attributes.geometryKind).toBe('mesh');
+    expect(record.tags).toContain('mesh-import');
+    expect(record.stepUrl).toBe(url);
+  });
+
+  it('disallowed host → url_host_not_allowed structured error', async () => {
+    const session = new CaptureSession();
+    const outcome = await fetchPartFromUrlHost(
+      { session },
+      'https://evil.example.com/p.step',
+      { fetchImpl: fetchOf(STEP_FIXTURE) },
+    );
+    expect(outcome).toEqual({
+      ok: false,
+      error: 'url_host_not_allowed',
+      host: 'evil.example.com',
+    });
+  });
+
+  it('vendor configurator host → link_out (never fetched)', async () => {
+    const session = new CaptureSession();
+    const fetchImpl = fetchOf(STEP_FIXTURE);
+    const outcome = await fetchPartFromUrlHost(
+      { session },
+      'https://igus.partcommunity.com/portal/x',
+      { fetchImpl },
+    );
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok || outcome.kind !== 'link_out')
+      throw new Error('expected link_out');
+    expect(outcome.url).toContain('partcommunity.com');
+    expect(outcome.instruction).toMatch(/fetch_part\(\{ file \}\)/);
+    // The configurator must never be fetched.
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/src/modeling/parts/findPart.ts
+++ b/src/modeling/parts/findPart.ts
@@ -7,7 +7,7 @@
 
 import { loadCatalog, queryCatalog } from './catalog';
 import { remoteFindParts, RemoteDisabledError } from './remoteClient';
-import type { PartRecord } from '../../shared/parts/types';
+import type { LicenseClass, PartRecord } from '../../shared/parts/types';
 
 export interface FindPartOpts {
   category?: string;
@@ -17,6 +17,22 @@ export interface FindPartOpts {
   limit?: number;
   source?: 'local' | 'remote' | 'auto';
   partsBaseUrl?: string;
+  /** Restrict results to records of this redistribution license class. Records
+   *  with NO licenseClass are treated as 'permissive' (the bundled catalog). */
+  licenseClass?: LicenseClass;
+}
+
+/** A record's effective license class — absent ⇒ 'permissive' (bundled catalog). */
+function effectiveLicenseClass(r: PartRecord): LicenseClass {
+  return r.licenseClass ?? 'permissive';
+}
+
+function filterByLicenseClass(
+  records: PartRecord[],
+  licenseClass: LicenseClass | undefined,
+): PartRecord[] {
+  if (licenseClass === undefined) return records;
+  return records.filter((r) => effectiveLicenseClass(r) === licenseClass);
 }
 
 export interface FindPartResult {
@@ -32,13 +48,16 @@ export async function findPartHost(
 ): Promise<FindPartResult> {
   const source = opts.source ?? 'auto';
   const catalog = loadCatalog();
-  const local = queryCatalog(catalog, query, {
-    ...(opts.category !== undefined ? { category: opts.category } : {}),
-    ...(opts.family !== undefined ? { family: opts.family } : {}),
-    ...(opts.standard !== undefined ? { standard: opts.standard } : {}),
-    ...(opts.tag !== undefined ? { tag: opts.tag } : {}),
-    ...(opts.limit !== undefined ? { limit: opts.limit } : {}),
-  });
+  const local = filterByLicenseClass(
+    queryCatalog(catalog, query, {
+      ...(opts.category !== undefined ? { category: opts.category } : {}),
+      ...(opts.family !== undefined ? { family: opts.family } : {}),
+      ...(opts.standard !== undefined ? { standard: opts.standard } : {}),
+      ...(opts.tag !== undefined ? { tag: opts.tag } : {}),
+      ...(opts.limit !== undefined ? { limit: opts.limit } : {}),
+    }),
+    opts.licenseClass,
+  );
   const remoteCandidate =
     (opts.partsBaseUrl !== undefined && opts.partsBaseUrl.length > 0) ||
     (process.env.KERNELCAD_PARTS_BASE_URL !== undefined &&
@@ -59,9 +78,11 @@ export async function findPartHost(
         ? { partsBaseUrl: opts.partsBaseUrl }
         : {}),
     });
+    const results = filterByLicenseClass(remote.results, opts.licenseClass);
     return {
-      results: remote.results,
-      totalMatches: remote.totalMatches,
+      results,
+      totalMatches:
+        opts.licenseClass !== undefined ? results.length : remote.totalMatches,
       source: 'remote',
       remoteEnabled: true,
     };
@@ -83,7 +104,11 @@ export async function findPartHost(
         : {}),
     });
     const merged = [...local];
-    for (const r of remote.results) {
+    const remoteResults = filterByLicenseClass(
+      remote.results,
+      opts.licenseClass,
+    );
+    for (const r of remoteResults) {
       if (!merged.find((m) => m.id === r.id)) merged.push(r);
     }
     return {

--- a/src/modeling/parts/findPartLicenseClass.test.ts
+++ b/src/modeling/parts/findPartLicenseClass.test.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/modeling/parts/findPartLicenseClass.test.ts
+//
+// find_part licenseClass filter. loadCatalog is mocked so the record set is
+// controlled (a record with NO licenseClass must be treated as 'permissive').
+// The real queryCatalog runs over the mocked records, so existing query/filter
+// behavior is exercised end-to-end alongside the new filter.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { PartRecord } from '../../shared/parts/types';
+
+function rec(
+  id: string,
+  licenseClass?: PartRecord['licenseClass'],
+): PartRecord {
+  return {
+    id,
+    name: id,
+    category: 'fastener',
+    family: 'fam',
+    tags: ['widget'],
+    attributes: {},
+    sha256: 'x',
+    source: 'local-catalog',
+    license: 'MIT',
+    connectors: [],
+    ...(licenseClass !== undefined ? { licenseClass } : {}),
+  };
+}
+
+const MOCK_RECORDS: PartRecord[] = [
+  rec('permissive-explicit', 'permissive'),
+  rec('share-alike-one', 'share-alike'),
+  rec('fetch-only-one', 'fetch-only'),
+  rec('no-license-class'), // implicit permissive
+];
+
+vi.mock('./catalog', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./catalog')>();
+  return {
+    ...actual,
+    loadCatalog: () => ({ dir: '/mock', records: MOCK_RECORDS }),
+  };
+});
+
+import { findPartHost } from './findPart';
+
+describe('findPart licenseClass filter', () => {
+  let prevEnv: string | undefined;
+  beforeEach(() => {
+    prevEnv = process.env.KERNELCAD_PARTS_BASE_URL;
+    process.env.KERNELCAD_PARTS_BASE_URL = 'off';
+  });
+  afterEach(() => {
+    if (prevEnv === undefined) delete process.env.KERNELCAD_PARTS_BASE_URL;
+    else process.env.KERNELCAD_PARTS_BASE_URL = prevEnv;
+  });
+
+  it('"permissive" includes explicit + no-licenseClass records, excludes others', async () => {
+    const r = await findPartHost('widget', {
+      source: 'local',
+      licenseClass: 'permissive',
+    });
+    const ids = r.results.map((x) => x.id).sort();
+    expect(ids).toEqual(['no-license-class', 'permissive-explicit']);
+  });
+
+  it('"share-alike" matches only share-alike records', async () => {
+    const r = await findPartHost('widget', {
+      source: 'local',
+      licenseClass: 'share-alike',
+    });
+    expect(r.results.map((x) => x.id)).toEqual(['share-alike-one']);
+  });
+
+  it('"fetch-only" matches only fetch-only records', async () => {
+    const r = await findPartHost('widget', {
+      source: 'local',
+      licenseClass: 'fetch-only',
+    });
+    expect(r.results.map((x) => x.id)).toEqual(['fetch-only-one']);
+  });
+
+  it('no licenseClass filter returns all matches; existing filters still apply', async () => {
+    const all = await findPartHost('widget', { source: 'local' });
+    expect(all.results.length).toBe(4);
+    const narrowed = await findPartHost('widget', {
+      source: 'local',
+      category: 'nonexistent',
+    });
+    expect(narrowed.results.length).toBe(0);
+  });
+});

--- a/src/shared/parts/taxonomy.ts
+++ b/src/shared/parts/taxonomy.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/shared/parts/taxonomy.ts
+//
+// Canonical robotics-aware top-level categories for the parts catalog. The
+// ingestion engine maps every part into exactly one of these via the source
+// registry's categoryMap (+ keyword heuristics); unmapped parts fall to
+// 'uncategorized' and are flagged for review rather than silently bucketed.
+
+/** Robotics-aware top-level categories. `family` remains the finer bucket. */
+export const PART_CATEGORIES = [
+  'actuator', // motors, servos, gearmotors, cycloidal/QDD drives
+  'gripper', // fingers, jaws, end-effectors
+  'structural-frame', // brackets, gussets, plates, links, extrusion profiles
+  'linear-motion', // rails, rods, blocks, lead screws, shaft supports
+  'wheel', // wheels, hubs, casters, omni/mecanum
+  'coupling', // shaft couplers, joints
+  'gear', // spur/helical/bevel/worm, pulleys, sprockets
+  'bearing', // ball/roller/bushing/thrust
+  'fastener', // screws, nuts, washers, inserts, standoffs
+  'sensor-mount', // sensor/camera mounts and brackets
+  'electronics-module', // breakouts, headers, connectors, dev boards, PCBs
+  'uncategorized', // heuristic fallback — flagged for review, never silently kept
+] as const;
+
+export type PartCategory = (typeof PART_CATEGORIES)[number];
+
+const CATEGORY_SET = new Set<string>(PART_CATEGORIES);
+
+export function isPartCategory(v: unknown): v is PartCategory {
+  return typeof v === 'string' && CATEGORY_SET.has(v);
+}
+
+/**
+ * Keyword heuristics used by the ingestion engine ONLY when a source's
+ * categoryMap does not assign a category. Order matters: first match wins.
+ * Keep conservative — a miss falls to 'uncategorized' (review), not a wrong bucket.
+ */
+export const CATEGORY_KEYWORDS: ReadonlyArray<readonly [PartCategory, readonly string[]]> = [
+  ['actuator', ['motor', 'servo', 'stepper', 'nema', 'gearmotor', 'bldc', 'cycloidal', 'qdd', 'dynamixel', 'actuator']],
+  ['gripper', ['gripper', 'finger', 'jaw', 'fin-ray', 'finray', 'end-effector', 'endeffector', 'claw']],
+  ['linear-motion', ['rail', 'lm8', 'mgn', 'sbr', 'lead-screw', 'leadscrew', 'shaft-support', 'linear', 'carriage', 'slider']],
+  ['wheel', ['wheel', 'omni', 'mecanum', 'caster', 'hub', 'tire']],
+  ['coupling', ['coupler', 'coupling', 'oldham', 'jaw-coupler', 'u-joint']],
+  ['gear', ['gear', 'pulley', 'sprocket', 'gt2', 'htd', 'pinion', 'rack']],
+  ['bearing', ['bearing', 'bushing', '608', '623', '624', '625', 'lm', 'thrust']],
+  ['fastener', ['screw', 'bolt', 'nut', 'washer', 'insert', 'standoff', 'shcs', 'm2', 'm3', 'm4', 'm5', 'm6']],
+  ['sensor-mount', ['sensor', 'camera-mount', 'lidar', 'imu-mount', 'mount']],
+  ['electronics-module', ['header', 'connector', 'jst', 'molex', 'breakout', 'feather', 'esp32', 'pcb', 'board', 'module']],
+  ['structural-frame', ['bracket', 'gusset', 'plate', 'link', 'extrusion', '2020', '2040', 'v-slot', 'vslot', 'frame', 'chassis']],
+];
+
+/** Best-effort category from a name/path when the registry gives no mapping. */
+export function guessCategory(text: string): PartCategory {
+  const t = text.toLowerCase();
+  for (const [cat, keywords] of CATEGORY_KEYWORDS) {
+    if (keywords.some((k) => t.includes(k))) return cat;
+  }
+  return 'uncategorized';
+}

--- a/src/shared/parts/types.ts
+++ b/src/shared/parts/types.ts
@@ -8,6 +8,25 @@
 
 export type PartSource = 'local-catalog' | 'remote';
 
+/**
+ * How a part's license governs redistribution of its geometry.
+ * - 'permissive'   — MIT/BSD/Apache/CC0/CC-BY: re-host freely (attribution kept).
+ * - 'share-alike'  — CC-BY-SA / CERN-OHL / GPL: re-host with copyleft obligations;
+ *                    kept in an attributed partition, served behind a legal gate.
+ * - 'fetch-only'   — NC/ND/unlicensed/vendor-ToS: NEVER mirrored; fetch-by-URL only.
+ */
+export type LicenseClass = 'permissive' | 'share-alike' | 'fetch-only';
+
+/** Whether kernelCAD re-hosts the geometry ('mirror') or only fetches it on demand. */
+export type RedistributionMode = 'mirror' | 'fetch-only';
+
+/** Where an ingested part came from, for provenance + attribution audit. */
+export interface UpstreamProvenance {
+  repo: string;
+  commit: string;
+  path: string;
+}
+
 export interface PartRecord {
   id: string;
   name: string;
@@ -22,6 +41,17 @@ export interface PartRecord {
   attribution?: string;
   connectors: string[];
   stepUrl?: string;
+  /** License class governing redistribution. Optional for back-compat with the
+   *  pre-ingestion bundled catalog (those records are implicitly 'permissive'). */
+  licenseClass?: LicenseClass;
+  /** Mirror vs fetch-only. Optional; absent ⇒ bundled/local ('mirror'). */
+  redistribution?: RedistributionMode;
+  /** Provenance for ingested (mirrored) parts. */
+  upstream?: UpstreamProvenance;
+}
+
+export function isLicenseClass(v: unknown): v is LicenseClass {
+  return v === 'permissive' || v === 'share-alike' || v === 'fetch-only';
 }
 
 export function isPartRecord(v: unknown): v is PartRecord {
@@ -37,5 +67,13 @@ export function isPartRecord(v: unknown): v is PartRecord {
   if (r.source !== 'local-catalog' && r.source !== 'remote') return false;
   if (typeof r.license !== 'string') return false;
   if (!Array.isArray(r.connectors)) return false;
+  if (r.licenseClass !== undefined && !isLicenseClass(r.licenseClass)) return false;
+  if (
+    r.redistribution !== undefined &&
+    r.redistribution !== 'mirror' &&
+    r.redistribution !== 'fetch-only'
+  ) {
+    return false;
+  }
   return true;
 }


### PR DESCRIPTION
Implements Phase 1 of the parts-catalog ingestion pipeline (spec in kernelCAD-private `docs/specs/2026-06-13-parts-ingestion-pipeline-design.md`). **No runtime behaviour changes until an operator runs the mass ingest** — this lands the engine, not the data.

**Foundation**
- `PartRecord`: `licenseClass` / `redistribution` / `upstream` provenance (back-compat: absent ⇒ permissive/bundled).
- `taxonomy.ts`: robotics-aware categories + keyword heuristics.

**Source registry + adapters** (`scripts/parts/`)
- `sources.ts`: 17 license-verified sources, each pinned to a real commit SHA.
- `stepPartsIngest.ts`: step.parts adapter — joins the REST index with `THIRD_PARTY_NOTICES.md`, gates to the redistributable subset.

**Engine** (`scripts/parts/engine.ts`, `mirrorStore.ts`, `workerTemplate.ts`)
- Registry-driven orchestrator; content-addressed mirror store (LocalFs + R2 via SigV4, no new dep).
- Gates: G1 parse / G2 mirror-integrity / G3 license-non-empty (never mirrors fetch-only) / G4 connector; sha256 dedup; no-silent-truncation run report.
- Worker excludes `legal-hold` (CC-BY-SA) sources by default; `licenseClass` query passthrough.
- Mass-run CLI is operator-guarded (never auto-triggered).

**Agent surface**
- `fetch_part { url }`: allowlisted direct-URL + mesh + vendor link-out; never re-hosts.
- `find_part { licenseClass }` filter. SKILL.md updated.

**Deferred (operator/ops, not in this PR):** provisioning R2, running the real ingest, deploying the worker; SLDPRT/FreeCAD→STEP conversion + monolithic decomposition (Phase 2); CC-BY-SA legal sign-off before KiCad/SparkFun go live; procedural-gen of gap parts (own spec).

Typecheck clean; parts-pipeline tests green (53 across the new + existing suites).