### PR TITLE
perf(parts): content-hash cache for parsed STEP geometry

### DIFF
--- a/src/modeling/parts/fromSTEP.ts
+++ b/src/modeling/parts/fromSTEP.ts
@@ -8,10 +8,10 @@
 // the lowered shape on the FeatureRecord's metadata so the lowerer can
 // hand it back without re-importing.
 
-import * as replicad from 'replicad';
 import { readFile } from 'node:fs/promises';
 import { resolveScriptRelativePath } from '../../shared/runtime/scriptRelativePath';
-import { OcctBackend, initOcct } from '../../kernel/backends/occt/occtBackend';
+import { OcctBackend } from '../../kernel/backends/occt/occtBackend';
+import { importStepCached, StepParseError } from './stepParseCache';
 import { Shape } from '../capture/proxy';
 import type { CaptureSession } from '../capture/captureSession';
 import { KernelError } from '../../shared/intent/kernelError';
@@ -48,16 +48,24 @@ export async function fromSTEP(ctx: FromSTEPContext, path: string): Promise<Shap
     );
   }
 
-  await initOcct();
-
-  // replicad.importSTEP wants a Blob. In Node 22+, Blob is global.
-  // The bytes copy is unavoidable: importSTEP reads the blob async.
-  const blob = new Blob([new Uint8Array(buf)]);
-
-  let imported: replicad.AnyShape;
+  // Parse (or reuse a content-hash-cached parse of) the STEP bytes. The cache
+  // is what keeps a Studio rebuild from re-importing an unchanged part on
+  // every code edit. We re-raise its failures as this call's KernelErrors so
+  // the agent-facing diagnostics are unchanged.
+  let backend: OcctBackend;
   try {
-    imported = await replicad.importSTEP(blob);
+    backend = await importStepCached(buf);
   } catch (e) {
+    if (e instanceof StepParseError && e.reason === 'no-solid') {
+      // A Shape3D-class result is required (Solid / CompSolid / Compound);
+      // 2D drawings and empty imports are rejected before the lowerer.
+      throw new KernelError(
+        'feature.kernel-failed',
+        `lib.fromSTEP: ${absPath} did not contain a 3D solid.`,
+        undefined,
+        'kernel-failed.lib.fromSTEP.no-solid — the STEP file must contain at least one closed solid body.',
+      );
+    }
     const msg = e instanceof Error ? e.message : String(e);
     throw new KernelError(
       'feature.kernel-failed',
@@ -66,24 +74,6 @@ export async function fromSTEP(ctx: FromSTEPContext, path: string): Promise<Shap
       'kernel-failed.lib.fromSTEP.parse — file is not a valid STEP solid; re-export from the source CAD as AP203/AP214 with solid bodies.',
     );
   }
-
-  // We expect a Shape3D-class result (Solid / CompSolid / Compound). Reject
-  // 2D drawings or empty imports up-front so the lowerer never sees them.
-  // Duck-typed against `meshShape` — the method lives on replicad's `_3DShape`
-  // prototype only, so a 2D `Sketch` import would correctly fail this check.
-  if (
-    !imported ||
-    typeof (imported as { meshShape?: unknown }).meshShape !== 'function'
-  ) {
-    throw new KernelError(
-      'feature.kernel-failed',
-      `lib.fromSTEP: ${absPath} did not contain a 3D solid.`,
-      undefined,
-      'kernel-failed.lib.fromSTEP.no-solid — the STEP file must contain at least one closed solid body.',
-    );
-  }
-
-  const backend = new OcctBackend(imported as replicad.Shape3D);
 
   // Park the lowered shape on the session's `importedGeometry` map (not in
   // metadata): replicad shapes carry circular refs that trip the
@@ -121,12 +111,18 @@ export async function fromStepBytes(
       'parts.fetch.empty-bytes — re-fetch and try again.',
     );
   }
