### PR TITLE
fix(viewer): review-paint resolves assembly parts to authored names, not shape#<index>

### DIFF
--- a/src/studio/components/Viewer.tsx
+++ b/src/studio/components/Viewer.tsx
@@ -186,7 +186,15 @@ export default function Viewer({ geometries, previewGeometries, sketchesGeometri
 
                 <group>
                     {geometries.map((g, i) => {
-                        const name = itemNames[i];
+                        // Prefer the authored assembly part name over the
+                        // return-variable name. For assemblies a single returned
+                        // variable expands into many per-part geometries, so
+                        // `itemNames[i]` is absent for all but the first — using
+                        // it alone leaves parts anonymous and downstream consumers
+                        // (selection, the marking/review overlay's `ownerId`) fall
+                        // back to `shape#<index>`. `assemblyPartName` carries the
+                        // real authored name per part. Mirrors `sectionPartKey`.
+                        const name = g.assemblyPartName ?? itemNames[i];
                         if (name && hiddenIds.includes(name)) return null;
                         // Hide whole assembly parts by name (the Parts list in the
                         // Scene tab toggles `assemblyPartName` into hiddenIds).


### PR DESCRIPTION
## Problem

When a user paints a region in Studio, `MarkingOverlay.struckPartsFromMask` raycasts the painted mask into the live three.js scene and resolves each hit by walking the object/userData/parent chain for an authored name (`ownerId → assemblyPartName → partName → name → object3D.name`), falling back to `shape#<shapeIndex>` only when none exist. For assembly parts the strokes resolved to `shape#15` etc. instead of the real part name.

## Root cause

The consolidated mesh's `userData.ownerId` is set from the `name` prop the Viewer passes to `<Shape>`. That `name` came solely from `itemNames[i]` = `codeContext.returnedVariables[i]`, the AST return-statement variable names, position-aligned with the `geometries` array.

An assembly is a *single* returned variable that expands into *many* per-part `GeometryResult`s. So `itemNames` has a name only for the first part; the rest are anonymous, `ownerId` is unset, and the overlay falls back to `shape#<index>`.

The authored name was already present the whole time: each per-part `GeometryResult` carries `assemblyPartName` (set to `part.name` during feature meshing, propagated through `GeometryContext`). The viewer just wasn't using it for the rendered mesh's name — only for hide-by-part. The sibling helper `sectionPartKey` already encodes the correct precedence.

## Fix

In `src/studio/components/Viewer.tsx` the per-geometry name now prefers the authored assembly part name:

```diff
-const name = itemNames[i];
+const name = g.assemblyPartName ?? itemNames[i];
```

This flows into `ConsolidatedShape`'s `userData.ownerId`, so painted strokes resolve to authored part names. It mirrors the existing `sectionPartKey` precedence (`assemblyPartName ?? itemName ?? positional`), and keeps selection/hide behaviour consistent with the Scene tab, which already keys assembly parts by `assemblyPartName`.

## Verification

- `npm run typecheck` — clean
- `npx eslint src/studio/components/Viewer.tsx` — clean
- `npx vitest run` viewer suites (sectionParts, SectionPanel, ShapeGeometry) — 21 passed

The viewer wiring is integration-level (r3f canvas), so it isn't unit-testable in isolation; the pure precedence rule it reuses is covered by `sectionParts.test.ts`.