### PR TITLE
perf(modeling): append-only incremental code-edit rebuild (Slice 1)

### DIFF
--- a/src/modeling/buildModel.ts
+++ b/src/modeling/buildModel.ts
@@ -15,6 +15,7 @@ import { runScript } from './runtime/runScript';
 import { KernelError } from '../shared/intent/kernelError';
 import { Shape } from './capture/proxy';
 import { Scene } from './validation/scene';
+import { computePrefixReuse, type RecordHealth } from './compute/prefixReuse';
 
 export interface BuildModelInput {
   code: string;
@@ -95,6 +96,109 @@ export async function buildModel(input: BuildModelInput): Promise<BuiltModel> {
     gatedFeatureNames: session.gatedFeatureNames,
   });
 
+  return assembleBuiltModel(session, run, result, warningsBefore, input.code);
+}
+
+/**
+ * Incremental code-edit rebuild — Slice 1 (append-only prefix reuse).
+ *
+ * `buildModel` re-lowers every record from scratch on a code edit. When an
+ * agent APPENDS a feature to the end of the script, the unchanged prefix is
+ * re-lowered needlessly. This function reuses the previous build's cached
+ * prefix shapes ONLY when it can prove the new record list is a pure
+ * append/strict-prefix-superset of the previous one (same ids, same resolved
+ * structural hash for the entire shared prefix, every prefix record healthy +
+ * cached). In that case it seeds the engine with the cached prefix shapes and
+ * lowers only the appended tail.
+ *
+ * In EVERY other case — an edit/insert/delete anywhere in the prefix, any hash
+ * mismatch, a missing cached shape, a non-healthy prefix record, or any
+ * unexpected condition — it falls back to a full `buildModel(input)`. Its
+ * output is shape-identical to `buildModel` for the append case and is
+ * literally `buildModel`'s output otherwise, so it never renders a stale or
+ * wrong model. See docs/specs/2026-06-14-incremental-code-rebuild-design.md.
+ *
+ * Slice 1 ships this alongside `buildModel`; existing callers are untouched.
+ */
+export async function rebuildModelIncremental(
+  prevModel: BuiltModel,
+  input: BuildModelInput,
+): Promise<BuiltModel> {
+  await initOcct();
+
+  // 1. Capture the new script. Capture is cheap (JS execution); the expensive
+  //    work is lowering, which we want to skip for the unchanged prefix. If the
+  //    script throws, fall back — `buildModel` reproduces the same failure path.
+  let run;
+  try {
+    run = await runScript(input);
+  } catch {
+    return buildModel(input);
+  }
+  const session = run.session;
+
+  // 2. Decide whether the entire previous record list is a healthy, cached
+  //    prefix of the new one (pure append).
+  const prevHealth: ReadonlyMap<string, RecordHealth> = prevModel.health;
+  const decision = computePrefixReuse({
+    prevRecords: prevModel.records,
+    nextRecords: run.records,
+    prevParamTable: prevModel.session.paramTable,
+    nextParamTable: session.paramTable,
+    hasCachedShape: id => prevModel.session.cachedShapes.has(id),
+    prevHealth,
+  });
+
+  if (!decision.reusable) {
+    // Not a provable append → full rebuild. The session we just captured is
+    // discarded; `buildModel` re-runs the script in a fresh session. Re-running
+    // is acceptable: capture is cheap and re-running guarantees the fallback is
+    // byte-identical to the normal build path (no half-seeded state leaks).
+    return buildModel(input);
+  }
+
+  // 3. Seed the engine with the previous build's cached prefix shapes and lower
+  //    only the appended tail.
+  const seedShapes = new Map<FeatureId, ShapeBackend>();
+  for (const id of decision.reusableIds) {
+    const cached = prevModel.session.cachedShapes.get(id);
+    // Defensive: computePrefixReuse already verified presence, but a missing
+    // entry here would mean lowering a record whose upstream shape we promised
+    // to seed — fall back rather than risk it.
+    if (!cached) return buildModel(input);
+    seedShapes.set(id, cached);
+  }
+
+  const engine = new RecomputeEngine(createOcctLowerer(session));
+  session.setEngine(engine);
+  const warningsBefore = session.warnings.length;
+  const result = await engine.run(run.records, {
+    paramTable: session.paramTable,
+    seedShapes,
+    warningSink: warning => session.warnings.push(warning),
+    warningPhase: 'build',
+    gatedFeatureNames: session.gatedFeatureNames,
+  });
+
+  return assembleBuiltModel(session, run, result, warningsBefore, input.code);
+}
+
+/** Shared post-`engine.run` assembly for `buildModel` /
+ *  `rebuildModelIncremental`: populates the session cache and derives the
+ *  tail/root shapes onto a `BuiltModel`. Keeping this in one place guarantees
+ *  the incremental path produces a `BuiltModel` shaped exactly like the full
+ *  build's. */
+function assembleBuiltModel(
+  session: CaptureSession,
+  run: { records: readonly FeatureRecord[]; returnValue: unknown },
+  result: {
+    shapes: Map<FeatureId, ShapeBackend>;
+    diagnostics: CompilerDiagnostic[];
+    health: Map<FeatureId, 'healthy' | 'warning' | 'error'>;
+  },
+  warningsBefore: number,
+  code: string,
+): BuiltModel {
   populateCache(session, result.shapes);
   const tailId = run.records.length > 0 ? run.records[run.records.length - 1].id : undefined;
   const tailShape = tailId ? result.shapes.get(tailId) : undefined;
@@ -113,7 +217,7 @@ export async function buildModel(input: BuildModelInput): Promise<BuiltModel> {
     rootId,
     rootShape,
     returnValue: run.returnValue,
-    code: input.code,
+    code,
   };
 }
 

