### PR TITLE
Studio: server-side (Supabase) revision history on /p/:slug

### DIFF
--- a/src/funnel/lib/apiClient.test.ts
+++ b/src/funnel/lib/apiClient.test.ts
@@ -7,7 +7,13 @@ const getSupabaseMock = vi.fn(() => ({ auth: { getSession: getSessionMock } }));
 
 vi.mock('./supabaseClient', () => ({ getSupabase: () => getSupabaseMock() }));
 
-import { setProjectPrivacy, postProjectRender, PRIVATE_REQUIRES_PAID } from './apiClient';
+import {
+  setProjectPrivacy,
+  postProjectRender,
+  PRIVATE_REQUIRES_PAID,
+  listProjectRevisions,
+  restoreProjectRevision,
+} from './apiClient';
 
 describe('setProjectPrivacy', () => {
   const fetchMock = vi.fn();
@@ -111,5 +117,87 @@ describe('postProjectRender', () => {
     fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true, url: 'u' }) });
     await postProjectRender('a/b', 'cG5n');
     expect(fetchMock.mock.calls[0]![0]).toBe('https://api.kernelcad.com/api/v1/projects/a%2Fb/render');
+  });
+});
+
+describe('listProjectRevisions', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    getSessionMock.mockReset();
+    getSupabaseMock.mockReturnValue({ auth: { getSession: getSessionMock } });
+    getSessionMock.mockResolvedValue({ data: { session: { access_token: 'tok-1' } } });
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.kernelcad.com');
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('GETs the revisions endpoint and unwraps the {revisions} envelope', async () => {
+    const revisions = [
+      { version: 3, created_at: '2026-06-15T12:00:00Z' },
+      { version: 2, created_at: '2026-06-14T12:00:00Z' },
+    ];
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ revisions }) });
+
+    await expect(listProjectRevisions('slug-1')).resolves.toEqual(revisions);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.kernelcad.com/api/v1/projects/slug-1/revisions');
+    expect(init.method).toBe('GET');
+    expect(init.headers.Authorization).toBe('Bearer tok-1');
+  });
+
+  it('returns [] when the envelope omits revisions', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+    await expect(listProjectRevisions('slug-1')).resolves.toEqual([]);
+  });
+
+  it('url-encodes the slug', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ revisions: [] }) });
+    await listProjectRevisions('a/b');
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://api.kernelcad.com/api/v1/projects/a%2Fb/revisions');
+  });
+});
+
+describe('restoreProjectRevision', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    getSessionMock.mockReset();
+    getSupabaseMock.mockReturnValue({ auth: { getSession: getSessionMock } });
+    getSessionMock.mockResolvedValue({ data: { session: { access_token: 'tok-1' } } });
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.kernelcad.com');
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs the restore endpoint with the version and returns the restored version', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ version: 5 }) });
+
+    await expect(restoreProjectRevision('slug-1', 5)).resolves.toEqual({ version: 5 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.kernelcad.com/api/v1/projects/slug-1/revisions/5/restore');
+    expect(init.method).toBe('POST');
+    expect(init.headers.Authorization).toBe('Bearer tok-1');
+    expect(JSON.parse(init.body)).toEqual({});
+  });
+
+  it('url-encodes the slug', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ version: 1 }) });
+    await restoreProjectRevision('a/b', 1);
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://api.kernelcad.com/api/v1/projects/a%2Fb/revisions/1/restore');
   });
 });

--- a/src/funnel/lib/apiClient.ts
+++ b/src/funnel/lib/apiClient.ts
@@ -145,6 +145,41 @@ export async function fetchProjectBySlug(slug: string): Promise<ProjectRow | nul
   return (data as ProjectRow | null) ?? null;
 }
 
