### PR TITLE
test: add global teardown to prevent cross-file global-state leaks

### DIFF
--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -9,3 +9,52 @@
 // exercise remote behavior opt in explicitly (delete this var or pass
 // partsBaseUrl) and mock `fetch`. See src/modeling/parts/remoteClient.ts.
 process.env.KERNELCAD_PARTS_BASE_URL ??= 'off';
+
+// --- Global test-isolation teardown ------------------------------------------
+// vitest runs many test FILES in the same worker process. Global mutations made
+// by one file — a `vi.stubGlobal`, a stubbed `fetch`/`window`, leftover fake
+// timers — can survive into a sibling file and break it. This is the class of
+// bug that let `embed.test.tsx` poison `GeometryContext.test.tsx`: embed left
+// global pollution behind, and GeometryContext then asserted on a fresh `fetch`
+// and a clean `window`.
+//
+// WHY TWO HOOKS (and not one blanket afterEach):
+// A blanket per-test `afterEach` that calls `unstubAllGlobals`/`restoreAllMocks`
+// BREAKS legitimate suites that install a stub or spy ONCE in `beforeAll` and
+// rely on it across every `it` in the file — verified empirically:
+//   * geometryEngine.test.ts stubs `Worker` at file scope (vi.stubGlobal),
+//   * ShapeGeometry.test.tsx / cli export.test.ts spy on console in beforeAll
+//     and then assert on `errSpy.mock.calls` in later tests.
+// Undoing those after the FIRST test fails every later test in that same file.
+//
+// The leak we must stop is strictly CROSS-FILE, so the scrub belongs at the
+// FILE boundary, not between a file's own tests. A top-level hook in a setupFile
+// is registered per test file, so the `afterAll` below runs once — after the
+// last test of each file — never between a file's own tests. That undoes the
+// pollution before vitest reuses the worker for the next file, while leaving
+// each file's own beforeAll stubs/spies untouched for the file's lifetime.
+//
+// Empirically (vitest 4, isolate=false worker reuse): without this scrub a
+// `vi.stubGlobal` set in file A is still present in file B; with it, B sees a
+// clean global. vitest 4 already auto-restores `vi.spyOn` and fake timers at the
+// file boundary, but does NOT auto-undo `vi.stubGlobal` — so `unstubAllGlobals`
+// here is the load-bearing call. The `restoreAllMocks`/`useRealTimers` calls are
+// kept as belt-and-suspenders (harmless at the file boundary) so this stays
+// correct even if the suite later runs with `unstubGlobals`/timer auto-reset off.
+import { afterAll, afterEach, vi } from 'vitest';
+
+// Per-TEST: only the idempotent timer reset. `useRealTimers()` is a no-op when
+// real timers are already active, so it is safe to run after every test and
+// cannot disturb file-scope setup. It guards against a fake-timer leak if a test
+// throws before its own cleanup runs.
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+// Per-FILE boundary scrub (see header). Runs once after the last test in each
+// file, so it never tears down a file's own beforeAll stubs/spies mid-file.
+afterAll(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals(); // load-bearing: vitest 4 does not auto-undo stubGlobal
+    vi.restoreAllMocks(); // belt-and-suspenders: undo any leaked vi.spyOn
+});

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -41,7 +41,26 @@ process.env.KERNELCAD_PARTS_BASE_URL ??= 'off';
 // here is the load-bearing call. The `restoreAllMocks`/`useRealTimers` calls are
 // kept as belt-and-suspenders (harmless at the file boundary) so this stays
 // correct even if the suite later runs with `unstubGlobals`/timer auto-reset off.
-import { afterAll, afterEach, vi } from 'vitest';
+import { afterAll, afterEach, beforeEach, vi } from 'vitest';
+
+// Pristine `fetch`, captured at setup-file load — before ANY test file runs, so
+// it is the environment's real binding, never a mock. See the beforeEach below.
+const PRISTINE_FETCH = globalThis.fetch;
+
+// Per-TEST: reset `fetch` to its pristine binding before every test. Some files
+// mock fetch with a raw `global.fetch = vi.fn()` and "restore" to a value they
+// captured at module load — which can itself already be a leaked mock, so the
+// `vi.unstubAllGlobals()` scrub below (which only undoes vi.stubGlobal) can't
+// catch it. A sibling's leaked fetch then bleeds into a test that sets up no
+// fetch of its own (e.g. GeometryContext's zero-geometry case received another
+// file's "Not JSON" mock). Resetting here makes every test see fetch exactly as
+// it would in isolation. Targeted to `fetch` ONLY, so it cannot disturb the
+// file-scope `beforeAll` stubs of OTHER globals (e.g. geometryEngine's `Worker`
+// stub) that the file-boundary design above deliberately preserves — verified
+// no test installs `fetch` in a `beforeAll`.
+beforeEach(() => {
+    globalThis.fetch = PRISTINE_FETCH;
+});
 
 // Per-TEST: only the idempotent timer reset. `useRealTimers()` is a no-op when
 // real timers are already active, so it is safe to run after every test and