--- a/src/modeling/compute/prefixReuse.ts
+++ b/src/modeling/compute/prefixReuse.ts
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// Incremental code-edit rebuild — Slice 1 (append-only prefix reuse).
+//
+// See docs/specs/2026-06-14-incremental-code-rebuild-design.md (kernelCAD-private).
+//
+// On a CODE edit, `buildModel` re-runs capture + lowers EVERY record from
+// scratch. When an agent appends a feature to the end of the script, the
+// unchanged prefix is re-lowered needlessly. This module computes — provably
+// and conservatively — how long a prefix of the new record list is identical
+// to the previous build, so `rebuildModelIncremental` can seed the engine with
+// the cached prefix shapes and lower only the appended tail.
+//
+// Safety bias: every ambiguity resolves toward "not reusable". A false
+// negative only costs a full rebuild (the existing, correct behaviour); a
+// false positive would render a STALE model, which is unacceptable. The
+// structural hash therefore OVER-includes fields rather than risk excluding
+// one that affects geometry.
+
+import type { FeatureRecord } from '../../shared/intent/featureRecord';
+import type { ParamTable } from '../../shared/runtime/paramTable';
+import { resolveParams } from '../../shared/runtime/resolveParams';
+
+/**
+ * Deterministic structural hash of a single record's lowering-relevant state,
+ * resolved against the supplied param table.
+ *
+ * The record's `params`/`metadata` may carry symbolic `paramRef`s; the engine
+ * pre-resolves these against the param table before lowering
+ * (`resolveParams(r, table)` in `recomputeEngine.run`). We hash the SAME
+ * resolved form so two records that lower to identical geometry hash equal even
+ * when one carries a paramRef whose current value matches the other's literal.
+ *
+ * Returns a stable JSON string. We compare strings, never parse them.
+ */
+export function structuralHashRecord(
+  record: FeatureRecord,
+  paramTable: ParamTable | undefined,
+): string {
+  const resolved = paramTable ? (resolveParams(record, paramTable) as FeatureRecord) : record;
+  // Strip derived / non-geometric keys from metadata. `paramRefs` is a derived
+  // dependency index populated at capture time, not a geometry input — two
+  // structurally-identical records always derive the same paramRefs, so
+  // including it is harmless, but we drop it to keep the hash about geometry.
+  const metadata = stripDerivedMetadata(resolved.metadata);
+  // Build a canonical, key-sorted view of exactly the fields that affect
+  // lowering. `id` is intentionally EXCLUDED — prefix matching checks id
+  // equality separately; the hash answers "is the content the same", not "is
+  // it the same record".
+  const canonical = {
+    kind: resolved.kind,
+    inputs: resolved.inputs,
+    params: resolved.params,
+    transforms: resolved.transforms,
+    suppressed: resolved.suppressed,
+    metadata,
+  };
+  return stableStringify(canonical);
+}
+
+function stripDerivedMetadata(
+  metadata: FeatureRecord['metadata'],
+): Record<string, unknown> | undefined {
+  if (metadata === undefined) return undefined;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(metadata)) {
+    if (key === 'paramRefs') continue;
+    out[key] = (metadata as Record<string, unknown>)[key];
+  }
+  return out;
+}
+
+/**
+ * Deterministic JSON stringify with sorted object keys, so two
+ * structurally-equal blobs that differ only in key insertion order hash equal.
+ * Arrays preserve order (order is semantic for transforms / control nets).
+ *
+ * Non-JSON values (functions, symbols, circular refs) should never appear in a
+ * FeatureRecord's lowering-relevant fields — records are plain serializable
+ * intent. If one ever does, `JSON.stringify` of the cyclic value would throw;
+ * callers run this inside a try/catch and fall back to a full rebuild, so a
+ * surprise non-serializable field degrades safely rather than crashing.
+ */
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(sortDeep(value));
+}
+
+function sortDeep(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(sortDeep);
+  const obj = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(obj).sort()) {
+    out[key] = sortDeep(obj[key]);
+  }
+  return out;
+}
+
+/** Per-record health from a prior build — only `'healthy'` records are
+ *  reusable (a `'warning'`/`'error'` prefix record may have produced no shape
+ *  or a degraded one we must not silently reuse). */
+export type RecordHealth = 'healthy' | 'warning' | 'error';
+
+export interface PrefixReuseInput {
+  prevRecords: readonly FeatureRecord[];
+  nextRecords: readonly FeatureRecord[];
+  /** Param table of the PREVIOUS build (used to resolve prev records' hashes). */
+  prevParamTable: ParamTable | undefined;
+  /** Param table of the NEW build (used to resolve next records' hashes). */
+  nextParamTable: ParamTable | undefined;
+  /** Whether the previous build has a cached shape for a given record id. */
+  hasCachedShape: (id: string) => boolean;
+  /** Previous build's per-record health, keyed by record id. */
+  prevHealth: ReadonlyMap<string, RecordHealth>;
+}
+
+export interface PrefixReuseDecision {
+  /**
+   * `true` when the ENTIRE previous record list is a verified, healthy, cached
+   * prefix of the new record list AND the new list only appends (length grew or
+   * stayed equal with the whole prev list matched). When `true`, the caller may
+   * seed the engine with the previous cached shapes for `reusableIds` and lower
+   * only the appended tail.
+   *
+   * Slice 1 reuses ONLY the full-prefix / pure-append case. A partial match
+   * (edit in the middle) yields `reusable: false` → full rebuild.
+   */
+  reusable: boolean;
+  /** Number of leading records that matched (id + structural hash + healthy +
+   *  cached). For diagnostics / tests; reuse only fires when this equals the
+   *  previous record count AND the predicate below holds. */
+  matchedPrefixLength: number;
+  /** Ids of the records whose cached shapes the caller should seed. Empty when
+   *  `reusable` is false. */
+  reusableIds: readonly string[];
+}
+
+/**
+ * Compute the append-only prefix-reuse decision. Pure + synchronous: it does
+ * no lowering, only compares records. The caller (`rebuildModelIncremental`)
+ * owns the actual seeding + fallback.
+ */
+export function computePrefixReuse(input: PrefixReuseInput): PrefixReuseDecision {
+  const { prevRecords, nextRecords, prevParamTable, nextParamTable, hasCachedShape, prevHealth } =
+    input;
+
+  const noReuse: PrefixReuseDecision = {
+    reusable: false,
+    matchedPrefixLength: 0,
+    reusableIds: [],
+  };
+
+  // Nothing to reuse if there was no previous build.
+  if (prevRecords.length === 0) return noReuse;
+
+  // Pure-append requirement: the new list must be at least as long as the old.
+  // Any shrink (delete) means a non-append edit ⇒ full rebuild.
+  if (nextRecords.length < prevRecords.length) return noReuse;
+
+  const limit = prevRecords.length; // we only ever try to match the prev prefix
+  let matched = 0;
+  const reusableIds: string[] = [];
+
+  for (let i = 0; i < limit; i++) {
+    const prev = prevRecords[i];
+    const next = nextRecords[i];
+
+    // Id stability: per-kind counters guarantee an unchanged prefix mints
+    // identical ids. A mismatch means the capture order diverged (insert /
+    // delete / reorder upstream) ⇒ stop.
+    if (prev.id !== next.id) break;
+
+    // The previous record must have produced a healthy cached shape; otherwise
+    // there is nothing trustworthy to seed.
+    if (prevHealth.get(prev.id) !== 'healthy') break;
+    if (!hasCachedShape(prev.id)) break;
+
+    // Content must be identical (resolved against each build's param table).
+    if (
+      structuralHashRecord(prev, prevParamTable) !==
+      structuralHashRecord(next, nextParamTable)
+    ) {
+      break;
+    }
+
+    matched += 1;
+    reusableIds.push(prev.id);
+  }
+
+  // Slice 1 reuses ONLY when the WHOLE previous record list matched as a
+  // healthy cached prefix of the new list. A partial match (edit somewhere in
+  // the middle) falls back to a full rebuild — partial-prefix reuse is a later
+  // slice (see spec §5/§6).
+  const reusable = matched === prevRecords.length && matched > 0;
+
+  return reusable
+    ? { reusable: true, matchedPrefixLength: matched, reusableIds }
+    : { ...noReuse, matchedPrefixLength: matched };
+}

