### PR TITLE
Electronics catalog: add 2.9" tri-color e-paper + LiPo pouch (Adafruit, MIT)

### DIFF
--- a/scripts/electronics-parts.json
+++ b/scripts/electronics-parts.json
@@ -67,6 +67,26 @@
       "mpn": "QFN-56",
       "model": "Package_DFN_QFN.3dshapes/QFN-56-1EP_7x7mm_P0.4mm_EP3.2x3.2mm.step",
       "tags": ["ic", "package", "qfn", "rp2040", "esp32s3"]
+    },
+    {
+      "id": "epaper-29-tricolor",
+      "name": "2.9\" tri-color e-paper panel",
+      "family": "Display",
+      "mpn": "Adafruit 4086",
+      "url": "https://raw.githubusercontent.com/adafruit/Adafruit_CAD_Parts/main/4086%20TriColor%20ePaper%20Display/4086-tricolor-epaper-display.step",
+      "tags": ["display", "epaper", "eink", "tricolor", "2.9inch"],
+      "license": "MIT",
+      "attribution": "Adafruit_CAD_Parts (github.com/adafruit/Adafruit_CAD_Parts), MIT"
+    },
+    {
+      "id": "lipo-1200mah-pouch",
+      "name": "LiPo pouch cell (~1200mAh, 53x37x5mm)",
+      "family": "Battery",
+      "mpn": "Adafruit 258",
+      "url": "https://raw.githubusercontent.com/adafruit/Adafruit_CAD_Parts/main/258%201200mAh%20lipo/258%201200mAh%20lipo.step",
+      "tags": ["battery", "lipo", "pouch", "power"],
+      "license": "MIT",
+      "attribution": "Adafruit_CAD_Parts (github.com/adafruit/Adafruit_CAD_Parts), MIT"
     }
   ]
 }

--- a/scripts/ingestElectronics.ts
+++ b/scripts/ingestElectronics.ts
@@ -29,8 +29,16 @@ interface ManifestPart {
   name: string;
   family: string;
   mpn: string;
-  model: string;
+  /** Path appended to the manifest baseModelUrl. Ignored if `url` is set. */
+  model?: string;
+  /** Full model URL (overrides baseModelUrl + model) — for parts from a
+   *  different CC-licensed source than the default catalog base. */
+  url?: string;
   tags?: string[];
+  /** Per-part license / attribution override (e.g. an MIT Adafruit STEP in an
+   *  otherwise CC-BY-SA KiCad manifest). Falls back to the manifest defaults. */
+  license?: string;
+  attribution?: string;
 }
 interface Manifest {
   baseModelUrl: string;
@@ -67,7 +75,8 @@ export async function ingestElectronics(
 
   let ok = 0;
   for (const part of manifest.parts) {
-    const url = `${manifest.baseModelUrl.replace(/\/$/, '')}/${part.model}`;
+    // Full per-part URL wins (different CC source); else baseModelUrl + model.
+    const url = part.url ?? `${manifest.baseModelUrl.replace(/\/$/, '')}/${part.model}`;
     const res = await fetch(url);
     if (!res.ok) {
       console.warn(`SKIP ${part.id}: fetch ${url} -> HTTP ${res.status}`);
@@ -90,8 +99,8 @@ export async function ingestElectronics(
           family: part.family,
           tags: part.tags ?? ['electronics', part.family],
           attributes: { mpn: part.mpn },
-          license: manifest.license,
-          attribution: manifest.attribution,
+          license: part.license ?? manifest.license,
+          attribution: part.attribution ?? manifest.attribution,
         },
         null,
         2,


### PR DESCRIPTION
Closes the two peripheral gaps with real, close-match CC-licensed models from **Adafruit_CAD_Parts (MIT)**: `epaper-29-tricolor` (Adafruit 4086, 2.9" tri-color e-paper) and `lipo-1200mah-pouch` (Adafruit 258, ~53×37×5mm — nearest pouch to a 503450 cell). `ingestElectronics` now supports a per-part full `url` + per-part `license`/`attribution` so an MIT Adafruit STEP sits alongside the CC-BY-SA KiCad packages. Verified: all 10 electronics ingest with measured bboxes.