### PR TITLE
Forward-port curated hosting-stability fixes to develop (un-strand them)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kernelcad",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kernelcad",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
@@ -19,7 +19,6 @@
         "@supabase/supabase-js": "^2.105.4",
         "@tanstack/react-router": "^1.170.2",
         "@tanstack/router-vite-plugin": "^1.167.3",
-        "@techstark/opencv-js": "^4.10.0-release.1",
         "@types/three": "^0.182.0",
         "acorn": "^8.15.0",
         "acorn-walk": "^8.3.4",
@@ -35,7 +34,7 @@
         "react-dom": "^19.2.0",
         "react-markdown": "^10.1.0",
         "replicad": "^0.23.1",
-        "replicad-opencascadejs": "github:w1ne/replicad-opencascadejs#kcad-v0.23.1",
+        "replicad-opencascadejs": "github:w1ne/replicad-opencascadejs#kcad-v0.23.2",
         "sharp": "^0.33.5",
         "shiki": "^1.29.2",
         "three": "^0.184.0",
@@ -2083,10 +2082,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
-    },
-    "node_modules/@techstark/opencv-js": {
-      "version": "4.10.0-release.1",
-      "license": "Apache-2.0"
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "@supabase/supabase-js": "^2.105.4",
     "@tanstack/react-router": "^1.170.2",
     "@tanstack/router-vite-plugin": "^1.167.3",
-    "@techstark/opencv-js": "^4.10.0-release.1",
     "@types/three": "^0.182.0",
     "acorn": "^8.15.0",
     "acorn-walk": "^8.3.4",

--- a/src/agent/mcp/toolRegistry.ts
+++ b/src/agent/mcp/toolRegistry.ts
@@ -50,6 +50,9 @@ export interface McpToolDefinition {
     type: 'object';
     properties: Record<string, unknown>;
     required?: string[];
+    /** Optional JSON Schema conditional blocks (if/then/else) for
+     *  required-by-discriminator fields. */
+    allOf?: unknown[];
   };
   /** MCP behavioral hints (readOnly/destructive/openWorld). Required for ChatGPT
    *  app-directory submission; merged from TOOL_ANNOTATIONS at build time. */
@@ -360,7 +363,11 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
             maxItems: 4,
           },
           continuity: {
-            description: "kind:'boundary' — continuity grade applied to every edge ('C0' | 'C1' | 'C2'), or an array of 4 grades (one per edge). Default 'C0'.",
+            description: "kind:'boundary' — continuity grade applied to every edge ('C0' | 'C1' | 'C2'), or an array of 4 grades (one per edge, bottom/right/top/left order). Default 'C0'.",
+            oneOf: [
+              { type: 'string', enum: ['C0', 'C1', 'C2'] },
+              { type: 'array', items: { type: 'string', enum: ['C0', 'C1', 'C2'] }, minItems: 4, maxItems: 4 },
+            ],
           },
           sampling: { type: 'integer', minimum: 1, description: "kind:'boundary' — OCCT NbPtsOnCur sampling parameter (default 15)." },
           binding_name: {
@@ -485,6 +492,10 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
           binding_name: { type: 'string', description: 'JS const name for the new Curve3D binding (default: _curve_<N>).' },
         },
         required: ['kind', 'code'],
+        allOf: [
+          { if: { properties: { kind: { const: 'nurbs' } } }, then: { required: ['controlPoints'] } },
+          { if: { properties: { kind: { const: 'hermite' } } }, then: { required: ['a', 'b'] } },
+        ],
       },
     },
     handler: input => addCurveTool(input as unknown as Parameters<typeof addCurveTool>[0]),
@@ -568,6 +579,11 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
           binding_name: { type: 'string', description: 'Reserved for future use; the segment injection mutates the chain anchor in place.' },
         },
         required: ['kind', 'code', 'chain_anchor'],
+        allOf: [
+          { if: { properties: { kind: { const: 'spline' } } }, then: { required: ['points'] } },
+          { if: { properties: { kind: { const: 'nurbs' } } }, then: { required: ['controlPoints'] } },
+          { if: { properties: { kind: { const: 'hermite' } } }, then: { required: ['a', 'b'] } },
+        ],
       },
     },
     handler: input => addPathSegmentTool(input as unknown as Parameters<typeof addPathSegmentTool>[0]),
@@ -748,11 +764,25 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
             angleDeg: { type: 'number', description: 'Optional; defaults to 360.' },
           }, required: ['count', 'axis'] },
           grid:      { type: 'object', description: 'Required when kind=grid.', properties: {
-            x: { type: 'object' }, y: { type: 'object' },
+            x: { type: 'object', description: 'First grid axis.', properties: {
+              count: { type: 'integer', minimum: 2 },
+              direction: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+              spacing: { type: 'number' },
+            }, required: ['count', 'direction', 'spacing'] },
+            y: { type: 'object', description: 'Second grid axis.', properties: {
+              count: { type: 'integer', minimum: 2 },
+              direction: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+              spacing: { type: 'number' },
+            }, required: ['count', 'direction', 'spacing'] },
           }, required: ['x', 'y'] },
           assign_to: { type: 'string', description: "Optional const-binding name; emits `const <assign_to> = <target>.patternX(...);`. Omit for statement form." },
         },
         required: ['code', 'target', 'kind'],
+        allOf: [
+          { if: { properties: { kind: { const: 'linear' } } }, then: { required: ['linear'] } },
+          { if: { properties: { kind: { const: 'circular' } } }, then: { required: ['circular'] } },
+          { if: { properties: { kind: { const: 'grid' } } }, then: { required: ['grid'] } },
+        ],
       },
     },
     handler: input => addPatternFeatureTool(input as unknown as Parameters<typeof addPatternFeatureTool>[0]),
@@ -966,12 +996,37 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
           entities: {
             type: 'array',
             description: 'Sketch entities to solve. Lines reference point ids; circles reference a center point id.',
-            items: { type: 'object' },
+            items: {
+              oneOf: [
+                { type: 'object', description: 'POINT — a 2D point.', properties: {
+                  id: { type: 'string' }, type: { type: 'string', enum: ['POINT'] },
+                  x: { type: 'number' }, y: { type: 'number' },
+                  fixed: { type: 'boolean', description: "If true, the solver won't move this point." },
+                }, required: ['id', 'type', 'x', 'y'] },
+                { type: 'object', description: 'LINE — references two point ids.', properties: {
+                  id: { type: 'string' }, type: { type: 'string', enum: ['LINE'] },
+                  p1: { type: 'string' }, p2: { type: 'string' },
+                }, required: ['id', 'type', 'p1', 'p2'] },
+                { type: 'object', description: 'CIRCLE — references a center point id.', properties: {
+                  id: { type: 'string' }, type: { type: 'string', enum: ['CIRCLE'] },
+                  center: { type: 'string' }, radius: { type: 'number' },
+                }, required: ['id', 'type', 'center', 'radius'] },
+              ],
+            },
           },
           constraints: {
             type: 'array',
             description: 'Constraints to apply to the entities.',
-            items: { type: 'object' },
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                type: { type: 'string', enum: ['COINCIDENT', 'DISTANCE', 'HORIZONTAL', 'VERTICAL', 'PARALLEL', 'PERPENDICULAR', 'EQUAL_LENGTH', 'TANGENT', 'RADIUS', 'ANGLE', 'CONCENTRIC', 'SYMMETRIC'] },
+                entities: { type: 'array', items: { type: 'string' }, description: 'Ids of the entities the constraint relates.' },
+                value: { type: 'number', description: 'Required for DISTANCE, RADIUS, and ANGLE.' },
+              },
+              required: ['id', 'type', 'entities'],
+            },
           },
         },
         required: ['entities', 'constraints'],