--- a/tests/unit/compute/prefixReuse.test.ts
+++ b/tests/unit/compute/prefixReuse.test.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { describe, expect, it } from 'vitest';
+import {
+  computePrefixReuse,
+  structuralHashRecord,
+  type PrefixReuseInput,
+  type RecordHealth,
+} from '../../../src/modeling/compute/prefixReuse';
+import type { FeatureRecord } from '../../../src/shared/intent/featureRecord';
+
+function rec(id: string, kind = 'box', extra: Partial<FeatureRecord> = {}): FeatureRecord {
+  return {
+    id,
+    kind: kind as FeatureRecord['kind'],
+    inputs: {},
+    params: {},
+    transforms: [],
+    suppressed: false,
+    ...extra,
+  };
+}
+
+function baseInput(
+  prev: FeatureRecord[],
+  next: FeatureRecord[],
+  overrides: Partial<PrefixReuseInput> = {},
+): PrefixReuseInput {
+  const health = new Map<string, RecordHealth>(prev.map(r => [r.id, 'healthy']));
+  return {
+    prevRecords: prev,
+    nextRecords: next,
+    prevParamTable: undefined,
+    nextParamTable: undefined,
+    hasCachedShape: () => true,
+    prevHealth: health,
+    ...overrides,
+  };
+}
+
+describe('computePrefixReuse', () => {
+  it('reuses when the new list is a pure append of the previous one', () => {
+    const prev = [rec('box_1'), rec('fillet_1', 'fillet')];
+    const next = [rec('box_1'), rec('fillet_1', 'fillet'), rec('box_2')];
+    const d = computePrefixReuse(baseInput(prev, next));
+    expect(d.reusable).toBe(true);
+    expect(d.matchedPrefixLength).toBe(2);
+    expect(d.reusableIds).toEqual(['box_1', 'fillet_1']);
+  });
+
+  it('reuses when the record list is byte-identical (no new tail)', () => {
+    const prev = [rec('box_1')];
+    const next = [rec('box_1')];
+    const d = computePrefixReuse(baseInput(prev, next));
+    expect(d.reusable).toBe(true);
+    expect(d.reusableIds).toEqual(['box_1']);
+  });
+
+  it('does NOT reuse on a shrink/delete (next shorter than prev)', () => {
+    const prev = [rec('box_1'), rec('fillet_1', 'fillet')];
+    const next = [rec('box_1')];
+    const d = computePrefixReuse(baseInput(prev, next));
+    expect(d.reusable).toBe(false);
+  });
+
+  it('does NOT reuse on a mid-prefix param edit (structural hash mismatch)', () => {
+    const prev = [rec('box_1', 'box', { params: { x: param(10) } }), rec('box_2')];
+    const next = [rec('box_1', 'box', { params: { x: param(99) } }), rec('box_2'), rec('box_3')];
+    const d = computePrefixReuse(baseInput(prev, next));
+    expect(d.reusable).toBe(false);
+    expect(d.matchedPrefixLength).toBe(0);
+  });
+
+  it('does NOT reuse when an id diverges in the prefix', () => {
+    const prev = [rec('box_1'), rec('box_2')];
+    const next = [rec('box_1'), rec('cylinder_1', 'cylinder'), rec('box_2')];
+    const d = computePrefixReuse(baseInput(prev, next));
+    expect(d.reusable).toBe(false);
+  });
+
+  it('does NOT reuse when a prefix record has no cached shape', () => {
+    const prev = [rec('box_1'), rec('box_2')];
+    const next = [rec('box_1'), rec('box_2'), rec('box_3')];
+    const d = computePrefixReuse(
+      baseInput(prev, next, { hasCachedShape: id => id !== 'box_2' }),
+    );
+    expect(d.reusable).toBe(false);
+  });
+
+  it('does NOT reuse when a prefix record was not healthy', () => {
+    const prev = [rec('box_1'), rec('box_2')];
+    const next = [rec('box_1'), rec('box_2'), rec('box_3')];
+    const health = new Map<string, RecordHealth>([
+      ['box_1', 'healthy'],
+      ['box_2', 'error'],
+    ]);
+    const d = computePrefixReuse(baseInput(prev, next, { prevHealth: health }));
+    expect(d.reusable).toBe(false);
+  });
+
+  it('does NOT reuse when there was no previous build', () => {
+    const d = computePrefixReuse(baseInput([], [rec('box_1')]));
+    expect(d.reusable).toBe(false);
+  });
+});
+
+describe('structuralHashRecord', () => {
+  it('is stable across object key order', () => {
+    const a = rec('box_1', 'box', { inputs: { a: fref('x_1'), b: fref('y_1') } });
+    const b = rec('box_1', 'box', { inputs: { b: fref('y_1'), a: fref('x_1') } });
+    expect(structuralHashRecord(a, undefined)).toBe(structuralHashRecord(b, undefined));
+  });
+
+  it('differs when a geometry-relevant param changes', () => {
+    const a = rec('box_1', 'box', { params: { x: param(10) } });
+    const b = rec('box_1', 'box', { params: { x: param(11) } });
+    expect(structuralHashRecord(a, undefined)).not.toBe(structuralHashRecord(b, undefined));
+  });
+
+  it('ignores the derived paramRefs metadata index', () => {
+    const a = rec('box_1', 'box', { metadata: { color: '#fff', paramRefs: ['w'] } });
+    const b = rec('box_1', 'box', { metadata: { color: '#fff' } });
+    expect(structuralHashRecord(a, undefined)).toBe(structuralHashRecord(b, undefined));
+  });
+});
+
+function param(evaluated: number): FeatureRecord['params'][string] {
+  return { expression: String(evaluated), unit: 'mm', evaluated };
+}
+
+function fref(id: string): FeatureRecord['inputs'][string] {
+  return { kind: 'feature', id };
+}

