### PR TITLE
Fail (not silently empty) assembly renders when all parts fail to mesh

### DIFF
--- a/src/modeling/capture/featureMeshing.assemblySkip.test.ts
+++ b/src/modeling/capture/featureMeshing.assemblySkip.test.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/modeling/capture/featureMeshing.assemblySkip.test.ts
+//
+// Server-side guard for the "successful-but-empty assembly render" bug: when
+// every part of an assembly SceneBackend fails to mesh, the build must surface
+// the assembly id in `failedFeatureIds` (so the mesh endpoint returns a 500 the
+// Studio client can report) instead of returning zero meshes as a success. A
+// partial assembly — at least one part meshes — must still render and must NOT
+// be failed.
+//
+// These tests live in a dedicated file because they `vi.mock` the OCCT meshing
+// module to force per-part mesh failures deterministically; the rest of the
+// featureMeshing suite exercises real meshing and must stay un-mocked.
+import { describe, it, expect, beforeAll, vi, beforeEach } from 'vitest';
+import type { GeometryResult } from '../../shared/worker/workerTypes';
+
+// Controls how the mocked `meshShape` behaves for each successive call within a
+// single `meshFeaturesPerFeature` run. Reset per test.
+let meshShapeBehavior: (callIndex: number) => GeometryResult | null = () => null;
+let meshShapeCallCount = 0;
+
+vi.mock('../../kernel/backends/occt/meshing', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../kernel/backends/occt/meshing')>();
+  return {
+    ...actual,
+    meshShape: (_shape: unknown): GeometryResult | null => {
+      const result = meshShapeBehavior(meshShapeCallCount);
+      meshShapeCallCount += 1;
+      return result;
+    },
+  };
+});
+
+import { initOcct } from '../../kernel/backends/occt/occtBackend';
+import { runScript } from '../runtime/runScript';
+import { meshFeaturesPerFeature } from './featureMeshing';
+
+/** A minimal but structurally valid single-triangle mesh so the assembly
+ *  fan-out helpers (planar-UV attach, FK transform, bounds aggregation) run
+ *  without crashing on a successfully-"meshed" part. */
+function fakeTriangleMesh(): GeometryResult {
+  return {
+    faces: [
+      {
+        vertices: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+        indices: new Uint32Array([0, 1, 2]),
+        normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+        faceId: 0,
+      },
+    ],
+    volume: 1,
+  };
+}
+
+/** A two-part assembly (base + link) authored exactly like the existing
+ *  fan-out identity fixture in featureMeshing.test.ts. */
+async function twoPartAssemblyRecords() {
+  const code = `
+    const arm = assembly('skip-test');
+    const base = arm.part('base', box(10, 10, 10));
+    const link = arm.part('link', box(10, 10, 30));
+    base.connector('yaw', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 10] }, axis: [0, 0, 1] });
+    link.connector('yaw', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm.mate('yaw', 'base.yaw', 'link.yaw', 'revolute');
+    return arm.solvedModel({ yaw: 0 });
+  `;
+  const { records } = await runScript({ code, fileName: 'assembly-skip.kcad.ts' });
+  const assembly = records[records.length - 1];
+  return { records, assemblyId: assembly.id };
+}
+
+beforeAll(async () => {
+  await initOcct();
+});
+
+beforeEach(() => {
+  meshShapeCallCount = 0;
+  meshShapeBehavior = () => null;
+});
+
+describe('meshFeaturesPerFeature — assembly all-parts-skip handling', () => {
+  it('fails the assembly when EVERY part fails to mesh', async () => {
+    // Every meshShape call returns null → both parts skip → assembly empty.
+    meshShapeBehavior = () => null;
+
+    const { records, assemblyId } = await twoPartAssemblyRecords();
+    const { features, failedFeatureIds } = await meshFeaturesPerFeature(records);
+
+    expect(failedFeatureIds).toContain(assemblyId);
+    // No part meshes were emitted for the failed assembly.
+    expect(features.some((f) => f.assemblyFeatureId === assemblyId)).toBe(false);
+  });
+
+  it('does NOT fail a partial assembly — one part meshes, one skips — and still emits meshes', async () => {
+    // First part meshes, second part fails. The assembly must still render.
+    meshShapeBehavior = (callIndex) => (callIndex === 0 ? fakeTriangleMesh() : null);
+
+    const { records, assemblyId } = await twoPartAssemblyRecords();
+    const { features, failedFeatureIds } = await meshFeaturesPerFeature(records);
+
+    expect(failedFeatureIds).not.toContain(assemblyId);
+    // Exactly one part mesh survived the partial failure.
+    const partMeshes = features.filter((f) => f.assemblyFeatureId === assemblyId);
+    expect(partMeshes).toHaveLength(1);
+  });
+});

