### PR TITLE
feat(studio): stateless param recompute when there's no live session

### DIFF
--- a/src/studio/context/GeometryContext.test.tsx
+++ b/src/studio/context/GeometryContext.test.tsx
@@ -87,6 +87,7 @@ function Probe() {
     error,
     setPreviewCode,
     setViewportDriverLock,
+    updateParam,
   } = useGeometry();
   const faceCount = geometries[0]?.faces.length ?? 0;
   const firstColor = geometries[0]?.color ?? '';
@@ -113,6 +114,7 @@ function Probe() {
       <button data-testid="trigger-preview-2" onClick={() => setPreviewCode('return makeBox(2,2,2);')}>Trigger2</button>
       <button data-testid="clear-preview" onClick={() => setPreviewCode(null)}>Clear</button>
       <button data-testid="lock-viewport" onClick={() => setViewportDriverLock?.(true)}>Lock</button>
+      <button data-testid="trigger-param" onClick={() => { void updateParam([{ name: 'w', value: 9 }]); }}>Param</button>
     </div>
   );
 }
@@ -601,6 +603,56 @@ describe('GeometryContext latest-intent-wins', () => {
 
     // Let the debounced build settle, then assert no error was raised.
     await flushUntil(() => screen.getByTestId('execution-count').textContent !== '0');
+    expect(screen.getByTestId('error').textContent).toBe('');
+  });
+
+  it('no session: a param edit re-runs the script through the dev mesh endpoint with overrides', async () => {
+    // The core "re-run on edit" fix: with no live session token, dragging a
+    // param must re-run the whole script (stateless) with the new value baked
+    // in, instead of throwing. Localhost dev → meshSourceDev path.
+    vi.stubEnv('DEV', '1');
+    mockEngine.executeCode.mockResolvedValue({ geometries: [], sketches: [] });
+
+    const meshPayload = {
+      features: [
+        {
+          featureId: 'b',
+          featureKind: 'box',
+          predecessors: [],
+          faces: [{ vertices: [0, 0, 0, 1, 0, 0, 0, 1, 0], indices: [0, 1, 2], normals: [0, 0, 1, 0, 0, 1, 0, 0, 1], faceId: 0 }],
+        },
+      ],
+      featureRecords: [{ id: 'b', kind: 'box' }],
+      bounds: { min: [0, 0, 0], max: [1, 1, 0] },
+      params: { w: 9 },
+      review: { ok: true, diagnostics: [] },
+    };
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => meshPayload,
+    } as Response);
+
+    render(
+      <GeometryProvider code={'return box(w, 1, 1);'}>
+        <Probe />
+      </GeometryProvider>,
+    );
+
+    // Initial (worker) build settles — no geometry yet.
+    await flushUntil(() => screen.getByTestId('execution-count').textContent !== '0');
+
+    // Drag a param with no session → stateless re-run.
+    await act(async () => {
+      screen.getByTestId('trigger-param').click();
+    });
+    await flushUntil(() => screen.getByTestId('face-count').textContent === '1');
+
+    const meshCall = fetchMock.mock.calls.find((c) => String(c[0]) === '/__kernelcad/mesh');
+    expect(meshCall).toBeTruthy();
+    expect(JSON.parse((meshCall![1] as RequestInit).body as string)).toEqual({
+      source: 'return box(w, 1, 1);',
+      params: { w: 9 },
+    });
     expect(screen.getByTestId('error').textContent).toBe('');
   });
 

--- a/src/studio/context/GeometryContext.tsx
+++ b/src/studio/context/GeometryContext.tsx
@@ -7,7 +7,7 @@ import { parseCode } from '../../shared/codeGeneration/ast';
 import { rehydrateFromBridge, type FeatureMeshSerialized } from '../../modeling/capture/featureMeshSerialize';
 import type { SerializedParamEntry, SerializedParamTable } from '../../shared/runtime/paramTable';
 import type { FeatureRecord } from '../../shared/intent/featureRecord';
