### PR TITLE
fix(naming): resolve canonical faces on swept/lofted/revolved solids

### DIFF
--- a/src/kernel/backends/occt/canonicalFaceAfterSweep.test.ts
+++ b/src/kernel/backends/occt/canonicalFaceAfterSweep.test.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/kernel/backends/occt/canonicalFaceAfterSweep.test.ts
+//
+// Regression: canonical face names ('top'/'bottom') on a swept/lofted/revolved
+// solid (no primitive `kind`, no lineage `historyMap`) used to fail with a
+// misleading 'requires an un-transformed primitive — apply transforms after the
+// feature' error. They now resolve by GEOMETRY for cylinder-topology solids,
+// and emit a clear, actionable diagnostic when they cannot.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as replicad from 'replicad';
+import { initOcct, OcctBackend } from './occtBackend';
+import { pickFace, pickEdges } from './edgeSelection';
+import { resolveCanonicalByGeometry } from './canonicalFaceGeometry';
+import type { FeatureRecord } from '../../../shared/intent/featureRecord';
+import type { CanonicalFace } from '../../../shared/intent/types';
+
+beforeAll(async () => {
+  await initOcct();
+});
+
+/** A solid cylinder built by SWEEPING a circle profile along a vertical rail.
+ *  The result has no primitive `kind` and no `historyMap` — exactly the
+ *  topology of an agent's swept/lofted wheel: two PLANE caps (z=0, z=h) plus
+ *  a curved (CYLINDRE) lateral wall. */
+function sweptCylinder(r = 5, h = 10): OcctBackend {
+  const sketch = OcctBackend.fromDrawing(replicad.drawCircle(r));
+  return OcctBackend.sweepFromSketch(sketch, [
+    [0, 0, 0],
+    [0, 0, h],
+  ]);
+}
+
+function canonicalFaceRecord(face: CanonicalFace): FeatureRecord {
+  return {
+    id: 'fillet-1',
+    kind: 'fillet',
+    params: {},
+    inputs: {
+      parent: { kind: 'feature', id: 'parent-0' },
+      face: {
+        kind: 'face',
+        featureId: 'parent-0',
+        ref: { kind: 'canonical', face },
+      },
+    },
+    transforms: [],
+    suppressed: false,
+    metadata: {},
+  } as unknown as FeatureRecord;
+}
+
+describe('resolveCanonicalByGeometry (unit)', () => {
+  it('resolves top/bottom on a revolved cylinder by geometry', () => {
+    const cyl = sweptCylinder(5, 10);
+    expect(cyl.kind).toBeUndefined();
+    expect(cyl.historyMap).toBeUndefined();
+    const shape = cyl.getReplicadShape();
+
+    const top = resolveCanonicalByGeometry(shape, 'top');
+    expect(top.kind).toBe('resolved');
+    if (top.kind === 'resolved') expect(top.face.center.z).toBeCloseTo(10, 2);
+
+    const bottom = resolveCanonicalByGeometry(shape, 'bottom');
+    expect(bottom.kind).toBe('resolved');
+    if (bottom.kind === 'resolved')
+      expect(bottom.face.center.z).toBeCloseTo(0, 2);
+  });
+
+  it('reports not-a-cap for left/right on a Z-axis cylinder', () => {
+    const cyl = sweptCylinder();
+    const res = resolveCanonicalByGeometry(cyl.getReplicadShape(), 'left');
+    expect(res.kind).toBe('not-a-cap');
+    if (res.kind === 'not-a-cap') expect(res.capAxisLabel).toBe('top/bottom');
+  });
+
+  it('reports no-canonical-faces for a sphere (no planar caps)', () => {
+    const sphere = OcctBackend.sphere(5);
+    const res = resolveCanonicalByGeometry(sphere.getReplicadShape(), 'top');
+    expect(res.kind).toBe('no-canonical-faces');
+  });
+});
+
+describe('pickFace / pickEdges on a swept solid (canonical refs)', () => {
+  it('pickFace resolves a canonical top face on a revolved cylinder', () => {
+    const cyl = sweptCylinder(5, 10);
+    const result = pickFace(canonicalFaceRecord('top'), cyl, undefined);
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.center.z).toBeCloseTo(10, 2);
+    }
+  });
+
+  it('pickEdges resolves canonical bottom-face edges on a revolved cylinder', () => {
+    const cyl = sweptCylinder(5, 10);
+    const result = pickEdges(canonicalFaceRecord('bottom'), cyl, undefined);
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('emits a clear, actionable diagnostic for a non-cap canonical name', () => {
+    const cyl = sweptCylinder(5, 10);
+    const result = pickFace(canonicalFaceRecord('left'), cyl, undefined);
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.error.code).toBe('feature.face-ref.not-applicable');
+      // The message must NOT send the agent chasing a phantom transform.
+      expect(result.error.message).not.toMatch(/un-transformed primitive/i);
+      expect(result.error.hint).toMatch(/kc\.q\.face|list_faces/);
+    }
+  });
+});

