### PR TITLE
Capture render after it settles (fix unframed auto-capture)

### DIFF
--- a/src/studio/routes/p.$slug.tsx
+++ b/src/studio/routes/p.$slug.tsx
@@ -84,31 +84,49 @@ function ProjectPage() {
   }, [slug]);
 
   // Render-to-image for web Claude: the hosted backend has no browser, so this
-  // open tab captures its own WebGL canvas after the model settles and uploads
-  // it to the render endpoint; an agent then fetches the stored image.
+  // open tab captures its own WebGL canvas and uploads it; an agent then fetches
+  // the stored image via get_latest_render.
   //
-  // Fires ~800 ms after the model loads and ~800 ms after each live update
-  // (debounced so a flurry only uploads once, and only after the render has
-  // settled). Strictly fire-and-forget: a failed capture or upload must never
-  // break the viewer, so every error is swallowed.
+  // Capture only once the render has SETTLED. A fixed delay grabs an empty /
+  // unframed frame, because meshing + the camera-fit tween finish well after the
+  // project metadata loads. Instead we poll the canvas and upload the first
+  // frame that is stable (two consecutive grabs of ~equal size) — i.e. after the
+  // model is meshed and the camera has stopped moving. Re-armed on initial load
+  // (project) and after each live update (lastLiveUpdate). Strictly
+  // fire-and-forget: a failed capture/upload must never break the viewer.
   useEffect(() => {
     if (!project) return;
+    const FIRST_DELAY_MS = 1000; // let the first paint happen before sampling
+    const POLL_MS = 600;
+    const MAX_TRIES = 25; // ~15s ceiling, then give up silently
+    const MIN_PNG_LEN = 2000; // skip a blank/near-empty canvas
+    const STABLE_FRAC = 0.02; // ≤2% size change between grabs == settled
     let disposed = false;
-    const timer = window.setTimeout(() => {
+    let timer: number | undefined;
+    let prevLen = 0;
+    let tries = 0;
+
+    const poll = () => {
       if (disposed) return;
-      try {
-        const png = captureViewerPngBase64();
-        if (!png) return;
-        postProjectRender(slug, png).catch(() => {});
-      } catch {
-        // best-effort: never surface capture/upload failures to the viewer
+      tries++;
+      let png: string | null = null;
+      try { png = captureViewerPngBase64(); } catch { png = null; }
+      if (png && png.length > MIN_PNG_LEN) {
+        const settled = prevLen > 0 && Math.abs(png.length - prevLen) <= prevLen * STABLE_FRAC;
+        if (settled) {
+          postProjectRender(slug, png).catch(() => {});
+          return; // done — captured the settled frame
+        }
+        prevLen = png.length;
       }
-    }, 800);
+      if (tries < MAX_TRIES) timer = window.setTimeout(poll, POLL_MS);
+    };
+
+    timer = window.setTimeout(poll, FIRST_DELAY_MS);
     return () => {
       disposed = true;
-      window.clearTimeout(timer);
+      if (timer !== undefined) window.clearTimeout(timer);
     };
-    // Re-run on initial load (project) and after each live update (lastLiveUpdate).
   }, [slug, project, lastLiveUpdate]);
 
   const handleClaim = useCallback(async () => {


### PR DESCRIPTION
## Problem
The `/p/:slug` auto-capture (render-to-image loop) fired on a fixed ~800ms timer after the project metadata loaded — which is *before* the model finishes meshing and the camera-fit tween settles. Result: it uploaded an empty/unframed frame (construction planes + a faint, off-camera model) even though the page itself renders the model correctly a few seconds later.

## Fix
Poll the canvas and upload the first frame that's **stable** — two consecutive grabs within 2% size of each other — i.e. after mesh + camera-fit have settled. ~1s initial delay, 600ms poll, ~15s ceiling then give up silently. Still strictly fire-and-forget; a failed/blank grab never breaks the viewer.

## Verification
typecheck + lint clean. Behavioral proof: a headless drive of the deployed page renders the model framed by ~few seconds (confirmed), but the old trigger captured at 800ms; this captures the settled frame instead. Will re-verify post-deploy by pulling the stored render and comparing to the page screenshot.