### PR TITLE
Parts catalog: ingest electronics (chips, modules, IC packages)

### DIFF
--- a/.github/workflows/parts-catalog.yml
+++ b/.github/workflows/parts-catalog.yml
@@ -43,6 +43,15 @@ jobs:
           --subdir "${{ github.event.inputs.subdir || 'Mechanical Parts' }}"
           --base-url https://kernelcad-parts.pages.dev
 
+      - name: Ingest electronics (chips, modules, IC packages)
+        # Fetches the CC-licensed 3D models declared in scripts/electronics-parts.json
+        # and MERGES them into the same catalog (never clobbers the mechanical parts).
+        # These are the parts LabWired supports, so a design can carry real geometry.
+        run: >
+          npx tsx scripts/ingestElectronics.ts catalog
+          --manifest scripts/electronics-parts.json
+          --base-url https://kernelcad-parts.pages.dev
+
       - name: Summarize
         run: |
           COUNT=$(node -e "console.log(require('./catalog/v1/catalog/parts.index.json').catalog.partCount)")

--- a/scripts/electronics-parts.json
+++ b/scripts/electronics-parts.json
@@ -53,12 +53,20 @@
       "tags": ["ic", "package", "lqfp", "stm32"]
     },
     {
+      "id": "ic-lqfp-144",
+      "name": "LQFP-144 (20x20mm, 0.5mm pitch)",
+      "family": "IC package",
+      "mpn": "LQFP-144",
+      "model": "Package_QFP.3dshapes/LQFP-144_20x20mm_P0.5mm.step",
+      "tags": ["ic", "package", "lqfp", "stm32"]
+    },
+    {
       "id": "ic-qfn-56-7x7",
       "name": "QFN-56 (7x7mm, 0.4mm pitch)",
       "family": "IC package",
       "mpn": "QFN-56",
       "model": "Package_DFN_QFN.3dshapes/QFN-56-1EP_7x7mm_P0.4mm_EP3.2x3.2mm.step",
-      "tags": ["ic", "package", "qfn", "rp2040"]
+      "tags": ["ic", "package", "qfn", "rp2040", "esp32s3"]
     }
   ]
 }

--- a/scripts/electronics-parts.json
+++ b/scripts/electronics-parts.json
@@ -1,0 +1,64 @@
+{
+  "_comment": "Declarative manifest of electronic parts for the kernelCAD catalog. Each entry maps a real, CC-licensed 3D model (fetched at ingest time, NOT committed) to a stable catalog id that LabWired chip/peripheral configs reference. Source: KiCad packages3D (CC-BY-SA 4.0 with the library exception). LabWired sims the silicon; the model placed in a design is the package/module a user actually solders. Where a part has no faithful off-the-shelf model yet, it is OMITTED here (not faked) so the coverage gate flags it.",
+  "baseModelUrl": "https://gitlab.com/kicad/libraries/kicad-packages3D/-/raw/master",
+  "license": "CC-BY-SA-4.0",
+  "attribution": "KiCad Libraries (kicad-packages3D), CC-BY-SA 4.0 with the KiCad library exception",
+  "parts": [
+    {
+      "id": "esp32-wroom-32",
+      "name": "ESP32-WROOM-32 module",
+      "family": "ESP32",
+      "mpn": "ESP32-WROOM-32",
+      "model": "RF_Module.3dshapes/ESP32-WROOM-32.step",
+      "tags": ["mcu", "module", "wifi", "ble", "esp32", "xtensa"]
+    },
+    {
+      "id": "esp32-s3-wroom-1",
+      "name": "ESP32-S3-WROOM-1 module",
+      "family": "ESP32",
+      "mpn": "ESP32-S3-WROOM-1",
+      "model": "RF_Module.3dshapes/ESP32-S3-WROOM-1.step",
+      "tags": ["mcu", "module", "wifi", "ble", "esp32", "esp32s3", "xtensa"]
+    },
+    {
+      "id": "esp32-c3-wroom-02",
+      "name": "ESP32-C3-WROOM-02 module",
+      "family": "ESP32",
+      "mpn": "ESP32-C3-WROOM-02",
+      "model": "RF_Module.3dshapes/ESP32-C3-WROOM-02.step",
+      "tags": ["mcu", "module", "wifi", "ble", "esp32", "esp32c3", "riscv"]
+    },
+    {
+      "id": "ic-lqfp-48",
+      "name": "LQFP-48 (7x7mm, 0.5mm pitch)",
+      "family": "IC package",
+      "mpn": "LQFP-48",
+      "model": "Package_QFP.3dshapes/LQFP-48_7x7mm_P0.5mm.step",
+      "tags": ["ic", "package", "lqfp", "stm32"]
+    },
+    {
+      "id": "ic-lqfp-64",
+      "name": "LQFP-64 (10x10mm, 0.5mm pitch)",
+      "family": "IC package",
+      "mpn": "LQFP-64",
+      "model": "Package_QFP.3dshapes/LQFP-64_10x10mm_P0.5mm.step",
+      "tags": ["ic", "package", "lqfp", "stm32"]
+    },
+    {
+      "id": "ic-lqfp-100",
+      "name": "LQFP-100 (14x14mm, 0.5mm pitch)",
+      "family": "IC package",
+      "mpn": "LQFP-100",
+      "model": "Package_QFP.3dshapes/LQFP-100_14x14mm_P0.5mm.step",
+      "tags": ["ic", "package", "lqfp", "stm32"]
+    },
+    {
+      "id": "ic-qfn-56-7x7",
+      "name": "QFN-56 (7x7mm, 0.4mm pitch)",
+      "family": "IC package",
+      "mpn": "QFN-56",
+      "model": "Package_DFN_QFN.3dshapes/QFN-56-1EP_7x7mm_P0.4mm_EP3.2x3.2mm.step",
+      "tags": ["ic", "package", "qfn", "rp2040"]
+    }
+  ]
+}