--- a/tests/unit/kernel/buildModel.test.ts
+++ b/tests/unit/kernel/buildModel.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { buildModel, buildModelFromFile, updateModelParams } from '../../../src/modeling/buildModel';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildModel,
+  buildModelFromFile,
+  rebuildModelIncremental,
+  updateModelParams,
+} from '../../../src/modeling/buildModel';
+import * as occtLowererModule from '../../../src/modeling/backends/occt/occtLowerer';
 
 describe('buildModel', () => {
   it('builds source into a session, records, shapes, tail shape, and cache', async () => {
@@ -84,5 +90,124 @@ describe('buildModel', () => {
     expect(updated.result.shape).toBe(updated.model.tailShape);
     expect(updated.result.relowered.length).toBeGreaterThan(0);
     expect(updated.model.session.paramTable.get('w').value).toBe(30);
+  });
+});
+
+/** Instrument `createOcctLowerer` so a test can observe exactly which record
+ *  ids were passed to the lowerer's `.lower()` during a build. Returns a
+ *  Set populated as lowering happens and a `restore()` to remove the spy. */
+function instrumentLoweredIds(): { loweredIds: Set<string>; restore: () => void } {
+  const loweredIds = new Set<string>();
+  const spy = vi
+    .spyOn(occtLowererModule, 'createOcctLowerer')
+    .mockImplementation((session?: Parameters<typeof occtLowererModule.createOcctLowerer>[0]) => {
+      // Call through to the real implementation captured before the spy, then
+      // wrap `.lower` so the test sees which record ids were actually lowered.
+      const lowerer = realCreateOcctLowerer(session);
+      const originalLower = lowerer.lower.bind(lowerer);
+      lowerer.lower = async (record, ctx) => {
+        loweredIds.add(record.id);
+        return originalLower(record, ctx);
+      };
+      return lowerer;
+    });
+  return { loweredIds, restore: () => spy.mockRestore() };
+}
+
+// Captured BEFORE any spy replaces the export, so the spy can call through.
+const realCreateOcctLowerer = occtLowererModule.createOcctLowerer;
+
+describe('rebuildModelIncremental', () => {
+  const PREFIX = `
+    const base = box(20, 20, 5);
+    const rounded = base.fillet(1);
+    return rounded;
+  `;
+  // Append-only: identical prefix, one extra feature added at the end, and a
+  // new return. The prefix records (box_1, fillet_1) must be byte-identical and
+  // mint the same ids, so their cached shapes are reusable.
+  const APPENDED = `
+    const base = box(20, 20, 5);
+    const rounded = base.fillet(1);
+    const post = box(4, 4, 30);
+    return rounded.union(post);
+  `;
+  // Mid-model edit: the FIRST feature's params changed (box dims). The prefix
+  // structural hash diverges at record 0, so reuse must NOT fire.
+  const MID_EDIT = `
+    const base = box(25, 20, 5);
+    const rounded = base.fillet(1);
+    const post = box(4, 4, 30);
+    return rounded.union(post);
+  `;
+
+  it('(a) reuses the unchanged prefix shapes on an append-only edit', async () => {
+    const prev = await buildModel({ fileName: 'm.kcad.ts', code: PREFIX });
+    expect(prev.diagnostics.filter(d => d.severity === 'error')).toEqual([]);
+    const prefixIds = prev.records.map(r => r.id);
+
+    const { loweredIds, restore } = instrumentLoweredIds();
+    try {
+      const next = await rebuildModelIncremental(prev, { fileName: 'm.kcad.ts', code: APPENDED });
+      // The prefix records must NOT have been re-lowered (they were seeded from
+      // the previous build's cache).
+      for (const id of prefixIds) {
+        expect(loweredIds.has(id)).toBe(false);
+      }
+      // The newly-appended records WERE lowered. There is exactly one extra
+      // primitive (`post` box) plus the new boolean union.
+      const newIds = next.records.map(r => r.id).filter(id => !prefixIds.includes(id));
+      expect(newIds.length).toBeGreaterThan(0);
+      for (const id of newIds) {
+        expect(loweredIds.has(id)).toBe(true);
+      }
+      // The seeded prefix shapes are reused object-identically.
+      for (const id of prefixIds) {
+        expect(next.shapes.get(id)).toBe(prev.shapes.get(id));
+      }
+      expect(next.diagnostics.filter(d => d.severity === 'error')).toEqual([]);
+    } finally {
+      restore();
+    }
+  });
+
+  it('(b) falls back to a full rebuild on a mid-model edit and lowers the prefix', async () => {
+    const prev = await buildModel({ fileName: 'm.kcad.ts', code: PREFIX });
+    const prefixIds = prev.records.map(r => r.id);
+
+    const { loweredIds, restore } = instrumentLoweredIds();
+    try {
+      const next = await rebuildModelIncremental(prev, { fileName: 'm.kcad.ts', code: MID_EDIT });
+      // The first record's params changed → the structural hash diverges at
+      // record 0 → reuse must not fire → the prefix is re-lowered from scratch.
+      expect(loweredIds.has(prefixIds[0])).toBe(true);
+      // And the prefix shapes are FRESH objects, not the previous build's.
+      expect(next.shapes.get(prefixIds[0])).not.toBe(prev.shapes.get(prefixIds[0]));
+      expect(next.diagnostics.filter(d => d.severity === 'error')).toEqual([]);
+    } finally {
+      restore();
+    }
+  });
+
+  it('(c) incremental and full paths produce identical final geometry for the append case', async () => {
+    const prev = await buildModel({ fileName: 'm.kcad.ts', code: PREFIX });
+    const incremental = await rebuildModelIncremental(prev, {
+      fileName: 'm.kcad.ts',
+      code: APPENDED,
+    });
+    const full = await buildModel({ fileName: 'm.kcad.ts', code: APPENDED });
+
+    // Same record topology.
+    expect(incremental.records.map(r => r.id)).toEqual(full.records.map(r => r.id));
+    // Same final-shape volume (geometry equivalence proxy). Both root shapes
+    // must exist and report the same volume within a tight tolerance.
+    expect(incremental.rootShape).toBeDefined();
+    expect(full.rootShape).toBeDefined();
+    const volA = incremental.rootShape!.volume();
+    const volB = full.rootShape!.volume();
+    expect(volA).toBeGreaterThan(0);
+    expect(Math.abs(volA - volB)).toBeLessThan(1e-6);
+    expect(incremental.diagnostics.filter(d => d.severity === 'error')).toEqual([]);
+    expect(full.diagnostics.filter(d => d.severity === 'error')).toEqual([]);
   });
 });


### PR DESCRIPTION
## What

Adds `rebuildModelIncremental(prevModel, input)` in `src/modeling/buildModel.ts`, **alongside** the unchanged `buildModel`. On a **code edit** (not a slider drag), today's `buildModel` re-lowers every feature `1..N` from scratch — so appending a part to the end of a script needlessly re-lowers the unchanged prefix through OCCT. This slice reuses the previous build's cached prefix shapes for the provably-safe **append-only** case.

The existing `params.update` incremental machinery (`buildSeedShapes` + `seedShapes` in `RecomputeEngine.run`) already skips lowering for any record whose id is seeded. This slice extends that idea to code edits, across sessions.

## Safety / fallback model

`rebuildModelIncremental` reuses the previous cached prefix shapes **only when it can prove the new record list is a pure append/strict-prefix-superset of the previous one**: every previous record matches its positional counterpart on **id** (FeatureIds are `${kind}_${perKindCounter}` minted in capture order, so an unchanged prefix mints identical ids) **and** on a **resolved structural hash** (params resolved against the param table, transforms, inputs, suppressed, metadata), and every previous prefix record was `healthy` and has a cached shape. In that case it seeds the engine with those cached shapes and lowers only the appended tail. In **every** other case — edit/insert/delete anywhere in the prefix, any hash mismatch, a missing cached shape, a non-healthy prefix record, or a script throw — it falls back to a full `buildModel(input)`. The structural hash is deliberately **conservative**: a false negative only costs a full rebuild (today's behaviour), while a false positive would render a stale model, so every ambiguity biases toward full rebuild. `buildModel`'s signature/behaviour is unchanged and no existing caller is rewired.

## Tests

- **(a)** append-only edit reuses the prefix: a `createOcctLowerer` spy asserts the prefix record ids are **not** passed to `.lower()`, the appended tail ids **are**, and the seeded prefix shapes are object-identical to the previous build.
- **(b)** mid-model edit (changed first feature) falls back to full rebuild: the prefix **is** re-lowered and its shapes are fresh objects.
- **(c)** incremental and full paths produce identical final geometry (same record topology + final root-shape volume within 1e-6) for the append case.
- Pure decision-table coverage for `computePrefixReuse` / `structuralHashRecord` (shrink/delete, id divergence, missing cache, non-healthy prefix, no-previous-build, key-order stability, paramRefs-index ignored).

## Covers vs defers

- **Covers:** pure append (prefix unchanged, statements added at the end) + hard fallback everywhere else.
- **Defers (later slices):** partial-prefix reuse when an edit lands mid-script (reuse everything before the edit point); content-addressed shape cache surviving id renumbering; wiring into Studio's live-edit path. Slice 1 ships the function + tests only, not wired into a production caller.

Design doc: `docs/specs/2026-06-14-incremental-code-rebuild-design.md` (kernelCAD-private).

## Gates
- `npm run typecheck` — clean
- `npx vitest run` on `prefixReuse`, `buildModel`, `recomputeEngine`, `recomputeEngineOnRelower` — 23 passed
- `npx eslint` on changed files — clean (exit 0)
- architecture-boundary guard — passes