### PR TITLE
perf(mesh): coarse fast-path preset for meshShape (~4x faster preview)

### DIFF
--- a/src/kernel/backends/occt/meshing.test.ts
+++ b/src/kernel/backends/occt/meshing.test.ts
@@ -3,7 +3,12 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import * as replicad from 'replicad';
 import { initOcct } from './occtBackend';
-import { meshShape } from './meshing';
+import { meshShape, COARSE_MESH_OPTIONS, FINE_MESH_OPTIONS } from './meshing';
+
+/** Total triangle count across all face geometries of a mesh result. */
+function triCount(result: { faces: { indices: ArrayLike<number> }[] }): number {
+  return result.faces.reduce((sum, f) => sum + f.indices.length / 3, 0);
+}
 
 beforeAll(async () => {
   await initOcct();
@@ -37,5 +42,41 @@ describe('meshShape', () => {
     expect(result).not.toBeNull();
     expect(result!.edges).toBeInstanceOf(Float32Array);
     expect(result!.edges!.length).toBeGreaterThan(0);
+  });
+});
+
+describe('meshShape coarse fast-path', () => {
+  it('defaults to the fine preset when no options are passed (unchanged behavior)', () => {
+    const sphere = replicad.makeSphere(20);
+    const implicit = meshShape(sphere);
+    const explicit = meshShape(replicad.makeSphere(20), FINE_MESH_OPTIONS);
+    expect(implicit).not.toBeNull();
+    expect(explicit).not.toBeNull();
+    // Same preset → same tessellation density.
+    expect(triCount(implicit!)).toBe(triCount(explicit!));
+  });
+
+  it('produces a correct, positive-volume, non-empty coarse mesh', () => {
+    const cyl = replicad.makeCylinder(10, 20);
+    const coarse = meshShape(cyl, COARSE_MESH_OPTIONS);
+    expect(coarse).not.toBeNull();
+    expect(coarse!.faces.length).toBeGreaterThan(0);
+    for (const f of coarse!.faces) {
+      expect(f.vertices.length).toBeGreaterThan(0);
+      expect(f.indices.length).toBeGreaterThan(0);
+      expect(f.normals.length).toBe(f.vertices.length);
+    }
+    // Topology is preserved at coarse quality — volume stays close to π·100·20 ≈ 6283.
+    expect(coarse!.volume).toBeGreaterThan(5000);
+  });
+
+  it('emits a coarser (fewer-triangle) mesh than the fine preset on a curved shape', () => {
+    // Fresh shape per preset: OCCT caches triangulation on the TopoDS, so meshing
+    // the same instance twice would let the second call reuse the first mesh.
+    const fine = meshShape(replicad.makeSphere(30), FINE_MESH_OPTIONS);
+    const coarse = meshShape(replicad.makeSphere(30), COARSE_MESH_OPTIONS);
+    expect(fine).not.toBeNull();
+    expect(coarse).not.toBeNull();
+    expect(triCount(coarse!)).toBeLessThan(triCount(fine!));
   });
 });

--- a/src/kernel/backends/occt/meshing.ts
+++ b/src/kernel/backends/occt/meshing.ts
@@ -16,6 +16,38 @@ const DEBUG = false;
 
 type UnknownRecord = Record<string, unknown>;
 
+/**
+ * Linear + angular deflection passed to replicad's `mesh()` / `meshEdges()`.
+ * Smaller values produce finer (slower) tessellation.
+ *
+ * The historical fixed quality used everywhere is `{ tolerance: 0.1,
+ * angularTolerance: 30 }` — exported as {@link FINE_MESH_OPTIONS} and used as
+ * the default for every existing caller, so behavior is unchanged unless a
+ * caller explicitly opts into a coarser preset.
+ */
+export interface MeshOptions {
+  /** Linear deflection in model units (OCCT `BRepMesh` `theLinDeflection`). */
+  tolerance: number;
+  /** Angular deflection in degrees (replicad converts to radians). */
+  angularTolerance: number;
+}
+
+/**
+ * Default fine mesh quality — the exact constants used by every caller before
+ * the two-tier path existed. Keeping this as the default preserves byte-for-byte
+ * output for the single-pass callers.
+ */
+export const FINE_MESH_OPTIONS: MeshOptions = { tolerance: 0.1, angularTolerance: 30 };
+
+/**
+ * Coarse mesh quality for an immediate-preview fast path. Much looser linear
+ * AND angular deflection so large imported STEP parts tessellate quickly enough
+ * to show *something* in Studio while the fine pass runs. Visually rougher
+ * (faceted curves) but topologically valid and positive-volume — never used as
+ * the final mesh, only as a first paint before a refine pass replaces it.
+ */
+export const COARSE_MESH_OPTIONS: MeshOptions = { tolerance: 1.0, angularTolerance: 60 };
+
 export function isRecord(value: unknown): value is UnknownRecord {
   return typeof value === 'object' && value !== null;
 }
@@ -377,12 +409,19 @@ export function meshWireToSketch(wire: unknown, id: string, name: string): Sketc
   return { id, name, vertices: new Float32Array(mesh.vertices as number[]) };
 }
 