-import { shouldUseHostedMesh, meshSourceHosted, devMeshAvailable, meshSourceDev, needsFullKernel, type BackendMeshPayload } from '../scriptSource';
+import { shouldUseHostedMesh, meshSourceHosted, devMeshAvailable, meshSourceDev, needsFullKernel, type BackendMeshPayload, type ParamOverrides } from '../scriptSource';
 import { apiCall, rewritePath, bearerToken, buildEventsUrl } from '../api/apiBase';
 
 export type ExecutionStatus = 'success' | 'error' | 'stale';
@@ -232,6 +232,11 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
     // 'failed' → session fetch failed, mesh effect falls back to by-script.
     const [sessionStatus, setSessionStatus] = useState<'idle' | 'pending' | 'resolved' | 'failed'>('idle');
     const mainRevisionRef = useRef(0);
+    // Accumulated param-slider overrides for the no-live-session recompute path
+    // (hosted viewer / arbitrary edited code). A param edit re-runs the whole
+    // script through the stateless mesh endpoint with these applied. Cleared
+    // when `code` changes (a fresh build starts from the script's defaults).
+    const paramOverridesRef = useRef<ParamOverrides>({});
     const previewRevisionRef = useRef(0);
     const activeMeshFetchAbortRef = useRef<AbortController | null>(null);
     const meshFetchBusyRef = useRef(false);
@@ -716,33 +721,100 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
     // Slice 2E.bridge: callback exposed to consumers (forwarded by
     // `useRecomputeResult`). Awaits the server ack; the SSE push that
     // follows is what actually refreshes context state.
