### PR TITLE
fix(studio): stop the chrome bars overlapping on narrow mobile viewports

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -43,6 +43,19 @@ body {
     background-color: #000;
 }
 
+/* Horizontal-scroll fallback for the fixed-height chrome bars (Header,
+ * Toolbar, StatusBar). On narrow viewports (e.g. a Pixel 8 at 412px) the bars
+ * carry more controls than fit; this lets them scroll instead of overlapping,
+ * with the scrollbar hidden so the thin bars stay clean. */
+.bar-scroll-x {
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none; /* Firefox */
+}
+.bar-scroll-x::-webkit-scrollbar {
+    display: none; /* Chromium / WebKit */
+}
+
 /* Studio workbench routes (StudioShell, DemoPlayerPage, AnonGenPage,
  * ProjectPage) provide their own h-screen overflow-hidden container, so the
  * body no longer needs the global viewport lock. Removing it lets the

--- a/src/studio/Toolbar.tsx
+++ b/src/studio/Toolbar.tsx
@@ -63,9 +63,9 @@ export function Toolbar({
     return (
         <div
             data-testid="studio-toolbar"
-            className="h-8 shrink-0 border-b border-[#2b313c] bg-[#111] flex items-center justify-between px-3 text-xs text-gray-300 select-none"
+            className="h-8 shrink-0 border-b border-[#2b313c] bg-[#111] flex items-center gap-2 px-3 text-xs text-gray-300 select-none bar-scroll-x"
         >
-            <div className="flex items-center gap-2 min-w-0">
+            <div className="flex items-center gap-2 shrink-0">
                 {!agentRailHidden && (
                     <button
                         type="button"
@@ -100,7 +100,7 @@ export function Toolbar({
                 )}
             </div>
 
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 ml-auto shrink-0">
                 <button
                     type="button"
                     onClick={onValidate}

--- a/src/studio/components/Layout/Header.tsx
+++ b/src/studio/components/Layout/Header.tsx
@@ -40,7 +40,7 @@ export function Header() {
     };
 
     return (
-        <div className="h-10 bg-[#111] border-b border-[#333] flex items-center px-4 justify-between select-none shrink-0" data-testid="header">
+        <div className="h-10 bg-[#111] border-b border-[#333] flex items-center px-4 gap-2 select-none shrink-0 bar-scroll-x" data-testid="header">
             <div className="flex items-center gap-3 min-w-0">
                 <button
                     onClick={() => setActiveDialog('projectManager')}
@@ -61,7 +61,7 @@ export function Header() {
                 )}
             </div>
 
-            <div className="flex gap-2 items-center">
+            <div className="flex gap-2 items-center ml-auto shrink-0">
                 {headerRight && (
                     <>
                         <div className="flex items-center gap-2">{headerRight}</div>

--- a/src/studio/components/Layout/StatusBar.tsx
+++ b/src/studio/components/Layout/StatusBar.tsx
@@ -51,7 +51,7 @@ export function StatusBar({
     return (
         <footer
             data-testid="status-bar"
-            className="h-6 shrink-0 border-t border-[#2b313c] bg-[#101318] text-[11px] text-gray-400 flex items-center justify-between px-3 select-none"
+            className="h-6 shrink-0 border-t border-[#2b313c] bg-[#101318] text-[11px] text-gray-400 flex items-center gap-3 px-3 select-none bar-scroll-x"
         >
             <div
                 role="status"
@@ -72,7 +72,7 @@ export function StatusBar({
                     <span className="truncate">No diagnostics</span>
                 )}
             </div>
-            <div className="flex items-center gap-3 shrink-0">
+            <div className="flex items-center gap-3 shrink-0 ml-auto">
                 <span>{bodyLabel}</span>
                 <span className="inline-flex items-center gap-1">
                     <MousePointer2 size={12} />


### PR DESCRIPTION
## Issue
On mobile (reported on a Pixel 8, 412px) the Studio chrome bars collide: **Connect/Validate** crumpled in the toolbar, **Sign in to save/Share** colliding in the project-viewer header, and Ready/bodies in the status bar. Otherwise mobile was fine.

## Root cause
Header, Toolbar and StatusBar each use `flex justify-between` with two child groups and **no overflow handling**. When the controls exceed the viewport width, `justify-between` keeps the two groups pinned to opposite edges and they grow until they **overlap in the middle** (children are `shrink-0`/`whitespace-nowrap`, so they layer instead of wrapping).

## Fix
Replace `justify-between` with `ml-auto` on the right group + a new `.bar-scroll-x` utility (`overflow-x:auto`, scrollbar hidden) + `shrink-0` groups, on all three bars. Wide screens look identical (auto-margin pushes the right group to the end, same as before); narrow screens **scroll horizontally instead of overlapping**.

## Verification (chrome-devtools, real render)
Measured group overlap (negative = gap, positive = collision) at two widths:
| Bar | 412px | 320px |
|-----|-------|-------|
| Toolbar | scrollW 603>412, gap **-8** | overflow, gap **-8** |
| Header | fits, gap -8 | overflow 400>320, gap **-8** |
| StatusBar | fits, gap -12 | overflow 389>320, gap **-12** |

No collision at either width; bars scroll under genuine overflow. The viewer-mode header (Sign in to save / Share) takes the same overflow path. Before/after screenshots captured at 412px.

36 layout tests green (Toolbar/Header/StatusBar), typecheck + eslint clean. No behavior change on desktop.