@@ -988,8 +1043,31 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
       inputSchema: {
         type: 'object',
         properties: {
-          constraints: { type: 'array', items: { type: 'object' } },
-          constraint: { type: 'object' },
+          constraints: {
+            type: 'array',
+            description: 'Existing constraint list to append to (omit for an empty list).',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                type: { type: 'string', enum: ['COINCIDENT', 'DISTANCE', 'HORIZONTAL', 'VERTICAL', 'PARALLEL', 'PERPENDICULAR', 'EQUAL_LENGTH', 'TANGENT', 'RADIUS', 'ANGLE', 'CONCENTRIC', 'SYMMETRIC'] },
+                entities: { type: 'array', items: { type: 'string' } },
+                value: { type: 'number' },
+              },
+              required: ['id', 'type', 'entities'],
+            },
+          },
+          constraint: {
+            type: 'object',
+            description: 'The constraint to append.',
+            properties: {
+              id: { type: 'string' },
+              type: { type: 'string', enum: ['COINCIDENT', 'DISTANCE', 'HORIZONTAL', 'VERTICAL', 'PARALLEL', 'PERPENDICULAR', 'EQUAL_LENGTH', 'TANGENT', 'RADIUS', 'ANGLE', 'CONCENTRIC', 'SYMMETRIC'] },
+              entities: { type: 'array', items: { type: 'string' }, description: 'Ids of the entities the constraint relates.' },
+              value: { type: 'number', description: 'Required for DISTANCE, RADIUS, and ANGLE.' },
+            },
+            required: ['id', 'type', 'entities'],
+          },
         },
         required: ['constraint'],
       },
@@ -1028,7 +1106,23 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
           part_binding: { type: 'string', description: 'JS identifier bound to an AssemblyPartRef, e.g. "basePart".' },
           name: { type: 'string', description: 'Connector name unique within the part.' },
           type: { type: 'string', enum: ['frame', 'axis', 'planar', 'ball'] },
-          origin: { description: 'Origin as [x, y, z] shorthand or structured ConnectorOrigin.' },
+          origin: {
+            description: 'Origin as [x, y, z] shorthand, or a structured ConnectorOrigin.',
+            oneOf: [
+              { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: '[x, y, z] shorthand.' },
+              { type: 'object', description: 'Explicit numeric origin.', properties: {
+                kind: { type: 'string', enum: ['vec3'] },
+                value: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3 },
+              }, required: ['kind', 'value'] },
+              { type: 'object', description: 'Topology-derived origin.', properties: {
+                kind: { type: 'string', enum: ['topology'] },
+                query: { type: 'object', properties: {
+                  kind: { type: 'string', enum: ['face-center', 'face-normal', 'vertex', 'edge-axis'] },
+                  name: { type: 'string' },
+                }, required: ['kind', 'name'] },
+              }, required: ['kind', 'query'] },
+            ],
+          },
           axis: { type: 'array', items: { type: 'number' }, description: 'Optional [x, y, z] axis.' },
           normal: { type: 'array', items: { type: 'number' }, description: 'Optional [x, y, z] normal.' },
         },
@@ -1073,6 +1167,11 @@ export const TOOL_REGISTRY: ToolRegistryEntry[] = [
           notes: { type: 'string', description: "relation:'transmission' — optional notes." },
         },
         required: ['code', 'assembly_binding'],
+        allOf: [
+          { if: { properties: { relation: { const: 'coupling' } }, required: ['relation'] }, then: { required: ['driven', 'source', 'ratio'] } },
+          { if: { properties: { relation: { const: 'transmission' } }, required: ['relation'] }, then: { required: ['name', 'kind', 'sourceMate', 'drivenMates', 'path'] } },
+          { if: { properties: { relation: { enum: ['coupling', 'transmission'] } }, required: ['relation'] }, then: {}, else: { required: ['name', 'a', 'b', 'type'] } },
+        ],
       },
     },
     handler: input => addMateAuthoringTool(input as unknown as Parameters<typeof addMateAuthoringTool>[0]),

--- a/src/agent/vision/index.ts
+++ b/src/agent/vision/index.ts
@@ -51,6 +51,38 @@ export type {
   VisionResponse,
 } from './anthropicVisionClient';
 