--- a/src/kernel/backends/occt/canonicalFaceGeometry.ts
+++ b/src/kernel/backends/occt/canonicalFaceGeometry.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/kernel/backends/occt/canonicalFaceGeometry.ts
+//
+// Geometry-based canonical face resolution for solids that carry NO primitive
+// `kind` tag and NO lineage `historyMap` — i.e. solids produced by
+// variableSweep / loft / revolve. Such solids previously rejected every
+// canonical face name ('top' / 'bottom' / ...) with a misleading
+// "requires an un-transformed primitive — apply transforms after the feature"
+// error, even though the agent never applied a transform.
+//
+// The common case the agent hits is a wheel: a cylinder built by sweeping or
+// lofting a circle, or by revolving a rectangle. Geometrically this is a
+// "cylinder-topology" solid: exactly two parallel PLANE end-caps plus one or
+// more curved (non-planar) lateral faces. For that topology we can resolve
+// 'top' / 'bottom' purely from geometry — the planar cap at max / min along the
+// cap axis — without any stored primitive kind.
+//
+// This module is intentionally narrow and conservative: it only claims a match
+// when the solid is unambiguously cylinder-topology and the requested name is
+// the cap along that axis. Anything else returns a structured outcome so the
+// caller can emit an actionable diagnostic instead of a silent / misleading
+// failure.
+
+import type { Face, Shape3D } from 'replicad';
+import type { CanonicalFace } from '../../../shared/intent/types';
+
+/** Tolerance (mm) for treating two cap centroids as distinct. */
+const TOL = 1e-4;
+/** Slack on the |normal·axis| ≈ 1 test (≈0.8°). */
+const AXIS_SLACK = 1e-4;
+/** Off-axis component bound for treating a normal as axis-aligned. */
+const OFF_AXIS = 0.01;
+
+type Axis = 0 | 1 | 2;
+
+export type CanonicalGeometryResult =
+  | { kind: 'resolved'; face: Face }
+  /** Solid is cylinder-topology but the requested name is not a cap. */
+  | { kind: 'not-a-cap'; capAxisLabel: 'top/bottom' | 'left/right' | 'front/back' }
+  /** Solid is not cylinder-topology — no canonical names derivable. */
+  | { kind: 'no-canonical-faces'; faceCount: number };
+
+/** Read the OCCT surface type string off a replicad Face (e.g. 'PLANE'). */
+function geomTypeOf(face: Face): string {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const gt = (face as any).geomType;
+  const raw = typeof gt === 'function' ? gt.call(face) : gt;
+  return typeof raw === 'string' ? raw.toUpperCase() : 'OTHER';
+}
+
+/** Unit normal at the face centre, as a [x,y,z] tuple, or null if unavailable. */
+function normalOf(face: Face): [number, number, number] | null {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const f = face as any;
+  // replicad exposes `normalAt(point?)`; fall back gracefully if absent.
+  let n: { x: number; y: number; z: number } | undefined;
+  try {
+    n = typeof f.normalAt === 'function' ? f.normalAt(f.center) : undefined;
+  } catch {
+    n = undefined;
+  }
+  if (!n) return null;
+  const len = Math.hypot(n.x, n.y, n.z);
+  if (len < 1e-9) return null;
+  return [n.x / len, n.y / len, n.z / len];
+}
+
+/** The axis (0=X,1=Y,2=Z) a unit normal is parallel to, or null if oblique. */
+function axisOfNormal(n: [number, number, number]): Axis | null {
+  for (const axis of [0, 1, 2] as Axis[]) {
+    const aligned = Math.abs(Math.abs(n[axis]) - 1) < AXIS_SLACK;
+    const off = (axis === 0 ? 0 : Math.abs(n[0])) +
+      (axis === 1 ? 0 : Math.abs(n[1])) +
+      (axis === 2 ? 0 : Math.abs(n[2]));
+    if (aligned && off < OFF_AXIS) return axis;
+  }
+  return null;
+}
+
+function centerComponent(face: Face, axis: Axis): number {
+  const c = face.center;
+  return axis === 0 ? c.x : axis === 1 ? c.y : c.z;
+}
+
+/**
+ * Resolve a canonical face name on a `kind`-less, lineage-less solid by
+ * geometry. Succeeds only for cylinder-topology solids (exactly two parallel
+ * planar caps + ≥1 curved lateral face) when asking for the cap along that
+ * axis ('top'/'bottom' for Z caps, etc.).
+ */
+export function resolveCanonicalByGeometry(
+  shape: Shape3D,
+  face: CanonicalFace,
+): CanonicalGeometryResult {
+  const faces = shape.faces;
+  const planar: Face[] = [];
+  let curvedCount = 0;
+  for (const f of faces) {
+    if (geomTypeOf(f) === 'PLANE') planar.push(f);
+    else curvedCount += 1;
+  }
+
+  // Cylinder-topology requires exactly two planar caps and at least one curved
+  // lateral face.
+  if (planar.length !== 2 || curvedCount < 1) {
+    return { kind: 'no-canonical-faces', faceCount: faces.length };
+  }
+
+  const n0 = normalOf(planar[0]);
+  const n1 = normalOf(planar[1]);
+  if (!n0 || !n1) return { kind: 'no-canonical-faces', faceCount: faces.length };
+
+  const axis0 = axisOfNormal(n0);
+  const axis1 = axisOfNormal(n1);
+  // Both caps must be axis-aligned to the SAME axis (parallel, opposed faces).
+  if (axis0 === null || axis1 === null || axis0 !== axis1) {
+    return { kind: 'no-canonical-faces', faceCount: faces.length };
+  }
+  const capAxis = axis0;
+
+  // Map the requested canonical name to (axis, which end).
+  // top/back/right = max along Z/Y/X ; bottom/front/left = min.
+  const spec = canonicalToAxisEnd(face);
+  if (spec.axis !== capAxis) {
+    return { kind: 'not-a-cap', capAxisLabel: axisLabel(capAxis) };
+  }
+
+  const v0 = centerComponent(planar[0], capAxis);
+  const v1 = centerComponent(planar[1], capAxis);
+  if (Math.abs(v0 - v1) < TOL) {
+    // Degenerate: both caps at the same coordinate — cannot disambiguate.
+    return { kind: 'no-canonical-faces', faceCount: faces.length };
+  }
+  const wantMax = spec.end === 'max';
+  const firstWins = wantMax ? v0 > v1 : v0 < v1;
+  return { kind: 'resolved', face: firstWins ? planar[0] : planar[1] };
+}
+
+function canonicalToAxisEnd(face: CanonicalFace): { axis: Axis; end: 'min' | 'max' } {
+  switch (face) {
+    case 'top':
+      return { axis: 2, end: 'max' };
+    case 'bottom':
+      return { axis: 2, end: 'min' };
+    case 'right':
+      return { axis: 0, end: 'max' };
+    case 'left':
+      return { axis: 0, end: 'min' };
+    case 'back':
+      return { axis: 1, end: 'max' };
+    case 'front':
+      return { axis: 1, end: 'min' };
+  }
+}
+
+function axisLabel(axis: Axis): 'top/bottom' | 'left/right' | 'front/back' {
+  return axis === 2 ? 'top/bottom' : axis === 0 ? 'left/right' : 'front/back';
+}