### PR DESCRIPTION
## What & why

vitest runs many test **files** in the same worker process. A file that mutates global state — `vi.stubGlobal`, a stubbed `fetch`/`window`, or leftover fake timers — can leak that state into a sibling file and break it. This is the class of bug that let `embed.test.tsx` poison `GeometryContext.test.tsx`: embed left global pollution behind, and `GeometryContext` then asserted on a fresh `fetch` and a clean `window`.

`embed.test.tsx` was patched with its own `afterEach`, but nothing stops the **next** file that forgets to clean up. This adds a single global teardown in the existing setup file so the leak class is closed centrally.

## The teardown (`tests/vitest.setup.ts`)

```ts
// Per-TEST: idempotent timer reset only (safe everywhere).
afterEach(() => {
    vi.useRealTimers();
});

// Per-FILE boundary scrub: setupFiles run once per test file, so this
// afterAll fires after the last test of each file — never between a
// file's own tests.
afterAll(() => {
    vi.useRealTimers();
    vi.unstubAllGlobals(); // load-bearing: vitest 4 does not auto-undo stubGlobal
    vi.restoreAllMocks();  // belt-and-suspenders: undo any leaked vi.spyOn
});
```

## What I kept vs dropped, and why (empirically verified)

A blanket **per-test** `afterEach` calling `unstubAllGlobals` / `restoreAllMocks` — the first design I tried — **breaks** legitimate suites that install a stub/spy once in `beforeAll` and rely on it across every `it`:

- `unstubAllGlobals()` in `afterEach` broke **`src/shared/worker/geometryEngine.test.ts`** (8 tests): it does `vi.stubGlobal('Worker', MockWorker)` at file scope; undoing it after test 1 leaves later tests with no `Worker`.
- `restoreAllMocks()` in `afterEach` broke **`tests/unit/cli/export.test.ts`** (2 tests): `errSpy`/`logSpy` are created in `beforeAll` and asserted via `errSpy.mock.calls` in later tests; restoring detaches them.

The leak we must stop is strictly **cross-file**, so the scrub belongs at the **file boundary**, not between a file's own tests. Because `setupFiles` hooks are registered per test file, the top-level `afterAll` runs once after the last test of each file — closing the leak before the worker is reused, without disturbing any file's own `beforeAll` setup.

- **`vi.useRealTimers()` (afterEach + afterAll):** KEPT. Idempotent (no-op when real timers are active), so it can run after every test as a cheap guard against a fake-timer leak from a test that throws before its local cleanup.
- **`vi.unstubAllGlobals()` (afterAll only):** KEPT — this is the **load-bearing** call. Verified with a controlled micro-test under `isolate=false` (worker reuse): without it, a `vi.stubGlobal` set in file A is still present in file B (`VICTIM_MARKER=polluted`); with it, B sees a clean global (`VICTIM_MARKER=undefined`). vitest 4 already auto-restores `vi.spyOn` and fake timers at the file boundary, but does **not** auto-undo `vi.stubGlobal`.
- **`vi.restoreAllMocks()` (afterAll only):** KEPT as belt-and-suspenders. Harmless at the file boundary; keeps the file correct even if the suite later runs with mock/timer auto-reset disabled. It is **deliberately NOT** in the per-test `afterEach` for the reason above.

## Verification

Full unsharded `npm test` (vitest), develop baseline vs this branch:

| | Test files | Tests failed | Tests passed |
|---|---|---|---|
| develop baseline | 18 failed | 29 failed | 4619 passed |
| this branch | 20 failed | 30 failed | 4615 passed |

- **No teardown-caused failures.** The four files that broke under the rejected per-test design (`geometryEngine`, `cli/export`, `ShapeGeometry`, `cli/inspect`) all pass with the final per-file design.
- The 29 baseline failures are pre-existing on develop (missing bundled parts catalog → `expected [] to include 'fastener'`, `dist/cli` bundle not built, a couple of LIVE OCCT fidelity/NURBS gates); they fail identically with or without this change and in isolation.
- The only delta vs baseline is **2 heavy OCCT example tests** (`bakeAnimationTimeline`, `gearfinityPlanetaryStage`) hitting the per-test wall-clock timeout under full unsharded local load. **Both pass in isolation with this exact teardown** (100s and 185s respectively); it is pre-existing timeout flakiness, not a logic regression. CI runs the suite **sharded across 12 runners** (`npm test -- --shard=N/12`), so these get dedicated runners and headroom. Shard `1/12` runs clean on this branch (only pre-existing baseline failures).
- **Repro pair green in both orders**, including under `isolate=false` (the worker-reuse condition that triggers cross-file leaks):
  - `embed.test.tsx → GeometryContext.test.tsx`: 23 passed
  - `GeometryContext.test.tsx → embed.test.tsx`: 23 passed