-  await initOcct();
-  const blob = new Blob([new Uint8Array(bytes)]);
-  let imported: replicad.AnyShape;
+  let backend: OcctBackend;
   try {
-    imported = await replicad.importSTEP(blob);
+    backend = await importStepCached(bytes);
   } catch (e) {
+    if (e instanceof StepParseError && e.reason === 'no-solid') {
+      throw new KernelError(
+        'feature.kernel-failed',
+        `lib.fetchPart: ${sourceLabel} did not contain a 3D solid.`,
+        undefined,
+        'kernel-failed.lib.fetchPart.no-solid.',
+      );
+    }
     const msg = e instanceof Error ? e.message : String(e);
     throw new KernelError(
       'feature.kernel-failed',
@@ -135,18 +131,6 @@ export async function fromStepBytes(
       'kernel-failed.lib.fetchPart.parse — file is not a valid STEP solid.',
     );
   }
-  if (
-    !imported ||
-    typeof (imported as { meshShape?: unknown }).meshShape !== 'function'
-  ) {
-    throw new KernelError(
-      'feature.kernel-failed',
-      `lib.fetchPart: ${sourceLabel} did not contain a 3D solid.`,
-      undefined,
-      'kernel-failed.lib.fetchPart.no-solid.',
-    );
-  }
-  const backend = new OcctBackend(imported as replicad.Shape3D);
   const shape = ctx.session.createShape({
     kind: 'importedStep',
     params: {},

--- a/src/modeling/parts/stepParseCache.test.ts
+++ b/src/modeling/parts/stepParseCache.test.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/modeling/parts/stepParseCache.test.ts
+//
+// The Studio "Computing" stall on models with imported parts is dominated by
+// re-running replicad.importSTEP every rebuild. This guards the content-hash
+// parse cache that removes the re-parse: identical bytes parse once, and each
+// call still hands back an independent clone the caller can safely consume.
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { OcctBackend, initOcct } from '../../kernel/backends/occt/occtBackend';
+import {
+  importStepCached,
+  StepParseError,
+  __stepParseCacheStats,
+  __resetStepParseCache,
+} from './stepParseCache';
+
+let boxBytes: Buffer;
+let smallBoxBytes: Buffer;
+
+beforeAll(async () => {
+  await initOcct();
+  boxBytes = Buffer.from(await OcctBackend.box(20, 30, 40, false).exportSTEPAsync());
+  smallBoxBytes = Buffer.from(await OcctBackend.box(5, 5, 5, false).exportSTEPAsync());
+});
+
+beforeEach(() => __resetStepParseCache());
+
+describe('importStepCached', () => {
+  it('parses STEP bytes into a positive-volume solid', async () => {
+    const backend = await importStepCached(boxBytes);
+    // 20 * 30 * 40 = 24000 mm³ — leave headroom for STEP rounding.
+    expect(backend.volume()).toBeGreaterThan(23000);
+    expect(backend.volume()).toBeLessThan(25000);
+  });
+
+  it('parses only once for identical bytes (second call is a cache hit)', async () => {
+    await importStepCached(boxBytes);
+    await importStepCached(boxBytes);
+    const stats = __stepParseCacheStats();
+    expect(stats.misses).toBe(1);
+    expect(stats.hits).toBe(1);
+    expect(stats.size).toBe(1);
+  });
+
+  it('hands back an independent clone — disposing one does not break the next', async () => {
+    const first = await importStepCached(boxBytes);
+    // Destroy this handle the way a downstream translate/rotate would.
+    first.dispose();
+    // The cached master must survive and still yield a usable solid.
+    const second = await importStepCached(boxBytes);
+    expect(second.volume()).toBeGreaterThan(23000);
+  });
+
+  it('keys on content, not identity — different bytes miss separately', async () => {
+    await importStepCached(boxBytes);
+    await importStepCached(smallBoxBytes);
+    const stats = __stepParseCacheStats();
+    expect(stats.misses).toBe(2);
+    expect(stats.size).toBe(2);
+  });
+
+  it('throws StepParseError(parse) on bytes that are not STEP', async () => {
+    const garbage = Buffer.from('this is not a STEP file');
+    await expect(importStepCached(garbage)).rejects.toBeInstanceOf(StepParseError);
+    await expect(importStepCached(garbage)).rejects.toMatchObject({ reason: 'parse' });
+  });
+});

--- a/src/modeling/parts/stepParseCache.ts
+++ b/src/modeling/parts/stepParseCache.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/modeling/parts/stepParseCache.ts
+//
+// Content-addressed cache for parsed STEP geometry.
+//
+// Every Studio rebuild re-runs the .kcad.ts capture phase from scratch, so
+// each `lib.fromSTEP` / `lib.fetchPart` call would otherwise re-run
+// replicad.importSTEP — the expensive STEP-text → BREP reconstruction — even
+// when the bytes are byte-identical to the previous rebuild. That repeated
+// re-parse is the dominant cost behind the Studio "Computing" stall on models
+// that carry imported parts.
+//
+// Keyed by sha256(bytes). On a hit we hand back `master.clone()`, never the
+// cached master itself: the per-session backend gets parked on
+// session.importedGeometry and is then consumed during lowering (replicad's
+// translate/rotate/mirror destroy their source OCCT handle), so the master
+// must stay independent and alive across sessions. This mirrors the
+// clone-on-handback contract the lowerer already uses for importedStep
+// records (occtLowerer.ts).
+//
+// The cache is a bounded LRU: capacity caps the number of live master BREP
+// shapes held in the OCCT WASM heap; evicted masters are disposed.
+
+import * as replicad from 'replicad';
+import { createHash } from 'node:crypto';
+import { OcctBackend, initOcct } from '../../kernel/backends/occt/occtBackend';
+
+/** Why a STEP byte buffer could not be turned into a 3D solid. Reported so
+ *  callers map to their own KernelError code/hint — the cache stays free of
+ *  caller-specific diagnostics. */
+export type StepParseFailure = 'parse' | 'no-solid';
+
+export class StepParseError extends Error {
+  // erasableSyntaxOnly forbids constructor parameter properties — declare explicitly.
+  readonly reason: StepParseFailure;
+  constructor(reason: StepParseFailure, message: string) {
+    super(message);
+    this.reason = reason;
+    this.name = 'StepParseError';
+  }
+}
+
+/** Max distinct parsed STEP master shapes kept alive. The working set is the
+ *  distinct imported parts in the current model; a few dozen covers a large
+ *  assembly while bounding WASM-heap growth across a long session. */
+const MAX_ENTRIES = 32;
+
+const cache = new Map<string, OcctBackend>();
+let hits = 0;
+let misses = 0;
+
+function sha256Hex(bytes: Buffer | Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+/**
+ * Parse STEP bytes into an OcctBackend, reusing a cached parse when the exact
+ * same bytes were seen before. Always returns a fresh clone the caller owns
+ * and may safely consume (transform / dispose) without affecting the cache.
+ *
+ * @throws StepParseError('parse')    replicad.importSTEP rejected the bytes
+ * @throws StepParseError('no-solid') the import held no 3D solid body
+ */
+export async function importStepCached(bytes: Buffer | Uint8Array): Promise<OcctBackend> {
+  const key = sha256Hex(bytes);
+
+  const cached = cache.get(key);
+  if (cached) {
+    // LRU bump: re-insert to mark most-recently-used.
+    cache.delete(key);
+    cache.set(key, cached);
+    hits++;
+    return cached.clone();
+  }
+
+  await initOcct();
+  // replicad.importSTEP wants a Blob. The bytes copy is unavoidable.
+  const blob = new Blob([new Uint8Array(bytes)]);
+  let imported: replicad.AnyShape;
+  try {
+    imported = await replicad.importSTEP(blob);
+  } catch (e) {
+    throw new StepParseError('parse', e instanceof Error ? e.message : String(e));
+  }
+  // Duck-type the Shape3D check: `meshShape` lives on replicad's `_3DShape`
+  // prototype only, so a 2D Sketch import correctly fails here.
+  if (!imported || typeof (imported as { meshShape?: unknown }).meshShape !== 'function') {
+    throw new StepParseError('no-solid', 'STEP import contained no 3D solid body');
+  }
+
+  const master = new OcctBackend(imported as replicad.Shape3D);
+  cache.set(key, master);
+  misses++;
+
+  // Evict oldest beyond capacity; dispose the evicted master's OCCT handle so
+  // the WASM heap doesn't grow unbounded. Outstanding clones are independent
+  // handles and are unaffected.
+  while (cache.size > MAX_ENTRIES) {
+    const oldestKey = cache.keys().next().value as string | undefined;
+    if (oldestKey === undefined) break;
+    const evicted = cache.get(oldestKey);
+    cache.delete(oldestKey);
+    evicted?.dispose();
+  }
+
+  return master.clone();
+}
+
+/** Test-only: parse-cache instrumentation. */
+export function __stepParseCacheStats(): { hits: number; misses: number; size: number } {
+  return { hits, misses, size: cache.size };
+}
+
+/** Test-only: drop all cached masters (disposing their OCCT handles) and reset counters. */
+export function __resetStepParseCache(): void {
+  for (const v of cache.values()) v.dispose();
+  cache.clear();
+  hits = 0;
+  misses = 0;
+}


### PR DESCRIPTION
## Issue
Studio shows "Computing…" for too long before an imported part appears (repro: app.kernelcad.com/p/43PSZn6U). Root cause (issues-book): every rebuild re-runs the full `.kcad.ts` capture phase, so each `lib.fromSTEP`/`lib.fetchPart` re-runs `replicad.importSTEP` — the expensive STEP→BREP reconstruction — even when the bytes are byte-identical to the previous rebuild. Only the STEP *bytes* were cached, never the parsed shape.

## Fix
New `stepParseCache.ts`: `importStepCached(bytes)`, a bounded-LRU (32 entries) keyed by `sha256(bytes)`. On a hit it hands back `master.clone()` — never the cached master — so the per-session backend can be consumed by destructive transforms (translate/rotate destroy OCCT handles) while the cached master survives across sessions. This mirrors the clone-on-handback contract the lowerer already uses for `importedStep` records. Evicted masters are `dispose()`d so the WASM heap stays bounded.

Both STEP loaders route through it; their `KernelError` codes/hints are byte-for-byte unchanged.

## Evidence
- 5 new cache tests (parse, single-parse-on-repeat, clone independence, content-keying, parse-error) + existing 59 parts tests green; typecheck + eslint clean.
- Benchmark on a real gear: `spur-gear-m2-z40.step` cold parse **662ms** vs warm cache hit **0.42ms** (**1574×**). Re-parse cost per imported part is now paid once, not every edit.

## Scope / follow-ups
This is Fix 1 of the issues-book entry (the dominant, lowest-risk win). Not in scope: incremental session-prefix rebuild (carry unchanged cachedShapes forward), two-tier meshing, and the *separate* swallowed-error bug where p/43PSZn6U rendered **empty** — that one needs its own repro/trace.