### PR TITLE
fix(ci): stop setup-cad hanging on apt mirror flake (flaky test-gate timeouts)

### DIFF
--- a/.github/actions/setup-cad/action.yml
+++ b/.github/actions/setup-cad/action.yml
@@ -5,8 +5,9 @@
 # not here — keep this composite tight.
 #
 # Steps:
-#   1. Install ffmpeg (needed by gallery video tests: blackFrameCheck,
-#      extractPoster, build-gallery).
+#   1. Ensure ffmpeg (needed by gallery video tests: blackFrameCheck,
+#      extractPoster, build-gallery). Preinstalled on the runner image, so the
+#      common path is a no-op; apt fallback is bounded + retried.
 #   2. setup-node (with built-in npm cache for ~/.npm).
 #   3. Cache node_modules keyed on package-lock.json hash → skips npm ci on hit.
 #   4. Cache .tsbuildinfo + node_modules/.cache + node_modules/.vite keyed on
@@ -19,12 +20,31 @@ description: Shared setup steps (node, caches, install) for parallel CI jobs.
 runs:
   using: composite
   steps:
-    - name: Install ffmpeg
+    - name: Ensure ffmpeg
       shell: bash
       run: |
-        sudo apt-get update -qq
-        sudo apt-get install -y -qq ffmpeg
-        ffmpeg -version | head -1
+        # ffmpeg is preinstalled on GitHub's ubuntu-latest runner images, so the
+        # common path touches no network at all. We only fall back to apt when it
+        # is genuinely missing — and even then every apt call is bounded by
+        # `timeout` and retried, so a hung/unreachable mirror can never consume
+        # the whole job. (The previous unbounded `apt-get update` regularly hung
+        # for the full 10-min timeout and cancelled shards → flaky `test` gate.)
+        if command -v ffmpeg >/dev/null 2>&1; then
+          echo "ffmpeg already present: $(ffmpeg -version | head -1)"
+          exit 0
+        fi
+        echo "ffmpeg not found — installing via apt (bounded + retried)"
+        for attempt in 1 2 3; do
+          if sudo timeout 120 apt-get update -qq \
+             && sudo timeout 180 apt-get install -y -qq ffmpeg; then
+            ffmpeg -version | head -1
+            exit 0
+          fi
+          echo "apt attempt ${attempt} failed (mirror flake/timeout); retrying in 5s…"
+          sleep 5
+        done
+        echo "::error::ffmpeg install failed after 3 bounded attempts"
+        exit 1
 
     - name: Setup Node
       uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,11 @@ jobs:
   # green only when ALL shards pass.
   test-shard:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # 15 (not 10) gives headroom for the shard that draws the heavy physics
+    # example-sweep tests (a single example can run ~6 min) so a legitimately
+    # slow run is never cancelled mid-test. Setup itself is now near-instant
+    # (ffmpeg preinstalled; apt fallback bounded) so this is pure test headroom.
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

The required `test` gate was flaking: shards got **CANCELLED** at the 10-minute job timeout. Step-timing on a cancelled shard showed the entire 606s was spent in the **first** setup-cad step — `sudo apt-get update -qq && apt-get install ffmpeg` — with zero apt output, i.e. it **hung on an unreachable apt mirror**. vitest never ran. Because `setup-cad` is the first step of *every* CI job (lint, build-and-checks, all 12 shards, e2e), any apt-mirror flake cancelled a shard and failed the merge gate.

## Fix

- **ffmpeg is preinstalled on GitHub's ubuntu-latest runners**, so `setup-cad` now **skips apt entirely when ffmpeg is present** (the normal case — no network touched).
- If ffmpeg is ever genuinely missing, the apt fallback bounds every call with `timeout` (120s/180s) and **retries 3×**, so a hung mirror can never consume the job.
- **`test-shard` timeout 10 → 15 min** for headroom on the shard that draws the heavy physics example-sweep tests (~6 min for one example), independent of the apt fix.

## Verification

- YAML parses; embedded bash passes `bash -n`; the skip-if-present path verified locally (detects ffmpeg, no apt call).
- This PR's own CI exercises the new `setup-cad` (local composite action resolves from the PR checkout), so green CI here = the fix works in situ.