### PR TITLE
fix(studio): surface empty-render builds instead of a silent blank viewport

### DIFF
--- a/src/studio/context/GeometryContext.test.tsx
+++ b/src/studio/context/GeometryContext.test.tsx
@@ -506,6 +506,104 @@ describe('GeometryContext latest-intent-wins', () => {
     expect(fetchMock).toHaveBeenCalled();
   });
 
+  it('hosted: surfaces an error when a solid-producing build renders zero geometry', async () => {
+    // Regression: app.kernelcad.com/p/43PSZn6U sat on "Computing" then went
+    // EMPTY with no signal — a swallowed build failure. A 200 mesh response
+    // carrying feature records but zero rendered meshes must surface, not show
+    // a green "Ready / 0 bodies".
+    vi.stubGlobal('window', {
+      ...window,
+      location: { ...window.location, hostname: 'app.kernelcad.com', search: '' },
+      localStorage: window.localStorage,
+      history: window.history,
+      crypto: window.crypto,
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        features: [], // build rendered nothing...
+        featureRecords: [{ id: 'b', kind: 'box' }], // ...but a solid was expected
+        bounds: { min: [0, 0, 0], max: [0, 0, 0] },
+        params: {},
+        review: { ok: true, diagnostics: [] },
+      }),
+    } as Response);
+
+    render(
+      <GeometryProvider code={'export default box(1, 1, 1);'}>
+        <Probe />
+      </GeometryProvider>,
+    );
+
+    await flushUntil(() => screen.getByTestId('error').textContent !== '');
+
+    expect(screen.getByTestId('error').textContent).toMatch(/no visible geometry/i);
+    expect(screen.getByTestId('face-count').textContent).toBe('0');
+  });
+
+  it('hosted: prefers the kernel error diagnostic in the empty-build message', async () => {
+    vi.stubGlobal('window', {
+      ...window,
+      location: { ...window.location, hostname: 'app.kernelcad.com', search: '' },
+      localStorage: window.localStorage,
+      history: window.history,
+      crypto: window.crypto,
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        features: [],
+        featureRecords: [{ id: 'cut', kind: 'boolean' }],
+        bounds: { min: [0, 0, 0], max: [0, 0, 0] },
+        params: {},
+        review: { ok: false, diagnostics: [{ severity: 'error', message: 'subtract removed all geometry' }] },
+      }),
+    } as Response);
+
+    render(
+      <GeometryProvider code={'export default cut;'}>
+        <Probe />
+      </GeometryProvider>,
+    );
+
+    await flushUntil(() => screen.getByTestId('error').textContent !== '');
+
+    expect(screen.getByTestId('error').textContent).toContain('subtract removed all geometry');
+  });
+
+  it('hosted: does NOT flag an empty/sketch-only build as an error', async () => {
+    vi.stubGlobal('window', {
+      ...window,
+      location: { ...window.location, hostname: 'app.kernelcad.com', search: '' },
+      localStorage: window.localStorage,
+      history: window.history,
+      crypto: window.crypto,
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        features: [],
+        featureRecords: [{ id: 's', kind: 'sketch' }],
+        bounds: { min: [0, 0, 0], max: [0, 0, 0] },
+        params: {},
+        review: { ok: true, diagnostics: [] },
+      }),
+    } as Response);
+
+    render(
+      <GeometryProvider code={'sketch().lineTo(1,0);'}>
+        <Probe />
+      </GeometryProvider>,
+    );
+
+    // Let the debounced build settle, then assert no error was raised.
+    await flushUntil(() => screen.getByTestId('execution-count').textContent !== '0');
+    expect(screen.getByTestId('error').textContent).toBe('');
+  });
+
   it('refreshes mesh AND review when params relower over SSE', async () => {
     // PR #315 / I1: relower MUST re-run review so the StudioShell HUD
     // (interferences: N) reflects the post-param model. Old behavior

--- a/src/studio/context/GeometryContext.tsx
+++ b/src/studio/context/GeometryContext.tsx
@@ -77,6 +77,37 @@ export interface ScriptReviewSummary {
     }>;
 }
 
+/**
+ * Detect a *silent* build failure in an otherwise-200 mesh response.
+ *
+ * The kernel can return a successful payload that renders nothing: an assembly
+ * whose parts all failed to mesh (`meshFeaturesPerFeature` skips them), a
+ * boolean that subtracted everything, or a feature that compiled to an empty
+ * solid. Left alone the viewport just goes blank under a green "Ready / 0
+ * bodies" — the swallowed-error symptom reported for app.kernelcad.com/p/43PSZn6U.
+ *
+ * Returns a message to surface via `error`, or null when the empty result is
+ * legitimate (an empty or sketch-only script renders no solids by design and
+ * must NOT be flagged). When the kernel attached its own error diagnostic
+ * (the hosted server includes `review`), that message is preferred.
+ */
+function detectEmptyBuild(
+    renderedMeshCount: number,
+    featureRecords: FeatureRecord[],
+    review: ScriptReviewSummary | null | undefined,
+): string | null {
+    if (renderedMeshCount > 0) return null;
+    // Empty or sketch-only scripts render no solids by design — not a failure.
+    if (!featureRecords.some((r) => r.kind !== 'sketch')) return null;
+    // A solid-producing model that rendered nothing is a swallowed build
+    // failure. Prefer the kernel's own error diagnostic when present.
+    const firstError = (review?.diagnostics ?? []).find((d) => (d.severity ?? 'error') === 'error');
+    if (firstError?.message) {
+        return `Model produced no visible geometry: ${firstError.message}`;
+    }
+    return 'Model compiled but produced no visible geometry. Open the Validity panel for diagnostics.';
+}
+
 export interface GeometryContextType {
     geometries: GeometryResult[];
     previewGeometries: GeometryResult[];
@@ -804,16 +835,24 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
                         staleRecorded = true;
                         return;
                     }
-                    setGeometries(featureMeshesToGeometries(payload.features as FeatureMeshSerialized[]));
+                    const hostedGeometries = featureMeshesToGeometries(payload.features as FeatureMeshSerialized[]);
+                    const hostedRecords = (payload.featureRecords as FeatureRecord[]) ?? [];
+                    const hostedReview = payload.review ?? { ok: true, diagnostics: [] };
+                    const emptyNotice = detectEmptyBuild(hostedGeometries.length, hostedRecords, hostedReview);
+                    setGeometries(hostedGeometries);
                     setGeometryTransformOverrides({});
-                    setFeatureRecords((payload.featureRecords as FeatureRecord[]) ?? []);
+                    setFeatureRecords(hostedRecords);
                     setScriptParams(Object.values(payload.params ?? {}));
-                    setScriptReview(payload.review ?? { ok: true, diagnostics: [] });
+                    setScriptReview(hostedReview);
                     setSketchesGeometries([]);
                     setPreviewGeometries([]);
-                    setError(null);
-                    setLastSuccessfulRevision(revision);
-                    pushExecutionRecord({ revision, status: 'success', executionCountAtRecord: executionCount + 1 });
+                    setError(emptyNotice);
+                    if (emptyNotice) {
+                        pushExecutionRecord({ revision, status: 'error', error: emptyNotice, executionCountAtRecord: executionCount + 1 });
+                    } else {
+                        setLastSuccessfulRevision(revision);
+                        pushExecutionRecord({ revision, status: 'success', executionCountAtRecord: executionCount + 1 });
+                    }
                 } catch (err: unknown) {
                     if (revision !== mainRevisionRef.current) {
                         setStaleMainResponsesDropped((prev) => prev + 1);
@@ -846,16 +885,24 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
             // net for any other API the worker happens to lack.
             const useDevKernel = devMeshAvailable() && needsFullKernel(code);
             const applyDevPayload = (payload: BackendMeshPayload) => {
-                setGeometries(featureMeshesToGeometries(payload.features as FeatureMeshSerialized[]));
+                const devGeometries = featureMeshesToGeometries(payload.features as FeatureMeshSerialized[]);
+                const devRecords = (payload.featureRecords as FeatureRecord[]) ?? [];
+                const devReview = payload.review ?? { ok: true, diagnostics: [] };
+                const emptyNotice = detectEmptyBuild(devGeometries.length, devRecords, devReview);
+                setGeometries(devGeometries);
                 setGeometryTransformOverrides({});
-                setFeatureRecords((payload.featureRecords as FeatureRecord[]) ?? []);
+                setFeatureRecords(devRecords);
                 setScriptParams(Object.values(payload.params ?? {}));
-                setScriptReview(payload.review ?? { ok: true, diagnostics: [] });
+                setScriptReview(devReview);
                 setSketchesGeometries([]);
                 setPreviewGeometries([]);
-                setError(null);
-                setLastSuccessfulRevision(revision);
-                pushExecutionRecord({ revision, status: 'success', executionCountAtRecord: executionCount + 1 });
+                setError(emptyNotice);
+                if (emptyNotice) {
+                    pushExecutionRecord({ revision, status: 'error', error: emptyNotice, executionCountAtRecord: executionCount + 1 });
+                } else {
+                    setLastSuccessfulRevision(revision);
+                    pushExecutionRecord({ revision, status: 'success', executionCountAtRecord: executionCount + 1 });
+                }
             };
             try {
                 if (useDevKernel) {


### PR DESCRIPTION
## Issue
`app.kernelcad.com/p/43PSZn6U` sat on "Computing…" and then rendered **empty** with no error — the swallowed-error half of the issues-book Computing entry.

## Root cause
A mesh response can return **HTTP 200 with zero rendered meshes** and no hard failure:
- an assembly whose per-part shapes all fail to mesh — `meshFeaturesPerFeature` (featureMeshing.ts:864) `continue`s **silently** and the assembly is not marked failed;
- a boolean that subtracts everything, or a feature that compiles to an empty solid.

The client's hosted **and** dev apply paths treated that as success: `setGeometries([])`, `setError(null)`, status `success`. The StatusBar then shows a green **Ready / No diagnostics / 0 bodies** over a blank canvas — no signal anything went wrong. Any error diagnostics rode in `review` (Validity tab only), invisible in the viewport.

## Fix
`detectEmptyBuild()` in `GeometryContext` — when a build renders **zero** meshes but carried a **solid-producing** feature record, surface a message via `error` instead of a silent empty success. It prefers the kernel's own error diagnostic (the hosted server attaches `review`) when present. Empty and **sketch-only** scripts render no solids by design and are explicitly exempt, so rendering models are unaffected. Wired into both the hosted (prod) and dev-kernel apply paths — the single funnel both backends pass through, so this ships to prod via the normal web deploy.

## Tests
3 new (empty-with-solid surfaces; kernel diagnostic preferred in the message; sketch-only exempt — no false positive) + existing 9 GeometryContext tests green. Typecheck + eslint clean (one pre-existing `exhaustive-deps` warning on develop, unrelated).

## Scope / follow-up
This is the **client surfacing** layer — it converts silent-empty-success into a visible, explained state for any backend. The deeper server-side root cause (the assembly all-parts-skip `continue` in `meshFeaturesPerFeature` should mark the assembly failed, not swallow it) lives partly in the separate hosted-kernel repo and is left as a tracked follow-up; this client guard protects regardless of whether that lands.