+/**
+ * Hard cap on any single backend dispatch. A backend must never hang the tool
+ * forever (the original prod bug was opencv-js WASM init never settling). On
+ * expiry the orchestrator returns a structured `trace_timeout` failure.
+ */
+const DEFAULT_BACKEND_TIMEOUT_MS = 20_000;
+
+function backendTimeoutMs(): number {
+  const configured = Number(process.env.KERNELCAD_TRACE_BACKEND_TIMEOUT_MS);
+  if (Number.isFinite(configured) && configured > 0) return configured;
+  return DEFAULT_BACKEND_TIMEOUT_MS;
+}
+
+/** Symbol thrown when a backend dispatch exceeds {@link backendTimeoutMs}. */
+const TRACE_TIMEOUT = Symbol('trace_timeout');
+
+async function withBackendTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(TRACE_TIMEOUT), timeoutMs);
+        // Don't keep the event loop alive solely for this timer.
+        if (typeof timer.unref === 'function') timer.unref();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 /** Options for callers that need to inject test seams. */
 export interface TraceFromImageOptions {
   /** Override the vision-LLM client (test seam). */
@@ -60,6 +92,8 @@ export interface TraceFromImageOptions {
     pngBytes: Buffer,
     maxWaypoints: number,
   ) => Promise<Vec2Normalized[]>;
+  /** Override the per-backend hard timeout in ms (test seam). */
+  backendTimeoutMs?: number;
 }
 
 /**
@@ -124,8 +158,10 @@ export async function traceFromImage(
   const extract = opts.extractSilhouettePolyline ?? defaultExtractSilhouettePolyline;
   const diagnostics: TraceDiagnostic[] = [];
 
-  // Step 5: dispatch.
+  // Step 5: dispatch (under a hard timeout so a backend can never hang).
+  const timeoutMs = opts.backendTimeoutMs ?? backendTimeoutMs();
   try {
+    const dispatch = async (): Promise<TraceFeatureResult[]> => {
     let results: TraceFeatureResult[];
     switch (backend) {
       case 'opencv': {
@@ -180,12 +216,13 @@ export async function traceFromImage(
         break;
       }
       default: {
-        return failOutput(
-          'tool.trace-from-image.backend-failed',
-          `unknown backend "${String(backend)}"`,
-        );
+        throw new Error(`unknown backend "${String(backend)}"`);
       }
     }
+    return results;
+    };
+
+    const results = await withBackendTimeout(dispatch(), timeoutMs);
 
     return {
       ok: results.length > 0,
@@ -194,6 +231,21 @@ export async function traceFromImage(
       diagnostics,
     };
   } catch (err) {
+    if (err === TRACE_TIMEOUT) {
+      return {
+        ok: false,
+        features: [],
+        imageDims,
+        diagnostics: [
+          ...diagnostics,
+          makeDiag(
+            'tool.trace-from-image.trace-timeout',
+            'error',
+            `${backend} backend timed out after ${timeoutMs}ms`,
+          ),
+        ],
+      };
+    }
     return {
       ok: false,
       features: [],

--- a/src/agent/vision/opencvBackend.test.ts
+++ b/src/agent/vision/opencvBackend.test.ts
@@ -2,52 +2,41 @@
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // src/agent/vision/opencvBackend.test.ts
 //
-// Tests for the pure-JS opencv silhouette backend.
+// Tests for the pure-JS silhouette backend. There is no longer any WASM/opencv
+// dependency, so the extractor runs in-process directly against the fixtures.
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { execFile } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { promisify } from 'node:util';
+import {
+  arcLength,
+  douglasPeucker,
+  extractSilhouettePolyline,
+  otsuThreshold,
+} from './opencvBackend';
 
 const FIXTURE_DIR = join(__dirname, '../../..', 'tests/fixtures/vision');
-const FAIL_FAST_MS = 4000;
-const execFileAsync = promisify(execFile);
 
-async function withFailFast<T>(promise: Promise<T>): Promise<T> {
-  let timer: NodeJS.Timeout | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<never>((_, reject) => {
-        timer = setTimeout(
-          () => reject(new Error(`test-side fail-fast after ${FAIL_FAST_MS}ms`)),
-          FAIL_FAST_MS,
-        );
-      }),
-    ]);
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
+async function fixture(name: string): Promise<Buffer> {
+  return readFile(join(FIXTURE_DIR, name));
 }
 
 describe('extractSilhouettePolyline', () => {
-  afterEach(() => {
-    vi.doUnmock('@techstark/opencv-js');
-    vi.resetModules();
-    delete process.env.KERNELCAD_OPENCV_INIT_TIMEOUT_MS;
-  });
+  it('extracts a ~4-corner polyline hugging the centered black square', async () => {
+    const t0 = Date.now();
+    const polyline = await extractSilhouettePolyline(await fixture('uniform-bg-square.png'), 12);
+    const elapsed = Date.now() - t0;
 
-  it('extracts a polyline hugging the centered black square on a white background', async () => {
-    const polyline = await runExtractorInNode('uniform-bg-square.png', 12);
-    // Must extract at least the 4 corners of the square.
+    // Must be fast — this replaces the path that used to hang forever.
+    expect(elapsed).toBeLessThan(1000);
+
+    // A square simplifies to its 4 corners (allow a couple extra for stairstep
+    // edges, but never the whole boundary).
     expect(polyline.length).toBeGreaterThanOrEqual(4);
-    expect(polyline.length).toBeLessThanOrEqual(12);
+    expect(polyline.length).toBeLessThanOrEqual(8);
 
-    // Bounding box of the extracted polyline should hug the centered 100×100
-    // square inside a 256×256 image. Square spans pixel rows/cols [78..177];
-    // normalised [78/256, 177/256] = [~0.305, ~0.691]. Allow a few px of slack
-    // for findContours' edge handling.
+    // Bounding box hugs the centered 100×100 square in a 256×256 image:
+    // rows/cols ~[78..177] → normalized ~[0.305, 0.691].
     const xs = polyline.map(([x]) => x);
     const ys = polyline.map(([, y]) => y);
     const minX = Math.min(...xs);
@@ -64,45 +53,104 @@ describe('extractSilhouettePolyline', () => {
     expect(maxY).toBeLessThan(0.75);
   }, 5000);
 
-  it('times out instead of hanging when opencv never initializes', async () => {
-    process.env.KERNELCAD_OPENCV_INIT_TIMEOUT_MS = '25';
-    vi.doMock('@techstark/opencv-js', () => ({ default: {} }));
-    const { extractSilhouettePolyline } = await import('./opencvBackend');
-    const png = await readFile(join(FIXTURE_DIR, 'uniform-bg-square.png'));
+  it('does not return the whole frame for the square fixture', async () => {
+    const polyline = await extractSilhouettePolyline(await fixture('uniform-bg-square.png'), 12);
+    const xs = polyline.map(([x]) => x);
+    const ys = polyline.map(([, y]) => y);
+    // None of the corners should touch the image border.
+    expect(Math.min(...xs)).toBeGreaterThan(0.05);
+    expect(Math.max(...xs)).toBeLessThan(0.95);
+    expect(Math.min(...ys)).toBeGreaterThan(0.05);
+    expect(Math.max(...ys)).toBeLessThan(0.95);
+  });
 
-    await expect(withFailFast(extractSilhouettePolyline(png, 12))).rejects.toThrow(
-      /opencv initialization timed out/i,
-    );
-  }, 1000);
+  it('terminates quickly on a cluttered photo (no hang)', async () => {
+    const t0 = Date.now();
+    const polyline = await extractSilhouettePolyline(await fixture('cluttered-photo.png'), 12);
+    expect(Date.now() - t0).toBeLessThan(1000);
+    expect(polyline.length).toBeGreaterThanOrEqual(3);
+    expect(polyline.length).toBeLessThanOrEqual(12);
+  }, 5000);
+
+  it('rejects maxWaypoints < 3', async () => {
+    await expect(
+      extractSilhouettePolyline(await fixture('uniform-bg-square.png'), 2),
+    ).rejects.toThrow(/maxWaypoints must be >= 3/);
+  });
+
+  it('throws no-foreground for a solid single-color image', async () => {
+    // 16×16 solid white PNG (1×1 won't decode to a usable mask).
+    const sharp = (await import('sharp')).default;
+    const white = await sharp({
+      create: { width: 16, height: 16, channels: 3, background: { r: 255, g: 255, b: 255 } },
+    })
+      .png()
+      .toBuffer();
+    await expect(extractSilhouettePolyline(white, 12)).rejects.toThrow(/no foreground contour/);
+  });
 });
 
-async function runExtractorInNode(fixtureName: string, maxWaypoints: number): Promise<[number, number][]> {
-  const script = `
-    import { readFile } from 'node:fs/promises';
-    import { join } from 'node:path';
-    import { extractSilhouettePolyline } from './src/agent/vision/opencvBackend.ts';
+describe('otsuThreshold', () => {
+  it('returns a between-class-maximizing threshold for a bimodal histogram', () => {
+    const hist = new Array(256).fill(0);
+    hist[10] = 1000;
+    hist[200] = 1000;
+    const t = otsuThreshold(hist);
+    // Threshold should sit between the two modes.
+    expect(t).toBeGreaterThanOrEqual(10);
+    expect(t).toBeLessThan(200);
+  });
 
-    const png = await readFile(join(${JSON.stringify(FIXTURE_DIR)}, ${JSON.stringify(fixtureName)}));
-    const polyline = await extractSilhouettePolyline(png, ${JSON.stringify(maxWaypoints)});
-    console.log(JSON.stringify(polyline));
-  `;
-  return runNodeExtractorScript(script);
-}
+  it('handles an empty histogram gracefully', () => {
+    expect(otsuThreshold(new Array(256).fill(0))).toBe(127);
+  });
+});
 
-async function runNodeExtractorScript(script: string): Promise<[number, number][]> {
-  try {
-    const { stdout } = await execFileAsync(
-      process.execPath,
-      ['--import', 'tsx', '--input-type=module', '-e', script],
-      {
-        cwd: join(__dirname, '../../..'),
-        timeout: FAIL_FAST_MS,
-        killSignal: 'SIGKILL',
-      },
-    );
-    return JSON.parse(stdout.trim()) as [number, number][];
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw new Error(message);
-  }
-}
+describe('arcLength', () => {
+  it('sums closed-loop segment lengths of a unit square', () => {
+    const square = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 0, y: 10 },
+    ];
+    expect(arcLength(square, true)).toBeCloseTo(40, 6);
+  });
+
+  it('drops the closing segment when open', () => {
+    const square = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 0, y: 10 },
+    ];
+    expect(arcLength(square, false)).toBeCloseTo(30, 6);
+  });
+});
+
+describe('douglasPeucker', () => {
+  it('collapses a straight run to its endpoints', () => {
+    const line = [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 2, y: 0 },
+      { x: 3, y: 0 },
+      { x: 4, y: 0 },
+    ];
+    const out = douglasPeucker(line, 0.1);
+    expect(out).toEqual([
+      { x: 0, y: 0 },
+      { x: 4, y: 0 },
+    ]);
+  });
+
+  it('keeps a vertex that deviates beyond epsilon', () => {
+    const bend = [
+      { x: 0, y: 0 },
+      { x: 5, y: 5 },
+      { x: 10, y: 0 },
+    ];
+    const out = douglasPeucker(bend, 1);
+    expect(out).toHaveLength(3);
+  });
+});

--- a/src/agent/vision/opencvBackend.ts
+++ b/src/agent/vision/opencvBackend.ts
@@ -2,143 +2,303 @@
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // src/agent/vision/opencvBackend.ts
 //
-// Pure-JS opencv silhouette extractor for the `trace_from_image` tool.
-// `@techstark/opencv-js` is ~1.5 MB and slow to initialize (~2 s on first
-// call), so it is **lazy-imported** here — the MCP server cold-start path
-// must never load opencv. We cache the init promise so subsequent calls in
-// the same process pay no extra cost.
+// Pure-JS silhouette extractor for the `trace_from_image` tool.
+//
+// Historically this used `@techstark/opencv-js` for grayscale conversion, Otsu
+// threshold, findContours and approxPolyDP. That dependency is a browser WASM
+// build whose runtime never signals ready under the hosted server's Node/ESM
+// context — importing it hangs forever, which is exactly the prod bug this file
+// fixes. The pipeline is now implemented in plain TypeScript:
+//
+//   1. Decode + RGBA via sharp (already a dep; no WASM contour kernel).
+//   2. Luma grayscale: 0.299R + 0.587G + 0.114B.
+//   3. Otsu threshold (256-bin histogram). Inverted (THRESH_BINARY_INV
+//      semantics): foreground = pixels darker than the threshold, i.e. a dark
+//      subject on a bright background.
+//   4. Largest 4-connected foreground component, then Moore-neighbour boundary
+//      tracing (with Jacob's stopping criterion) of its outer boundary.
+//   5. arcLength = summed closed-loop segment lengths.
+//   6. Douglas-Peucker simplify with epsilon ramped up until the polyline has
+//      at most `maxWaypoints` vertices.
+//   7. Normalize to `[0..1]` with top-left origin.
+//
+// Deterministic, fast (<1s for typical fixtures), no WASM, no hang.
 
 import sharp from 'sharp';
 import type { Vec2Normalized } from './types';
 
-let cvInitPromise: Promise<typeof import('@techstark/opencv-js')> | null = null;
-const DEFAULT_OPENCV_INIT_TIMEOUT_MS = 5000;
-
-type OpenCvModule = typeof import('@techstark/opencv-js');
-type OpenCvRuntime = OpenCvModule & {
-  ready?: Promise<unknown>;
-  Mat?: unknown;
-  onRuntimeInitialized?: () => void;
-  then?: (onReady: (cv: OpenCvRuntime) => void) => unknown;
-};
+/** Pixel-space point used internally before normalization. */
+type Point = { x: number; y: number };
 
 /**
- * Lazy-load `@techstark/opencv-js` and wait for its asynchronous WASM init.
- * Returns the cached `cv` namespace on subsequent calls.
+ * Compute an Otsu threshold from a 256-bin grayscale histogram.
+ * Returns the grayscale value `t` that maximizes between-class variance.
+ * Foreground (object) is taken as pixels with `grey < t` (inverted), matching
+ * OpenCV's `THRESH_BINARY_INV + THRESH_OTSU` for a dark-on-light subject.
  */
