### PR TITLE
fix(studio): don't hover-highlight section-clipped geometry

### DIFF
--- a/src/studio/components/viewer/clipFilter.test.ts
+++ b/src/studio/components/viewer/clipFilter.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { filterClippedIntersections } from './clipFilter';
+import { sectionPlaneFromState, cutawayPlanesFromState } from './sectionPlane';
+
+// A minimal fake intersection carrying just what the filter reads.
+function hit(
+  point: [number, number, number],
+  material: { clippingPlanes?: THREE.Plane[] | null; clipIntersection?: boolean } | null,
+  materialIndex?: number,
+): THREE.Intersection {
+  const object = { material: material ?? undefined } as unknown as THREE.Object3D;
+  return {
+    point: new THREE.Vector3(...point),
+    object,
+    distance: 0,
+    ...(materialIndex !== undefined ? { face: { materialIndex } } : {}),
+  } as unknown as THREE.Intersection;
+}
+
+// z, position 10, unflipped → keep z<10, remove z>10.
+const planeZ = sectionPlaneFromState('z', false, 10);
+
+describe('filterClippedIntersections', () => {
+  it('keeps everything when the material has no clipping planes (section off / kept-whole)', () => {
+    const hits = [hit([0, 0, 50], { clippingPlanes: [] }), hit([0, 0, 50], null)];
+    expect(filterClippedIntersections(hits)).toHaveLength(2);
+  });
+
+  it('rejects a hit in the removed region of a single section plane', () => {
+    const hits = [hit([0, 0, 11], { clippingPlanes: [planeZ], clipIntersection: true })];
+    expect(filterClippedIntersections(hits)).toHaveLength(0);
+  });
+
+  it('keeps a hit in the visible region of a single section plane', () => {
+    const hits = [hit([0, 0, 9], { clippingPlanes: [planeZ], clipIntersection: true })];
+    expect(filterClippedIntersections(hits)).toHaveLength(1);
+  });
+
+  it('keeps a hit exactly on the cut plane (distance 0, not < 0)', () => {
+    const hits = [hit([0, 0, 10], { clippingPlanes: [planeZ], clipIntersection: true })];
+    expect(filterClippedIntersections(hits)).toHaveLength(1);
+  });
+
+  it('clipIntersection=true (corner wedge): rejects only points behind ALL planes', () => {
+    // Remove +x (x>5) AND +z (z>10); the removed region is the corner where both hold.
+    const planes = cutawayPlanesFromState(
+      { x: true, y: false, z: true },
+      { x: true, y: false, z: true },
+      { x: 5, y: 0, z: 10 },
+    );
+    const mat = { clippingPlanes: planes, clipIntersection: true };
+    const inCorner = hit([6, 0, 11], mat); // behind both → removed
+    const oneSideOnly = hit([4, 0, 11], mat); // behind z only → still visible
+    expect(filterClippedIntersections([inCorner])).toHaveLength(0);
+    expect(filterClippedIntersections([oneSideOnly])).toHaveLength(1);
+  });
+
+  it('clipIntersection=false (union): rejects points behind ANY plane', () => {
+    const planes = cutawayPlanesFromState(
+      { x: true, y: false, z: true },
+      { x: true, y: false, z: true },
+      { x: 5, y: 0, z: 10 },
+    );
+    const mat = { clippingPlanes: planes, clipIntersection: false };
+    const oneSideOnly = hit([4, 0, 11], mat); // behind z → removed under union
+    expect(filterClippedIntersections([oneSideOnly])).toHaveLength(0);
+  });
+
+  it('resolves the per-face material for a multi-material object', () => {
+    const clipped = { clippingPlanes: [planeZ], clipIntersection: true };
+    const notClipped = { clippingPlanes: [] as THREE.Plane[] };
+    // Hit point z=11 (removed by the clipped material); materialIndex 1 picks the clipped one.
+    expect(
+      filterClippedIntersections([hit([0, 0, 11], [notClipped, clipped] as never, 1)]),
+    ).toHaveLength(0);
+    // Same point but materialIndex 0 (unclipped) → kept.
+    expect(
+      filterClippedIntersections([hit([0, 0, 11], [notClipped, clipped] as never, 0)]),
+    ).toHaveLength(1);
+  });
+});

--- a/src/studio/components/viewer/clipFilter.test.ts
+++ b/src/studio/components/viewer/clipFilter.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import { describe, it, expect } from 'vitest';
 import * as THREE from 'three';
 import { filterClippedIntersections } from './clipFilter';