--- a/src/kernel/backends/occt/edgeSelection.ts
+++ b/src/kernel/backends/occt/edgeSelection.ts
@@ -33,6 +33,7 @@ import { resolveEdgeQuery, resolveFaceQuery, computeDihedralPublic } from './edg
 import type { FaceQuery } from './edgeQueries';
 import { EDGE_QUERY_KEYS } from '../../../shared/intent/queryKeys';
 import { resolveFaceRef } from '../../naming/resolveFaceRef';
+import { resolveCanonicalByGeometry } from './canonicalFaceGeometry';
 import { resolveEdgeRef } from '../../naming/resolveEdgeRef';
 import {
   parseFaceSelector,
@@ -293,7 +294,15 @@ export function pickEdges(
     return edgesOfFaceByHash(base, resolved.faceHash);
   }
 
-  // No historyMap → must be an un-transformed primitive (kind tag set).
+  // No historyMap → either an un-transformed primitive (kind tag set), or a
+  // swept/lofted/revolved solid (no kind tag). For the latter, resolve
+  // canonical top/bottom by geometry on cylinder-topology solids, else emit an
+  // actionable diagnostic instead of the misleading "apply transforms" message.
+  if (!base.kind && faceRef.ref.kind === 'canonical') {
+    const f = canonicalFaceOnSweptSolid(record, base, faceRef.ref.face);
+    if ('error' in f) return f;
+    return f.edges;
+  }
   if (!base.kind) {
     return {
       error: {
@@ -523,6 +532,53 @@ function findCanonicalFace(base: OcctBackend, face: CanonicalFace): Face | null 
   return null; // sphere has no canonical faces
 }
 
+/**
+ * Resolve a canonical face name on a solid that carries NO primitive `kind`
+ * and NO lineage `historyMap` — i.e. a swept / lofted / revolved solid.
+ *
+ * Such solids have no STORED canonical face names. For the common
+ * cylinder-topology case (an agent's wheel: a swept/lofted circle or a
+ * revolved rectangle) we resolve 'top'/'bottom' purely from geometry. When the
+ * geometry can't back the requested name, we emit a clear, actionable
+ * diagnostic — NOT the legacy "requires an un-transformed primitive — apply
+ * transforms after the feature" message, which sent agents chasing a phantom
+ * transform they never applied.
+ */
+function canonicalFaceOnSweptSolid(
+  record: FeatureRecord,
+  base: OcctBackend,
+  face: CanonicalFace,
+): Face | { error: CompilerDiagnostic } {
+  const shape = base.getReplicadShape();
+  const res = resolveCanonicalByGeometry(shape, face);
+  if (res.kind === 'resolved') {
+    return res.face;
+  }
+  if (res.kind === 'not-a-cap') {
+    return {
+      error: {
+        target: 'export-occt',
+        code: 'feature.face-ref.not-applicable',
+        featureId: record.id,
+        severity: 'error',
+        message: `Canonical face '${face}' is not applicable to this swept/lofted/revolved solid; its only canonical faces are the '${res.capAxisLabel}' end caps.`,
+        hint: `Use '${res.capAxisLabel.replace('/', "' or '")}' for the end caps, or select the side wall with a query like kc.q.face({ ofSurfaceType: 'CYLINDER' }) — run list_faces to see all faces on this solid.`,
+      },
+    };
+  }
+  // no-canonical-faces
+  return {
+    error: {
+      target: 'export-occt',
+      code: 'feature.face-ref.not-applicable',
+      featureId: record.id,
+      severity: 'error',
+      message: `This swept/lofted/revolved solid has no canonical face names; canonical names ('top'/'bottom'/...) exist only on primitives and cylinder-topology solids. It has ${res.faceCount} face${res.faceCount === 1 ? '' : 's'}.`,
+      hint: `Select faces by query instead, e.g. kc.q.face({ byNormal: 'Z' }) for an upward-facing face or kc.q.face({ atZ: <height> }) for a face at a known height, or run list_faces to enumerate all ${res.faceCount} faces on this solid.`,
+    },
+  };
+}
+
 function findFaceByPlane(
   shape: import('replicad').Shape3D,
   axisIndex: 0 | 1 | 2,
@@ -727,20 +783,15 @@ export function pickFace(
       };
     }
 
-    // No historyMap → must be an un-transformed primitive (kind tag set).
-    if (!base.kind) {
-      return {
-        error: {
-          target: 'export-occt',
-          code: 'feature.face-ref.not-resolvable',
-          featureId: record.id,
-          severity: 'error',
-          message: `Canonical face refs require an un-transformed primitive (box, cylinder, or sphere). Apply transforms after the face feature instead of before.`,
-          hint: 'Apply the face feature (e.g. shell) before transforms; or use a label / FaceQuery instead of a canonical face name.',
-        },
-      };
-    }
+    // No historyMap → either an un-transformed primitive (kind tag set), or a
+    // swept/lofted/revolved solid (no kind tag). The latter has no stored
+    // canonical names; resolve top/bottom by geometry for cylinder-topology
+    // solids, else emit an actionable diagnostic (NOT the misleading
+    // "apply transforms after" message).
     const face = faceRef.ref.face as CanonicalFace;
+    if (!base.kind) {
+      return canonicalFaceOnSweptSolid(record, base, face);
+    }
     const f = findCanonicalFace(base, face);
     if (f === null) {
       return {

--- a/tests/unit/backends/occt/edgeSelection.pickFace.test.ts
+++ b/tests/unit/backends/occt/edgeSelection.pickFace.test.ts
@@ -51,7 +51,7 @@ describe('pickFace', () => {
     const box = OcctBackend.box(20, 20, 20).translate(5, 0, 0);
     const result = pickFace(shellWithFace('box_1', 'top'), box, undefined);
     if (!('error' in result)) throw new Error('expected error, got face');
-    expect(result.error.code).toBe('feature.face-ref.not-resolvable');
+    expect(result.error.code).toBe('feature.face-ref.not-applicable');
   });
 
   it('returns face-ref-not-resolvable on a non-primitive (boolean result)', () => {
@@ -60,7 +60,7 @@ describe('pickFace', () => {
     const bool = box.subtract(cyl);
     const result = pickFace(shellWithFace('bool_1', 'top'), bool, undefined);
     if (!('error' in result)) throw new Error('expected error, got face');
-    expect(result.error.code).toBe('feature.face-ref.not-resolvable');
+    expect(result.error.code).toBe('feature.face-ref.not-applicable');
   });
 
   it('returns face-ref-not-applicable for cylinder side face', () => {

--- a/tests/unit/backends/occt/edgeSelection.test.ts
+++ b/tests/unit/backends/occt/edgeSelection.test.ts
@@ -51,7 +51,7 @@ describe('pickEdges', () => {
     const bool = box.subtract(cyl); // result has no kind tag
     const result = pickEdges(filletWithFace('bool_1', 'top'), bool, undefined);
     if (!('error' in result)) throw new Error('expected error, got edges');
-    expect(result.error.code).toBe('feature.face-ref.not-resolvable');
+    expect(result.error.code).toBe('feature.face-ref.not-applicable');
     expect(result.error.severity).toBe('error');
   });
 
@@ -59,7 +59,7 @@ describe('pickEdges', () => {
     const box = OcctBackend.box(20, 20, 20).translate(5, 0, 0); // transform drops kind tag
     const result = pickEdges(filletWithFace('box_1', 'top'), box, undefined);
     if (!('error' in result)) throw new Error('expected error, got edges');
-    expect(result.error.code).toBe('feature.face-ref.not-resolvable');
+    expect(result.error.code).toBe('feature.face-ref.not-applicable');
   });
 
   it('returns error when canonical face is not applicable to this primitive', () => {

--- a/tests/unit/backends/occt/mirror.test.ts
+++ b/tests/unit/backends/occt/mirror.test.ts
@@ -66,6 +66,6 @@ describe('Shape.mirror(plane)', () => {
     const engine = new RecomputeEngine(new OcctLowerer());
     const result = await engine.run(run.records);
     const codes = result.diagnostics.map(d => d.code);
-    expect(codes).toContain('feature.face-ref.not-resolvable');
+    expect(codes).toContain('feature.face-ref.not-applicable');
   }, 60000);
 });

--- a/tests/unit/backends/occt/occtLowerer.fillet.test.ts
+++ b/tests/unit/backends/occt/occtLowerer.fillet.test.ts
@@ -55,7 +55,7 @@ describe('OcctLowerer fillet', () => {
     const result = await new OcctLowerer().lower(r, { byKey: { base } });
     const errs = result.diagnostics.filter(d => d.severity === 'error');
     expect(errs).toHaveLength(1);
-    expect(errs[0].code).toBe('feature.face-ref.not-resolvable');
+    expect(errs[0].code).toBe('feature.face-ref.not-applicable');
   });
 
   it('emits short-edges-skipped when radius exceeds half the edge length', async () => {

--- a/tests/unit/backends/occt/occtLowerer.shell.test.ts
+++ b/tests/unit/backends/occt/occtLowerer.shell.test.ts
@@ -54,7 +54,7 @@ describe('OcctLowerer shell', () => {
     const result = await new OcctLowerer().lower(r, { byKey: { base } });
     const errs = result.diagnostics.filter(d => d.severity === 'error');
     expect(errs).toHaveLength(1);
-    expect(errs[0].code).toBe('feature.face-ref.not-resolvable');
+    expect(errs[0].code).toBe('feature.face-ref.not-applicable');
   });
 
   it('emits feature.shell.failed when thickness is too large', async () => {


### PR DESCRIPTION
## Problem

Canonical face names (\`top\`/\`bottom\`/...) on a solid produced by \`variableSweep\` / \`loft\` / \`revolve\` failed with a misleading error:

> Canonical face refs require an un-transformed primitive (box, cylinder, or sphere). Apply transforms after the face feature instead of before.

These solids carry **no primitive \`kind\` tag** and **no lineage \`historyMap\`**, so \`pickFace\` / \`pickEdges\` fell into the no-\`kind\` branch and told the agent to undo a transform it never applied. An agent trying to fillet a swept/lofted wheel (a cylinder built via sweep/loft) hit a dead end: *"tried to fillet cylinder faces that don't exist by those names"* → gave up.

## What shipped

**1. Actionable diagnostics (priority 1)** — when a canonical name can't be resolved on a \`kind\`-less, lineage-less solid, emit a clear \`feature.face-ref.not-applicable\` diagnostic that:
- states the solid has no canonical face names (or only end caps),
- reports how many faces it has,
- tells the agent how to select them: \`kc.q.face({ byNormal: 'Z' })\` / \`kc.q.face({ atZ: <h> })\` / \`list_faces\`.

This alone fixes the flailing — no more phantom-transform message.

**2. Geometry-based resolution (priority 2)** — for a \`kind\`-less, lineage-less solid that is genuinely **cylinder-topology** (exactly two parallel planar end-caps + ≥1 curved lateral face), resolve \`top\`/\`bottom\` by **geometry** (the planar cap at max/min along the cap axis), not by stored primitive kind. This covers the common wheel case (swept/lofted circle, revolved rectangle). Implemented in the new \`canonicalFaceGeometry.ts\` module and wired into both \`pickFace\` and \`pickEdges\`.

## Scope / discipline

- The stable-naming core (\`resolveFaceRef\` / \`resolveTopoRef\` / query DSL) is **untouched**.
- Primitives (box/cylinder/sphere) and lineage-bearing shapes keep their existing paths byte-for-byte.
- Conservative: geometry resolution only claims a match for unambiguous cylinder-topology; everything else returns a structured "no canonical names" outcome → diagnostic.

## Deferred / follow-ups

- **Non-cap canonical names on cylinder-topology** (e.g. \`left\`/\`right\` on a Z-axis cylinder): intentionally not resolved — they have no single geometric face. Diagnostic points the agent at the end caps or a query.
- **\`lateral\` / side-wall canonical name**: \`CanonicalFace\` only has the six axis names; the side wall is reachable via \`kc.q.face({ ofSurfaceType: 'CYLINDER' })\`. A dedicated \`lateral\` canonical name could be a future ergonomic add.
- **Non-cylinder swept/lofted solids** (tapers, multi-section lofts): correctly fall through to the "no canonical names — use a query" diagnostic; geometric naming for those is out of scope.

## Tests

New \`canonicalFaceAfterSweep.test.ts\` drives the **real WASM path** through \`pickFace\` / \`pickEdges\` on a swept cylinder (circle profile swept along a Z rail → 2 PLANE caps + curved wall, no \`kind\`, no \`historyMap\`):
- top/bottom resolve by geometry (unit + integration),
- non-cap name → clear diagnostic, asserts the message does **not** mention "un-transformed primitive" and the hint points at \`kc.q.face\` / \`list_faces\`,
- sphere → no-canonical-faces.

\`\`\`
canonicalFaceAfterSweep.test.ts: 6/6 pass
naming + occt backend + fillet integration suites: 265/265 pass
npm run typecheck (tsc -b): clean
eslint (changed files): clean
\`\`\`