### PR TITLE
Auto-capture /p viewer canvas and upload to render endpoint

### DIFF
--- a/src/funnel/lib/apiClient.test.ts
+++ b/src/funnel/lib/apiClient.test.ts
@@ -7,7 +7,7 @@ const getSupabaseMock = vi.fn(() => ({ auth: { getSession: getSessionMock } }));
 
 vi.mock('./supabaseClient', () => ({ getSupabase: () => getSupabaseMock() }));
 
-import { setProjectPrivacy, PRIVATE_REQUIRES_PAID } from './apiClient';
+import { setProjectPrivacy, postProjectRender, PRIVATE_REQUIRES_PAID } from './apiClient';
 
 describe('setProjectPrivacy', () => {
   const fetchMock = vi.fn();
@@ -56,5 +56,60 @@ describe('setProjectPrivacy', () => {
     });
 
     await expect(setProjectPrivacy('slug-1', 'private')).rejects.toThrow(PRIVATE_REQUIRES_PAID);
+  });
+});
+
+describe('postProjectRender', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    getSessionMock.mockReset();
+    getSupabaseMock.mockReturnValue({ auth: { getSession: getSessionMock } });
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.kernelcad.com');
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs the render endpoint with the png body and a bearer token, returning the url', async () => {
+    getSessionMock.mockResolvedValue({ data: { session: { access_token: 'tok-1' } } });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ok: true, url: 'https://cdn.kernelcad.com/r/slug-1.png' }),
+    });
+
+    await expect(postProjectRender('slug-1', 'aGVsbG8=')).resolves.toEqual({
+      ok: true,
+      url: 'https://cdn.kernelcad.com/r/slug-1.png',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.kernelcad.com/api/v1/projects/slug-1/render');
+    expect(init.method).toBe('POST');
+    expect(init.headers.Authorization).toBe('Bearer tok-1');
+    expect(JSON.parse(init.body)).toEqual({ png: 'aGVsbG8=' });
+  });
+
+  it('works anonymously (no session → no Authorization header)', async () => {
+    getSessionMock.mockResolvedValue({ data: { session: null } });
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true, url: 'u' }) });
+
+    await postProjectRender('slug-2', 'eHl6');
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect(init.headers.Authorization).toBeUndefined();
+    expect(JSON.parse(init.body)).toEqual({ png: 'eHl6' });
+  });
+
+  it('url-encodes the slug', async () => {
+    getSessionMock.mockResolvedValue({ data: { session: null } });
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true, url: 'u' }) });
+    await postProjectRender('a/b', 'cG5n');
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://api.kernelcad.com/api/v1/projects/a%2Fb/render');
   });
 });

--- a/src/funnel/lib/apiClient.ts
+++ b/src/funnel/lib/apiClient.ts
@@ -92,6 +92,19 @@ export async function claimProject(slug: string): Promise<{ claimed: boolean }> 
   return authedFetch<{ claimed: boolean }>('POST', `/api/v1/projects/${encodeURIComponent(slug)}/claim`, {});
 }
 
+/** POST a viewer-captured PNG (base64, no `data:` prefix) to the backend render
+ *  endpoint. The hosted backend has no browser, so the user's open Studio tab
+ *  captures its own WebGL canvas and uploads it here; an agent then fetches the
+ *  stored image. Anonymous-capable: the slug is the capability (same pattern as
+ *  claimProject). Returns the URL the agent can read the image from. */
+export async function postProjectRender(slug: string, pngBase64: string): Promise<{ url: string }> {
+  return authedFetch<{ ok: true; url: string }>(
+    'POST',
+    `/api/v1/projects/${encodeURIComponent(slug)}/render`,
+    { png: pngBase64 },
+  );
+}
+
 /** Thrown when a free user tries to make a project private — the body text
  *  authedFetch surfaces on a 403 carries this code. Lets the UI show an
  *  upgrade CTA instead of a generic failure. */