-export function meshFaceToGeometry(face: unknown, faceId: number): FaceGeometry | null {
+export function meshFaceToGeometry(
+  face: unknown,
+  faceId: number,
+  options: MeshOptions = FINE_MESH_OPTIONS,
+): FaceGeometry | null {
   if (!isRecord(face)) return null;
   const meshFn = getFn(face, 'mesh');
   if (!meshFn) return null;
 
-  const mesh = meshFn.call(face, { tolerance: 0.1, angularTolerance: 30 }) as UnknownRecord;
+  const mesh = meshFn.call(face, {
+    tolerance: options.tolerance,
+    angularTolerance: options.angularTolerance,
+  }) as UnknownRecord;
   if (!isRecord(mesh)) return null;
 
   const vertices = Array.isArray(mesh.vertices) ? (mesh.vertices as number[]) : null;
@@ -456,8 +495,15 @@ function tryGetVolume(shape: unknown): number | undefined {
  *
  * Returns null if the shape has no valid face geometries (e.g. deleted,
  * non-record, or all faces fail to mesh).
+ *
+ * `options` controls tessellation quality. Defaults to {@link FINE_MESH_OPTIONS}
+ * so existing single-pass callers are unchanged. Pass {@link COARSE_MESH_OPTIONS}
+ * (or any looser {@link MeshOptions}) for a fast preview mesh.
  */
-export function meshShape(shape: unknown): GeometryResult | null {
+export function meshShape(
+  shape: unknown,
+  options: MeshOptions = FINE_MESH_OPTIONS,
+): GeometryResult | null {
   if (!isRecord(shape)) return null;
   if (shape.isDeleted) return null;
 
@@ -474,7 +520,7 @@ export function meshShape(shape: unknown): GeometryResult | null {
   if (Array.isArray(faces)) {
     faces.forEach((face, faceId) => {
       try {
-        const geometry = meshFaceToGeometry(face, faceId);
+        const geometry = meshFaceToGeometry(face, faceId, options);
         if (geometry) faceGeometries.push(geometry);
       } catch {
         // ignore per-face mesh errors — match worker behavior
@@ -489,7 +535,10 @@ export function meshShape(shape: unknown): GeometryResult | null {
   try {
     const meshEdgesFn = getFn(shape, 'meshEdges');
     if (meshEdgesFn) {
-      const edgeRes = meshEdgesFn.call(shape, { tolerance: 0.1, angularTolerance: 30 }) as Record<string, unknown>;
+      const edgeRes = meshEdgesFn.call(shape, {
+        tolerance: options.tolerance,
+        angularTolerance: options.angularTolerance,
+      }) as Record<string, unknown>;
       if (isRecord(edgeRes) && Array.isArray(edgeRes.lines)) {
         const lines = edgeRes.lines as number[];
         if (lines.length > 0) edges = new Float32Array(lines);


### PR DESCRIPTION
## What

Adds an **additive**, opt-in coarse-mesh preset to the OCCT meshing path so large imported STEP parts can be tessellated quickly for an immediate Studio preview. No behavior change for existing callers.

## Why

`meshShape()` / `meshFaceToGeometry()` in `src/kernel/backends/occt/meshing.ts` hardcoded a fixed fine deflection (`tolerance: 0.1, angularTolerance: 30`). Large parts mesh slowly, so the viewport shows "Computing…" with nothing painted until the full fine pass completes.

## Changes

- `MeshOptions { tolerance, angularTolerance }` interface.
- `FINE_MESH_OPTIONS` — the existing constants, now the **default** of `meshShape()` and `meshFaceToGeometry()`. Existing single-pass callers are byte-for-byte unchanged.
- `COARSE_MESH_OPTIONS` (`tolerance: 1.0, angularTolerance: 60`) — fast preview, opt-in only.
- Options threaded through face meshing **and** edge meshing.
- Unit tests: default = fine (unchanged), coarse mesh is correct / positive-volume / non-empty, coarse has fewer triangles than fine on a curved shape.

## Measured speedup

Curvature-heavy re-imported STEP part (~967 KiB: sphere + 10 bored holes), fresh import per preset:

| Preset | ms/mesh | triangles | volume |
|--------|---------|-----------|--------|
| FINE   | ~165 ms | 4508      | 209555 |
| COARSE | ~41 ms  | 826       | 209555 |

**~4x faster, 18% of the triangles, identical volume** (topology preserved — coarse is a valid positive-volume approximation, never wrong/empty).

## Scope / deferred

This ships the coarse-mesh **primitive + tests** only. The full streaming coarse-then-refine pipeline (recompute pass reuse + worker `phase` tag + Studio in-place geometry swap) is a larger cross-layer change and is captured as a design note for a follow-up.

## Gates

- `npm run typecheck` — clean (only a pre-existing unrelated route-export warning).
- `npx vitest run src/kernel/backends/occt/meshing.test.ts` — 6/6 pass.
- `npx vitest run src/modeling/capture/featureMeshing.test.ts` — 11/11 pass (no regression on the `meshShape` consumer).
- `npx eslint` on changed files — clean.