+    // Apply a stateless re-run mesh payload to context state (mirrors the main
+    // execution loop's apply, incl. the empty-build guard). Used by the
+    // no-session param recompute path.
+    const applyBridgePayload = useCallback((payload: BackendMeshPayload, revision: number) => {
+        const geos = featureMeshesToGeometries(payload.features as FeatureMeshSerialized[]);
+        const recs = (payload.featureRecords as FeatureRecord[]) ?? [];
+        const review = payload.review ?? { ok: true, diagnostics: [] };
+        const emptyNotice = detectEmptyBuild(geos.length, recs, review);
+        setGeometries(geos);
+        setGeometryTransformOverrides({});
+        setFeatureRecords(recs);
+        setScriptParams(Object.values(payload.params ?? {}));
+        setScriptReview(review);
+        setSketchesGeometries([]);
+        setPreviewGeometries([]);
+        setError(emptyNotice);
+        if (emptyNotice) {
+            pushExecutionRecord({ revision, status: 'error', error: emptyNotice, executionCountAtRecord: executionCount + 1 });
+        } else {
+            setLastSuccessfulRevision(revision);
+            pushExecutionRecord({ revision, status: 'success', executionCountAtRecord: executionCount + 1 });
+        }
+    }, [executionCount, pushExecutionRecord]);
+
+    // Clear accumulated param overrides whenever the script changes — a code
+    // edit re-meshes from the declared defaults (main loop), and stale
+    // overrides must not leak onto the new build.
+    useEffect(() => {
+        paramOverridesRef.current = {};
+    }, [code]);
+
     const updateParam = useCallback(async (
         edits: { name: string; value: number | boolean }[],
     ) => {
-        if (!sessionToken) {
-            throw new Error('updateParam called before a session token was issued');
+        // Live session (pooled `?script=`): incremental params.update — only the
+        // edited feature + downstream re-lower, pushed back over SSE.
+        if (sessionToken) {
+            const { base, headers } = await apiCall();
+            const res = await fetch(
+                rewritePath(
+                    `/__kernelcad/params?session=${encodeURIComponent(sessionToken)}`,
+                    base,
+                ),
+                {
+                    method: 'POST',
+                    headers: { 'content-type': 'application/json', ...headers },
+                    body: JSON.stringify({ edits }),
+                },
+            );
+            if (!res.ok) {
+                let message = res.statusText;
+                try {
+                    const body = await res.json();
+                    if (typeof body?.error === 'string') message = body.error;
+                } catch { /* keep statusText fallback */ }
+                throw new Error(message);
+            }
+            return;
         }
-        const { base, headers } = await apiCall();
-        const res = await fetch(
-            rewritePath(
-                `/__kernelcad/params?session=${encodeURIComponent(sessionToken)}`,
-                base,
-            ),
-            {
-                method: 'POST',
-                headers: { 'content-type': 'application/json', ...headers },
-                body: JSON.stringify({ edits }),
-            },
-        );
-        if (!res.ok) {
-            let message = res.statusText;
-            try {
-                const body = await res.json();
-                if (typeof body?.error === 'string') message = body.error;
-            } catch { /* keep statusText fallback */ }
-            throw new Error(message);
+
+        // No live session (hosted viewer / arbitrary edited code): re-run the
+        // whole script through the stateless mesh endpoint with the param
+        // overrides applied. This is what makes a declared parameter actually
+        // move the model when there is no pooled kernel session behind the tab.
+        const hosted = shouldUseHostedMesh();
+        if (!hosted && !devMeshAvailable()) {
+            throw new Error(
+                'Editing parameters needs a live kernel session or a compute backend.',
+            );
         }
-    }, [sessionToken]);
+        const overrides: ParamOverrides = { ...paramOverridesRef.current };
+        for (const edit of edits) overrides[edit.name] = edit.value;
+        paramOverridesRef.current = overrides;
+
+        const revision = ++mainRevisionRef.current;
+        setCurrentCodeRevision(revision);
+        setIsComputing(true);
+        try {
+            const payload = hosted
+                ? await meshSourceHosted(code, overrides)
+                : await meshSourceDev(code, overrides);
+            // Superseded by a newer edit (code change or another param drag).
+            if (revision !== mainRevisionRef.current) return;
+            applyBridgePayload(payload, revision);
+        } catch (err) {
+            if (revision !== mainRevisionRef.current) return;
+            setError(err instanceof Error ? err.message : String(err));
+        } finally {
+            if (revision === mainRevisionRef.current) {
+                setIsComputing(false);
+                setExecutionCount(prev => prev + 1);
+            }
+        }
+    }, [sessionToken, code, applyBridgePayload]);
 
     const setGeometryTransformOverride = useCallback((partName: string, transform: number[]) => {
         if (transform.length !== 16) return;

--- a/src/studio/scriptSource.test.ts
+++ b/src/studio/scriptSource.test.ts
@@ -11,11 +11,12 @@ vi.mock('../funnel/lib/supabaseClient', () => ({
   }),
 }));
 
-import { loadGalleryScriptSource, loadStudioScriptSource, meshSourceDev, needsFullKernel } from './scriptSource';
+import { loadGalleryScriptSource, loadStudioScriptSource, meshSourceDev, meshSourceHosted, needsFullKernel } from './scriptSource';
 
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
 });
 
 describe('needsFullKernel', () => {
@@ -75,6 +76,42 @@ describe('meshSourceDev', () => {
       json: async () => ({ notFeatures: true }),
     } as Response);
     await expect(meshSourceDev('x')).rejects.toThrow(/did not return features/);
+  });
+});
+
+describe('param overrides (stateless re-run path)', () => {
+  it('meshSourceDev includes params in the POST body when overrides are given', async () => {
+    const payload = { features: [], featureRecords: [], bounds: { min: [0, 0, 0], max: [1, 1, 1] }, params: { w: 5 } };
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, json: async () => payload } as Response);
+    await meshSourceDev('return box(w,1,1);', { w: 5 });
+    expect(fetchMock).toHaveBeenCalledWith('/__kernelcad/mesh', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source: 'return box(w,1,1);', params: { w: 5 } }),
+    });
+  });
+
+  it('meshSourceDev omits params when overrides are empty', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, json: async () => ({ features: [] }) } as Response);
+    await meshSourceDev('x', {});
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body).toEqual({ source: 'x' });
+  });
+
+  it('meshSourceHosted skips the static precompute and posts params to the backend when overrides are given', async () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com');
+    const payload = { features: [], featureRecords: [], bounds: { min: [0, 0, 0], max: [1, 1, 1] }, params: { w: 7 } };
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, json: async () => payload } as Response);
+
+    await meshSourceHosted('return box(w,1,1);', { w: 7 });
+
+    // First (and only) fetch must be the backend POST — proving the precompute
+    // GET was skipped (it cannot reflect an override).
+    expect(String(fetchMock.mock.calls[0][0])).toBe('https://api.example.com/__kernelcad/mesh');
+    expect(fetchMock).toHaveBeenCalledWith('https://api.example.com/__kernelcad/mesh', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ source: 'return box(w,1,1);', params: { w: 7 } }),
+    }));
   });
 });
 

