### PR TITLE
studio: review-paint strokes carry intent (note + preset tags)

### DIFF
--- a/scripts/review-paint-server.mjs
+++ b/scripts/review-paint-server.mjs
@@ -100,6 +100,9 @@ const server = createServer(async (req, res) => {
       JSON.stringify(
         {
           note: parsed.meta?.note ?? '',
+          // Preset intent tags the user picked ("too thick", "missing", …).
+          // Carries WHAT is wrong, complementing struckParts (WHERE).
+          tags: Array.isArray(parsed.meta?.tags) ? parsed.meta.tags : [],
           scriptPath: scriptPath ? relative(repoRoot, scriptPath) : null,
           ts: parsed.meta?.ts ?? new Date().toISOString(),
           ua: parsed.meta?.ua ?? '',

--- a/src/agent/mcp/toolRegistry.ts
+++ b/src/agent/mcp/toolRegistry.ts
@@ -1106,7 +1106,9 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
         'over the 3D viewport; this tool scans the known kernelCAD-web checkouts and returns the ' +
         'freshest one within a configurable freshness window (default 30 minutes). Returns base64 ' +
         'PNGs of the screenshot + mask in-band so any MCP client can see the marked regions ' +
-        'without local-disk Read access. Call this whenever the user says "look at my mark", ' +
+        'without local-disk Read access. The packet also carries the user\'s intent — an optional ' +
+        'one-line note and preset tags (e.g. "too thick", "missing", "wrong angle") describing ' +
+        'WHAT is wrong, not just where. Call this whenever the user says "look at my mark", ' +
         '"check what I painted", or any equivalent.',
       inputSchema: {
         type: 'object',

--- a/src/agent/mcp/tools/reviewPaint.ts
+++ b/src/agent/mcp/tools/reviewPaint.ts
@@ -58,6 +58,9 @@ export interface ReviewPaintPacket {
   ts: string;
   /** One-line note the user typed when painting (`""` if none). */
   note: string;
+  /** Preset intent tags the user picked ("too thick", "missing", …). Carries
+   *  WHAT is wrong, complementing struck_parts (WHERE). Empty array if none. */
+  tags: string[];
   /** Repo-relative .kcad.ts file under review (null when the packet was
    *  saved without a script context — e.g. user testing at `/`). */
   script_path: string | null;
@@ -127,7 +130,7 @@ export async function reviewPaintPeekLatestTool(
   // Pull out into local for narrowing inside TypeScript (the loop assigns
   // `best` inside a callback and the inferrer needs the rebind).
   const found: { dir: string; mtime: number } = best;
-  let meta: { note?: string; scriptPath?: string | null; ts?: string; struckParts?: string[] } = {};
+  let meta: { note?: string; tags?: string[]; scriptPath?: string | null; ts?: string; struckParts?: string[] } = {};
   try { meta = JSON.parse(readFileSync(join(found.dir, 'meta.json'), 'utf8')); } catch {
     // keep defaults
   }
@@ -139,6 +142,7 @@ export async function reviewPaintPeekLatestTool(
     meta_path: join(found.dir, 'meta.json'),
     ts: meta.ts ?? new Date(found.mtime).toISOString(),
     note: meta.note ?? '',
+    tags: Array.isArray(meta.tags) ? meta.tags : [],
     script_path: meta.scriptPath ?? null,
     struck_parts: Array.isArray(meta.struckParts) ? meta.struckParts : [],
   };

--- a/src/studio/components/viewer/overlays/MarkingOverlay.test.tsx
+++ b/src/studio/components/viewer/overlays/MarkingOverlay.test.tsx
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MarkingOverlay } from './MarkingOverlay';
+
+// The overlay resolves a POST target from the URL; pin it to a single URL pair
+// so the test asserts on a known endpoint.
+vi.mock('./reviewPaintTargets', () => ({
+  resolveReviewPaintTargets: () => ({
+    slug: null,
+    urls: ['http://test.invalid/save', 'http://test.invalid/fallback'],
+  }),
+}));
+
+// No live three.js scene in the test — return an empty snapshot so the raycast
+// helper short-circuits to zero struck parts.
+vi.mock('../rendererSnapshot', () => ({
+  rendererSnapshot: { scene: null, camera: null },
+}));
+
+/** jsdom's <canvas> has no real 2d context; stub just enough for the overlay's
+ *  paint + read path so a pointer-down marks the canvas dirty and toDataURL
+ *  returns a non-trivial data URL. */
+function stubCanvas() {
+  const ctxStub = {
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 0,
+    lineCap: '',
+    lineJoin: '',
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    getImageData: vi.fn(() => ({ data: new Uint8ClampedArray(0), width: 0, height: 0 })),
+  } as unknown as CanvasRenderingContext2D;
+  HTMLCanvasElement.prototype.getContext = vi.fn(() => ctxStub) as unknown as HTMLCanvasElement['getContext'];
+  HTMLCanvasElement.prototype.toDataURL = vi.fn(
+    () => 'data:image/png;base64,' + 'A'.repeat(200),
+  ) as unknown as HTMLCanvasElement['toDataURL'];
+  HTMLElement.prototype.setPointerCapture = vi.fn();
+  HTMLElement.prototype.releasePointerCapture = vi.fn();
+  // jsdom has no ResizeObserver — the overlay observes its parent for sizing.
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+}
+
+describe('MarkingOverlay intent panel', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    stubCanvas();
+    fetchMock = vi.fn(() => Promise.resolve({ ok: true, status: 200 } as Response));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('renders the note input and preset tag buttons', () => {
+    render(<MarkingOverlay visible={true} />);
+    expect(screen.getByTestId('marking-intent-panel')).toBeTruthy();
+    expect(screen.getByTestId('marking-note-input')).toBeTruthy();
+    expect(screen.getByTestId('marking-tag-too thick')).toBeTruthy();
+    expect(screen.getByTestId('marking-tag-missing')).toBeTruthy();
+  });
+
+  it('tag buttons toggle aria-pressed', () => {
+    render(<MarkingOverlay visible={true} />);
+    const btn = screen.getByTestId('marking-tag-missing');
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+    fireEvent.click(btn);
+    expect(btn.getAttribute('aria-pressed')).toBe('true');
+    fireEvent.click(btn);
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('includes the trimmed note + selected tags in the saved packet meta', () => {
+    vi.useFakeTimers();
+    try {
+      render(<MarkingOverlay visible={true} />);
+
+      // Type a note and pick a tag.
+      fireEvent.change(screen.getByTestId('marking-note-input'), {
+        target: { value: '  side glass too thick  ' },
+      });
+      fireEvent.click(screen.getByTestId('marking-tag-too thick'));
+
+      // Paint a stroke so the save isn't gated out as a blank canvas. The
+      // pointer-up schedules a 500 ms debounced persist while still mounted.
+      const canvas = screen.getByTestId('marking-overlay-canvas');
+      fireEvent.pointerDown(canvas, { pointerId: 1, clientX: 10, clientY: 10 });
+      fireEvent.pointerUp(canvas, { pointerId: 1, clientX: 10, clientY: 10 });
+      vi.advanceTimersByTime(600);
+
+      expect(fetchMock).toHaveBeenCalled();
+      const [, init] = fetchMock.mock.calls[0]!;
+      const body = JSON.parse((init as RequestInit).body as string) as {
+        meta: { note: string; tags: string[] };
+      };
+      expect(body.meta.note).toBe('side glass too thick');
+      expect(body.meta.tags).toEqual(['too thick']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('omits intent by sending empty note + empty tags when none provided', () => {
+    vi.useFakeTimers();
+    try {
+      render(<MarkingOverlay visible={true} />);
+      const canvas = screen.getByTestId('marking-overlay-canvas');
+      fireEvent.pointerDown(canvas, { pointerId: 1, clientX: 10, clientY: 10 });
+      fireEvent.pointerUp(canvas, { pointerId: 1, clientX: 10, clientY: 10 });
+      vi.advanceTimersByTime(600);
+
+      expect(fetchMock).toHaveBeenCalled();
+      const [, init] = fetchMock.mock.calls[0]!;
+      const body = JSON.parse((init as RequestInit).body as string) as {
+        meta: { note: string; tags: string[] };
+      };
+      expect(body.meta.note).toBe('');
+      expect(body.meta.tags).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/studio/components/viewer/overlays/MarkingOverlay.tsx
+++ b/src/studio/components/viewer/overlays/MarkingOverlay.tsx
@@ -27,6 +27,20 @@ import { resolveReviewPaintTargets } from './reviewPaintTargets';
 
 const FIXED_BRUSH_PX = 24;
 
+/** Max stored note length — mirrors the backend NOTE_MAX_LEN cap so the input
+ *  can't paste in more than the server will keep. */
+const NOTE_MAX_LEN = 280;
+
+/** Preset intent tags. A blob says WHERE; these say WHAT is wrong. Kept short
+ *  and ordered roughly by how often they come up reviewing CAD. */
+const PRESET_TAGS = [
+  'too thick',
+  'too thin',
+  'missing',
+  'wrong angle/position',
+  'wrong shape',
+] as const;
+
 export function MarkingOverlay({ visible }: { visible: boolean }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   // True once the user has painted anything; gates the auto-save on
@@ -36,6 +50,21 @@ export function MarkingOverlay({ visible }: { visible: boolean }) {
   const [cursorPos, setCursorPos] = useState<{ x: number; y: number } | null>(null);
   const drawingRef = useRef(false);
   const lastPointRef = useRef<{ x: number; y: number } | null>(null);
+
+  // Intent: a one-line note + preset tags carried with the stroke so the agent
+  // reads WHAT is wrong, not just where. State drives the UI; refs let the
+  // unmount-time / debounced persistMark read the latest values without being
+  // re-created on every keystroke.
+  const [note, setNote] = useState('');
+  const [tags, setTags] = useState<string[]>([]);
+  const noteRef = useRef('');
+  const tagsRef = useRef<string[]>([]);
+  noteRef.current = note;
+  tagsRef.current = tags;
+
+  function toggleTag(tag: string) {
+    setTags((prev) => (prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]));
+  }
 
   // Escape closes marking mode — Photoshop / Figma muscle memory.
   useEffect(() => {
@@ -294,6 +323,14 @@ export function MarkingOverlay({ visible }: { visible: boolean }) {
       console.log('[marking-overlay] nothing painted — skipping save');
       return;
     }
+    // The mask canvas is the source of truth for the stroke. If its ref is
+    // already detached (e.g. React nulled it during unmount), there's nothing
+    // to read — bail rather than throw. The pointer-up debounce path normally
+    // persists while still mounted, so this only guards the unmount race.
+    if (!canvasRef.current) {
+      console.warn('[marking-overlay] canvas detached before save — skipping');
+      return;
+    }
     let screenshot: string | null;
     try {
       screenshot = screenshotAsPng();
@@ -320,7 +357,11 @@ export function MarkingOverlay({ visible }: { visible: boolean }) {
       apiBase,
     );
     const meta = {
-      note: '',
+      // One-line note + preset tags carried with the stroke (WHAT is wrong, not
+      // just where). Both optional — backend caps/sanitises and stays
+      // backward-compatible when omitted.
+      note: noteRef.current.trim(),
+      tags: tagsRef.current,
       scriptPath: scriptParam,
       ts: new Date().toISOString(),
       ua: navigator.userAgent,
@@ -422,6 +463,82 @@ export function MarkingOverlay({ visible }: { visible: boolean }) {
           }}
         />
       )}
+
+      {/* Intent panel: a one-line note + preset tags so the stroke carries
+          WHAT is wrong. Unobtrusive (bottom-left), optional, and captures its
+          own pointer events so interacting with it never paints on the canvas
+          underneath. */}
+      <div
+        data-testid="marking-intent-panel"
+        // Stop pointer/wheel events from reaching the painting canvas below.
+        onPointerDown={(e) => e.stopPropagation()}
+        onPointerMove={(e) => e.stopPropagation()}
+        onPointerUp={(e) => e.stopPropagation()}
+        style={{
+          position: 'absolute',
+          left: 12,
+          bottom: 12,
+          maxWidth: 360,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 6,
+          padding: '8px 10px',
+          borderRadius: 8,
+          background: 'rgba(20, 20, 24, 0.82)',
+          border: '1px solid rgba(255,255,255,0.12)',
+          boxShadow: '0 2px 10px rgba(0,0,0,0.4)',
+          cursor: 'default',
+          pointerEvents: 'auto',
+        }}
+      >
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+          {PRESET_TAGS.map((tag) => {
+            const active = tags.includes(tag);
+            return (
+              <button
+                key={tag}
+                type="button"
+                data-testid={`marking-tag-${tag}`}
+                aria-pressed={active}
+                onClick={() => toggleTag(tag)}
+                style={{
+                  fontSize: 11,
+                  lineHeight: 1.2,
+                  padding: '3px 8px',
+                  borderRadius: 999,
+                  cursor: 'pointer',
+                  border: active
+                    ? '1px solid rgba(239, 68, 68, 0.9)'
+                    : '1px solid rgba(255,255,255,0.18)',
+                  background: active ? 'rgba(239, 68, 68, 0.25)' : 'rgba(255,255,255,0.06)',
+                  color: active ? '#fecaca' : 'rgba(255,255,255,0.82)',
+                }}
+              >
+                {tag}
+              </button>
+            );
+          })}
+        </div>
+        <input
+          type="text"
+          data-testid="marking-note-input"
+          value={note}
+          maxLength={NOTE_MAX_LEN}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="Add a note: what's wrong? (optional)"
+          style={{
+            width: '100%',
+            boxSizing: 'border-box',
+            fontSize: 12,
+            padding: '5px 8px',
+            borderRadius: 6,
+            border: '1px solid rgba(255,255,255,0.18)',
+            background: 'rgba(255,255,255,0.06)',
+            color: '#fff',
+            outline: 'none',
+          }}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## What

A painted blob says **where**, not **what** is wrong. The marking overlay now lets a stroke carry intent:

- A small, unobtrusive panel (bottom-left) with a one-line **note** input.
- Preset **tag** chips: `too thick`, `too thin`, `missing`, `wrong angle/position`, `wrong shape`.

Both are optional. They ride along in the existing packet POST and surface to the agent via `review_paint_peek_latest`, so the agent reads *what's wrong*, not just the masked region.

## Contract (matches the server PR)

Packet POST `meta` gains (both optional):
- `note: string` — input capped at 280 chars (server truncates to the same cap).
- `tags: string[]` — selected preset chips (server trims/de-dups/caps).

The peek tool's `packet` gains `tags: string[]` alongside the existing `note`.

Pairs with kernelCAD-server PR #40 (store + return). Backward-compatible on both sides — omitting the fields behaves exactly as before.

## Changes
- `MarkingOverlay.tsx`: intent panel (note input + tag chips), `note`/`tags` carried into the save body via refs so the debounced/unmount persist reads the latest values. The panel captures its own pointer events so interacting with it never paints. Also guards `persistMark` against a detached canvas on the unmount race.
- `scripts/review-paint-server.mjs` (local dev save server): persists `tags` into `meta.json`.
- `src/agent/mcp/tools/reviewPaint.ts` (local MCP tool): returns `tags` (lockstep with hosted).
- `toolRegistry.ts`: `review_paint_peek_latest` description mentions the note/tags intent signal.
- New `MarkingOverlay.test.tsx`: panel renders, tag toggles, and saved-meta carries note/tags (and empty when none).

## Verification
- `npm run typecheck` — clean.
- eslint on all changed files — clean.
- `MarkingOverlay.test.tsx` — 4 passed; `reviewPaintTargets.test.ts` — 5 passed (regression check).