### PR TITLE
fix(studio): clean render-to-image capture — hide origin planes + grid

### DIFF
--- a/src/studio/components/Viewer.tsx
+++ b/src/studio/components/Viewer.tsx
@@ -32,6 +32,12 @@ import { SelectionOutline } from "./viewer/overlays/SelectionOutline";
 import { SceneBackground } from "./viewer/SceneBackground";
 import { ViewGizmo } from "./viewer/overlays/ViewGizmo";
 import type { ViewTarget } from "./viewer/controllers/cameraPose";
+import { CAPTURE_HIDDEN_FLAG } from "./viewer/captureViewerPng";
+
+// Tag value for scene furniture (origin construction planes + ground grid) that
+// render-to-image capture hides so the PNG shows the clean framed model, not the
+// authoring view. Read by captureViewerPngBase64; see captureViewerPng.ts.
+const CAPTURE_HIDDEN_USERDATA = { [CAPTURE_HIDDEN_FLAG]: true } as const;
 
 // Constants
 export const SKETCH_FOV = 40;
@@ -171,17 +177,19 @@ export default function Viewer({ geometries, previewGeometries, sketchesGeometri
                 <SelectionOutline geometries={geometries} itemNames={itemNames} selectedItemIds={selectedItemIds} />
 
                 {!sketchMode.active && gridVisible && (
-                    <Grid
-                        position={[0, 0, gridPlacement.z]}
-                        rotation={[Math.PI / 2, 0, 0]}
-                        infiniteGrid
-                        cellSize={5}
-                        sectionSize={25}
-                        cellColor="#404040"
-                        sectionColor="#606060"
-                        fadeDistance={gridPlacement.fade}
-                        fadeStrength={1.5}
-                    />
+                    <group userData={CAPTURE_HIDDEN_USERDATA}>
+                        <Grid
+                            position={[0, 0, gridPlacement.z]}
+                            rotation={[Math.PI / 2, 0, 0]}
+                            infiniteGrid
+                            cellSize={5}
+                            sectionSize={25}
+                            cellColor="#404040"
+                            sectionColor="#606060"
+                            fadeDistance={gridPlacement.fade}
+                            fadeStrength={1.5}
+                        />
+                    </group>
                 )}
 
                 <group>
@@ -254,7 +262,9 @@ export default function Viewer({ geometries, previewGeometries, sketchesGeometri
                     </group>
                 )}
 
-                <PlaneLayer planes={planes} />
+                <group userData={CAPTURE_HIDDEN_USERDATA}>
+                    <PlaneLayer planes={planes} />
+                </group>
                 {sketchMode.active && <ParametricLayer />}
                 <OrbitControls
                     makeDefault

--- a/src/studio/components/viewer/captureViewerPng.test.ts
+++ b/src/studio/components/viewer/captureViewerPng.test.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+/** @vitest-environment happy-dom */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+import { CAPTURE_HIDDEN_FLAG, captureViewerPngBase64 } from './captureViewerPng';
+import { rendererSnapshot } from './rendererSnapshot';
+
+// The capture forces a fresh render with editing-only furniture (origin
+// construction planes + ground grid, tagged CAPTURE_HIDDEN_FLAG in Viewer.tsx)
+// hidden, then restores visibility. These tests assert that contract without a
+// real WebGL context: a fake renderer records each object's `.visible` at the
+// moment `gl.render` is invoked, which is the frame that lands in the canvas.
+
+afterEach(() => {
+  rendererSnapshot.scene = null;
+  rendererSnapshot.camera = null;
+  rendererSnapshot.gl = null;
+  vi.restoreAllMocks();
+});
+
+function buildScene() {
+  const scene = new THREE.Scene();
+
+  const model = new THREE.Mesh();
+  model.name = 'model';
+
+  const furnitureGroup = new THREE.Object3D();
+  furnitureGroup.userData = { [CAPTURE_HIDDEN_FLAG]: true };
+  const furnitureChild = new THREE.Mesh();
+  furnitureGroup.add(furnitureChild);
+
+  scene.add(model);
+  scene.add(furnitureGroup);
+  return { scene, model, furnitureGroup };
+}
+
+function fakeGl(scene: THREE.Scene, onRender: () => void) {
+  const canvas = document.createElement('canvas');
+  // happy-dom's canvas has no real toDataURL output; stub a valid data URL.
+  canvas.toDataURL = () => 'data:image/png;base64,AAAA';
+  return {
+    domElement: canvas,
+    render: vi.fn(() => onRender()),
+  } as unknown as THREE.WebGLRenderer & { render: ReturnType<typeof vi.fn> };
+}
+
+describe('captureViewerPngBase64', () => {
+  it('hides tagged furniture during the render and restores it after', () => {
+    const { scene, model, furnitureGroup } = buildScene();
+    let visibleAtRender: boolean | null = null;
+    let modelVisibleAtRender: boolean | null = null;
+
+    const gl = fakeGl(scene, () => {
+      visibleAtRender = furnitureGroup.visible;
+      modelVisibleAtRender = model.visible;
+    });
+    rendererSnapshot.scene = scene;
+    rendererSnapshot.camera = new THREE.PerspectiveCamera();
+    rendererSnapshot.gl = gl;
+
+    const out = captureViewerPngBase64();
+
+    // Furniture was hidden for the captured frame...
+    expect(visibleAtRender).toBe(false);
+    // ...the actual model stayed visible...
+    expect(modelVisibleAtRender).toBe(true);
+    // ...and visibility was restored before returning.
+    expect(furnitureGroup.visible).toBe(true);
+    expect(out).toBe('AAAA');
+  });
+
+  it('restores furniture visibility even if the render throws', () => {
+    const { scene, furnitureGroup } = buildScene();
+    const gl = fakeGl(scene, () => {
+      throw new Error('webgl context lost');
+    });
+    rendererSnapshot.scene = scene;
+    rendererSnapshot.camera = new THREE.PerspectiveCamera();
+    rendererSnapshot.gl = gl;
+
+    // A throwing render must not throw out of capture and must restore state.
+    const out = captureViewerPngBase64();
+    expect(furnitureGroup.visible).toBe(true);
+    // Falls back to the buffered frame via toDataURL.
+    expect(out).toBe('AAAA');
+  });
+
+  it('returns null when no renderer canvas is available', () => {
+    rendererSnapshot.scene = null;
+    rendererSnapshot.camera = null;
+    rendererSnapshot.gl = null;
+    expect(captureViewerPngBase64()).toBeNull();
+  });
+});

--- a/src/studio/components/viewer/captureViewerPng.ts
+++ b/src/studio/components/viewer/captureViewerPng.ts
@@ -12,7 +12,34 @@
 // callers must treat capture as best-effort and never break the viewer on a
 // missing/failed grab.
 
+import type * as THREE from 'three';
 import { rendererSnapshot } from './rendererSnapshot';
+
+/** Objects tagged with `userData[CAPTURE_HIDDEN_FLAG] === true` are hidden for
+ *  the duration of a render-to-image capture and restored immediately after.
+ *  Used to keep editing-only scene furniture — the red/green/blue origin
+ *  construction planes and the ground grid — out of the captured PNG so it
+ *  matches the clean framed model the user reviews, not the authoring view.
+ *  Tagged at the group level in Viewer.tsx; see hideCaptureFurniture below. */
+export const CAPTURE_HIDDEN_FLAG = 'kcCaptureHidden';
+
+/** Walk the scene and hide every object (and its subtree, implicitly via
+ *  three.js visibility inheritance) flagged with CAPTURE_HIDDEN_FLAG. Returns a
+ *  restore() that puts every touched object's `.visible` back exactly as it was.
+ *  Best-effort: a throw mid-traversal still leaves restore() able to undo what
+ *  was already changed. */
+function hideCaptureFurniture(scene: THREE.Scene): () => void {
+  const touched: Array<{ obj: THREE.Object3D; prev: boolean }> = [];
+  scene.traverse((obj) => {
+    if ((obj.userData as Record<string, unknown>)?.[CAPTURE_HIDDEN_FLAG] === true) {
+      touched.push({ obj, prev: obj.visible });
+      obj.visible = false;
+    }
+  });
+  return () => {
+    for (const { obj, prev } of touched) obj.visible = prev;
+  };
+}
 
 /** Find the three.js WebGL canvas in the document. The viewer mounts exactly
  *  one such canvas; the brush overlay's transient 2D canvas is excluded by the
@@ -40,14 +67,30 @@ export function findRendererCanvas(): HTMLCanvasElement | null {
  *  / pre-camera-fit), giving an unframed shot. The brush avoids this only
  *  because it captures right after the user moved the camera. Re-rendering
  *  scene+camera into the preserved buffer makes an idle auto-capture read the
- *  CURRENT view. */
+ *  CURRENT view.
+ *
+ *  The forced render is done with the origin construction planes and ground
+ *  grid (tagged CAPTURE_HIDDEN_FLAG in Viewer.tsx) hidden, so the captured PNG
+ *  shows the clean framed model the user reviews rather than the authoring view
+ *  buried under colored planes. Visibility is restored before returning, so the
+ *  on-screen frame the r3f loop paints next is unaffected. */
 export function captureViewerPngBase64(): string | null {
   try {
     const { gl, scene, camera } = rendererSnapshot;
     const canvas = gl?.domElement ?? findRendererCanvas();
     if (!canvas) return null;
     if (gl && scene && camera) {
-      try { gl.render(scene, camera); } catch { /* fall back to the buffered frame */ }
+      // Hide editing-only furniture for the captured frame, then restore so the
+      // next on-screen r3f frame is identical to before. If gl.render throws we
+      // still restore (finally) and fall back to the buffered frame.
+      const restore = hideCaptureFurniture(scene);
+      try {
+        gl.render(scene, camera);
+      } catch {
+        /* fall back to the buffered frame */
+      } finally {
+        restore();
+      }
     }
     const dataUrl = canvas.toDataURL('image/png');
     const comma = dataUrl.indexOf(',');


### PR DESCRIPTION
## Problem

The render-to-image capture (`captureViewerPngBase64`, follow-up to PRs #484–#486) forces a fresh `gl.render(scene, camera)` before reading the canvas. That render includes the red/green/blue **origin construction planes** (`PlaneLayer`, the default `base-xy`/`base-xz`/`base-yz` planes) and the **ground grid** (drei `<Grid>`). The captured PNG therefore looked like the authoring view — model buried under colored planes — instead of the clean framed model the user reviews on screen.

## Composite-capture vs hide-planes safe-win

Investigated first: the viewer has **no EffectComposer / post-processing / custom frameloop** (verified by search). The on-screen "Shaded + Edges" composite *is* the default r3f `gl.render(scene, camera)` plus HTML/CSS overlays (gizmo, version label) that live outside the WebGL canvas and were never in the capture. So there was no deep r3f pipeline to reproduce — the only delta between the captured PNG and the clean on-screen model was the editing furniture in the scene graph. Hiding it gives the **true composite capture**, not a degraded fallback.

## Change

- `captureViewerPng.ts`: export `CAPTURE_HIDDEN_FLAG`; before the forced render, traverse the scene, set `.visible = false` on every object tagged with that flag, render, then restore in a `finally`.
- `Viewer.tsx`: wrap the `<Grid>` and `<PlaneLayer>` in groups tagged `userData={{ kcCaptureHidden: true }}`.

## How v1 is not regressed

- Capture stays best-effort: returns `null` on any failure, never throws.
- Visibility restore runs in `finally`, so a throwing `gl.render` still leaves the scene untouched and falls back to the buffered frame (existing behavior).
- Only `.visible` flags are toggled around a single synchronous render; the r3f loop's next on-screen frame is identical to before. No render-loop, material, or camera changes.

## Verification

- `npm run typecheck` — clean
- `npx eslint` on all 3 changed files — clean
- New `captureViewerPng.test.ts` (3 tests): furniture hidden at render time, model stays visible, visibility restored after, restore survives a throwing render.
- Full viewer suite + `App.liveViewer.test.tsx`: 64 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)