-async function getCv(): Promise<typeof import('@techstark/opencv-js')> {
-  if (!cvInitPromise) {
-    cvInitPromise = (async () => {
-      const mod = await import('@techstark/opencv-js');
-      const cv = ((mod as { default?: OpenCvModule }).default ?? mod) as OpenCvRuntime;
-      await waitForOpenCvReady(cv, openCvInitTimeoutMs());
-      // Emscripten exposes `then` for callback-style readiness. If an async
-      // function returns that same thenable object, native Promise resolution
-      // keeps assimilating it and never settles.
-      delete cv.then;
-      return cv as OpenCvModule;
-    })();
+export function otsuThreshold(histogram: number[] | Uint32Array): number {
+  let total = 0;
+  for (let i = 0; i < 256; i++) total += histogram[i];
+  if (total === 0) return 127;
+
+  let sum = 0;
+  for (let i = 0; i < 256; i++) sum += i * histogram[i];
+
+  let sumB = 0;
+  let wB = 0;
+  let maxVar = -1;
+  let threshold = 0;
+  for (let t = 0; t < 256; t++) {
+    wB += histogram[t];
+    if (wB === 0) continue;
+    const wF = total - wB;
+    if (wF === 0) break;
+    sumB += t * histogram[t];
+    const mB = sumB / wB;
+    const mF = (sum - sumB) / wF;
+    const between = wB * wF * (mB - mF) * (mB - mF);
+    if (between > maxVar) {
+      maxVar = between;
+      threshold = t;
+    }
   }
-  return cvInitPromise;
+  return threshold;
 }
 
-async function waitForOpenCvReady(cv: OpenCvRuntime, timeoutMs: number): Promise<void> {
-  if (cv.Mat) return;
-
-  if (cv.ready && typeof cv.ready.then === 'function') {
-    await withTimeout(
-      cv.ready.then(() => undefined),
-      timeoutMs,
-    );
-  } else if (typeof cv.then === 'function') {
-    await withTimeout(
-      new Promise<void>((resolve) => {
-        cv.then?.(() => resolve());
-      }),
-      timeoutMs,
-    );
-  } else {
-    await waitForRuntimeCallbackOrMat(cv, timeoutMs);
+/**
+ * Sum of consecutive segment lengths around a closed polyline (the OpenCV
+ * `arcLength(curve, closed=true)` equivalent).
+ */
+export function arcLength(points: Point[], closed = true): number {
+  if (points.length < 2) return 0;
+  let len = 0;
+  for (let i = 0; i < points.length - 1; i++) {
+    len += dist(points[i], points[i + 1]);
   }
-
-  if (!cv.Mat) {
-    throw new Error('opencvBackend: OpenCV initialized without Mat constructor');
-  }
+  if (closed) len += dist(points[points.length - 1], points[0]);
+  return len;
 }
 
-async function waitForRuntimeCallbackOrMat(cv: OpenCvRuntime, timeoutMs: number): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const previous = cv.onRuntimeInitialized;
-    let settled = false;
-    const cleanup = () => {
-      clearInterval(interval);
-      clearTimeout(timer);
-    };
-    const finish = () => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      resolve();
-    };
-    const fail = () => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      reject(new Error(`opencvBackend: OpenCV initialization timed out after ${timeoutMs}ms`));
-    };
-    const interval = setInterval(() => {
-      if (cv.Mat) finish();
-    }, 25);
-    const timer = setTimeout(fail, timeoutMs);
-    cv.onRuntimeInitialized = () => {
-      previous?.();
-      finish();
-    };
-  });
+function dist(a: Point, b: Point): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return Math.sqrt(dx * dx + dy * dy);
 }
 
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  let timer: NodeJS.Timeout | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<never>((_, reject) => {
-        timer = setTimeout(
-          () => reject(new Error(`opencvBackend: OpenCV initialization timed out after ${timeoutMs}ms`)),
-          timeoutMs,
-        );
-      }),
-    ]);
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
+/** Perpendicular distance from point `p` to the line through `a` and `b`. */
+function perpDistance(p: Point, a: Point, b: Point): number {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const segLenSq = dx * dx + dy * dy;
+  if (segLenSq === 0) return dist(p, a);
+  // Distance from point to infinite line a→b.
+  const cross = Math.abs(dy * p.x - dx * p.y + b.x * a.y - b.y * a.x);
+  return cross / Math.sqrt(segLenSq);
 }
 
