### PR TITLE
Studio: client-side project revision history

### DIFF
--- a/src/authoring/projectService.test.ts
+++ b/src/authoring/projectService.test.ts
@@ -3,7 +3,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { projectService } from './projectService';
 
 describe('projectService', () => {
@@ -103,5 +103,87 @@ describe('projectService', () => {
         expect(mockLink.href).toBe('blob:test');
         expect(mockLink.click).toHaveBeenCalled();
         expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:test');
+    });
+
+    describe('revisions', () => {
+        const id = 'rev-proj';
+        const make = (code: string) => projectService.createProject(code, mockViewState, 'Rev Project');
+
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it('snapshots a revision on first save', () => {
+            projectService.saveProject(id, make('code A'));
+            const revs = projectService.listRevisions(id);
+            expect(revs).toHaveLength(1);
+            expect(revs[0]).toMatchObject({ v: 1, code: 'code A' });
+        });
+
+        it('dedupes when code is unchanged across saves', () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+            projectService.saveProject(id, make('same'));
+            // Advance well beyond the coalesce window so dedupe (not coalesce) applies.
+            vi.setSystemTime(new Date('2026-01-01T00:01:00.000Z'));
+            projectService.saveProject(id, make('same'));
+
+            const revs = projectService.listRevisions(id);
+            expect(revs).toHaveLength(1);
+            expect(revs[0].code).toBe('same');
+        });
+
+        it('coalesces two code changes within 10s into one revision', () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+            projectService.saveProject(id, make('first'));
+            vi.setSystemTime(new Date('2026-01-01T00:00:05.000Z'));
+            projectService.saveProject(id, make('second'));
+
+            const revs = projectService.listRevisions(id);
+            expect(revs).toHaveLength(1);
+            expect(revs[0]).toMatchObject({ v: 1, code: 'second' });
+        });
+
+        it('appends a new revision when saves are more than 10s apart', () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+            projectService.saveProject(id, make('first'));
+            vi.setSystemTime(new Date('2026-01-01T00:00:11.000Z'));
+            projectService.saveProject(id, make('second'));
+
+            const revs = projectService.listRevisions(id);
+            expect(revs).toHaveLength(2);
+            expect(revs[0]).toMatchObject({ v: 1, code: 'first' });
+            expect(revs[1]).toMatchObject({ v: 2, code: 'second' });
+        });
+
+        it('caps at 50 revisions, dropping the oldest', () => {
+            vi.useFakeTimers();
+            // Each save 11s apart (past coalesce window) and unique code -> a new revision.
+            for (let i = 0; i < 60; i++) {
+                vi.setSystemTime(new Date(Date.UTC(2026, 0, 1, 0, 0, 0) + i * 11000));
+                projectService.saveProject(id, make(`code ${i}`));
+            }
+
+            const revs = projectService.listRevisions(id);
+            expect(revs).toHaveLength(50);
+            // Oldest 10 (code 0..9) dropped; first retained is code 10.
+            expect(revs[0].code).toBe('code 10');
+            expect(revs[revs.length - 1].code).toBe('code 59');
+        });
+
+        it('clears revisions when the project is deleted', () => {
+            projectService.saveProject(id, make('code A'));
+            expect(projectService.listRevisions(id)).toHaveLength(1);
+            projectService.deleteProject(id);
+            expect(projectService.listRevisions(id)).toHaveLength(0);
+        });
+
+        it('returns [] for an unknown project or corrupt data', () => {
+            expect(projectService.listRevisions('nope')).toEqual([]);
+            localStorage.setItem('kernelcad_project_revisions_bad', 'not json');
+            expect(projectService.listRevisions('bad')).toEqual([]);
+        });
     });
 });

--- a/src/authoring/projectService.ts
+++ b/src/authoring/projectService.ts
@@ -27,9 +27,26 @@ export interface ProjectMetadata {
     lastUpdated: string;
 }
 
+/** A single point-in-time snapshot of a project's code. Stored client-side
+ *  only (localStorage); newest revision is the last element of the array. */
+export interface ProjectRevision {
+    v: number;
+    code: string;
+    ts: string;
+}
+
 const CURRENT_PROJECT_VERSION = '1.1';
 const INDEX_KEY = 'kernelcad_project_index';
 const LEGACY_STORAGE_KEY = 'kernelcad_current_project';
+
+/** Max revisions retained per project; oldest are dropped past this. */
+const MAX_REVISIONS = 50;
+/** Window within which rapid editor autosaves coalesce into one revision. */
+const REVISION_COALESCE_MS = 10000;
+
+function revisionsKey(id: string): string {
+    return `kernelcad_project_revisions_${id}`;
+}
 
 const ViewModeSchema = z.enum(['code', 'gui']);
 