+// ---------------------------------------------------------------------------
+// Server-side revision history (Supabase-backed, owner-or-slug auth).
+//   GET  /api/v1/projects/:slug/revisions            -> { revisions: [...] }
+//   POST /api/v1/projects/:slug/revisions/:v/restore -> { version }
+// ---------------------------------------------------------------------------
+
+export interface ProjectRevision {
+  version: number;
+  created_at: string;
+}
+
+/** Newest-first list of saved server revisions for a slug-backed project.
+ *  Unwraps the `{ revisions: [...] }` envelope; returns `[]` when missing. */
+export async function listProjectRevisions(slug: string): Promise<ProjectRevision[]> {
+  const res = await authedFetch<{ revisions?: ProjectRevision[] }>(
+    'GET',
+    `/api/v1/projects/${encodeURIComponent(slug)}/revisions`,
+  );
+  return res.revisions ?? [];
+}
+
+/** Restore the project's code to a prior revision; returns the restored
+ *  version. The displayed model is refreshed by the caller via
+ *  fetchProjectBySlug. */
+export async function restoreProjectRevision(
+  slug: string,
+  version: number,
+): Promise<{ version: number }> {
+  return authedFetch<{ version: number }>(
+    'POST',
+    `/api/v1/projects/${encodeURIComponent(slug)}/revisions/${version}/restore`,
+    {},
+  );
+}
+
 export async function listMyProjects(): Promise<ProjectRow[]> {
   const supabase = getSupabase();
   const { data, error } = await supabase

--- a/src/studio/__tests__/ServerRevisionHistory.test.tsx
+++ b/src/studio/__tests__/ServerRevisionHistory.test.tsx
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+/** @vitest-environment happy-dom */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const listProjectRevisions = vi.fn();
+const restoreProjectRevision = vi.fn();
+const fetchProjectBySlug = vi.fn();
+
+vi.mock('../../funnel/lib/apiClient', () => ({
+  listProjectRevisions: (...args: unknown[]) => listProjectRevisions(...args),
+  restoreProjectRevision: (...args: unknown[]) => restoreProjectRevision(...args),
+  fetchProjectBySlug: (...args: unknown[]) => fetchProjectBySlug(...args),
+}));
+
+import { ServerRevisionHistory } from '../../studio/routes/-ServerRevisionHistory';
+
+const TWO_REVS = [
+  { version: 3, created_at: '2026-06-15T12:00:00Z' },
+  { version: 2, created_at: '2026-06-14T12:00:00Z' },
+];
+
+beforeEach(() => {
+  listProjectRevisions.mockReset();
+  restoreProjectRevision.mockReset();
+  fetchProjectBySlug.mockReset();
+});
+
+afterEach(() => cleanup());
+
+describe('ServerRevisionHistory', () => {
+  it('renders the history button and lists revisions newest-first when opened', async () => {
+    listProjectRevisions.mockResolvedValue(TWO_REVS);
+
+    render(<ServerRevisionHistory slug="demo" onRestored={vi.fn()} />);
+
+    const button = await screen.findByTestId('server-history-button');
+    fireEvent.click(button);
+
+    await waitFor(() => expect(screen.getByTestId('server-history-dropdown')).toBeTruthy());
+    expect(screen.getByText('v3')).toBeTruthy();
+    expect(screen.getByText('v2')).toBeTruthy();
+    // Newest-first: v3 appears before v2 in the DOM.
+    const dropdown = screen.getByTestId('server-history-dropdown');
+    expect(dropdown.textContent!.indexOf('v3')).toBeLessThan(dropdown.textContent!.indexOf('v2'));
+  });
+
+  it('hides the whole control when fewer than two revisions exist', async () => {
+    listProjectRevisions.mockResolvedValue([{ version: 1, created_at: '2026-06-14T12:00:00Z' }]);
+
+    const { container } = render(<ServerRevisionHistory slug="demo" onRestored={vi.fn()} />);
+
+    await waitFor(() => expect(listProjectRevisions).toHaveBeenCalled());
+    await waitFor(() => expect(container.querySelector('[data-testid="server-history-button"]')).toBeNull());
+  });
+
+  it('restores a revision: calls the API, refreshes, and pushes restored code to onRestored', async () => {
+    listProjectRevisions.mockResolvedValue(TWO_REVS);
+    restoreProjectRevision.mockResolvedValue({ version: 2 });
+    fetchProjectBySlug.mockResolvedValue({ current_code: 'cube(2)' });
+    const onRestored = vi.fn();
+
+    render(<ServerRevisionHistory slug="demo" onRestored={onRestored} />);
+
+    fireEvent.click(await screen.findByTestId('server-history-button'));
+    await screen.findByTestId('server-history-dropdown');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restore revision v2' }));
+
+    await waitFor(() => expect(restoreProjectRevision).toHaveBeenCalledWith('demo', 2));
+    await waitFor(() => expect(fetchProjectBySlug).toHaveBeenCalledWith('demo'));
+    await waitFor(() => expect(onRestored).toHaveBeenCalledWith('cube(2)'));
+  });
+});

--- a/src/studio/routes/-ServerRevisionHistory.tsx
+++ b/src/studio/routes/-ServerRevisionHistory.tsx
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { History, RotateCcw } from 'lucide-react';
+import {
+  listProjectRevisions,
+  restoreProjectRevision,
+  fetchProjectBySlug,
+  type ProjectRevision,
+} from '../../funnel/lib/apiClient';
+
+export interface ServerRevisionHistoryProps {
+  slug: string;
+  /** Called with the restored project's current_code so the viewer can
+   *  re-render the 3D model to that revision (via the liveCode mechanism). */
+  onRestored: (code: string) => void;
+}
+
+function formatRevisionTime(ts: string): string {
+  const date = new Date(ts);
+  return (
+    date.toLocaleDateString() +
+    ' ' +
+    date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  );
+}
+
+/** Server-side revision history dropdown for slug-backed projects, mirroring
+ *  the localStorage History dropdown in the Studio Header. Lists Supabase
+ *  revisions newest-first; each row can restore that revision server-side and
+ *  push the restored code back into the viewer. Hidden when fewer than two
+ *  revisions exist (nothing meaningful to move between). */
+export function ServerRevisionHistory({
+  slug,
+  onRestored,
+}: ServerRevisionHistoryProps): ReactNode {
+  const [revisions, setRevisions] = useState<ProjectRevision[]>([]);
+  const [open, setOpen] = useState(false);
+  const [restoring, setRestoring] = useState<number | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const loadRevisions = useCallback(() => {
+    listProjectRevisions(slug)
+      .then(setRevisions)
+      .catch(() => {
+        // Transient / unauthorized — leave the list as-is.
+      });
+  }, [slug]);
+
+  // Load on mount (so we know whether to show the control) and refresh on open.
+  useEffect(() => {
+    loadRevisions();
+  }, [loadRevisions]);
+
+  useEffect(() => {
+    if (open) loadRevisions();
+  }, [open, loadRevisions]);
+
+  // Close the menu on outside click / Escape.
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  const handleRestore = useCallback(
+    async (version: number) => {
+      setRestoring(version);
+      try {
+        await restoreProjectRevision(slug, version);
+        const project = await fetchProjectBySlug(slug);
+        if (project) onRestored(project.current_code);
+        loadRevisions();
+        setOpen(false);
+      } catch {
+        // Transient — leave the row available to retry.
+      } finally {
+        setRestoring(null);
+      }
+    },
+    [slug, onRestored, loadRevisions],
+  );
+
+  // History is only meaningful once there are at least two distinct revisions
+  // to move between.
+  if (revisions.length < 2) return null;
+
+  return (
+    <div className="relative" ref={ref} data-testid="server-history-menu">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className={`p-1 rounded transition-colors ${open ? 'bg-[#333] text-white' : 'text-gray-400 hover:text-white hover:bg-[#333]'}`}
+        aria-label="Revision history"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title="Revision history"
+        data-testid="server-history-button"
+      >
+        <History className="w-4 h-4" />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full mt-1 w-64 max-h-80 overflow-y-auto bg-[#1a1a1a] border border-[#333] rounded shadow-lg z-50 py-1"
+          data-testid="server-history-dropdown"
+        >
+          <div className="px-3 py-1.5 text-[10px] uppercase tracking-wide text-gray-500 font-medium">
+            Revision history
+          </div>
+          {revisions.map((rev) => (
+            <div
+              key={rev.version}
+              className="group flex items-center justify-between gap-2 px-3 py-1.5 hover:bg-[#222]"
+            >
+              <div className="min-w-0">
+                <div className="text-xs text-gray-300">v{rev.version}</div>
+                <div className="text-[10px] text-gray-500 truncate">{formatRevisionTime(rev.created_at)}</div>
+              </div>
+              <button
+                type="button"
+                onClick={() => handleRestore(rev.version)}
+                disabled={restoring !== null}
+                className="flex items-center gap-1 text-[10px] text-gray-400 hover:text-white px-1.5 py-1 rounded hover:bg-[#333] transition-colors shrink-0 disabled:opacity-50"
+                aria-label={`Restore revision v${rev.version}`}
+                title={`Restore v${rev.version}`}
+              >
+                <RotateCcw className="w-3 h-3" />
+                {restoring === rev.version ? 'Restoring…' : 'Restore'}
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/studio/routes/p.$slug.tsx
+++ b/src/studio/routes/p.$slug.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import App from '../App';
 import { SignInButton } from '../../funnel/components/SignInButton';
 import { ProjectViewerActions } from './-ProjectViewerActions';
+import { ServerRevisionHistory } from './-ServerRevisionHistory';
 import { useSession } from '../../funnel/hooks/useSession';
 import {
   fetchProjectBySlug,
@@ -158,6 +159,16 @@ function ProjectPage() {
     }
   }, [slug, project?.privacy]);
 
+  // A server-side revision restore changes the project's current_code. Push it
+  // through the same liveCode/lastLiveUpdate path the SSE updates use so the 3D
+  // viewer re-renders to the restored revision immediately, and bump the
+  // version guard so a stale in-flight SSE refetch can't clobber it.
+  const handleRestored = useCallback((code: string) => {
+    if (versionRef.current != null) versionRef.current += 1;
+    setLiveCode(code);
+    setLastLiveUpdate(new Date());
+  }, []);
+
   const handleUpgrade = useCallback(async () => {
     try {
       const { url } = await createCheckoutSession();
@@ -239,6 +250,7 @@ function ProjectPage() {
   const headerRight: ReactNode = (
     <div className="flex items-center gap-2 min-w-0">
       {claimControl}
+      <ServerRevisionHistory slug={slug} onRestored={handleRestored} />
       <ProjectViewerActions
         slug={slug}
         project={project}


### PR DESCRIPTION
Completes unify-on-Supabase: the server now writes a `project_revisions` row on every model change (open_in_studio + save, shipped in kernelCAD-server #53). This makes that history **viewable + restorable in the Studio** for slug-backed projects.

- `apiClient`: `listProjectRevisions(slug)`, `restoreProjectRevision(slug, version)`.
- `ServerRevisionHistory` dropdown in the `/p/:slug` header — newest-first `v{n}` + timestamp, per-row Restore; hidden <2 revisions; mirrors the existing Header history UI.
- Restore → server restore → re-fetch → feeds code through the same `liveCode`/SSE path so the 3D model re-renders (version bump rejects stale SSE).
- localStorage history stays for purely-local Studio drafts.

Verified: typecheck + 16 vitest (apiClient + component + ProjectViewerActions) + vite build.