--- a/src/studio/scriptSource.ts
+++ b/src/studio/scriptSource.ts
@@ -133,11 +133,25 @@ export function needsFullKernel(code: string): boolean {
  * consumes it identically. Used as the localhost fallback when the
  * in-browser worker can't evaluate the script (e.g. assembly models).
  */
-export async function meshSourceDev(source: string): Promise<BackendMeshPayload> {
+/** Override map for declared parameters: `{ paramName: value }`. Applied to the
+ *  param table after the script runs but before lowering, so a slider edit
+ *  re-runs the script with the new value baked in — the stateless recompute
+ *  path used when there is no live kernel session (hosted viewer / arbitrary
+ *  edited code). Empty/undefined = use the script's declared defaults. */
+export type ParamOverrides = Record<string, number | boolean>;
+
+function hasOverrides(p?: ParamOverrides): p is ParamOverrides {
+  return !!p && Object.keys(p).length > 0;
+}
+
+export async function meshSourceDev(
+  source: string,
+  paramOverrides?: ParamOverrides,
+): Promise<BackendMeshPayload> {
   const response = await fetch('/__kernelcad/mesh', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ source }),
+    body: JSON.stringify({ source, ...(hasOverrides(paramOverrides) ? { params: paramOverrides } : {}) }),
   });
   const payload = await response.json().catch(() => null);
   if (!response.ok) {
@@ -172,26 +186,33 @@ function isBridgePayload(value: unknown): value is BackendMeshPayload {
  * to the server mesh endpoint (`POST {VITE_API_BASE_URL}/__kernelcad/mesh`)
  * for edited code, when a backend is configured. Throws if neither resolves.
  */
-export async function meshSourceHosted(source: string): Promise<BackendMeshPayload> {
-  // 1. Static precompute by source hash.
-  try {
-    const hash = await sha256Hex(source);
-    const res = await fetch(galleryPrecomputedMeshUrl(hash));
-    if (res.ok) {
-      const payload = await res.json().catch(() => null);
-      if (isBridgePayload(payload)) return payload;
+export async function meshSourceHosted(
+  source: string,
+  paramOverrides?: ParamOverrides,
+): Promise<BackendMeshPayload> {
+  // 1. Static precompute by source hash — ONLY when there are no param
+  //    overrides. The precompute is keyed on the unmodified source, so it
+  //    cannot reflect a slider edit; with overrides we must hit the backend.
+  if (!hasOverrides(paramOverrides)) {
+    try {
+      const hash = await sha256Hex(source);
+      const res = await fetch(galleryPrecomputedMeshUrl(hash));
+      if (res.ok) {
+        const payload = await res.json().catch(() => null);
+        if (isBridgePayload(payload)) return payload;
+      }
+    } catch {
+      // fall through to backend
     }
-  } catch {
-    // fall through to backend
   }
 
-  // 2. Server mesh endpoint for edited / non-gallery code.
+  // 2. Server mesh endpoint for edited / non-gallery code (and param edits).
   const base = import.meta.env.VITE_API_BASE_URL;
   if (typeof base === 'string' && base.length > 0) {
     const response = await fetch(`${base}/__kernelcad/mesh`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ source }),
+      body: JSON.stringify({ source, ...(hasOverrides(paramOverrides) ? { params: paramOverrides } : {}) }),
     });
     const payload = await response.json().catch(() => null);
     if (!response.ok) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -269,7 +269,7 @@ function kernelCadMeshEndpoint(): Plugin {
             // runScript carries no extra trust boundary.
             const chunks: Buffer[] = [];
             for await (const chunk of req) chunks.push(chunk as Buffer);
-            let parsedBody: { source?: unknown };
+            let parsedBody: { source?: unknown; params?: unknown };
             try {
               parsedBody = JSON.parse(Buffer.concat(chunks).toString('utf-8') || '{}');
             } catch {
@@ -295,6 +295,19 @@ function kernelCadMeshEndpoint(): Plugin {
             });
             records = run.records;
             paramTable = run.paramTable;
+            // Stateless param recompute: apply any `{ params: { name: value } }`
+            // overrides to the freshly-built param table BEFORE meshing, so a
+            // slider edit re-runs the script with the new value baked in (the
+            // path used when there is no live kernel session). ParamRefs in the
+            // records resolve against this table at lower time, so the override
+            // flows into the geometry. The echoed `params` below reflects them.
+            if (parsedBody.params && typeof parsedBody.params === 'object') {
+              for (const [name, value] of Object.entries(parsedBody.params as Record<string, unknown>)) {
+                if (typeof value === 'number' || typeof value === 'boolean') {
+                  paramTable.set(name, value);
+                }
+              }
+            }
             meshSession = run.session as unknown as typeof meshSession;
           } else if (sessionToken) {
             const bundle = await getPoolBundle();


### PR DESCRIPTION
## Issue
Declared parameters don't move the model in the hosted viewer (`/p/<slug>`). A slider edit goes through `updateParam`, which **required a pooled session token** (acquired only on the `?script=` path) and **threw** otherwise. The hosted viewer and any arbitrary edited code run the stateless mesh path with no token, so every param changed the number but never re-ran the kernel.

## Fix — re-run on edit (stateless)
When there's no live session, `updateParam` re-runs the whole script through the stateless mesh endpoint with the new value applied:
- `meshSourceDev` / `meshSourceHosted` take a `paramOverrides` map (`meshSourceHosted` skips the static precompute when overrides are present — it can't reflect them).
- The mesh endpoint applies the overrides to the param table **after** the script runs and **before** lowering, so the value flows into the geometry via the records' ParamRefs. The echoed `params` reflect the overrides.
- Overrides accumulate per code revision and clear on code change.
- The pooled-session path (incremental `params.update` over SSE) is **unchanged**.

This is also **Tier-2 of the scale design** (kernelCAD-private spec): stateless `(source, params) → mesh` is the horizontally-scalable, cacheable compute primitive — no per-user server state.

## Verification
- **End-to-end through the real dev kernel:** `box(param('w',10),5,5)` → override `w=40` changes bounds from `[10,5,5]` to `[40,5,5]`; echoed param `value:40, default:10`.
- 14 `scriptSource` tests (override threading) + 13 `GeometryContext` tests (no-session slider re-runs + applies new geometry, correct request body) green. Typecheck + eslint clean (one pre-existing `exhaustive-deps` warning).

## Follow-up (for the LIVE app)
`app.kernelcad.com` also needs the **kernelCAD-server** mesh endpoint to honor the `params` override — a small mirror of the vite endpoint change (separate private repo). Tracked; this PR makes the client + dev kernel work and is the foundation.