### PR TITLE
Add 8 authored electronics part models for proto.cat catalog coverage

### DIFF
--- a/.github/workflows/parts-catalog.yml
+++ b/.github/workflows/parts-catalog.yml
@@ -36,6 +36,11 @@ jobs:
 
       - run: npm ci
 
+      # The electronics ingest compiles authored .kcad.ts part sources to STEP via
+      # the kernelCAD CLI (dist/cli/index.js); build it first or those parts SKIP.
+      - name: Build kernelCAD CLI
+        run: npm run build:cli
+
       - name: Ingest FreeCAD library
         run: >
           npx tsx scripts/ingestFreecadLibrary.ts

--- a/scripts/electronics-parts.json
+++ b/scripts/electronics-parts.json
@@ -117,6 +117,86 @@
       "tags": ["connector", "m12", "iolink", "io-link", "5pin", "a-coded", "phoenix-contact"],
       "license": "OSHW",
       "attribution": "Phoenix Contact via oro-os/link (github.com/oro-os/link), OSHW"
+    },
+    {
+      "id": "ssd1306-oled-096",
+      "name": "SSD1306 0.96\" I2C OLED display module (27×27×4mm)",
+      "family": "Display",
+      "mpn": "generic SSD1306 0.96in OLED breakout",
+      "kcad_source": "scripts/parts/authored/ssd1306-oled-096.kcad.ts",
+      "tags": ["display", "oled", "i2c", "ssd1306", "096inch", "128x64"],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "dht22",
+      "name": "DHT22 / AM2302 temperature + humidity sensor (15×25×8mm)",
+      "family": "Sensor",
+      "mpn": "DHT22",
+      "kcad_source": "scripts/parts/authored/dht22.kcad.ts",
+      "tags": ["sensor", "temperature", "humidity", "dht22", "am2302"],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "ws2812-strip",
+      "name": "WS2812B NeoPixel LED strip segment — 3 pixels (17×10×3mm)",
+      "family": "LED",
+      "mpn": "WS2812B (3-pixel strip segment)",
+      "kcad_source": "scripts/parts/authored/ws2812-strip.kcad.ts",
+      "tags": ["led", "neopixel", "ws2812b", "rgb", "addressable", "strip"],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "bme280",
+      "name": "BME280 environmental sensor breakout (19×18×3mm)",
+      "family": "Sensor",
+      "mpn": "BME280 breakout (Adafruit 2652 / SparkFun)",
+      "kcad_source": "scripts/parts/authored/bme280.kcad.ts",
+      "tags": ["sensor", "temperature", "humidity", "pressure", "bme280", "i2c", "spi"],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "microsd-spi",
+      "name": "microSD SPI adapter breakout module (24×30×4mm)",
+      "family": "Storage",
+      "mpn": "generic microSD SPI breakout",
+      "kcad_source": "scripts/parts/authored/microsd-spi.kcad.ts",
+      "tags": ["storage", "microsd", "spi", "sdcard", "module"],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "pushbutton-6mm",
+      "name": "6mm tactile pushbutton (6×6×5mm)",
+      "family": "Switch",
+      "mpn": "generic 6mm tact switch",
+      "kcad_source": "scripts/parts/authored/pushbutton-6mm.kcad.ts",
+      "tags": ["switch", "button", "tactile", "pushbutton", "6mm"],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "max14827",
+      "name": "MAX14827 IO-Link PHY breakout (12×10×2mm)",
+      "family": "IO-Link",
+      "mpn": "MAX14827",
+      "kcad_source": "scripts/parts/authored/max14827.kcad.ts",
+      "tags": ["iolink", "io-link", "phy", "max14827", "industrial"],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "buck-24v-3v3",
+      "name": "24V→3.3V step-down buck regulator module (18×12×4mm)",
+      "family": "Power",
+      "mpn": "generic 24V 3.3V buck module",
+      "kcad_source": "scripts/parts/authored/buck-24v-3v3.kcad.ts",
+      "tags": ["power", "buck", "regulator", "24v", "3v3", "stepdown"],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
     }
   ]
 }

