### PR TITLE
chore: add dependency-free pre-commit hooks (SPDX + cookbook drift)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+#
+# Dependency-free pre-commit hook. Catches — locally, before push — the two
+# "forgot to regenerate the derived artifact" failures that have wasted CI:
+#   (a) missing SPDX headers on new/edited TS source under src/, and
+#   (b) stale cookbook artifacts (src/agent/skills/.../SKILL.md) when their
+#       cookbook source (src/agent/cookbook/**) is part of the commit.
+#
+# Design goals:
+#   - FAST: only acts on what is staged; cookbook:build runs ONLY when a
+#     cookbook source file is staged (never on every commit).
+#   - NON-BLOCKING: if node/scripts are missing (partial checkout) it warns and
+#     exits 0 rather than blocking commits.
+#   - SKIPPABLE: `git commit --no-verify` bypasses it via git's own mechanism.
+#
+# Wired up via core.hooksPath (set by the `prepare` npm script). No husky / no
+# dependencies.
+set -euo pipefail
+
+# Resolve to the repo root so relative script/path checks are stable regardless
+# of the directory the commit was invoked from.
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "${repo_root}" ]; then
+  exit 0
+fi
+cd "${repo_root}"
+
+# Partial checkout / missing toolchain: warn and let the commit through.
+if ! command -v node >/dev/null 2>&1; then
+  echo "pre-commit: node not found; skipping SPDX/cookbook checks." >&2
+  exit 0
+fi
+
+# Staged added/copied/modified files (renames/deletes excluded by --diff-filter).
+mapfile -t staged < <(git diff --cached --name-only --diff-filter=ACM)
+if [ "${#staged[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# (a) SPDX headers on staged TS source under src/.
+# ---------------------------------------------------------------------------
+ts_staged=()
+for f in "${staged[@]}"; do
+  case "${f}" in
+    src/*.ts | src/*.tsx) ts_staged+=("${f}") ;;
+  esac
+done
+
+if [ "${#ts_staged[@]}" -gt 0 ]; then
+  if [ ! -f scripts/addSpdxHeaders.mjs ]; then
+    echo "pre-commit: scripts/addSpdxHeaders.mjs missing; skipping SPDX check." >&2
+  else
+    # The script rewrites all tracked src/scripts/eval *.ts in place and is
+    # idempotent. Run it, then re-stage only the staged files it touched so we
+    # never silently add unrelated working-tree changes to the commit.
+    node scripts/addSpdxHeaders.mjs >/dev/null
+    spdx_fixed=()
+    for f in "${ts_staged[@]}"; do
+      if ! git diff --quiet -- "${f}"; then
+        git add -- "${f}"
+        spdx_fixed+=("${f}")
+      fi
+    done
+    if [ "${#spdx_fixed[@]}" -gt 0 ]; then
+      echo "pre-commit: inserted missing SPDX header(s) and re-staged:" >&2
+      for f in "${spdx_fixed[@]}"; do echo "  ${f}" >&2; done
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# (b) Cookbook drift — only when a cookbook source file is staged.
+# ---------------------------------------------------------------------------
+cookbook_touched=0
+for f in "${staged[@]}"; do
+  case "${f}" in
+    src/agent/cookbook/*) cookbook_touched=1; break ;;
+  esac
+done
+
+if [ "${cookbook_touched}" -eq 1 ]; then
+  skill_md="src/agent/skills/kernelcad-authoring/SKILL.md"
+  if ! npm run --silent cookbook:build >/dev/null 2>&1; then
+    echo "pre-commit: cookbook:build unavailable; skipping cookbook drift check." >&2
+  elif [ -f "${skill_md}" ] && ! git diff --quiet -- "${skill_md}"; then
+    git add -- "${skill_md}"
+    echo "pre-commit: regenerated stale cookbook artifact and re-staged:" >&2
+    echo "  ${skill_md}" >&2
+  fi
+fi
+
+exit 0

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "preview": "vite preview",
     "release": "npx tsx scripts/release.ts",
     "prepack": "npm run build:cli && npm run build:studio && npm run build:player",
-    "prepare": "npm run build:studio",
+    "prepare": "git config core.hooksPath .githooks || true; npm run build:studio",
     "generate:parts": "npx tsx scripts/generateSeedCatalog.ts assets/parts",
     "prepublishOnly": "npm run generate:parts",
     "pretest": "npm run generate:parts",


### PR DESCRIPTION
## What

Adds a lightweight, **dependency-free** git pre-commit hook that catches — locally, before push — the two "forgot to regenerate the derived artifact" failures that have repeatedly wasted CI on PRs:

- **(a) Missing SPDX headers** on new/edited TS source under `src/`.
- **(b) Stale cookbook artifacts** (`src/agent/skills/kernelcad-authoring/SKILL.md`) when their cookbook source (`src/agent/cookbook/**`) is part of the commit.

## How it works

- **No dependencies / no husky.** Wired via git's native `core.hooksPath`, pointed at the committed `.githooks/` dir by the `prepare` npm script (`git config core.hooksPath .githooks || true; npm run build:studio`). `npm ci` / `npm install` sets it up automatically; the `|| true` keeps CI/non-git checkouts from failing, and it composes with the existing `build:studio` prepare step.
- **Fast & staged-scoped.** It only inspects `git diff --cached --name-only --diff-filter=ACM`:
  - SPDX: runs `node scripts/addSpdxHeaders.mjs` only when staged `src/**/*.ts(x)` exist, then re-stages **only** the staged files it actually touched (never sweeps unrelated working-tree changes). Idempotent — quiet when nothing changes.
  - Cookbook: runs `npm run cookbook:build` **only** when a `src/agent/cookbook/**` file is staged, then re-stages the regenerated `SKILL.md`. It never runs on commits that don't touch cookbook source.
- **Skippable.** `git commit --no-verify` bypasses it via git's standard mechanism.
- **Robust on partial checkouts.** If `node` or the scripts are missing, it warns and exits 0 rather than blocking commits.

## Behavior choice (auto-fix vs fail-fast)

The hook **auto-fixes and re-stages** rather than failing, because both fixers are deterministic regenerators (insert canonical header / regenerate a `<!-- COOKBOOK -->` block) — fixing in place is faster and less surprising than aborting the commit and asking the dev to re-run a command by hand. Notices are printed to stderr so the dev sees what was added.

## Verification

- `bash -n .githooks/pre-commit` — syntax OK.
- Functional test: created a header-less `src/studio/__hooktest__.ts`, staged it, ran the hook directly → it inserted the two-line SPDX header and re-staged the file (working tree matched index afterward). Temp file removed, not committed.
- `core.hooksPath` resolves to `.githooks` after the prepare wiring runs.