--- a/src/studio/components/viewer/captureViewerPng.ts
+++ b/src/studio/components/viewer/captureViewerPng.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// Grab the rendered three.js viewer canvas as a base64 PNG (no `data:` prefix).
+//
+// This mirrors the review-paint brush capture in MarkingOverlay
+// (`findRendererCanvas()` + `renderer.toDataURL('image/png')`): the renderer is
+// mounted with `preserveDrawingBuffer: true` (see Viewer.tsx) so reading the
+// canvas after compositing returns the actual frame instead of a blank PNG.
+//
+// Returns null if the renderer canvas isn't in the DOM yet or the read fails —
+// callers must treat capture as best-effort and never break the viewer on a
+// missing/failed grab.
+
+/** Find the three.js WebGL canvas in the document. The viewer mounts exactly
+ *  one such canvas; the brush overlay's transient 2D canvas is excluded by the
+ *  `webgl` context probe. */
+export function findRendererCanvas(): HTMLCanvasElement | null {
+  const all = Array.from(document.querySelectorAll('canvas')) as HTMLCanvasElement[];
+  return (
+    all.find((c) => {
+      try {
+        return !!(c.getContext('webgl2') || c.getContext('webgl'));
+      } catch {
+        return false;
+      }
+    }) ?? null
+  );
+}
+
+/** Capture the viewer canvas as a base64 PNG with the `data:image/png;base64,`
+ *  prefix stripped (the backend render endpoint wants the raw base64). Returns
+ *  null on any failure — capture is best-effort. */
+export function captureViewerPngBase64(): string | null {
+  try {
+    const canvas = findRendererCanvas();
+    if (!canvas) return null;
+    const dataUrl = canvas.toDataURL('image/png');
+    const comma = dataUrl.indexOf(',');
+    if (comma < 0) return null;
+    return dataUrl.slice(comma + 1) || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/studio/routes/p.$slug.tsx
+++ b/src/studio/routes/p.$slug.tsx
@@ -11,10 +11,12 @@ import {
   claimProject,
   setProjectPrivacy,
   createCheckoutSession,
+  postProjectRender,
   PRIVATE_REQUIRES_PAID,
   type ProjectRow,
 } from '../../funnel/lib/apiClient';
 import { shouldApplyProjectUpdate } from '../../funnel/lib/liveProject';
+import { captureViewerPngBase64 } from '../components/viewer/captureViewerPng';
 
 export const Route = createFileRoute('/p/$slug')({
   component: ProjectPage,
@@ -80,6 +82,34 @@ function ProjectPage() {
     es.addEventListener('error', () => { hadError = true; });
     return () => { disposed = true; es.close(); };
   }, [slug]);
+
+  // Render-to-image for web Claude: the hosted backend has no browser, so this
+  // open tab captures its own WebGL canvas after the model settles and uploads
+  // it to the render endpoint; an agent then fetches the stored image.
+  //
+  // Fires ~800 ms after the model loads and ~800 ms after each live update
+  // (debounced so a flurry only uploads once, and only after the render has
+  // settled). Strictly fire-and-forget: a failed capture or upload must never
+  // break the viewer, so every error is swallowed.
+  useEffect(() => {
+    if (!project) return;
+    let disposed = false;
+    const timer = window.setTimeout(() => {
+      if (disposed) return;
+      try {
+        const png = captureViewerPngBase64();
+        if (!png) return;
+        postProjectRender(slug, png).catch(() => {});
+      } catch {
+        // best-effort: never surface capture/upload failures to the viewer
+      }
+    }, 800);
+    return () => {
+      disposed = true;
+      window.clearTimeout(timer);
+    };
+    // Re-run on initial load (project) and after each live update (lastLiveUpdate).
+  }, [slug, project, lastLiveUpdate]);
 
   const handleClaim = useCallback(async () => {
     setClaiming(true);


### PR DESCRIPTION
## What

Frontend half of render-to-image for web Claude. The hosted backend has no browser, so the user's open Studio viewer tab captures its own WebGL canvas after each live update and uploads it; the agent then fetches the stored image.

## Changes

- **`apiClient.ts`** — `postProjectRender(slug, pngBase64) → { url }` via the existing `authedFetch` (`POST /api/v1/projects/:slug/render`, body `{ png }`). Anonymous-capable, same pattern as `claimProject`: the slug is the capability.
- **`captureViewerPng.ts`** (new) — reuses the review-paint brush capture approach: locate the `preserveDrawingBuffer` WebGL canvas in the DOM and `toDataURL('image/png')`, then strip the `data:` prefix. Best-effort: returns `null` on any failure.
- **`p.$slug.tsx`** — debounced ~800ms capture+upload, fired once after the initial model load and once after each live update (keyed on `project` / `lastLiveUpdate`, which the SSE flow already sets). Strictly fire-and-forget: every capture/upload error is swallowed so a failed grab can never break the viewer.

## Reuse

The capture mirrors `MarkingOverlay.tsx`'s brush flow (`findRendererCanvas()` + `renderer.toDataURL('image/png')`), which relies on the renderer being mounted with `preserveDrawingBuffer: true` in `Viewer.tsx`. No existing capture code was refactored.

## Verification

- `npm run typecheck` — clean.
- `npx eslint` on changed files — clean.
- `npx vitest run src/funnel/lib/apiClient.test.ts` — 6 passed (added POST url/body/bearer, anonymous-no-auth-header, and slug-encoding cases for `postProjectRender`).