### PR TITLE
chore(ci): merge-queue support, npm ci retry, login-based DCO exemption

### DIFF
--- a/.github/actions/setup-cad/action.yml
+++ b/.github/actions/setup-cad/action.yml
@@ -86,4 +86,14 @@ runs:
     - name: Install dependencies (only if node_modules cache missed)
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
       shell: bash
-      run: npm ci
+      run: |
+        # Retry: npm ci hits the registry and is the other place (besides
+        # ffmpeg) a transient registry/CDN blip could fail a shard. Bounded
+        # retries keep a one-off network hiccup from flaking the gate.
+        for attempt in 1 2 3; do
+          if npm ci --no-audit --no-fund; then exit 0; fi
+          echo "npm ci attempt ${attempt} failed; retrying in 10s…"
+          sleep 10
+        done
+        echo "::error::npm ci failed after 3 attempts"
+        exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,18 @@ on:
       - 'doc/**'
       - 'archive/**'
   workflow_dispatch:
+  # Required so the branch-protection merge queue gets its checks: the queue
+  # tests a speculative merge on a temporary `merge_group` ref and waits for the
+  # same required checks (lint / build-and-checks / test) to report there.
+  merge_group:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.ref }}
+  # Keyed per-PR (a new push cancels the prior run) but per-run for merge_group
+  # so queued entries never cancel one another.
+  group: ci-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 # Three independent QC jobs run in parallel; e2e (master-only) gates on all

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -13,11 +13,22 @@ jobs:
         with:
           fetch-depth: 0
       - name: Verify external commits are signed off
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # DCO sign-off is required from EXTERNAL contributors only. Commits
-          # authored by maintainers are exempt (they accept the DCO implicitly).
-          # Add maintainer author emails here.
+          # DCO sign-off is required from EXTERNAL contributors only. Maintainer
+          # commits are exempt (they accept the DCO implicitly). A maintainer is
+          # recognised two ways so committing from a new machine doesn't flake
+          # the gate:
+          #   1. by author email (covers the canonical noreply / primary email), or
+          #   2. by GitHub login — resolved from the commit's GitHub author —
+          #      which covers any machine whose git email is associated with the
+          #      maintainer's GitHub account.
+          # (A commit authored with an email NOT associated with any GitHub
+          # account can't be attributed and still needs a Signed-off-by; set your
+          # git email to your @users.noreply.github.com address to avoid that.)
           MAINTAINER_EMAILS="14119286+w1ne@users.noreply.github.com andrii@shylenko.com"
+          MAINTAINER_LOGINS="w1ne"
           fail=0
           for c in $(git rev-list --no-merges ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}); do
             email=$(git show -s --format=%ae "$c")
@@ -25,9 +36,15 @@ jobs:
             for m in $MAINTAINER_EMAILS; do
               if [ "$email" = "$m" ]; then skip=1; break; fi
             done
+            if [ "$skip" = "0" ]; then
+              login=$(gh api "repos/${{ github.repository }}/commits/$c" --jq '.author.login // ""' 2>/dev/null || echo "")
+              for l in $MAINTAINER_LOGINS; do
+                if [ -n "$login" ] && [ "$login" = "$l" ]; then skip=1; break; fi
+              done
+            fi
             if [ "$skip" = "1" ]; then continue; fi
             if ! git show -s --format=%B "$c" | grep -q '^Signed-off-by: '; then
-              echo "::error::Commit $c by external contributor $email is missing a Signed-off-by line (see CONTRIBUTING.md)"
+              echo "::error::Commit $c by external contributor $email is missing a Signed-off-by line (see CONTRIBUTING.md). Maintainers: set your git email to a GitHub-associated address (e.g. your @users.noreply.github.com) or add a Signed-off-by trailer."
               fail=1
             fi
           done


### PR DESCRIPTION
Infrastructure hardening surfaced while merging the recent PR backlog. Three independent CI robustness fixes:

## 1. Merge-queue support (removes the serial-merge bottleneck)
`develop` requires branches be up-to-date (strict), so with multiple open PRs only **one can merge per full CI cycle** — each merge re-stales the rest. Adds the `merge_group` trigger so a GitHub **merge queue** can be enabled: the queue tests a speculative merge on a temporary ref and waits for the same required checks (`lint`/`build-and-checks`/`test`). Concurrency group reworked so queued entries don't cancel each other.
**Follow-up (admin):** after this merges, enable *Settings → Branches → develop → Require merge queue*. The workflow side (this PR) must land first or queued entries would have no checks.

## 2. `npm ci` retry
The cache-miss `npm ci` is the other network call (besides ffmpeg, fixed in #508) that a transient registry/CDN blip could fail. Wrapped in a bounded 3× retry.

## 3. DCO login-based exemption
The `Check sign-offs` gate exempted maintainers by a hardcoded **email** list, so committing from a machine with a different git email failed (hit during #431). Now also exempts by **GitHub login** (resolved from the commit's GitHub author), covering any machine whose git email is associated with the account, with a clearer error otherwise.

## Verification
All three YAML files parse; edited bash blocks pass `bash -n`. This PR's own CI exercises the new setup-cad npm-ci retry path.