--- a/scripts/ingestElectronics.ts
+++ b/scripts/ingestElectronics.ts
@@ -93,13 +93,17 @@ export async function ingestElectronics(
       const scriptPath = resolve(repoRoot, part.kcad_source);
       const stepOut = join(src, `${part.id}.step`);
       try {
+        // CLI signature is positional: `export <format> <file> -o <out>`
+        // (there is no `-f` flag). Capture stderr into the warning on failure.
         execFileSync(
           process.execPath,
-          [cliPath, 'export', '-f', 'step', '-o', stepOut, scriptPath],
+          [cliPath, 'export', 'step', scriptPath, '-o', stepOut],
           { stdio: ['ignore', 'pipe', 'pipe'], timeout: 120_000 },
         );
       } catch (e) {
-        console.warn(`SKIP ${part.id}: kernelcad export failed — ${String(e)}`);
+        const err = e as { stderr?: Buffer; message?: string };
+        const detail = err.stderr?.toString().trim() || err.message || String(e);
+        console.warn(`SKIP ${part.id}: kernelcad export failed — ${detail}`);
         continue;
       }
       buf = readFileSync(stepOut);

--- a/scripts/ingestElectronics.ts
+++ b/scripts/ingestElectronics.ts
@@ -20,8 +20,9 @@
 // inspect electronics alone.
 
 import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, existsSync, copyFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
 import { ingestDirectory, type CatalogRecord } from './ingestParts';
 
 interface ManifestPart {
@@ -29,11 +30,16 @@ interface ManifestPart {
   name: string;
   family: string;
   mpn: string;
-  /** Path appended to the manifest baseModelUrl. Ignored if `url` is set. */
+  /** Path appended to the manifest baseModelUrl. Ignored if `url` or `kcad_source` is set. */
   model?: string;
   /** Full model URL (overrides baseModelUrl + model) — for parts from a
    *  different CC-licensed source than the default catalog base. */
   url?: string;
+  /** Path to a kernelCAD `.kcad.ts` authored source (relative to repo root).
+   *  When set, the ingest step compiles the script and exports it to STEP using
+   *  the bundled kernelCAD CLI (`node dist/cli/index.js export -f step …`).
+   *  Takes priority over `url` and `model`. */
+  kcad_source?: string;
   tags?: string[];
   /** Per-part license / attribution override (e.g. an MIT Adafruit STEP in an
    *  otherwise CC-BY-SA KiCad manifest). Falls back to the manifest defaults. */
@@ -73,22 +79,51 @@ export async function ingestElectronics(
   const src = mkdtempSync(join(tmpdir(), 'kc-electronics-'));
   mkdirSync(src, { recursive: true });
 
+  // Resolve the kernelCAD CLI so authored parts can be compiled to STEP.
+  // The CLI is built into dist/cli/index.js relative to the repo root.
+  const repoRoot = resolve(dirname(manifestPath), '..');
+  const cliPath = join(repoRoot, 'dist', 'cli', 'index.js');
+
   let ok = 0;
   for (const part of manifest.parts) {
-    // Full per-part URL wins (different CC source); else baseModelUrl + model.
-    const url = part.url ?? `${manifest.baseModelUrl.replace(/\/$/, '')}/${part.model}`;
-    const res = await fetch(url);
-    if (!res.ok) {
-      console.warn(`SKIP ${part.id}: fetch ${url} -> HTTP ${res.status}`);
-      continue;
+    let buf: Buffer;
+
+    if (part.kcad_source) {
+      // Authored model: compile the .kcad.ts script to STEP using the kernelCAD CLI.
+      const scriptPath = resolve(repoRoot, part.kcad_source);
+      const stepOut = join(src, `${part.id}.step`);
+      try {
+        execFileSync(
+          process.execPath,
+          [cliPath, 'export', '-f', 'step', '-o', stepOut, scriptPath],
+          { stdio: ['ignore', 'pipe', 'pipe'], timeout: 120_000 },
+        );
+      } catch (e) {
+        console.warn(`SKIP ${part.id}: kernelcad export failed — ${String(e)}`);
+        continue;
+      }
+      buf = readFileSync(stepOut);
+      if (!buf.subarray(0, 64).toString('latin1').includes('ISO-10303-21')) {
+        console.warn(`SKIP ${part.id}: exported file is not a STEP file`);
+        continue;
+      }
+      // Step file is already written to src by the CLI; skip the writeFileSync below.
+    } else {
+      // Remote URL (full per-part URL wins; else baseModelUrl + model path).
+      const url = part.url ?? `${manifest.baseModelUrl.replace(/\/$/, '')}/${part.model}`;
+      const res = await fetch(url);
+      if (!res.ok) {
+        console.warn(`SKIP ${part.id}: fetch ${url} -> HTTP ${res.status}`);
+        continue;
+      }
+      buf = Buffer.from(await res.arrayBuffer());
+      // Guard against an HTML 404 page slipping through as a "200" on some CDNs.
+      if (!buf.subarray(0, 64).toString('latin1').includes('ISO-10303-21')) {
+        console.warn(`SKIP ${part.id}: ${url} did not return a STEP file`);
+        continue;
+      }
+      writeFileSync(join(src, `${part.id}.step`), buf);
     }
-    const buf = Buffer.from(await res.arrayBuffer());
-    // Guard against an HTML 404 page slipping through as a "200" on some CDNs.
-    if (!buf.subarray(0, 64).toString('latin1').includes('ISO-10303-21')) {
-      console.warn(`SKIP ${part.id}: ${url} did not return a STEP file`);
-      continue;
-    }
-    writeFileSync(join(src, `${part.id}.step`), buf);
     writeFileSync(
       join(src, `${part.id}.meta.json`),
       JSON.stringify(

--- a/scripts/parts/authored/bme280.kcad.ts
+++ b/scripts/parts/authored/bme280.kcad.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/bme280.kcad.ts
+//
+// BME280 environmental sensor breakout (Adafruit / SparkFun style).
+// Overall footprint: 19 x 18 x 3 mm.
+// Layout: blue PCB slab; BME280 LGA package (2.5×2.5×0.9mm) near center;
+// 6-pin 2.54mm header on one long edge; a few 0402 passives.
+
+const PCB_L = 19.0;
+const PCB_W = 18.0;
+const PCB_T = 1.6;
+
+const PCB_BLUE = '#1a2a4a';
+const IC_DARK  = '#282830';
+const GOLD     = '#c8a040';
+const PASSIVE  = '#7a6040';
+
+// PCB slab
+const pcb = box(PCB_L, PCB_W, PCB_T).color(PCB_BLUE);
+
+// BME280 LGA chip (2.5×2.5×0.9mm, center of board slightly toward +X)
+const bme = box(2.5, 2.5, 0.9).color(IC_DARK).translate(9.5, 8.0, PCB_T);
+
+// 6-pin header (2.54mm pitch) on the left short edge (x=0 side)
+const pinCount = 6;
+const pinPitch = 2.54;
+const headerH = (pinCount - 1) * pinPitch + 2.5;
+const headerY = (PCB_W - headerH) / 2;
+const headerBody = box(2.5, headerH, 2.5).color('#222236').translate(-2.5, headerY, PCB_T);
+const headerPins: Shape[] = [];
+for (let i = 0; i < pinCount; i++) {
+  const py = headerY + 1.25 + i * pinPitch;
+  headerPins.push(
+    box(6.0, 0.6, 0.6).color(GOLD).translate(-6.0, py, PCB_T + 0.9),
+  );
+}
+
+// 0402 decoupling capacitors
+const caps: Shape[] = [];
+const capPos: [number, number][] = [
+  [14.0, 6.0], [14.0, 8.5], [14.0, 11.0], [16.0, 6.0],
+];
+for (const [cx, cy] of capPos) {
+  caps.push(box(1.0, 0.5, 0.5).color(PASSIVE).translate(cx, cy, PCB_T));
+}
+
+const asm = assembly('bme280');
+asm.part('pcb', pcb);
+asm.part('bme280-ic', bme);
+asm.part('header-body', headerBody);
+headerPins.forEach((p, i) => asm.part(`header-pin-${i}`, p));
+caps.forEach((c, i) => asm.part(`cap-${i}`, c));
+
+return asm.model();

--- a/scripts/parts/authored/buck-24v-3v3.kcad.ts
+++ b/scripts/parts/authored/buck-24v-3v3.kcad.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/buck-24v-3v3.kcad.ts
+//
+// 24V → 3.3V step-down (buck) regulator breakout module.
+// Overall footprint: 18 x 12 x 4 mm.
+// Dominant features: shielded power inductor (4×4×3mm), buck controller IC,
+// input/output ceramic caps, and a 2-pin screw terminal on each end.
+
+const PCB_L = 18.0;
+const PCB_W = 12.0;
+const PCB_T = 1.6;
+
+const PCB_BLUE   = '#1a2a4a';
+const INDUCTOR   = '#4a4a4a';  // ferrite-shielded inductor
+const IC_DARK    = '#1c1c24';
+const CAP_YELLOW = '#c8aa20';  // ceramic MLCC (large, yellow-ish)
+const ELEC_BLUE  = '#204070';  // electrolytic cap
+const PIN_METAL  = '#b8b8b0';
+const TERM_GRAY  = '#505060';
+
+// PCB slab
+const pcb = box(PCB_L, PCB_W, PCB_T).color(PCB_BLUE);
+
+// Shielded power inductor (4×4×3mm, near center of board)
+const inductor = box(4.0, 4.0, 3.0).color(INDUCTOR).translate(7.0, 4.0, PCB_T);
+
+// Buck controller IC (SOP-8, ~5×4×1.2mm, next to inductor)
+const ic = box(5.0, 4.0, 1.2).color(IC_DARK).translate(1.5, 4.0, PCB_T);
+
+// Input bulk capacitor (electrolytic 5×5.4mm), near +Y edge
+const inputCap = cylinder(3.4, 2.5, 32).color(ELEC_BLUE).translate(13.5, 6.5, PCB_T);
+const inputCapTop = box(5.5, 5.5, 0.3).color('#101830').translate(11.2, 4.2, PCB_T + 3.4);
+
+// Output ceramic caps (1206 package, ~3.2×1.6×1.8mm)
+const outCap1 = box(3.2, 1.6, 1.8).color(CAP_YELLOW).translate(13.0, 1.5, PCB_T);
+const outCap2 = box(3.2, 1.6, 1.8).color(CAP_YELLOW).translate(13.0, 4.0, PCB_T);
+
+// Feedback resistors (0402)
+const res: Shape[] = [];
+for (const [rx, ry] of [[7.0, 1.0], [9.5, 1.0], [7.0, 10.0]] as [number, number][]) {
+  res.push(box(1.0, 0.5, 0.5).color('#8a6040').translate(rx, ry, PCB_T));
+}
+
+// 2-pin screw terminal, input end (x=0), 5mm pitch
+const termIn = box(11.5, 6.0, 4.0).color(TERM_GRAY).translate(-3.0, 3.0, PCB_T);
+const termInSlot1 = box(2.5, 2.5, 3.5).color('#282834').translate(-2.7, 3.2, PCB_T + 0.5);
+const termInSlot2 = box(2.5, 2.5, 3.5).color('#282834').translate(-2.7, 7.2, PCB_T + 0.5);
+// Screw heads
+const screw1 = cylinder(0.5, 1.1, 16).color('#888898').translate(-1.5, 4.4, PCB_T + 3.5);
+const screw2 = cylinder(0.5, 1.1, 16).color('#888898').translate(-1.5, 8.4, PCB_T + 3.5);
+
+// 2-pin screw terminal, output end (x=18)
+const termOut = box(11.5, 6.0, 4.0).color(TERM_GRAY).translate(PCB_L - 8.5, 3.0, PCB_T);
+const termOutSlot1 = box(2.5, 2.5, 3.5).color('#282834').translate(PCB_L + 0.2, 3.2, PCB_T + 0.5);
+const termOutSlot2 = box(2.5, 2.5, 3.5).color('#282834').translate(PCB_L + 0.2, 7.2, PCB_T + 0.5);
+const screw3 = cylinder(0.5, 1.1, 16).color('#888898').translate(PCB_L + 1.0, 4.4, PCB_T + 3.5);
+const screw4 = cylinder(0.5, 1.1, 16).color('#888898').translate(PCB_L + 1.0, 8.4, PCB_T + 3.5);
+
+const asm = assembly('buck-24v-3v3');
+asm.part('pcb', pcb);
+asm.part('inductor', inductor);
+asm.part('buck-ic', ic);
+asm.part('input-cap', inputCap);
+asm.part('input-cap-top', inputCapTop);
+asm.part('output-cap-1', outCap1);
+asm.part('output-cap-2', outCap2);
+res.forEach((r, i) => asm.part(`resistor-${i}`, r));
+asm.part('term-in-body', termIn);
+asm.part('term-in-slot-1', termInSlot1);
+asm.part('term-in-slot-2', termInSlot2);
+asm.part('screw-1', screw1);
+asm.part('screw-2', screw2);
+asm.part('term-out-body', termOut);
+asm.part('term-out-slot-1', termOutSlot1);
+asm.part('term-out-slot-2', termOutSlot2);
+asm.part('screw-3', screw3);
+asm.part('screw-4', screw4);
+
+return asm.model();

--- a/scripts/parts/authored/buck-24v-3v3.kcad.ts
+++ b/scripts/parts/authored/buck-24v-3v3.kcad.ts
@@ -16,7 +16,6 @@ const INDUCTOR   = '#4a4a4a';  // ferrite-shielded inductor
 const IC_DARK    = '#1c1c24';
 const CAP_YELLOW = '#c8aa20';  // ceramic MLCC (large, yellow-ish)
 const ELEC_BLUE  = '#204070';  // electrolytic cap
-const PIN_METAL  = '#b8b8b0';
 const TERM_GRAY  = '#505060';
 
 // PCB slab

--- a/scripts/parts/authored/dht22.kcad.ts
+++ b/scripts/parts/authored/dht22.kcad.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/dht22.kcad.ts
+//
+// DHT22 / AM2302 temperature + humidity sensor.
+// Overall footprint: 15 x 25 x 8 mm.
+// Iconic feature: white rectangular body with a ventilation grille on the
+// back face; four straight 1mm square pins protrude from the bottom (-Z).
+// Grille is represented by overlaid dark strips (no boolean subtraction).
+
+const BDY_L = 15.0;  // X
+const BDY_W = 8.0;   // Y (depth)
+const BDY_H = 25.0;  // Z (height)
+
+const WHITE = '#e8e8ec';
+const GRAY  = '#555560';  // grille strips
+const DARK  = '#2a2a30';  // label area
+const PIN   = '#c8c8c0';  // metallic pin
+
+// Main body
+const body = box(BDY_L, BDY_W, BDY_H).color(WHITE);
+
+// Ventilation grille — dark strips on the back (+Y) face
+const grille: Shape[] = [];
+for (let i = 0; i < 8; i++) {
+  const z = 3.0 + i * 2.2;
+  if (z + 1.2 > BDY_H - 1.5) break;
+  grille.push(box(BDY_L, 0.5, 1.2).color(GRAY).translate(0, BDY_W - 0.5, z));
+}
+
+// Small raised bump/nub at the top (sensor dome indicator)
+const dome = cylinder(1.5, 2.5, 32).color('#d0d0d4').translate(BDY_L / 2, BDY_W / 2, BDY_H);
+
+// Connector part-number label (dark rectangle on front face, near bottom)
+const label = box(10.0, 0.3, 4.0).color(DARK).translate(2.5, 0.0, 3.0);
+
+// Four 0.5mm square pins, 2.54mm pitch (centered in X)
+const pins: Shape[] = [];
+const pinH = 4.5;
+const pinStartX = (BDY_L - 3 * 2.54) / 2;
+for (let i = 0; i < 4; i++) {
+  pins.push(
+    box(0.5, 0.5, pinH)
+      .color(PIN)
+      .translate(pinStartX + i * 2.54, (BDY_W - 0.5) / 2, -pinH),
+  );
+}
+
+const asm = assembly('dht22');
+asm.part('body', body);
+grille.forEach((g, i) => asm.part(`grille-${i}`, g));
+asm.part('dome', dome);
+asm.part('label', label);
+pins.forEach((p, i) => asm.part(`pin-${i}`, p));
+
+return asm.model();

--- a/scripts/parts/authored/max14827.kcad.ts
+++ b/scripts/parts/authored/max14827.kcad.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/max14827.kcad.ts
+//
+// MAX14827 IO-Link PHY breakout module.
+// Overall footprint: 12 x 10 x 2 mm.
+// Layout: small green PCB (12×10×1.6mm); MAX14827 QFN IC (~4×4×0.8mm) centered;
+// 2-pin C/Q connector block on one long edge; a few bypass caps; crystal/oscillator.
+
+const PCB_L = 12.0;
+const PCB_W = 10.0;
+const PCB_T = 1.6;
+
+const PCB_GREEN = '#1a3020';
+const IC_DARK   = '#1e1e26';
+const GOLD      = '#c8a040';
+const PASSIVE   = '#7a6040';
+const XTAL_GRAY = '#808090';
+
+// PCB slab
+const pcb = box(PCB_L, PCB_W, PCB_T).color(PCB_GREEN);
+
+// MAX14827 QFN-24 package (4×4×0.8mm) — IO-Link PHY, center-ish
+const ic = box(4.0, 4.0, 0.8).color(IC_DARK).translate((PCB_L - 4) / 2, (PCB_W - 4) / 2, PCB_T);
+
+// 2-pin IO-Link C/Q terminal connector on +Y edge
+const connW = 5.0;
+const connH = 3.5;
+const connDepth = 4.0;
+const connX = (PCB_L - connW) / 2;
+const connBody = box(connW, connDepth, connH).color('#2a2a36').translate(connX, PCB_W - 1.0, PCB_T);
+// two terminal holes (visual only, as slightly recessed boxes)
+const term1 = box(1.5, 1.5, connH - 0.6).color('#101018').translate(connX + 0.5, PCB_W + 1.0, PCB_T + 0.3);
+const term2 = box(1.5, 1.5, connH - 0.6).color('#101018').translate(connX + 3.0, PCB_W + 1.0, PCB_T + 0.3);
+
+// 4-pin debug/power header on -Y edge
+const dbgPinCount = 4;
+const dbgPinPitch = 2.54;
+const dbgHeaderW = (dbgPinCount - 1) * dbgPinPitch + 2.5;
+const dbgHeaderX = (PCB_L - dbgHeaderW) / 2;
+const dbgHeader = box(dbgHeaderW, 2.5, 2.5).color('#1a1a28').translate(dbgHeaderX, -2.5, PCB_T);
+const dbgPins: Shape[] = [];
+for (let i = 0; i < dbgPinCount; i++) {
+  const px = dbgHeaderX + 1.25 + i * dbgPinPitch;
+  dbgPins.push(box(0.6, 6.0, 0.6).color(GOLD).translate(px, -6.0, PCB_T + 0.9));
+}
+
+// 16MHz crystal (2016 package, 2×1.6×0.8mm)
+const xtal = box(2.0, 1.6, 0.8).color(XTAL_GRAY).translate(1.5, 1.5, PCB_T);
+
+// 0402 bypass capacitors
+const caps: Shape[] = [];
+for (const [cx, cy] of [[1.5, 4.0], [1.5, 6.0], [9.0, 4.0]] as [number, number][]) {
+  caps.push(box(1.0, 0.5, 0.5).color(PASSIVE).translate(cx, cy, PCB_T));
+}
+
+const asm = assembly('max14827');
+asm.part('pcb', pcb);
+asm.part('max14827-ic', ic);
+asm.part('connector-body', connBody);
+asm.part('terminal-1', term1);
+asm.part('terminal-2', term2);
+asm.part('debug-header', dbgHeader);
+dbgPins.forEach((p, i) => asm.part(`dbg-pin-${i}`, p));
+asm.part('xtal', xtal);
+caps.forEach((c, i) => asm.part(`cap-${i}`, c));
+
+return asm.model();

--- a/scripts/parts/authored/microsd-spi.kcad.ts
+++ b/scripts/parts/authored/microsd-spi.kcad.ts
@@ -28,7 +28,7 @@ const slotHousingW = 13.0;
 const slotHousingH = 2.0;
 const slotX = (PCB_L - slotHousingL) / 2;
 const slotY = PCB_W - slotHousingW;
-let sdSlot = box(slotHousingL, slotHousingW, slotHousingH)
+const sdSlot = box(slotHousingL, slotHousingW, slotHousingH)
   .color(SD_SILVER)
   .translate(slotX, slotY, PCB_T);
 // Card opening at the +Y end (1.4mm tall, card slides in)

--- a/scripts/parts/authored/microsd-spi.kcad.ts
+++ b/scripts/parts/authored/microsd-spi.kcad.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/microsd-spi.kcad.ts
+//
+// microSD SPI adapter breakout module.
+// Overall footprint: 24 x 30 x 4 mm.
+// Layout: blue PCB (24×30×1.6mm); microSD push-push slot (~14.5×13×2mm) on
+// the +Y end with card ejection toward +Y; 6-pin 2.54mm SPI header on the
+// -Y end; 3.3V LDO regulator and a few passives.
+
+const PCB_L = 24.0;  // X
+const PCB_W = 30.0;  // Y
+const PCB_T = 1.6;
+
+const PCB_BLUE  = '#1e3a5a';
+const SD_SILVER = '#c0c0c8';
+const SD_DARK   = '#383840';
+const GOLD      = '#c8a040';
+const PASSIVE   = '#7a6040';
+const IC_DARK   = '#222228';
+
+// PCB slab
+const pcb = box(PCB_L, PCB_W, PCB_T).color(PCB_BLUE);
+
+// microSD slot housing (~14.5 wide × 13 deep × 2 tall, top-mount on +Y side)
+const slotHousingL = 14.5;
+const slotHousingW = 13.0;
+const slotHousingH = 2.0;
+const slotX = (PCB_L - slotHousingL) / 2;
+const slotY = PCB_W - slotHousingW;
+let sdSlot = box(slotHousingL, slotHousingW, slotHousingH)
+  .color(SD_SILVER)
+  .translate(slotX, slotY, PCB_T);
+// Card opening at the +Y end (1.4mm tall, card slides in)
+const cardOpening = box(slotHousingL - 2.0, 0.6, 1.4)
+  .color(SD_DARK)
+  .translate(slotX + 1.0, PCB_W - 0.3, PCB_T + 0.3);
+
+// 6-pin SPI header on -Y end (Vcc, GND, MISO, MOSI, SCK, CS)
+const pinCount = 6;
+const pinPitch = 2.54;
+const headerW = (pinCount - 1) * pinPitch + 2.5;
+const headerX = (PCB_L - headerW) / 2;
+const headerBody = box(headerW, 2.5, 2.5).color('#1a1a28').translate(headerX, -2.5, PCB_T);
+const pins: Shape[] = [];
+for (let i = 0; i < pinCount; i++) {
+  const px = headerX + 1.25 + i * pinPitch;
+  pins.push(box(0.6, 6.0, 0.6).color(GOLD).translate(px, -6.0, PCB_T + 0.9));
+}
+
+// 3.3V LDO (SOT-23-5 footprint)
+const ldo = box(2.9, 2.8, 1.5).color(IC_DARK).translate(2.0, 5.0, PCB_T);
+
+// Decoupling capacitors
+const caps: Shape[] = [];
+for (const [cx, cy] of [[5.0, 5.0], [5.0, 7.5], [18.0, 5.0], [18.0, 7.5]] as [number, number][]) {
+  caps.push(box(1.0, 0.5, 0.5).color(PASSIVE).translate(cx, cy, PCB_T));
+}
+
+const asm = assembly('microsd-spi');
+asm.part('pcb', pcb);
+asm.part('sd-slot', sdSlot);
+asm.part('card-opening', cardOpening);
+asm.part('header-body', headerBody);
+pins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('ldo', ldo);
+caps.forEach((c, i) => asm.part(`cap-${i}`, c));
+
+return asm.model();

--- a/scripts/parts/authored/pushbutton-6mm.kcad.ts
+++ b/scripts/parts/authored/pushbutton-6mm.kcad.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/pushbutton-6mm.kcad.ts
+//
+// 6mm tactile pushbutton (SMD/THT tact switch).
+// Overall footprint: 6 x 6 x 5 mm (body 3.5mm + 1.5mm actuator cap on top).
+// Four J-legs at corners; square dark-grey body; rounded cylindrical actuator cap.
+
+const BTN_L = 6.0;
+const BTN_W = 6.0;
+const BTN_BODY_H = 3.5;
+const BTN_CAP_H  = 1.5;
+
+const BODY_GRAY = '#3a3a40';
+const CAP_GRAY  = '#5a5a62';
+const PIN_METAL = '#b8b8b0';
+
+// Main body (6×6×3.5mm, square, dark grey)
+const body = box(BTN_L, BTN_W, BTN_BODY_H).color(BODY_GRAY);
+
+// Actuator cap (cylindrical, diameter ~3.5mm, height 1.5mm)
+const cap = cylinder(BTN_CAP_H, 1.75, 32)
+  .color(CAP_GRAY)
+  .translate(BTN_L / 2, BTN_W / 2, BTN_BODY_H);
+
+// J-shaped legs at all four corners (simplified as flat metal tabs)
+// Each leg: a small rectangular tab that extends slightly beyond the body footprint
+const legs: Shape[] = [];
+const legL = 1.5;
+const legW = 0.8;
+const legT = 0.3;
+// corner offsets: [x, y] relative to button corner, with the tab protruding outward
+const legDefs: [number, number, number, number][] = [
+  // [x, y, tab extends in x(-1=neg,+1=pos), tab extends in y]
+  [0, 0, -1, 0],
+  [BTN_L - legL, 0, 1, 0],
+  [0, BTN_W - legW, -1, 0],
+  [BTN_L - legL, BTN_W - legW, 1, 0],
+];
+// Simplified: just small rectangular flat pads at each corner
+const padL = 1.5;
+const padW = 0.8;
+const padH = 0.3;
+const cornerOffsets: [number, number][] = [
+  [-padL + 0.2, 0.3],
+  [BTN_L - 0.2, 0.3],
+  [-padL + 0.2, BTN_W - padW - 0.3],
+  [BTN_L - 0.2, BTN_W - padW - 0.3],
+];
+for (const [ox, oy] of cornerOffsets) {
+  legs.push(box(padL, padW, padH).color(PIN_METAL).translate(ox, oy, 0));
+}
+
+const asm = assembly('pushbutton-6mm');
+asm.part('body', body);
+asm.part('cap', cap);
+legs.forEach((l, i) => asm.part(`leg-${i}`, l));
+
+return asm.model();

--- a/scripts/parts/authored/pushbutton-6mm.kcad.ts
+++ b/scripts/parts/authored/pushbutton-6mm.kcad.ts
@@ -23,21 +23,9 @@ const cap = cylinder(BTN_CAP_H, 1.75, 32)
   .color(CAP_GRAY)
   .translate(BTN_L / 2, BTN_W / 2, BTN_BODY_H);
 
-// J-shaped legs at all four corners (simplified as flat metal tabs)
-// Each leg: a small rectangular tab that extends slightly beyond the body footprint
+// Four J-legs at the corners, simplified as small flat metal pads that
+// extend slightly beyond the body footprint.
 const legs: Shape[] = [];
-const legL = 1.5;
-const legW = 0.8;
-const legT = 0.3;
-// corner offsets: [x, y] relative to button corner, with the tab protruding outward
-const legDefs: [number, number, number, number][] = [
-  // [x, y, tab extends in x(-1=neg,+1=pos), tab extends in y]
-  [0, 0, -1, 0],
-  [BTN_L - legL, 0, 1, 0],
-  [0, BTN_W - legW, -1, 0],
-  [BTN_L - legL, BTN_W - legW, 1, 0],
-];
-// Simplified: just small rectangular flat pads at each corner
 const padL = 1.5;
 const padW = 0.8;
 const padH = 0.3;

--- a/scripts/parts/authored/ssd1306-oled-096.kcad.ts
+++ b/scripts/parts/authored/ssd1306-oled-096.kcad.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/ssd1306-oled-096.kcad.ts
+//
+// SSD1306 0.96" I2C OLED display module.
+// Overall footprint: 27 x 27 x 4 mm.
+// Layout: PCB slab (27x27x1.6mm, black); OLED glass panel (~23.5x23.5mm) sits
+// on top inset from the PCB edge; active pixel area ~21x11mm (128x64 aspect).
+// 4-pin I2C header (2.54mm pitch) on the bottom edge (+Y side).
+
+const PCB_L = 27;
+const PCB_W = 27;
+const PCB_T = 1.6;
+
+const PCB_BLACK = '#101014';
+const GLASS_BLUE = '#0d1a2a';
+const PIXEL_GLOW = '#1a3060';
+const HEADER_GOLD = '#c8a040';
+const PASSIVE_TAN = '#8a7050';
+
+// PCB slab
+const pcb = box(PCB_L, PCB_W, PCB_T).color(PCB_BLACK);
+
+// OLED glass panel (sits on top of PCB, centered)
+const glassL = 23.5;
+const glassW = 23.5;
+const glassT = 1.6;
+const glassX = (PCB_L - glassL) / 2;
+const glassY = (PCB_W - glassW) / 2;
+const glass = box(glassL, glassW, glassT).color(GLASS_BLUE).translate(glassX, glassY, PCB_T);
+
+// Active pixel area (slightly recessed into glass)
+const activeL = 21.7;
+const activeW = 11.0;
+const activeT = 0.4;
+const activeX = glassX + (glassL - activeL) / 2;
+const activeY = glassY + (glassW - activeW) / 2 + 1.5;
+const activeArea = box(activeL, activeW, activeT).color(PIXEL_GLOW).translate(activeX, activeY, PCB_T + glassT - 0.2);
+
+// 4-pin I2C header on the top edge (y=0 side), 2.54mm pitch, centered in X
+const pinCount = 4;
+const pinPitch = 2.54;
+const headerW = (pinCount - 1) * pinPitch + 2.5;
+const headerX = (PCB_L - headerW) / 2;
+const headerY = -2.5;
+const headerBody = box(headerW, 2.5, 2.5).color('#222230').translate(headerX, headerY, PCB_T);
+// individual gold pins
+const headerPins: Shape[] = [];
+for (let i = 0; i < pinCount; i++) {
+  const px = headerX + 1.25 + i * pinPitch;
+  headerPins.push(
+    box(0.6, 6.0, 0.6)
+      .color(HEADER_GOLD)
+      .translate(px, headerY - 3.5, PCB_T + 0.9),
+  );
+}
+
+// A few decoupling capacitors (0402) on the back side
+const caps: Shape[] = [];
+const capPositions: [number, number][] = [
+  [4, 4], [4, 7], [22, 4],
+];
+for (const [cx, cy] of capPositions) {
+  caps.push(box(1.0, 0.5, 0.5).color(PASSIVE_TAN).translate(cx, cy, PCB_T));
+}
+
+// SSD1306 driver IC (small QFN on back of PCB, shown on underside)
+const ic = box(4.0, 4.0, 0.8).color('#181820').translate(11, 11, -0.8);
+
+const asm = assembly('ssd1306-oled-096');
+asm.part('pcb', pcb);
+asm.part('glass', glass);
+asm.part('active-area', activeArea);
+asm.part('header-body', headerBody);
+headerPins.forEach((p, i) => asm.part(`header-pin-${i}`, p));
+caps.forEach((c, i) => asm.part(`cap-${i}`, c));
+asm.part('ssd1306-ic', ic);
+
+return asm.model();

--- a/scripts/parts/authored/ws2812-strip.kcad.ts
+++ b/scripts/parts/authored/ws2812-strip.kcad.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/ws2812-strip.kcad.ts
+//
+// WS2812B NeoPixel LED strip segment (3 pixels).
+// Overall footprint: 17 x 10 x 3 mm.
+// Layout: dark PCB strip; three WS2812B packages (5×5×1.7mm) evenly spaced;
+// copper pads visible at both ends for daisy-chain wiring; 4 solder tabs each.
+
+const STRIP_L = 17.0;
+const STRIP_W = 10.0;
+const STRIP_T = 1.6;
+
+const PCB_GREEN = '#1a3020';
+const LED_WHITE = '#e0e0e4';
+const COPPER    = '#b8763a';
+const LED_LENS  = '#dde8dd';  // diffused white lens
+
+// PCB strip
+const pcb = box(STRIP_L, STRIP_W, STRIP_T).color(PCB_GREEN);
+
+// Three WS2812B LED packages, 5×5×1.7mm, evenly spaced
+const ledCount = 3;
+const ledL = 5.0;
+const ledW = 5.0;
+const ledT = 1.7;
+const ledPitch = (STRIP_L - ledL) / (ledCount - 1);
+
+const leds: Shape[] = [];
+const lenses: Shape[] = [];
+for (let i = 0; i < ledCount; i++) {
+  const lx = i === 0 ? 0 : i === 1 ? (STRIP_L - ledL) / 2 : STRIP_L - ledL;
+  const ly = (STRIP_W - ledW) / 2;
+  // LED package body (black epoxy)
+  leds.push(
+    box(ledL, ledW, ledT)
+      .color('#101010')
+      .translate(lx, ly, STRIP_T),
+  );
+  // Diffused lens window (center, slightly recessed)
+  lenses.push(
+    box(3.5, 3.5, 0.3)
+      .color(LED_LENS)
+      .translate(lx + (ledL - 3.5) / 2, ly + (ledW - 3.5) / 2, STRIP_T + ledT - 0.2),
+  );
+}
+
+// Copper connection pads at each end of the strip (4 pads per end)
+const pads: Shape[] = [];
+const padPositions = [0.4, 0.5 + 2.0, 0.5 + 4.0, 0.5 + 6.0]; // Y positions
+for (const py of padPositions) {
+  // left end
+  pads.push(box(2.0, 1.2, 0.1).color(COPPER).translate(-1.5, py, STRIP_T));
+  // right end
+  pads.push(box(2.0, 1.2, 0.1).color(COPPER).translate(STRIP_L - 0.5, py, STRIP_T));
+}
+
+const asm = assembly('ws2812-strip');
+asm.part('pcb', pcb);
+leds.forEach((l, i) => asm.part(`led-${i}`, l));
+lenses.forEach((l, i) => asm.part(`lens-${i}`, l));
+pads.forEach((p, i) => asm.part(`pad-${i}`, p));
+
+return asm.model();

--- a/scripts/parts/authored/ws2812-strip.kcad.ts
+++ b/scripts/parts/authored/ws2812-strip.kcad.ts
@@ -12,7 +12,6 @@ const STRIP_W = 10.0;
 const STRIP_T = 1.6;
 
 const PCB_GREEN = '#1a3020';
-const LED_WHITE = '#e0e0e4';
 const COPPER    = '#b8763a';
 const LED_LENS  = '#dde8dd';  // diffused white lens
 
@@ -24,7 +23,6 @@ const ledCount = 3;
 const ledL = 5.0;
 const ledW = 5.0;
 const ledT = 1.7;
-const ledPitch = (STRIP_L - ledL) / (ledCount - 1);
 
 const leds: Shape[] = [];
 const lenses: Shape[] = [];


### PR DESCRIPTION
Adds 8 license-clean authored kernelCAD part models so the proto.cat catalog covers the components currently rendered as bare boxes: SSD1306 OLED, DHT22, WS2812 strip, BME280, microSD-SPI, 6mm pushbutton, MAX14827 IO-Link PHY, and 24V→3V3 buck.

Each is a parametric .kcad.ts assembly under scripts/parts/authored/, registered in scripts/electronics-parts.json via the new `kcad_source` field; ingestElectronics.ts compiles them to STEP through the kernelCAD CLI at ingest time (same path as URL-sourced parts).

Verification (local, this branch): all 8 export to valid STEP (ISO-10303-21) via `kernelcad export step`; all 8 render with their iconic features intact (OLED panel + I2C header, DHT22 grille + dome + pins, 3 WS2812 packages + copper pads, BME280 chip + header, microSD slot housing, tact-switch cap + legs, MAX14827 IC + C/Q terminal, buck dual screw-terminals + inductor). The mechanism-broken render watermark is the expected orphan-part/interpenetration noise for static decorative multi-part models.