--- a/scripts/ingestElectronics.ts
+++ b/scripts/ingestElectronics.ts
@@ -19,7 +19,7 @@
 // records and rewrites the index to include both); or into its own dir to
 // inspect electronics alone.
 
-import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, existsSync, readdirSync, copyFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, existsSync, copyFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { ingestDirectory, type CatalogRecord } from './ingestParts';

--- a/scripts/ingestElectronics.ts
+++ b/scripts/ingestElectronics.ts
@@ -1,0 +1,184 @@
+// Ingest the electronics parts (chips, modules, IC packages) declared in
+// scripts/electronics-parts.json into the kernelCAD parts catalog. Mirrors the
+// FreeCAD-library ingest, but the source models are fetched at run time from a
+// CC-licensed remote (KiCad packages3D) per the manifest — nothing binary is
+// committed to this repo. Each part becomes a catalog record with a MEASURED
+// bbox (not guessed), so the same `find_part` / `fetch_part` path that serves
+// mechanical parts now serves the chips/peripherals LabWired supports.
+//
+// Usage:
+//   npx tsx scripts/ingestElectronics.ts <outDir> \
+//     [--manifest scripts/electronics-parts.json] \
+//     [--base-url https://kernelcad-parts.pages.dev]
+//
+// Run AFTER the mechanical ingest into the SAME outDir to merge (this appends
+// records and rewrites the index to include both); or into its own dir to
+// inspect electronics alone.
+
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, existsSync, readdirSync, copyFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ingestDirectory, type CatalogRecord } from './ingestParts';
+
+interface ManifestPart {
+  id: string;
+  name: string;
+  family: string;
+  mpn: string;
+  model: string;
+  tags?: string[];
+}
+interface Manifest {
+  baseModelUrl: string;
+  license: string;
+  attribution: string;
+  parts: ManifestPart[];
+}
+
+function parseArgs(argv: string[]) {
+  const out = { outDir: '', manifest: 'scripts/electronics-parts.json', baseUrl: 'https://kernelcad-parts.pages.dev' };
+  const rest: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--manifest') out.manifest = argv[++i];
+    else if (argv[i] === '--base-url') out.baseUrl = argv[++i];
+    else rest.push(argv[i]);
+  }
+  out.outDir = rest[0] ?? '';
+  return out;
+}
+
+/**
+ * Fetch each manifest model into a temp dir as `<id>.step` + an `<id>.meta.json`
+ * sidecar (category Electronics + family/license/attribution/mpn), then hand the
+ * dir to ingestDirectory which measures + records each. Returns the records.
+ */
+export async function ingestElectronics(
+  manifestPath: string,
+  outDir: string,
+  baseUrl: string,
+): Promise<CatalogRecord[]> {
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Manifest;
+  const src = mkdtempSync(join(tmpdir(), 'kc-electronics-'));
+  mkdirSync(src, { recursive: true });
+
+  let ok = 0;
+  for (const part of manifest.parts) {
+    const url = `${manifest.baseModelUrl.replace(/\/$/, '')}/${part.model}`;
+    const res = await fetch(url);
+    if (!res.ok) {
+      console.warn(`SKIP ${part.id}: fetch ${url} -> HTTP ${res.status}`);
+      continue;
+    }
+    const buf = Buffer.from(await res.arrayBuffer());
+    // Guard against an HTML 404 page slipping through as a "200" on some CDNs.
+    if (!buf.subarray(0, 64).toString('latin1').includes('ISO-10303-21')) {
+      console.warn(`SKIP ${part.id}: ${url} did not return a STEP file`);
+      continue;
+    }
+    writeFileSync(join(src, `${part.id}.step`), buf);
+    writeFileSync(
+      join(src, `${part.id}.meta.json`),
+      JSON.stringify(
+        {
+          id: part.id,
+          name: part.name,
+          category: 'Electronics',
+          family: part.family,
+          tags: part.tags ?? ['electronics', part.family],
+          attributes: { mpn: part.mpn },
+          license: manifest.license,
+          attribution: manifest.attribution,
+        },
+        null,
+        2,
+      ),
+    );
+    ok++;
+  }
+  console.log(`fetched ${ok}/${manifest.parts.length} electronics models -> ${src}`);
+
+  // Ingest into a temp dir, then MERGE into outDir so we never clobber an
+  // existing (e.g. mechanical) catalog already written there. ingestDirectory
+  // rewrites parts.index.json from only its own records, so a naive second run
+  // into the same dir would drop everything ingested before it.
+  const tmpOut = mkdtempSync(join(tmpdir(), 'kc-elec-out-'));
+  const records = await ingestDirectory(src, tmpOut, {
+    baseUrl,
+    license: manifest.license,
+    attribution: manifest.attribution,
+  });
+
+  mergeCatalog(tmpOut, outDir, records);
+  return records;
+}
+
+/** Copy a freshly-ingested catalog (step/ + v1/parts/) into `outDir` and rewrite
+ *  the discovery index + sha manifest as the UNION of what was already there and
+ *  the new records (new records win on id collision). */
+function mergeCatalog(fromDir: string, outDir: string, fresh: CatalogRecord[]): void {
+  mkdirSync(join(outDir, 'step'), { recursive: true });
+  mkdirSync(join(outDir, 'v1', 'parts'), { recursive: true });
+  mkdirSync(join(outDir, 'v1', 'catalog'), { recursive: true });
+
+  for (const r of fresh) {
+    copyFileSync(join(fromDir, 'step', `${r.id}.step`), join(outDir, 'step', `${r.id}.step`));
+    copyFileSync(join(fromDir, 'v1', 'parts', `${r.id}.json`), join(outDir, 'v1', 'parts', `${r.id}.json`));
+  }
+
+  const indexPath = join(outDir, 'v1', 'catalog', 'parts.index.json');
+  const freshIds = new Set(fresh.map((r) => r.id));
+  let existing: CatalogRecord[] = [];
+  if (existsSync(indexPath)) {
+    try {
+      existing = (JSON.parse(readFileSync(indexPath, 'utf8')) as { items?: CatalogRecord[] }).items ?? [];
+    } catch {
+      existing = [];
+    }
+  }
+  const merged = [...existing.filter((r) => !freshIds.has(r.id)), ...fresh];
+  writeFileSync(indexPath, JSON.stringify({ catalog: { partCount: merged.length }, items: merged }, null, 2));
+
+  const shaPath = join(outDir, 'sha256-manifest.json');
+  let sha: Record<string, string> = {};
+  if (existsSync(shaPath)) {
+    try {
+      sha = JSON.parse(readFileSync(shaPath, 'utf8')) as Record<string, string>;
+    } catch {
+      sha = {};
+    }
+  }
+  for (const r of fresh) sha[r.id] = r.sha256;
+  writeFileSync(shaPath, JSON.stringify(sha, null, 2));
+
+  // Serving shim: copy if the target doesn't already have one.
+  const worker = join(outDir, '_worker.js');
+  if (!existsSync(worker) && existsSync(join(fromDir, '_worker.js'))) {
+    copyFileSync(join(fromDir, '_worker.js'), worker);
+  }
+  console.log(`merged ${fresh.length} records into ${outDir} (catalog now ${merged.length} parts)`);
+}
+
+const invokedDirectly =
+  Array.isArray(process.argv) &&
+  process.argv[1] !== undefined &&
+  /ingestElectronics\.(ts|js)$/.test(process.argv[1]);
+
+if (invokedDirectly) {
+  const { outDir, manifest, baseUrl } = parseArgs(process.argv.slice(2));
+  if (!outDir) {
+    console.error('usage: ingestElectronics <outDir> [--manifest PATH] [--base-url URL]');
+    process.exit(1);
+  }
+  ingestElectronics(manifest, outDir, baseUrl)
+    .then((records) => {
+      console.log(`ingested ${records.length} electronics parts -> ${outDir}`);
+      for (const r of records) {
+        const a = r.attributes;
+        console.log(`  ${r.id}  ${a.bboxXmm}x${a.bboxYmm}x${a.bboxZmm}mm  (${r.byteSize}b)`);
+      }
+    })
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
+    });
+}