-function openCvInitTimeoutMs(): number {
-  const configured = Number(process.env.KERNELCAD_OPENCV_INIT_TIMEOUT_MS);
-  if (Number.isFinite(configured) && configured > 0) {
-    return configured;
+/**
+ * Douglas-Peucker polyline simplification (the OpenCV `approxPolyDP`
+ * equivalent). `epsilon` is the max perpendicular deviation allowed before a
+ * vertex is kept. Operates on an open polyline; callers handle closure.
+ */
+export function douglasPeucker(points: Point[], epsilon: number): Point[] {
+  if (points.length < 3) return points.slice();
+
+  let maxDist = 0;
+  let index = 0;
+  const end = points.length - 1;
+  for (let i = 1; i < end; i++) {
+    const d = perpDistance(points[i], points[0], points[end]);
+    if (d > maxDist) {
+      maxDist = d;
+      index = i;
+    }
   }
-  return DEFAULT_OPENCV_INIT_TIMEOUT_MS;
+
+  if (maxDist > epsilon) {
+    const left = douglasPeucker(points.slice(0, index + 1), epsilon);
+    const right = douglasPeucker(points.slice(index), epsilon);
+    // Drop the duplicated junction vertex.
+    return left.slice(0, -1).concat(right);
+  }
+  return [points[0], points[end]];
+}
+
+/**
+ * Find the largest 4-connected foreground component in a binary mask and return
+ * its label set as a fast membership predicate plus the component's pixel count.
+ * Foreground pixels are `mask[y*width+x] === 1`.
+ */
+function largestComponent(
+  mask: Uint8Array,
+  width: number,
+  height: number,
+): { member: Uint8Array; size: number; seed: Point | null } {
+  const labels = new Int32Array(width * height).fill(-1);
+  const stack: number[] = [];
+  let bestLabel = -1;
+  let bestSize = 0;
+  let bestSeed: Point | null = null;
+  let nextLabel = 0;
+
+  for (let start = 0; start < mask.length; start++) {
+    if (mask[start] === 0 || labels[start] !== -1) continue;
+    const label = nextLabel++;
+    let size = 0;
+    let seedIdx = start;
+    stack.length = 0;
+    stack.push(start);
+    labels[start] = label;
+    while (stack.length > 0) {
+      const idx = stack.pop() as number;
+      size++;
+      // Track the top-most, left-most pixel of this component as a trace seed.
+      if (idx < seedIdx) seedIdx = idx;
+      const x = idx % width;
+      const y = (idx - x) / width;
+      // 4-connectivity.
+      if (x > 0) pushIf(idx - 1);
+      if (x < width - 1) pushIf(idx + 1);
+      if (y > 0) pushIf(idx - width);
+      if (y < height - 1) pushIf(idx + width);
+    }
+    if (size > bestSize) {
+      bestSize = size;
+      bestLabel = label;
+      const sx = seedIdx % width;
+      bestSeed = { x: sx, y: (seedIdx - sx) / width };
+    }
+
+    function pushIf(n: number): void {
+      if (mask[n] === 1 && labels[n] === -1) {
+        labels[n] = label;
+        stack.push(n);
+      }
+    }
+  }
+
+  const member = new Uint8Array(width * height);
+  if (bestLabel >= 0) {
+    for (let i = 0; i < labels.length; i++) {
+      if (labels[i] === bestLabel) member[i] = 1;
+    }
+  }
+  return { member, size: bestSize, seed: bestSeed };
+}
+
+// Moore-neighbour offsets, clockwise starting from the west neighbour. The
+// canonical Moore order is the 8 neighbours walked clockwise; we start the
+// search from the pixel we entered the boundary from (backtrack) per Jacob's
+// criterion.
+const MOORE: ReadonlyArray<readonly [number, number]> = [
+  [-1, 0], // W
+  [-1, -1], // NW
+  [0, -1], // N
+  [1, -1], // NE
+  [1, 0], // E
+  [1, 1], // SE
+  [0, 1], // S
+  [-1, 1], // SW
+];
+
+function isForeground(member: Uint8Array, width: number, height: number, x: number, y: number): boolean {
+  if (x < 0 || y < 0 || x >= width || y >= height) return false;
+  return member[y * width + x] === 1;
+}
+
+/**
+ * Moore-neighbour boundary tracing with Jacob's stopping criterion. `seed` is a
+ * foreground pixel guaranteed to be on the boundary (the top-most/left-most
+ * pixel of the component). Returns the ordered outer-boundary pixels (closed
+ * loop, first vertex not repeated at the end).
+ */
+function mooreTrace(
+  member: Uint8Array,
+  width: number,
+  height: number,
+  seed: Point,
+): Point[] {
+  const boundary: Point[] = [];
+  const start = seed;
+
+  // Direction index in MOORE we came FROM (backtrack). The seed is the
+  // top-left-most pixel; we entered it conceptually from the west.
+  let current = start;
+  // The pixel we were on before stepping onto `current`.
+  let backtrack: Point = { x: start.x - 1, y: start.y };
+
+  // Jacob's criterion: stop when we re-enter the start pixel AND the next pixel
+  // visited would be the same as the second pixel of the boundary.
+  let firstStep: Point | null = null;
+  const maxSteps = width * height * 8 + 8; // hard safety bound
+  let steps = 0;
+
+  do {
+    boundary.push({ x: current.x, y: current.y });
+
+    // Start scanning clockwise from the neighbour just after the backtrack
+    // direction.
+    const backDir = neighbourIndex(current, backtrack);
+    let found: Point | null = null;
+    let foundBack: Point = backtrack;
+    for (let i = 1; i <= 8; i++) {
+      const dirIdx = (backDir + i) % 8;
+      const nx = current.x + MOORE[dirIdx][0];
+      const ny = current.y + MOORE[dirIdx][1];
+      if (isForeground(member, width, height, nx, ny)) {
+        found = { x: nx, y: ny };
+        // The backtrack for the next step is the previous neighbour we checked.
+        const prevIdx = (dirIdx + 7) % 8; // dirIdx - 1
+        foundBack = { x: current.x + MOORE[prevIdx][0], y: current.y + MOORE[prevIdx][1] };
+        break;
+      }
+    }
+
+    if (!found) {
+      // Isolated pixel — single-pixel component.
+      break;
+    }
+
+    if (firstStep === null) {
+      firstStep = found;
+    } else if (
+      current.x === start.x &&
+      current.y === start.y &&
+      found.x === firstStep.x &&
+      found.y === firstStep.y
+    ) {
+      // Jacob's stopping criterion met: drop the duplicated start we just pushed.
+      boundary.pop();
+      break;
+    }
+
+    backtrack = foundBack;
+    current = found;
+    steps++;
+  } while (steps < maxSteps);
+
+  return boundary;
+}
+
+/** Index into MOORE of `neighbour` relative to `center`, or 0 if not adjacent. */
+function neighbourIndex(center: Point, neighbour: Point): number {
+  const dx = neighbour.x - center.x;
+  const dy = neighbour.y - center.y;
+  for (let i = 0; i < 8; i++) {
+    if (MOORE[i][0] === dx && MOORE[i][1] === dy) return i;
+  }
+  return 0;
 }
 
 /**
  * Extract a normalized silhouette polyline from `pngBytes`.
  *
- * Pipeline:
- * 1. Decode + grayscale via sharp (no opencv decoder dep).
- * 2. Otsu threshold (inverted — assumes bright background, dark subject).
- *    This matches the common "product photo on white" case the opencv backend
- *    is designed for. The router refuses opencv when the corner-color stddev
- *    suggests the background is non-uniform.
- * 3. `findContours(RETR_EXTERNAL)`, pick largest by `arcLength`.
- * 4. `approxPolyDP` with epsilon ramped up to 6× until the polyline has at
- *    most `maxWaypoints` vertices.
- * 5. Normalize to `[0..1]` with top-left origin.
+ * Pipeline (see file header). Throws `'opencvBackend: no foreground contour
+ * found'` when Otsu cannot split the image into figure/ground (e.g. a pure
+ * solid-color image).
  *
- * Throws `'opencvBackend: no foreground contour found'` if no contour is
- * detected (e.g. pure-white image, all-black image, or anything Otsu can't
- * split into figure/ground).
+ * @param pngBytes  Encoded image bytes (any sharp-decodable format).
+ * @param maxWaypoints  Cap on output vertices (>= 3). Epsilon ramps until met.
  */
 export async function extractSilhouettePolyline(
   pngBytes: Buffer,
@@ -147,100 +307,75 @@ export async function extractSilhouettePolyline(
   if (maxWaypoints < 3) {
     throw new Error(`opencvBackend: maxWaypoints must be >= 3 (got ${maxWaypoints})`);
   }
-  const cv = await getCv();
 
   const { data, info } = await sharp(pngBytes)
     .ensureAlpha()
     .raw()
     .toBuffer({ resolveWithObject: true });
   const { width, height } = info;
-
-  // matFromImageData needs an ImageData-like { data, width, height }. `ImageData`
-  // itself is a DOM type and not present under `tsconfig.cli.json` (no DOM lib),
-  // so use a structural type that satisfies opencv's runtime expectations.
-  type ImageDataLike = { data: Uint8ClampedArray; width: number; height: number; colorSpace?: string };
-  const src = cv.matFromImageData({
-    data: new Uint8ClampedArray(data.buffer, data.byteOffset, data.byteLength),
-    width,
-    height,
-    colorSpace: 'srgb',
-  } as ImageDataLike as unknown as Parameters<typeof cv.matFromImageData>[0]);
-
-  const grey = new cv.Mat();
-  cv.cvtColor(src, grey, cv.COLOR_RGBA2GRAY);
-
-  const binary = new cv.Mat();
-  // INV: dark subject on bright bg → subject pixels become 255 after threshold.
-  cv.threshold(grey, binary, 0, 255, cv.THRESH_BINARY_INV + cv.THRESH_OTSU);
-
-  const contours = new cv.MatVector();
-  const hierarchy = new cv.Mat();
-  cv.findContours(binary, contours, hierarchy, cv.RETR_EXTERNAL, cv.CHAIN_APPROX_SIMPLE);
-
-  // Pick largest contour by perimeter.
-  let bestIdx = -1;
-  let bestLen = -1;
-  for (let i = 0; i < contours.size(); i++) {
-    const c = contours.get(i);
-    const len = cv.arcLength(c, true);
-    if (len > bestLen) {
-      bestLen = len;
-      bestIdx = i;
-    }
-    c.delete();
+  const channels = info.channels; // 4 after ensureAlpha
+  if (width === 0 || height === 0) {
+    throw new Error('opencvBackend: image has zero dimension');
   }
 
-  if (bestIdx < 0 || bestLen <= 0) {
-    src.delete();
-    grey.delete();
-    binary.delete();
-    contours.delete();
-    hierarchy.delete();
+  // 1+2: grayscale via luma, build histogram.
+  const grey = new Uint8Array(width * height);
+  const histogram = new Uint32Array(256);
+  for (let p = 0, g = 0; g < grey.length; g++, p += channels) {
+    const r = data[p];
+    const gg = data[p + 1];
+    const b = data[p + 2];
+    const lum = (0.299 * r + 0.587 * gg + 0.114 * b) | 0;
+    grey[g] = lum;
+    histogram[lum]++;
+  }
+
+  // 3: Otsu threshold, inverted mask (foreground = darker than threshold).
+  const t = otsuThreshold(histogram);
+  const mask = new Uint8Array(width * height);
+  // OpenCV THRESH_BINARY_INV: dst = (src > t) ? 0 : maxval, i.e. foreground is
+  // `src <= t`. Using `<=` (not `<`) is what makes a perfectly bimodal mask
+  // (Otsu returns t=0 for black-on-white) still capture the dark subject.
+  for (let i = 0; i < grey.length; i++) {
+    mask[i] = grey[i] <= t ? 1 : 0;
+  }
+
+  // 4: largest 4-connected foreground component → outer boundary trace.
+  const { member, size, seed } = largestComponent(mask, width, height);
+  if (size <= 0 || !seed) {
     throw new Error('opencvBackend: no foreground contour found');
   }
 
-  const best = contours.get(bestIdx);
+  const boundary = mooreTrace(member, width, height, seed);
+  if (boundary.length < 3) {
+    throw new Error('opencvBackend: no foreground contour found');
+  }
 
-  // approxPolyDP — ramp epsilon up to 6× until <= maxWaypoints.
-  let approx = new cv.Mat();
-  let epsilonRatio = 0.01; // 1% of perimeter to start.
+  // 5: arcLength of the closed boundary.
+  const perimeter = arcLength(boundary, true);
+  if (perimeter <= 0) {
+    throw new Error('opencvBackend: no foreground contour found');
+  }
+
+  // 6: Douglas-Peucker, ramp epsilon up to 6× until <= maxWaypoints. We close
+  // the boundary by appending the first point so DP keeps the closing corner,
+  // then drop the duplicate.
+  const closedBoundary = boundary.concat([boundary[0]]);
+  let simplified: Point[] = closedBoundary;
+  let epsilonRatio = 0.01; // 1% of perimeter to start (matches prior call).
   for (let attempt = 0; attempt < 7; attempt++) {
-    if (attempt > 0) {
-      approx.delete();
-      approx = new cv.Mat();
-    }
-    cv.approxPolyDP(best, approx, epsilonRatio * bestLen, true);
-    if (approx.rows <= maxWaypoints) break;
+    const eps = epsilonRatio * perimeter;
+    const dp = douglasPeucker(closedBoundary, eps);
+    // Drop the duplicated closing vertex appended above.
+    simplified = dp.length > 1 && samePoint(dp[0], dp[dp.length - 1]) ? dp.slice(0, -1) : dp;
+    if (simplified.length <= maxWaypoints) break;
     epsilonRatio *= Math.sqrt(2);
   }
 
-  // Extract (x, y) pairs and normalize.
-  const polyline: Vec2Normalized[] = [];
-  for (let i = 0; i < approx.rows; i++) {
-    // approxPolyDP returns a CV_32SC2 Mat (int32 x, int32 y per row).
-    const x = approx.data32S[i * 2];
-    const y = approx.data32S[i * 2 + 1];
-    polyline.push([x / width, y / height]);
-  }
-
-  best.delete();
-  approx.delete();
-  src.delete();
-  grey.delete();
-  binary.delete();
-  contours.delete();
-  hierarchy.delete();
-
-  return polyline;
+  // 7: normalize to [0..1], top-left origin.
+  return simplified.map(({ x, y }) => [x / width, y / height] as Vec2Normalized);
 }
 
-/**
- * Test-only export — resets the cached opencv init promise. Lets tests verify
- * the lazy-import contract by inspecting `cvInitPromise` after a deliberate
- * reset. Not part of the public surface.
- *
- * @internal
- */
-export function _resetCvInitForTests(): void {
-  cvInitPromise = null;
+function samePoint(a: Point, b: Point): boolean {
+  return a.x === b.x && a.y === b.y;
 }

--- a/src/agent/vision/orchestrator.test.ts
+++ b/src/agent/vision/orchestrator.test.ts
@@ -137,6 +137,19 @@ describe('traceFromImage orchestrator', () => {
     expect(out.diagnostics.some((d) => d.code === 'tool.trace-from-image.backend-failed')).toBe(true);
   });
 
+  it('emits trace-timeout when a backend hangs past the hard timeout', async () => {
+    const hangingExtract = vi.fn(
+      () => new Promise<Vec2Normalized[]>(() => {}), // never resolves
+    );
+    const out = await traceFromImage(
+      { imageUrl: UNIFORM_FILE_URL, backend: 'opencv' },
+      { extractSilhouettePolyline: hangingExtract, backendTimeoutMs: 25 },
+    );
+    expect(out.ok).toBe(false);
+    expect(out.features).toEqual([]);
+    expect(out.diagnostics.some((d) => d.code === 'tool.trace-from-image.trace-timeout')).toBe(true);
+  });
+
   it('emits image-fetch-failed when a file:// path does not exist', async () => {
     const out = await traceFromImage({
       imageUrl: `file://${FIXTURE_DIR}/does-not-exist.png`,

--- a/src/modeling/capture/featureMeshing.ts
+++ b/src/modeling/capture/featureMeshing.ts
@@ -699,6 +699,11 @@ export async function meshFeaturesPerFeature(
      *  Optional — scripts without `arm.tendon(...)` (or that don't
      *  expose an assemblies map) render unchanged. */
     assemblies?: ReadonlyMap<string, unknown>;
+    /** Streaming hook: fired as each FeatureMesh is produced during the
+     *  interleaved lower+mesh pass, so a caller can flush it progressively
+     *  instead of waiting for the whole build. Optional — non-streaming callers
+     *  omit it and the emitted set / return value are byte-identical. */
+    onFeature?: (mesh: FeatureMesh) => void;
   },
 ): Promise<MeshFeaturesResult> {
   await initOcct();
@@ -711,6 +716,13 @@ export async function meshFeaturesPerFeature(
   }
   const engine = new RecomputeEngine(lowerer);
   const features: FeatureMesh[] = [];
+  // Collect every produced FeatureMesh, and — when a streaming caller passed
+  // `session.onFeature` — flush it immediately so the viewport can paint parts
+  // as they finish instead of waiting for the whole build.
+  const emitFeature = (mesh: FeatureMesh): void => {
+    features.push(mesh);
+    session?.onFeature?.(mesh);
+  };
   const failedFeatureIds: FeatureId[] = [];
   const recordById = new Map<FeatureId, FeatureRecord>(records.map((r) => [r.id, r]));
   let minX = Infinity, minY = Infinity, minZ = Infinity;
@@ -758,7 +770,7 @@ export async function meshFeaturesPerFeature(
       const cameraTgt = r.kind === 'cameraTarget'
         ? (r.metadata as unknown as CameraTargetMetadata)
         : undefined;
-      features.push({
+      emitFeature({
         featureId: r.id,
         featureKind: r.kind,
         predecessors: [],
@@ -898,7 +910,7 @@ export async function meshFeaturesPerFeature(
             ...(edges ? { edges } : {}),
           };
           if (!cachedPart) attachPlanarUVs(local.faces);
-          features.push({
+          emitFeature({
             ...local,
             assemblyFeatureId: event.featureId,
             assemblyPartName: part.name,
@@ -949,7 +961,7 @@ export async function meshFeaturesPerFeature(
         // sourced directly off the SceneBackend.
         const tendonMeshes = collectTendonMeshes(event.shape, event.featureId, assembliesIn);
         for (const tm of tendonMeshes) {
-          features.push(tm);
+          emitFeature(tm);
           for (const f of tm.faces) {
             for (let i = 0; i < f.vertices.length; i += 3) {
               const x = f.vertices[i], y = f.vertices[i + 1], z = f.vertices[i + 2];
@@ -1067,7 +1079,7 @@ export async function meshFeaturesPerFeature(
         ...(material !== undefined ? { material } : {}),
         ...(materialByFaceId !== undefined ? { materialByFaceId } : {}),
       };
-      features.push(emitted);
+      emitFeature(emitted);
       // Populate per-feature mesh cache so a subsequent `params.update` whose
       // first-affected scan keeps this record's lowered shape can re-emit the
       // cached mesh directly instead of calling `meshShape` again.
@@ -1100,7 +1112,7 @@ export async function meshFeaturesPerFeature(
       const cached = cachedFeatureMeshes.get(r.id);
       if (!cached) continue;
       const mesh = cached as FeatureMesh;
-      features.push(mesh);
+      emitFeature(mesh);
       for (const f of mesh.faces) {
         for (let i = 0; i < f.vertices.length; i += 3) {
           const x = f.vertices[i], y = f.vertices[i + 1], z = f.vertices[i + 2];

--- a/src/shared/diagnostics/registry.ts
+++ b/src/shared/diagnostics/registry.ts
@@ -1583,6 +1583,14 @@ export const DIAGNOSTIC_REGISTRY = {
     group: 'tool',
     description: 'A point/bbox feature was requested but the opencv backend was forced, so only the silhouette polyline could be returned.',
   },
+  'tool.trace-from-image.trace-timeout': {
+    hintTemplate:
+      "The selected backend did not return within the hard time budget and was aborted to avoid hanging the tool. Retry with a smaller image, a different `backend`, or check that the vision-LLM credentials/network are reachable.",
+    nextAction: { kind: 'inspect-message' },
+    defaultSeverity: 'error',
+    group: 'tool',
+    description: 'A trace_from_image backend exceeded the hard per-call timeout and was aborted.',
+  },
   // K1 watertight gap enrichment — STL export tessellation self-intersects on revolved cones.
   'mesher.cone-self-intersection': {
     hintTemplate:

--- a/tests/unit/diagnostics/codes.test.ts
+++ b/tests/unit/diagnostics/codes.test.ts
@@ -31,8 +31,9 @@ describe('diagnostic catalogue invariants', () => {
     // + 1 mechanism.unverified-budget-exceeded (this PR — T3 post-condition
     //   gate: the over-budget BREP pose-sweep skip is now a LOUD structured
     //   diagnostic instead of a silent console.warn). = 237.
-    expect(DIAGNOSTIC_CODES).toHaveLength(237);
-    expect(new Set(DIAGNOSTIC_CODES).size).toBe(237);
+    // + 1 tool.trace-from-image.trace-timeout (forward-ported: pure-JS tracer hard per-call timeout). = 238.
+    expect(DIAGNOSTIC_CODES).toHaveLength(238);
+    expect(new Set(DIAGNOSTIC_CODES).size).toBe(238);
   });
 
   it('every code has a non-empty hint template', () => {

--- a/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
+++ b/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
@@ -160,7 +160,8 @@ describe('every diagnostic code emitted in src/ is in the catalogue', () => {
     //  +  2 feature.intersection-empty, feature.empty-result = 236.
     //  +  1 mechanism.unverified-budget-exceeded (this PR — T3 over-budget
     //       BREP pose-sweep skip is now a LOUD structured diagnostic) = 237.
-    expect(catalogue.size).toBe(237);
+    //  +  1 tool.trace-from-image.trace-timeout (forward-ported) = 238.
+    expect(catalogue.size).toBe(238);
   });
 
   it('no emit site uses a code outside the catalogue', () => {


### PR DESCRIPTION
The MCP deploys a *curated* vendor line, not develop, because these hosting-stability fixes lived ONLY on the curated line — develop was missing them, so it can't be deployed. This forward-ports them so the divergence stops growing (part of moving to a protected `release` branch + release-line deploy guard in kernelCAD-server #62).

**Ported (5):**
- `feat(mesh)`: optional `onFeature` stream hook
- `feat(mcp)`: tighten tool input schemas (ChatGPT app review)
- Replace opencv-js silhouette extractor with a **pure-JS contour tracer** (the opencv WASM hangs in Node — this is why hosted `trace_from_image` broke). Keeps the `extractSilhouettePolyline` interface `hybridBackend` imports, so develop's vision goes Node-safe transparently.
- Hard per-call **timeout** on `trace_from_image` backends (can never hang). Adds `tool.trace-from-image.trace-timeout` → diagnostic count 237 → 238 (count assertions updated).
- Drop `@techstark/opencv-js` (now unused after the tracer rewrite); lockfile regenerated.

**NOT ported (1), deliberately:** `perf(viewport): size-relative display tessellation deflection`. develop independently evolved `meshFaceToGeometry` to take `MeshOptions`, while the curated commit evolved the same function to take a `tolerance: number`. That's a real API reconciliation, not a clean cherry-pick — it needs a decision on whether develop's `MeshOptions` path should carry the size-relative deflection, so I left it out rather than risk a viewport regression.

Conflicts resolved: diagnostics code-count catalogs (additive, +1), package-lock (regenerated). Letting CI validate the vision/tsc surface.