--- a/src/modeling/capture/featureMeshing.ts
+++ b/src/modeling/capture/featureMeshing.ts
@@ -844,6 +844,12 @@ export async function meshFeaturesPerFeature(
       // by changing group matrices instead of remeshing on every joint tick.
       if (isSceneBackend(event.shape)) {
         let partCache = cachedAssemblyPartMeshes?.get(event.featureId);
+        // Track part-meshing outcomes so an assembly whose parts ALL fail to
+        // mesh is surfaced as a failure rather than returning a silently-empty
+        // (but "successful") build. A partial assembly — at least one part
+        // meshed — must still render, so we only fail when nothing was emitted.
+        const partCount = event.shape.parts.length;
+        let emittedPartCount = 0;
         for (const part of event.shape.parts) {
           // Pose-cache fast path: when the assembly is being re-lowered for a
           // pose-only edit, the per-part LOCAL shape is unchanged (same OCCT
@@ -861,9 +867,14 @@ export async function meshFeaturesPerFeature(
           } else {
             const meshed = meshShape(extractRawShape(part.shape));
             if (!meshed) {
-              // Per-part shape failed to mesh; skip silently — the lowerer
-              // already populated the part shape, and the SceneBackend itself
-              // is not a single-shape unit so we don't fail the whole assembly.
+              // Per-part shape failed to mesh. Skip THIS part — the lowerer
+              // already populated the part shape, and a single bad part must
+              // not sink an otherwise-renderable assembly. Surface a soft
+              // warning so the skip is not silently lost; the post-loop check
+              // below escalates to a hard failure only when EVERY part skips.
+              console.warn(
+                `meshFeaturesPerFeature: assembly '${event.featureId}' part '${part.name}' compiled but produced no mesh — skipping part`,
+              );
               continue;
             }
             faces = meshed.faces;
@@ -902,6 +913,7 @@ export async function meshFeaturesPerFeature(
             ...(part.color !== undefined ? { color: part.color } : {}),
             ...(part.material !== undefined ? { material: part.material } : {}),
           });
+          emittedPartCount += 1;
           // Aggregate bounds from FK-transformed vertices while keeping the
           // emitted mesh local for viewport-side transforms.
           const transformed = transformFeatureMesh(local, part.worldTransform);
@@ -913,6 +925,20 @@ export async function meshFeaturesPerFeature(
               if (z < minZ) minZ = z; if (z > maxZ) maxZ = z;
             }
           }
+        }
+        // Escalate an all-parts-skipped assembly to a hard failure. When the
+        // assembly declared at least one part but NONE produced a mesh, the
+        // build would otherwise return a successful-but-empty result (zero
+        // part-meshes, assembly absent from `failedFeatureIds`). Surface it so
+        // the mesh endpoint turns it into a 500 the client can report instead
+        // of silently rendering nothing. Partial assemblies (emittedPartCount
+        // > 0) still render and are intentionally NOT failed here.
+        if (partCount > 0 && emittedPartCount === 0) {
+          console.warn(
+            `meshFeaturesPerFeature: assembly '${event.featureId}' produced no part meshes (all ${partCount} part(s) failed to mesh)`,
+          );
+          failedFeatureIds.push(event.featureId);
+          return;
         }
         // P7 — emit one synthetic tendon FeatureMesh per declared
         // `arm.tendon(...)` record on the owning Assembly. The cylinder


### PR DESCRIPTION
## Root cause

In `src/modeling/capture/featureMeshing.ts`, the SceneBackend/assembly fan-out inside `meshFeaturesPerFeature` meshes each assembly part. When a per-part shape failed to mesh (`meshShape(...)` returned null), it `continue`d **silently**. An assembly whose parts ALL failed to mesh therefore emitted zero part-meshes but was never added to `failedFeatureIds` — so the build returned a successful-but-EMPTY result.

The mesh endpoint (`vite.config.ts:340`) only turns a build into a 500 when `failedFeatureIds` is non-empty, so the all-parts-failed assembly served an empty scene instead of an error. In Studio this surfaced as an empty render with no diagnostic. PR #491 added the client-side surfacing; this is the server-side root cause.

The non-assembly path already pushes un-meshable features to `failedFeatureIds`; the assembly path did not.

## Fix

- Track per-assembly part outcomes (`partCount`, `emittedPartCount`).
- After the part loop, if the assembly declared at least one part but emitted **zero** meshes, push the assembly feature id to `failedFeatureIds` so the endpoint returns a 500 the client can report.
- **Partial assemblies** (at least one part meshed) still render and are intentionally NOT failed.
- Individually-skipped parts now emit a `console.warn(...)` so the skip is not silently lost — matching the existing soft-warning pattern in this file (same as the non-assembly un-meshable path).

No gate/test was weakened; the defect is fixed in the code.

## Tests

New `src/modeling/capture/featureMeshing.assemblySkip.test.ts` (mocks the OCCT meshing module to force per-part mesh failures deterministically, kept in a dedicated file so the rest of the suite stays un-mocked):

- **all parts skip** → asserts the assembly id lands in `failedFeatureIds` and no part meshes are emitted.
- **partial assembly** (one part meshes, one skips) → asserts the assembly is NOT failed and exactly one part mesh survives.

## Gates

- `npm run typecheck` — clean
- `npx vitest run src/modeling/capture/featureMeshing` — 2 files, 13 tests passed
- `npx eslint` on both changed files — clean