--- a/scripts/ingestElectronics.ts
+++ b/scripts/ingestElectronics.ts
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/ingestElectronics.ts
+//
 // Ingest the electronics parts (chips, modules, IC packages) declared in
 // scripts/electronics-parts.json into the kernelCAD parts catalog. Mirrors the
 // FreeCAD-library ingest, but the source models are fetched at run time from a


### PR DESCRIPTION
## What

The kernelCAD parts catalog was **mechanical-only** (fasteners, bearings). LabWired supports ~17 chips + peripherals but none carried a 3D model — so a generated design could only ever be a box. This adds an **Electronics** category sourced from real, CC-licensed 3D models.

## How

- **`scripts/electronics-parts.json`** — declarative manifest: stable catalog id → CC-licensed model URL (KiCad packages3D, CC-BY-SA 4.0 w/ library exception) + MPN/family/tags. The chip fleet dedupes to a handful of shared IC packages (LQFP-48/64/100, QFN-56) plus the ESP32 WROOM modules, so ~10 STEPs cover everything. Models are **fetched at ingest time, not committed**. Parts with no faithful off-the-shelf model are **omitted, not faked**.
- **`scripts/ingestElectronics.ts`** — fetches each model, writes meta sidecars, runs the existing `ingestDirectory` (measured bbox, synthesized connectors), and **merges** into the catalog so the 2419 mechanical parts are never clobbered.
- **`parts-catalog.yml`** — runs the electronics ingest after the FreeCAD ingest, before deploy.

## Verified locally

7/7 ingest with **datasheet-correct measured bboxes** (WROOM-32 18×25.5×3.1mm, LQFP-64 12×12×1.5mm, QFN-56 7×7×0.9mm); merge preserves a pre-existing catalog (2 + 7 = 9, no clobber). Records carry `stepUrl`, `sha256`, `license`, `mpn`, and connectors.

## Next (separate)

Bind each LabWired chip/peripheral config to its catalog id (`catalog_ref`), add a coverage gate (no designable part without a real model), and have enclosure/assembly generation place `fetch_part` geometry instead of boxes. e-paper panels + LiPo need non-KiCad model sources.