--- a/src/studio/components/viewer/clipFilter.ts
+++ b/src/studio/components/viewer/clipFilter.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import * as THREE from 'three';
 
 /**

--- a/src/studio/components/viewer/clipFilter.ts
+++ b/src/studio/components/viewer/clipFilter.ts
@@ -1,0 +1,67 @@
+import * as THREE from 'three';
+
+/**
+ * Reject raycast intersections that land on geometry the active section /
+ * clipping planes have visually removed.
+ *
+ * `THREE.Raycaster` ignores `material.clippingPlanes`, so a section/cutaway view
+ * clips the rendered mesh but NOT the pick geometry. Without this filter the
+ * hover/selection highlight fires on the cut-away ("invisible") structures,
+ * making it impossible to look inside a section.
+ *
+ * The clip state is read off each hit object's OWN material rather than
+ * reconstructed from the section-tool store. That makes the filter:
+ *   - correct for parts excluded from sectioning (`sectionKeepWhole` →
+ *     `NO_PLANES`): their material has no clipping planes, so they're never
+ *     rejected (they're still fully visible),
+ *   - exact about which planes apply to which object, and
+ *   - mode-aware: it honours `material.clipIntersection`.
+ *
+ * Clip-mode semantics (matching how the viewer renders, see sectionPlane.ts):
+ *   - `clipIntersection = true` (the viewer's cutaway): a fragment is removed
+ *     only where it is behind EVERY plane (the corner-wedge intersection of the
+ *     negative half-spaces).
+ *   - `clipIntersection = false` (union): removed where behind ANY plane.
+ * A point exactly on a plane has distance 0 (not < 0), so the visible cut face
+ * itself stays hoverable.
+ */
+
+function clipStateOf(
+  intersection: THREE.Intersection,
+): { planes: THREE.Plane[]; clipIntersection: boolean } | null {
+  const obj = intersection.object as THREE.Object3D & {
+    material?: THREE.Material | THREE.Material[];
+  };
+  const raw = obj.material;
+  if (!raw) return null;
+  const material = Array.isArray(raw)
+    ? raw[intersection.face?.materialIndex ?? 0] ?? raw[0]
+    : raw;
+  const planes = (material as THREE.Material & { clippingPlanes?: THREE.Plane[] | null })
+    ?.clippingPlanes;
+  if (!planes || planes.length === 0) return null;
+  const clipIntersection = Boolean(
+    (material as THREE.Material & { clipIntersection?: boolean }).clipIntersection,
+  );
+  return { planes, clipIntersection };
+}
+
+function isRemoved(
+  point: THREE.Vector3,
+  planes: readonly THREE.Plane[],
+  clipIntersection: boolean,
+): boolean {
+  return clipIntersection
+    ? planes.every((p) => p.distanceToPoint(point) < 0)
+    : planes.some((p) => p.distanceToPoint(point) < 0);
+}
+
+export function filterClippedIntersections(
+  intersects: readonly THREE.Intersection[],
+): THREE.Intersection[] {
+  return intersects.filter((hit) => {
+    const clip = clipStateOf(hit);
+    if (!clip) return true;
+    return !isRemoved(hit.point, clip.planes, clip.clipIntersection);
+  });
+}

--- a/src/studio/components/viewer/controllers/InteractionHandler.tsx
+++ b/src/studio/components/viewer/controllers/InteractionHandler.tsx
@@ -5,6 +5,7 @@ import * as THREE from "three";
 import { useRef } from "react";
 import { HoverManager, type HoverResult } from "../../../features-ui/interaction/HoverManager";
 import { SnapManager, type SnapResult } from "../../../features-ui/interaction/SnapManager";
+import { filterClippedIntersections } from "../clipFilter";
 
 interface InteractionHandlerProps {
     setHovered: (h: HoverResult | null) => void;
@@ -24,7 +25,12 @@ export function InteractionHandler({ setHovered, setSnap }: InteractionHandlerPr
         raycaster.setFromCamera(pointer, camera);
         const intersects = raycaster.intersectObjects(scene.children, true);
 
-        const best = HoverManager.getBestHover(intersects);
+        // In a section/cutaway view the Raycaster still hits geometry that the
+        // clipping planes have visually removed; drop those so hover/selection
+        // doesn't highlight the cut-away ("invisible") structures.
+        const visible = filterClippedIntersections(intersects);
+
+        const best = HoverManager.getBestHover(visible);
         setHovered(best);
         setSnap(SnapManager.getSnapFromHover(best));
     });


### PR DESCRIPTION
## Problem
In a section/cutaway view, `THREE.Raycaster` ignores `material.clippingPlanes`, so hover/selection still picks the **cut-away** geometry — highlighting "invisible" structures and making it impossible to look inside the section.

## Fix
Filter raycast intersections whose hit point falls in the clipped-away region, **before** hover/selection. Clip state is read off each hit object's own material (`clippingPlanes` + `clipIntersection`), so:
- section-excluded ("kept whole") parts are never wrongly culled,
- the viewer's `clipIntersection = true` cutaway semantics are honored (removed only when behind **all** planes — the corner wedge, not "any plane"),
- the visible cut face itself stays hoverable (distance 0, not < 0).

One chokepoint touched: `InteractionHandler` filters via a new pure helper `clipFilter.ts`.

## Tests
7 unit tests: single plane (in/out/on-plane), corner-wedge `clipIntersection=true`, union `false`, kept-whole/no-planes, multi-material objects. Typecheck clean.