@@ -136,7 +153,41 @@ export const projectService = {
         const updatedProject = { ...project, lastUpdated: new Date().toISOString() };
         localStorage.setItem(`kernelcad_project_${id}`, JSON.stringify(updatedProject));
         this.updateIndex(id, updatedProject.name, updatedProject.lastUpdated);
+        this.snapshotRevision(id, updatedProject.code);
         return updatedProject;
+    },
+
+    listRevisions(id: string): ProjectRevision[] {
+        const raw = localStorage.getItem(revisionsKey(id));
+        if (!raw) return [];
+        try {
+            return JSON.parse(raw);
+        } catch {
+            return [];
+        }
+    },
+
+    /** Append/coalesce a code snapshot into the project's revision history.
+     *  Identical-code saves are skipped; rapid saves (<10s) replace the last
+     *  revision in place so editor autosaves don't explode into hundreds. */
+    snapshotRevision(id: string, code: string) {
+        const revs = this.listRevisions(id);
+        const last = revs[revs.length - 1];
+
+        if (last && last.code === code) return;
+
+        if (last && (Date.now() - Date.parse(last.ts)) < REVISION_COALESCE_MS) {
+            last.code = code;
+            last.ts = new Date().toISOString();
+        } else {
+            revs.push({ v: (last?.v ?? 0) + 1, code, ts: new Date().toISOString() });
+        }
+
+        while (revs.length > MAX_REVISIONS) {
+            revs.shift();
+        }
+
+        localStorage.setItem(revisionsKey(id), JSON.stringify(revs));
     },
 
     updateIndex(id: string, name: string, lastUpdated: string) {
@@ -153,6 +204,7 @@ export const projectService = {
 
     deleteProject(id: string) {
         localStorage.removeItem(`kernelcad_project_${id}`);
+        localStorage.removeItem(revisionsKey(id));
         const index = this.listProjects().filter(p => p.id !== id);
         localStorage.setItem(INDEX_KEY, JSON.stringify(index));
     },

--- a/src/studio/components/Layout/Header.tsx
+++ b/src/studio/components/Layout/Header.tsx
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { useEffect, useRef, useState } from 'react';
 import { useWorkbench } from '../../context/WorkbenchContext';
-import { Loader2, Download, FileDown, Undo2, Redo2, Box, Grid as GridIcon, Grid3x3, Circle, FolderOpen, Moon, Sun, LayoutGrid } from 'lucide-react';
+import { Loader2, Download, FileDown, Undo2, Redo2, Box, Grid as GridIcon, Grid3x3, Circle, FolderOpen, Moon, Sun, LayoutGrid, History, RotateCcw } from 'lucide-react';
 import { exportSTEP, exportSTL } from '../../../shared/worker/geometryEngine';
 import { formatTooltip, SHORTCUT_HINTS } from '../../../shared/constants/shortcuts';
 import { useProject } from '../../context/ProjectContext';
@@ -16,7 +17,43 @@ export function Header() {
     } = useWorkbench();
     const { viewportBackground, setViewportBackground, gridVisible, setGridVisible } = useUI();
 
-    const { activeProject } = useProject();
+    const { activeProject, revisions, restoreRevision } = useProject();
+
+    const [historyOpen, setHistoryOpen] = useState(false);
+    const historyRef = useRef<HTMLDivElement>(null);
+
+    // Close the history menu on outside click / Escape.
+    useEffect(() => {
+        if (!historyOpen) return;
+        const onPointerDown = (e: MouseEvent) => {
+            if (historyRef.current && !historyRef.current.contains(e.target as Node)) {
+                setHistoryOpen(false);
+            }
+        };
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') setHistoryOpen(false);
+        };
+        document.addEventListener('mousedown', onPointerDown);
+        document.addEventListener('keydown', onKeyDown);
+        return () => {
+            document.removeEventListener('mousedown', onPointerDown);
+            document.removeEventListener('keydown', onKeyDown);
+        };
+    }, [historyOpen]);
+
+    // History is only meaningful once there are at least two distinct revisions
+    // to move between; ephemeral funnel projects report zero revisions.
+    const historyAvailable = revisions.length >= 2;
+
+    const formatRevisionTime = (ts: string) => {
+        const date = new Date(ts);
+        return date.toLocaleDateString() + ' ' + date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    };
+
+    const handleRestore = (v: number) => {
+        restoreRevision(v);
+        setHistoryOpen(false);
+    };
 
     const handleExport = async (type: 'step' | 'stl') => {
         try {
@@ -159,6 +196,53 @@ export function Header() {
                 >
                     <Redo2 className="w-4 h-4" />
                 </button>
+
+                {historyAvailable && (
+                    <div className="relative" ref={historyRef} data-testid="history-menu">
+                        <button
+                            onClick={() => setHistoryOpen(o => !o)}
+                            className={`p-1 rounded transition-colors ${historyOpen ? 'bg-[#333] text-white' : 'text-gray-400 hover:text-white hover:bg-[#333]'}`}
+                            aria-label="Revision history"
+                            aria-haspopup="menu"
+                            aria-expanded={historyOpen}
+                            title="Revision history"
+                            data-testid="history-button"
+                        >
+                            <History className="w-4 h-4" />
+                        </button>
+                        {historyOpen && (
+                            <div
+                                role="menu"
+                                className="absolute right-0 top-full mt-1 w-64 max-h-80 overflow-y-auto bg-[#1a1a1a] border border-[#333] rounded shadow-lg z-50 py-1"
+                                data-testid="history-dropdown"
+                            >
+                                <div className="px-3 py-1.5 text-[10px] uppercase tracking-wide text-gray-500 font-medium">
+                                    Revision history
+                                </div>
+                                {[...revisions].reverse().map((rev) => (
+                                    <div
+                                        key={rev.v}
+                                        className="group flex items-center justify-between gap-2 px-3 py-1.5 hover:bg-[#222]"
+                                    >
+                                        <div className="min-w-0">
+                                            <div className="text-xs text-gray-300">v{rev.v}</div>
+                                            <div className="text-[10px] text-gray-500 truncate">{formatRevisionTime(rev.ts)}</div>
+                                        </div>
+                                        <button
+                                            onClick={() => handleRestore(rev.v)}
+                                            className="flex items-center gap-1 text-[10px] text-gray-400 hover:text-white px-1.5 py-1 rounded hover:bg-[#333] transition-colors shrink-0"
+                                            aria-label={`Restore revision v${rev.v}`}
+                                            title={`Restore v${rev.v}`}
+                                        >
+                                            <RotateCcw className="w-3 h-3" />
+                                            Restore
+                                        </button>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                )}
 
                 <div className="h-6 w-px bg-[#333] mx-2" />
 

--- a/src/studio/context/ProjectContext.tsx
+++ b/src/studio/context/ProjectContext.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import { projectService, type KernelCADProject, type ProjectMetadata } from '../../authoring/projectService';
+import { projectService, type KernelCADProject, type ProjectMetadata, type ProjectRevision } from '../../authoring/projectService';
 import { defaultCode } from '../../shared/worker/geometryEngine';
 
 interface ProjectContextType {
@@ -14,6 +14,8 @@ interface ProjectContextType {
     deleteProject: (id: string) => void;
     renameActiveProject: (newName: string) => void;
     saveActiveProject: (project: Partial<KernelCADProject>) => void;
+    revisions: ProjectRevision[];
+    restoreRevision: (v: number) => void;
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
@@ -97,6 +99,15 @@ export function ProjectProvider({ children, initialCode, projectName }: {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [activeProjectId, projectVersion, ephemeralProject]);
 
+    // Revision history for the active, persisted project. Ephemeral funnel
+    // projects never persist, so they have no revisions. Recomputes on save
+    // (projectVersion) and on project switch (activeProjectId).
+    const revisions = useMemo<ProjectRevision[]>(() => {
+        if (!activeProjectId || activeProjectId === EPHEMERAL_ID) return [];
+        return projectService.listRevisions(activeProjectId);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [activeProjectId, projectVersion]);
+
     const openProject = useCallback((id: string) => {
         setActiveProjectId(id);
     }, []);
@@ -159,6 +170,13 @@ export function ProjectProvider({ children, initialCode, projectName }: {
         setTimeout(() => setIsSaving(false), 500);
     }, [activeProjectId, activeProject]);
 
+    const restoreRevision = useCallback((v: number) => {
+        if (!activeProjectId || activeProjectId === EPHEMERAL_ID) return;
+        const rev = revisions.find(r => r.v === v);
+        if (!rev) return;
+        saveActiveProject({ code: rev.code });
+    }, [activeProjectId, revisions, saveActiveProject]);
+
     const value = useMemo(() => ({
         activeProjectId,
         projects,
@@ -168,8 +186,10 @@ export function ProjectProvider({ children, initialCode, projectName }: {
         createProject,
         deleteProject,
         renameActiveProject,
-        saveActiveProject
-    }), [activeProjectId, projects, activeProject, isSaving, openProject, createProject, deleteProject, renameActiveProject, saveActiveProject]);
+        saveActiveProject,
+        revisions,
+        restoreRevision
+    }), [activeProjectId, projects, activeProject, isSaving, openProject, createProject, deleteProject, renameActiveProject, saveActiveProject, revisions, restoreRevision]);
 
     return <ProjectContext.Provider value={value}>{children}</ProjectContext.Provider>;
 }


### PR DESCRIPTION
Adds browseable + restorable revision history to the Studio, entirely client-side (localStorage) — no kernelCAD-server / Supabase changes.

**What**
- Each saved code state snapshots into a per-project revision list (`kernelcad_project_revisions_<id>`). Saves dedupe on identical code and coalesce within 10s so editor autosaves don't explode; capped at 50 (oldest dropped). `deleteProject` clears revisions.
- `ProjectContext` exposes `revisions` + `restoreRevision(v)` (restore = save that revision's code as the new head). Ephemeral funnel projects excluded.
- A **History** dropdown in the Header lists revisions newest-first (v#, timestamp) with one-click Restore. Shown only with 2+ revisions.

**Why**: device/model designs (incl. proto.cat's `open_in_studio` updates) evolve a model in place — this keeps the prior states so you can review/restore, instead of losing them on overwrite.

**Verify**: vitest (7 new revision tests + existing Header/funnel green, 19 total), `tsc -b`, `vite build`, eslint — all pass.