### PR TITLE
Rename Scene browser 'History' folder to 'Features'

### DIFF
--- a/src/studio/components/SceneBrowser.tsx
+++ b/src/studio/components/SceneBrowser.tsx
@@ -57,7 +57,7 @@ const SceneBrowser: React.FC<SceneBrowserProps> = ({
     onDelete
 }) => {
     const [constructionOpen, setConstructionOpen] = React.useState(true);
-    const [historyOpen, setHistoryOpen] = React.useState(true);
+    const [featuresOpen, setFeaturesOpen] = React.useState(true);
 
     const [contextMenu, setContextMenu] = React.useState<{ x: number, y: number, item: HistoryItem } | null>(null);
 
@@ -179,17 +179,17 @@ const SceneBrowser: React.FC<SceneBrowserProps> = ({
                 )}
             </div>
 
-            {/* History Folder */}
+            {/* Features Folder — the construction operations (box, fillet, extrude, …) */}
             <div className="bg-[#1a1a1a] border-t border-[#333]">
                 <button
-                    onClick={() => setHistoryOpen(!historyOpen)}
+                    onClick={() => setFeaturesOpen(!featuresOpen)}
                     className="w-full px-3 py-2 flex items-center gap-2 text-gray-400 hover:text-white uppercase tracking-wider font-semibold border-b border-[#333]"
                 >
-                    {historyOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                    {featuresOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
                     <Layers size={12} />
-                    History
+                    Features
                 </button>
-                {historyOpen && (
+                {featuresOpen && (
                     <div className="py-1">
                         {items.length === 0 ? (
                             <div className="px-6 py-4 text-gray-500 italic">No operations yet.</div>


### PR DESCRIPTION
## Why
In the Studio Scene tab's non-assembly view (the legacy `SceneBrowser`), the operation list was labeled **History** — feature-timeline heritage. But the rows are construction **features** (box, fillet, extrude, …; empty state already reads "No operations yet"). For a multi-body model that lands in this fallback, "History" reads wrong when you're looking at what are effectively your bodies/features.

## Change
Rename that folder's label **History → Features** (and the local `historyOpen` state → `featuresOpen`). One file, label-only.

- The **Construction** folder (origin planes) is unchanged.
- The assembly-aware **Parts** view (`SceneTab` when `assembly().part(...)` is used) is unchanged — that already correctly says "Parts".

## Verification
typecheck clean; lint clean; SidePanel tests pass (3). No tests asserted the visible "History" text; no other user-visible "History" label lists features/parts.