### PR TITLE
fix(ci): install ffmpeg from GitHub CDN, not the apt mirror

### DIFF
--- a/.github/actions/setup-cad/action.yml
+++ b/.github/actions/setup-cad/action.yml
@@ -6,8 +6,11 @@
 #
 # Steps:
 #   1. Ensure ffmpeg (needed by gallery video tests: blackFrameCheck,
-#      extractPoster, build-gallery). Preinstalled on the runner image, so the
-#      common path is a no-op; apt fallback is bounded + retried.
+#      extractPoster, build-gallery). Uses a static build fetched from GitHub's
+#      release CDN — NOT apt — because ubuntu-24.04 runners don't ship ffmpeg
+#      and the Ubuntu apt mirror is unreliable from CI (it hung/failed for the
+#      full job timeout, flaking the `test` gate). Skip-if-present, retried,
+#      non-fatal.
 #   2. setup-node (with built-in npm cache for ~/.npm).
 #   3. Cache node_modules keyed on package-lock.json hash → skips npm ci on hit.
 #   4. Cache .tsbuildinfo + node_modules/.cache + node_modules/.vite keyed on
@@ -23,28 +26,38 @@ runs:
     - name: Ensure ffmpeg
       shell: bash
       run: |
-        # ffmpeg is preinstalled on GitHub's ubuntu-latest runner images, so the
-        # common path touches no network at all. We only fall back to apt when it
-        # is genuinely missing — and even then every apt call is bounded by
-        # `timeout` and retried, so a hung/unreachable mirror can never consume
-        # the whole job. (The previous unbounded `apt-get update` regularly hung
-        # for the full 10-min timeout and cancelled shards → flaky `test` gate.)
+        set -uo pipefail
+        # Why not apt? ubuntu-24.04 runners (current `ubuntu-latest`) don't ship
+        # ffmpeg, and the Ubuntu apt mirror is unreachable from CI — `apt-get
+        # update` hung for the full 10-min job timeout and cancelled shards,
+        # flaking the required `test` gate. The runner DOES reach GitHub's CDN
+        # (checkout/setup-node/cache all succeed there), so we fetch a static
+        # ffmpeg build from a GitHub release instead. No apt mirror dependency.
         if command -v ffmpeg >/dev/null 2>&1; then
           echo "ffmpeg already present: $(ffmpeg -version | head -1)"
           exit 0
         fi
-        echo "ffmpeg not found — installing via apt (bounded + retried)"
+        echo "ffmpeg not on runner image — fetching static build from GitHub CDN"
+        url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz"
+        work="$(mktemp -d)"
         for attempt in 1 2 3; do
-          if sudo timeout 120 apt-get update -qq \
-             && sudo timeout 180 apt-get install -y -qq ffmpeg; then
-            ffmpeg -version | head -1
-            exit 0
+          if curl -fsSL --retry 3 --retry-delay 3 --max-time 180 "$url" -o "$work/ffmpeg.tar.xz" \
+             && tar -xJf "$work/ffmpeg.tar.xz" -C "$work"; then
+            bindir="$(dirname "$(find "$work" -type f -name ffmpeg | head -1)")"
+            if [ -x "$bindir/ffmpeg" ] \
+               && sudo install -m755 "$bindir/ffmpeg" "$bindir/ffprobe" /usr/local/bin/; then
+              ffmpeg -version | head -1
+              exit 0
+            fi
           fi
-          echo "apt attempt ${attempt} failed (mirror flake/timeout); retrying in 5s…"
+          echo "ffmpeg fetch attempt ${attempt} failed; retrying in 5s…"
           sleep 5
         done
-        echo "::error::ffmpeg install failed after 3 bounded attempts"
-        exit 1
+        # Non-fatal: most shards don't use ffmpeg, so a fetch failure must not
+        # cancel them. The few gallery-video tests that need it will fail with a
+        # clear per-test error if it's truly absent — a real signal, not infra.
+        echo "::warning::could not install ffmpeg; gallery-video tests needing it may fail, other tests proceed"
+        exit 0
 
     - name: Setup Node
       uses: actions/setup-node@v4


### PR DESCRIPTION
## Why (follow-up to #507)

#507 bounded the apt calls so setup-cad could no longer *hang* for the full 10-min timeout. But CI logs from the next run revealed the real problem:

- **ubuntu-24.04 (current `ubuntu-latest`) does not ship ffmpeg** — `command -v ffmpeg` returns nothing, so the apt path is always taken.
- **The Ubuntu apt mirror is unreachable from these runners** — all 3 bounded `apt-get update`/`install` attempts failed (~3 min each), so the shard still failed (cleanly now, but failed).

The runner *does* have working internet: checkout, setup-node and actions/cache all download from GitHub/Azure CDNs successfully. Only `azure.archive.ubuntu.com` is unreachable.

## Fix

Fetch a **static ffmpeg build from a GitHub release** (BtbN/FFmpeg-Builds) instead of apt:
- **skip-if-present** (no-op when ffmpeg already on PATH),
- **3× retry** with `curl --retry` + bounded `--max-time`,
- **non-fatal**: most shards don't use ffmpeg, so a fetch miss logs a warning and proceeds; the few gallery-video tests that need it fail with a clear per-test error only if it's genuinely absent.

No apt-mirror dependency remains.

## Verification

- YAML parses; embedded bash passes `bash -n`; skip-if-present path verified locally.
- Download + extract + `ffmpeg -version` verified locally against the GitHub release URL (302 → GitHub release-assets CDN, the same infra checkout/cache use).
- This PR's own CI exercises the new setup-cad, so green here = rock-stable in situ.