### PR TITLE
Fix joint/kinematic-check findings (revolute API, pose limits, load-capacity, mounting-holes, error clarity)

### DIFF
--- a/src/agent/mcp/tools/checkMountingHoleConsistency.ts
+++ b/src/agent/mcp/tools/checkMountingHoleConsistency.ts
@@ -23,6 +23,9 @@ export type CheckMountingHoleConsistencyOutput =
   | {
       ok: boolean;
       source: 'local';
+      /** Fastened-mate interfaces actually examined. 0 => vacuous green;
+       *  the diagnostics carry a kinematic.mounting-holes.no-coverage note. */
+      checked: number;
       mismatches: ReadonlyArray<MountingHoleMismatch>;
       diagnostics: ReadonlyArray<KinematicDiagnostic>;
     }
@@ -61,6 +64,7 @@ export async function checkMountingHoleConsistencyTool(
   return {
     ok: result.ok,
     source: result.source,
+    checked: result.checked,
     mismatches: result.mismatches,
     diagnostics: result.diagnostics,
   };

--- a/src/agent/mcp/tools/checkMountingHoleConsistency.ts
+++ b/src/agent/mcp/tools/checkMountingHoleConsistency.ts
@@ -24,7 +24,7 @@ export type CheckMountingHoleConsistencyOutput =
       ok: boolean;
       source: 'local';
       /** Fastened-mate interfaces actually examined. 0 => vacuous green;
-       *  the diagnostics carry a kinematic.mounting-holes.no-coverage note. */
+       *  the diagnostics carry a kinematic.mounting-hole.no-coverage note. */
       checked: number;
       mismatches: ReadonlyArray<MountingHoleMismatch>;
       diagnostics: ReadonlyArray<KinematicDiagnostic>;

--- a/src/kinematic/beamMaterials.ts
+++ b/src/kinematic/beamMaterials.ts
@@ -57,9 +57,28 @@ export const MATERIAL_CATALOG: Readonly<
   pet: { yieldStressPa: 55e6, youngsModulusPa: 2.7e9, densityKgPerM3: 1380 },
 });
 
+/** Catalog keys (everything except `custom`) — the runtime-valid bulk kinds. */
+export const CATALOG_KINDS: ReadonlyArray<Exclude<MaterialKind, 'custom'>> = [
+  'steel',
+  'aluminum',
+  'pla',
+  'abs',
+  'pet',
+];
+
 export type ResolveMaterialResult =
   | { readonly ok: true; readonly props: MaterialProps }
-  | { readonly ok: false; readonly missingField: 'yieldStressMPa' | 'youngsModulusGPa' };
+  | {
+      readonly ok: false;
+      readonly reason: 'missing-custom-field';
+      readonly missingField: 'yieldStressMPa' | 'youngsModulusGPa';
+    }
+  | {
+      readonly ok: false;
+      readonly reason: 'unknown-material';
+      /** The offending value as the caller passed it, for the diagnostic. */
+      readonly material: string;
+    };
 
 /**
  * Resolve a per-part `MaterialDeclarationEntry` to its numeric SI props.
@@ -72,17 +91,23 @@ export type ResolveMaterialResult =
  *   default density.
  * - `material: 'custom'` requires both `yieldStressMPa` and
  *   `youngsModulusGPa`. Missing either field returns
- *   `{ ok: false, missingField }` and the caller emits K8.
+ *   `{ ok: false, reason: 'missing-custom-field', missingField }` and the
+ *   caller emits K8.
+ * - An unrecognised `material` value (a typo or bare SKU like
+ *   `'aluminum-6061'` that is neither `'custom'` nor a catalog key) returns
+ *   `{ ok: false, reason: 'unknown-material', material }` instead of crashing
+ *   on an undefined catalog row — the caller turns this into a clear
+ *   diagnostic naming the offending value.
  */
 export function resolveMaterialProps(
   entry: MaterialDeclarationEntry,
 ): ResolveMaterialResult {
   if (entry.material === 'custom') {
     if (entry.yieldStressMPa === undefined || !Number.isFinite(entry.yieldStressMPa)) {
-      return { ok: false, missingField: 'yieldStressMPa' };
+      return { ok: false, reason: 'missing-custom-field', missingField: 'yieldStressMPa' };
     }
     if (entry.youngsModulusGPa === undefined || !Number.isFinite(entry.youngsModulusGPa)) {
-      return { ok: false, missingField: 'youngsModulusGPa' };
+      return { ok: false, reason: 'missing-custom-field', missingField: 'youngsModulusGPa' };
     }
     return {
       ok: true,
@@ -93,7 +118,12 @@ export function resolveMaterialProps(
       },
     };
   }
-  const catalog = MATERIAL_CATALOG[entry.material];
+  // Guard the catalog lookup: a value outside the known kinds (a typo or a
+  // bare SKU string) would otherwise read `yieldStressPa` off `undefined`.
+  const catalog = MATERIAL_CATALOG[entry.material as Exclude<MaterialKind, 'custom'>];
+  if (catalog === undefined) {
+    return { ok: false, reason: 'unknown-material', material: String(entry.material) };
+  }
   return {
     ok: true,
     props: {

--- a/src/kinematic/checkLoadCapacity.ts
+++ b/src/kinematic/checkLoadCapacity.ts
@@ -25,8 +25,12 @@
 // Out-of-applicability triggers (each fires K7, severity 'warn', and the
 // part is not added to `result.elements` — its data would be unreliable):
 //   - no declared `crossSection` on the part;
-//   - more than one mate on the part (so the cantilever assumption fails);
-//   - zero mates on the part (no root reference for the moment arm).
+//   - more than one anchor on the part (so the cantilever assumption fails);
+//   - zero anchors on the part (no root reference for the moment arm).
+//
+// An "anchor" is a single mate OR a directly-registered joint
+// (`arm.revolute()` / `arm.prismatic()` / `arm.fixed()`, first-class since
+// issue #535) — both pin the part's root frame for the moment-arm reference.
 //
 // Real FEA (multi-mate, swept volumes, non-uniform sections, NURBS
 // cross-section beams, deflection limit gates) is deferred to a v2
@@ -44,7 +48,7 @@ import type {
 } from './types';
 import { DIAGNOSTIC_REGISTRY, type DiagnosticCode } from '../shared/diagnostics/registry';
 import { sectionProperties } from './beamGeometry';
-import { resolveMaterialProps, type MaterialProps } from './beamMaterials';
+import { resolveMaterialProps, CATALOG_KINDS, type MaterialProps } from './beamMaterials';
 import { validateJointLoadCapacity } from '../modeling/mates/jointLoadCapacity';
 
 const DEFAULT_SF_THRESHOLD = 1.5;
@@ -186,15 +190,27 @@ function runBeamMode(
 
   const parts = arm.__parts();
   const mates = arm.__mates();
+  const joints = arm.__joints();
   const partByName = new Map(parts.map((p) => [p.name, p]));
-  // Mate-count per part — single-mate parts satisfy the cantilever boundary
-  // condition; >1 mate is multi-supported (beam-not-applicable in v1).
-  const mateCount = new Map<string, number>();
+  const partNameById = new Map(parts.map((p) => [p.id, p.name]));
+  // Anchor-count per part — a single anchor (mate OR directly-registered
+  // joint) satisfies the cantilever boundary condition (one root reference
+  // for the moment arm); >1 anchor is multi-supported (beam-not-applicable
+  // in v1), 0 anchors has no root. Joints from `arm.revolute()` /
+  // `arm.prismatic()` / `arm.fixed()` (first-class since #535) anchor a part
+  // the same way a mate does — each has a parent/child and an origin — so a
+  // part held only by a joint is still a valid cantilever root (issue #540).
+  const anchorCount = new Map<string, number>();
+  const bump = (name: string | undefined): void => {
+    if (name !== undefined) anchorCount.set(name, (anchorCount.get(name) ?? 0) + 1);
+  };
   for (const m of mates) {
-    const aPart = m.a.split('.')[0];
-    const bPart = m.b.split('.')[0];
-    if (aPart !== undefined) mateCount.set(aPart, (mateCount.get(aPart) ?? 0) + 1);
-    if (bPart !== undefined) mateCount.set(bPart, (mateCount.get(bPart) ?? 0) + 1);
+    bump(m.a.split('.')[0]);
+    bump(m.b.split('.')[0]);
+  }
+  for (const j of joints) {
+    bump(partNameById.get(j.parentPartId));
+    bump(partNameById.get(j.childPartId));
   }
 
   let worstSF = Number.POSITIVE_INFINITY;
@@ -204,13 +220,12 @@ function runBeamMode(
     const matEntry: MaterialDeclarationEntry = opts!.materials![partName]!;
     const matResolved = resolveMaterialProps(matEntry);
     if (!matResolved.ok) {
+      const message =
+        matResolved.reason === 'unknown-material'
+          ? `Material declaration for '${partName}' names unknown material '${matResolved.material}' (valid: ${CATALOG_KINDS.join('|')}, or material: 'custom' with yieldStressMPa + youngsModulusGPa).`
+          : `Material declaration for '${partName}' uses material: 'custom' but is missing ${matResolved.missingField}. Both yieldStressMPa and youngsModulusGPa are required for custom materials.`;
       diagnostics.push(
-        buildDiag(
-          'kinematic.no-material-declared',
-          'error',
-          `Material declaration for '${partName}' uses material: 'custom' but is missing ${matResolved.missingField}. Both yieldStressMPa and youngsModulusGPa are required for custom materials.`,
-          partName,
-        ),
+        buildDiag('kinematic.no-material-declared', 'error', message, partName),
       );
       continue;
     }
@@ -240,24 +255,24 @@ function runBeamMode(
       continue;
     }
 
-    const partMateCount = mateCount.get(partName) ?? 0;
-    if (partMateCount === 0) {
+    const partAnchorCount = anchorCount.get(partName) ?? 0;
+    if (partAnchorCount === 0) {
       diagnostics.push(
         buildDiag(
           'kinematic.load.beam-not-applicable',
           'warn',
-          `Part '${partName}' has no declared mate; the cantilever boundary requires exactly one root mate.`,
+          `Part '${partName}' has no declared mate or anchoring joint; the cantilever boundary requires exactly one root anchor.`,
           partName,
         ),
       );
       continue;
     }
-    if (partMateCount > 1) {
+    if (partAnchorCount > 1) {
       diagnostics.push(
         buildDiag(
           'kinematic.load.beam-not-applicable',
           'warn',
-          `Part '${partName}' is bound by ${partMateCount} mates; the v1 cantilever approximation requires exactly one. Decompose the part into single-mate segments or wait for v2 FEA.`,
+          `Part '${partName}' is bound by ${partAnchorCount} anchors (mates + joints); the v1 cantilever approximation requires exactly one. Decompose the part into single-anchor segments or wait for v2 FEA.`,
           partName,
         ),
       );

--- a/src/kinematic/checkMountingHoleConsistency.ts
+++ b/src/kinematic/checkMountingHoleConsistency.ts
@@ -43,6 +43,15 @@ export async function checkMountingHoleConsistency(
 ): Promise<MountingHoleResult> {
   const raw: ValidatorDiagnostic[] = validateMountingHoleConsistency(arm);
   const diagnostics: KinematicDiagnostic[] = raw.map(translateDiagnostic);
+  // Coverage count: how many fastened-mate interfaces the substrate had to
+  // examine. The substrate gates exactly the `type === 'fastened'` mates, so
+  // this mirrors its loop. When it is 0 there was nothing to verify and a
+  // green `ok` would be vacuous — emit an explicit no-coverage signal so the
+  // caller can tell "0 interfaces checked" apart from "all interfaces pass".
+  const checked = arm.__mates().filter((m) => m.type === 'fastened').length;
+  if (checked === 0) {
+    diagnostics.push(noCoverageDiagnostic());
+  }
   // P3 (2026-06-01): assembly.mounting-hole.mismatch was demoted from
   // 'error' to 'info' severity (it's now advisory; the merge gate is
   // mechanism.disconnect). The mismatches view still wants to surface
@@ -66,7 +75,28 @@ export async function checkMountingHoleConsistency(
   return {
     ok: mismatches.length === 0,
     mismatches,
+    checked,
     diagnostics,
+    source: 'local',
+  };
+}
+
+/**
+ * Build the zero-coverage info diagnostic. Stamped from the registry the same
+ * way as the substrate-derived ones (canonical severity + nextAction), with
+ * source: 'local' provenance. `ok` is deliberately left untouched (a clean
+ * assembly with no fastened mates still reports ok:true); this diagnostic is
+ * the signal that the green carries no verification behind it.
+ */
+function noCoverageDiagnostic(): KinematicDiagnostic {
+  const code: DiagnosticCode = 'kinematic.mounting-holes.no-coverage';
+  const registryEntry = DIAGNOSTIC_REGISTRY[code];
+  return {
+    code,
+    severity: 'info',
+    message: 'No fastened mates found; nothing was checked.',
+    hint: registryEntry.hintTemplate,
+    nextAction: registryEntry.nextAction,
     source: 'local',
   };
 }

--- a/src/kinematic/checkMountingHoleConsistency.ts
+++ b/src/kinematic/checkMountingHoleConsistency.ts
@@ -89,7 +89,7 @@ export async function checkMountingHoleConsistency(
  * the signal that the green carries no verification behind it.
  */
 function noCoverageDiagnostic(): KinematicDiagnostic {
-  const code: DiagnosticCode = 'kinematic.mounting-holes.no-coverage';
+  const code: DiagnosticCode = 'kinematic.mounting-hole.no-coverage';
   const registryEntry = DIAGNOSTIC_REGISTRY[code];
   return {
     code,

--- a/src/kinematic/types.ts
+++ b/src/kinematic/types.ts
@@ -81,7 +81,7 @@ export interface MountingHoleResult extends KinematicResultBase {
   readonly mismatches: ReadonlyArray<MountingHoleMismatch>;
   /** Number of fastened-mate interfaces actually examined by the gate. When
    *  0 the result is vacuous — a green `ok` verifies nothing, so the gate
-   *  also emits a `kinematic.mounting-holes.no-coverage` info diagnostic. */
+   *  also emits a `kinematic.mounting-hole.no-coverage` info diagnostic. */
   readonly checked: number;
 }
 

--- a/src/kinematic/types.ts
+++ b/src/kinematic/types.ts
@@ -79,6 +79,10 @@ export interface MountingHoleSideState {
 
 export interface MountingHoleResult extends KinematicResultBase {
   readonly mismatches: ReadonlyArray<MountingHoleMismatch>;
+  /** Number of fastened-mate interfaces actually examined by the gate. When
+   *  0 the result is vacuous — a green `ok` verifies nothing, so the gate
+   *  also emits a `kinematic.mounting-holes.no-coverage` info diagnostic. */
+  readonly checked: number;
 }
 
 // ===== checkSweptCollision =====

--- a/src/modeling/capture/assembly.chaining.test.ts
+++ b/src/modeling/capture/assembly.chaining.test.ts
@@ -47,3 +47,67 @@ describe('Assembly.part(...) fluent chaining', () => {
     expect(arm.__parts().map((p) => p.name)).toEqual(['base', 'link', 'tip']);
   });
 });
+
+// Issue #535: `assembly.revolute(...)` was removed in v0.5 and the only way to
+// declare a drivable revolute was reaching into internals. The public method is
+// restored — it must capture the joint on the body-tree graph and drive FK.
+describe('Assembly.revolute(...) capture', () => {
+  it('captures a revolute joint with kind/axis/origin/limitsDeg', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('arm');
+
+    const base = arm.part('base', kcad.box(10, 10, 10));
+    const link = arm.part('link', kcad.box(10, 10, 10), { at: [0, 0, 10] });
+
+    const ref = arm.revolute('hinge', base, link, {
+      axis: [0, 1, 0],
+      origin: [0, 0, 0],
+      limitsDeg: [-90, 90],
+    });
+
+    expect(ref).toEqual({ id: ref.id, name: 'hinge', kind: 'revolute' });
+
+    const joints = arm.__joints();
+    expect(joints).toHaveLength(1);
+    expect(joints[0]).toMatchObject({
+      name: 'hinge',
+      kind: 'revolute',
+      parentPartId: base.id,
+      childPartId: link.id,
+      axis: [0, 1, 0],
+      origin: [0, 0, 0],
+      limitsDeg: [-90, 90],
+    });
+  });
+
+  it('drives forward kinematics via solve({ hinge })', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('arm');
+
+    const base = arm.part('base', kcad.box(10, 10, 10));
+    const link = arm.part('link', kcad.box(10, 10, 10), { at: [0, 0, 10] });
+    arm.revolute('hinge', base, link, { axis: [0, 1, 0], origin: [0, 0, 0] });
+
+    const solved = arm.solve({ hinge: 60 });
+    expect(solved.value('hinge')).toBe(60);
+    // The driven child part has a defined world transform under the pose.
+    expect(solved.transform('link')).toBeDefined();
+  });
+
+  it('rejects a non-finite axis', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('arm');
+    const base = arm.part('base', kcad.box(10, 10, 10));
+    const link = arm.part('link', kcad.box(10, 10, 10));
+
+    expect(() =>
+      arm.revolute('hinge', base, link, {
+        axis: [Number.NaN, 0, 0],
+        origin: [0, 0, 0],
+      }),
+    ).toThrow(/revolute joint axis must be a finite Vec3/);
+  });
+});

--- a/src/modeling/capture/assembly.chaining.test.ts
+++ b/src/modeling/capture/assembly.chaining.test.ts
@@ -111,3 +111,66 @@ describe('Assembly.revolute(...) capture', () => {
     ).toThrow(/revolute joint axis must be a finite Vec3/);
   });
 });
+
+// Issue #536: a revolute declared via `arm.mate(name, a, b, 'revolute')` is a
+// constraint, not a drivable joint — it is NOT in `arm.__joints()`. Posing it
+// with `arm.solve({ <name>: deg })` used to fall through to forwardKinematics
+// and crash with a cryptic `TypeError: Cannot read properties of undefined
+// (reading 'kind')`. solve() must now reject the mate name with a clear
+// diagnostic that names the key and points at the joint API.
+describe('Assembly.solve(...) rejects posing a mate name (issue #536)', () => {
+  const buildMate = () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('arm');
+    arm
+      .part('base', kcad.box(10, 10, 10))
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm
+      .part('link', kcad.box(10, 10, 10), { at: [0, 0, 10] })
+      .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+    arm.mate('hinge', 'base.axis', 'link.axis', 'revolute');
+    return arm;
+  };
+
+  it('throws a clear "not a drivable joint" error naming the mate + the joint API', () => {
+    const arm = buildMate();
+    // The mate is a constraint, not a posable DOF — not in __joints().
+    expect(arm.__joints()).toHaveLength(0);
+
+    let thrown: unknown;
+    try {
+      arm.solve({ hinge: 30 } as Parameters<typeof arm.solve>[0]);
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeDefined();
+    const msg = (thrown as Error).message;
+    // Clear diagnostic, NOT the raw undefined-read crash.
+    expect(msg).toMatch(/not a drivable joint/);
+    expect(msg).toMatch(/hinge/);
+    expect(msg).toMatch(/mate/);
+    expect(msg).toMatch(/assembly\.revolute/);
+    expect(msg).not.toMatch(/reading 'kind'/);
+  });
+
+  it('throws "not a drivable joint" for a totally unknown pose key too', () => {
+    const arm = buildMate();
+    expect(() =>
+      arm.solve({ nope: 30 } as Parameters<typeof arm.solve>[0]),
+    ).toThrow(/not a drivable joint/);
+  });
+
+  it('still solves a real joint pose (no regression)', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('arm');
+    const base = arm.part('base', kcad.box(10, 10, 10));
+    const link = arm.part('link', kcad.box(10, 10, 10), { at: [0, 0, 10] });
+    arm.revolute('hinge', base, link, { axis: [0, 1, 0], origin: [0, 0, 0] });
+
+    const solved = arm.solve({ hinge: 45 });
+    expect(solved.value('hinge')).toBe(45);
+    expect(solved.transform('link')).toBeDefined();
+  });
+});

--- a/src/modeling/capture/assembly.chaining.test.ts
+++ b/src/modeling/capture/assembly.chaining.test.ts
@@ -66,7 +66,10 @@ describe('Assembly.revolute(...) capture', () => {
       limitsDeg: [-90, 90],
     });
 
-    expect(ref).toEqual({ id: ref.id, name: 'hinge', kind: 'revolute' });
+    expect(typeof ref.id).toBe('string');
+    expect(ref.id.length).toBeGreaterThan(0);
+    expect(ref.name).toBe('hinge');
+    expect(ref.kind).toBe('revolute');
 
     const joints = arm.__joints();
     expect(joints).toHaveLength(1);
@@ -109,6 +112,37 @@ describe('Assembly.revolute(...) capture', () => {
         origin: [0, 0, 0],
       }),
     ).toThrow(/revolute joint axis must be a finite Vec3/);
+  });
+
+  it('rejects a non-finite origin', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('arm');
+    const base = arm.part('base', kcad.box(10, 10, 10));
+    const link = arm.part('link', kcad.box(10, 10, 10));
+
+    expect(() =>
+      arm.revolute('hinge', base, link, {
+        axis: [0, 1, 0],
+        origin: [0, Number.POSITIVE_INFINITY, 0],
+      }),
+    ).toThrow(/revolute joint origin must be a finite Vec3/);
+  });
+
+  it('rejects limitsDeg with min >= max', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('arm');
+    const base = arm.part('base', kcad.box(10, 10, 10));
+    const link = arm.part('link', kcad.box(10, 10, 10));
+
+    expect(() =>
+      arm.revolute('hinge', base, link, {
+        axis: [0, 1, 0],
+        origin: [0, 0, 0],
+        limitsDeg: [90, -90],
+      }),
+    ).toThrow(/revolute joint limitsDeg/);
   });
 });
 

--- a/src/modeling/capture/assembly.ts
+++ b/src/modeling/capture/assembly.ts
@@ -2389,6 +2389,17 @@ export class SolvedKinematics {
    * is intentionally unsupported on snapshot Scenes — call
    * `Assembly.solvedModel(poses).toCompound()` for a TopoDS_Compound that
    * preserves per-part identity through the lowerer.
+   *
+   * Rendering note (issue #538): this snapshot Scene carries NO upstream
+   * feature id (`__sourceFeatureId()` is undefined), so RETURNING it from a
+   * script does not route to the SceneBackend mesh fan-out — `resolveRootId`
+   * falls back to the chain tail (the last `assemblyJoint`/part record) and
+   * the viewport renders that single record, not a posed multi-part scene.
+   * For a posed AND per-part-colored scene that renders, return
+   * `Assembly.solvedModel(poses)` directly (the reactive Scene whose lowerer
+   * emits a colored, FK-posed SceneBackend); use this snapshot handle for
+   * in-script analysis (`transform(part)`, `bodies()`) or `.toUnion()` for a
+   * fused single Shape.
    */
   toScene(): Scene {
     if (this.partsByName.size === 0) {

--- a/src/modeling/capture/assembly.ts
+++ b/src/modeling/capture/assembly.ts
@@ -1616,17 +1616,31 @@ export class Assembly {
    * same Assembly compounds transforms; build a fresh assembly per query.
    */
   solve(poses: Poses): SolvedKinematics {
-    // 1. Validate joint names supplied in poses.
+    // 1. Validate joint names supplied in poses. A pose key must resolve to a
+    //    drivable joint declared via assembly.revolute/prismatic/fixed/ball
+    //    (i.e. present in `this.joints` / `arm.__joints()`). Reject anything
+    //    else BEFORE forwardKinematics reads `.kind` off the (undefined)
+    //    lookup — that raw `TypeError: Cannot read properties of undefined
+    //    (reading 'kind')` was issue #536. A *mate* (a constraint, not a
+    //    posable DOF) gets a tailored hint pointing at the joint API.
     for (const name of Object.keys(poses)) {
-      if (!this.joints.find(j => j.name === name)) {
-        const known = this.joints.map(j => j.name);
+      if (this.joints.find(j => j.name === name)) continue;
+      const mate = this.mates.find(m => m.name === name);
+      if (mate) {
         throw new KernelError(
           'feature.invalid-args',
-          `assembly.solve: unknown joint '${name}'. Defined joints: ${known.length === 0 ? '(none)' : known.join(', ')}.`,
+          `assembly.solve: '${name}' is not a drivable joint. A ${mate.type} *mate* is a constraint, not a posable DOF — declare the joint with assembly.revolute(name, parent, child, { axis, origin }) (or .prismatic/.ball) to pose it.`,
           undefined,
-          'invalid-args.solve.unknown-joint — pass only joint names declared via assembly.revolute/prismatic/fixed/ball.',
+          'invalid-args.solve.mate-not-joint — mates constrain DOFs; only joints declared via assembly.revolute/prismatic/fixed/ball are posable by solve(). To articulate the existing mate graph instead, call assembly.solvedModel(poses).',
         );
       }
+      const known = this.joints.map(j => j.name);
+      throw new KernelError(
+        'feature.invalid-args',
+        `assembly.solve: '${name}' is not a drivable joint. Defined joints: ${known.length === 0 ? '(none)' : known.join(', ')}.`,
+        undefined,
+        'invalid-args.solve.unknown-joint — pass only joint names declared via assembly.revolute/prismatic/fixed/ball.',
+      );
     }
 
     // 2. Validate pose value shapes per joint kind, then resolve any ParamRef

--- a/src/modeling/capture/assembly.ts
+++ b/src/modeling/capture/assembly.ts
@@ -317,10 +317,16 @@ export interface AssemblyConnectRef {
   kind: 'fixed';
 }
 
-// RevoluteJointOpts / FixedJointOpts removed in G0 (2026-05-31): the v0.5
-// `arm.revolute(...)` / `arm.fixed(...)` methods no longer exist. Use
-// `arm.mate(name, a, b, 'revolute'|'fastened', opts?)` instead — limits and
-// pose are carried on the MateRecord directly.
+// FixedJointOpts removed in G0 (2026-05-31): the v0.5 `arm.fixed(...)` method
+// no longer exists. Use `arm.mate(name, a, b, 'fastened')` instead — pose is
+// carried on the MateRecord directly. `arm.revolute(...)` was restored (see
+// issue #535) so the body-tree-FK surface has a public drivable revolute again.
+
+export interface RevoluteJointOpts {
+  axis: Vec3;
+  origin: Vec3;
+  limitsDeg?: [number, number];
+}
 
 export interface PrismaticJointOpts {
   axis: Vec3;
@@ -645,12 +651,54 @@ export class Assembly {
     };
   }
 
-  // arm.revolute(...) was the v0.5 body-tree-FK API. Removed in G0
-  // (2026-05-31, mechanism-delivery workstream) because it bypassed
-  // `arm.__mates()` — every v0.7 kinematic-grounding gate (Gates 1-4) reads
-  // the mate graph and silently early-exited on legacy-only assemblies.
-  // Use `arm.connector(...)` + `arm.mate(name, a, b, 'revolute', { ... })`
-  // instead. See examples/robot-arm/desktop-3axis-mates.kcad.ts.
+  // arm.revolute(...) is the body-tree-FK API for a single-DOF rotational
+  // joint (restored per issue #535). It declares a drivable revolute directly
+  // on the joint graph that solve()/solvedModel() walk — no need to reach into
+  // `session.assemblyJoint(...)` + `joints.push(...)` internals. For mate-graph
+  // gated mechanisms prefer `arm.connector(...)` + `arm.mate(name, a, b,
+  // 'revolute', { ... })`; both surfaces coexist.
+  revolute(name: string, a: AssemblyPartRef, b: AssemblyPartRef, opts: RevoluteJointOpts): AssemblyJointRef {
+    if (!isValidVec3(opts.axis)) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `revolute joint axis must be a finite Vec3; got ${formatScalarForError(opts.axis)}.`,
+        undefined,
+        'Pass axis: [x, y, z].',
+      );
+    }
+    if (!isValidVec3(opts.origin)) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `revolute joint origin must be a finite Vec3; got ${formatScalarForError(opts.origin)}.`,
+        undefined,
+        'Pass origin: [x, y, z] in the parent part local frame.',
+      );
+    }
+    if (opts.limitsDeg !== undefined && !isValidJointLimits(opts.limitsDeg)) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `revolute joint limitsDeg must be [minDeg, maxDeg] finite numbers with min < max; got ${formatScalarForError(opts.limitsDeg)}.`,
+        undefined,
+        'Pass limitsDeg: [minDeg, maxDeg], or omit it.',
+      );
+    }
+    const record = this.session.assemblyJoint(this.name, name, 'revolute', a, b, {
+      axis: opts.axis,
+      origin: opts.origin,
+      ...(opts.limitsDeg !== undefined ? { limitsDeg: opts.limitsDeg } : {}),
+    });
+    this.joints.push({
+      id: record.id,
+      name,
+      kind: 'revolute',
+      parentPartId: a.id,
+      childPartId: b.id,
+      axis: opts.axis,
+      origin: opts.origin,
+      ...(opts.limitsDeg !== undefined ? { limitsDeg: opts.limitsDeg } : {}),
+    });
+    return { id: record.id, name, kind: 'revolute' };
+  }
 
   prismatic(name: string, a: AssemblyPartRef, b: AssemblyPartRef, opts: PrismaticJointOpts): AssemblyJointRef {
     if (!isValidVec3(opts.axis)) {

--- a/src/modeling/capture/assembly.ts
+++ b/src/modeling/capture/assembly.ts
@@ -37,7 +37,7 @@ import {
   type PoseEnvelopeDiagnostic,
 } from '../mates/poseEnvelope';
 import { solveMates } from '../mates/solver';
-import { validateAssemblyWithMates } from '../mates/validator';
+import { validateAssemblyWithMates, type ValidatorDiagnostic } from '../mates/validator';
 import {
   validateWorkspaceTargetOpts,
   type WorkspaceTargetOpts,
@@ -1697,9 +1697,17 @@ export class Assembly {
       part.originalShape.transform(T);
     }
 
-    // 6. Build SolvedKinematics handle. Hand it the already-resolved numeric
+    // 6. Issue #537 — advisory out-of-limits warnings for poses beyond a
+    //    joint's declared limitsDeg/limitsMm. Computed (not thrown) so solve()
+    //    still applies the pose; surfaced on the SolvedKinematics handle and
+    //    its toScene() Scene.warnings.
+    const limitWarnings = checkPoseLimits(this.joints, poses, this.session);
+
+    // 7. Build SolvedKinematics handle. Hand it the already-resolved numeric
     //    pose record so the snapshot can never accidentally re-resolve.
-    return new SolvedKinematics(this.name, this.parts, this.joints, worldT, numericPoses, this.session);
+    return new SolvedKinematics(
+      this.name, this.parts, this.joints, worldT, numericPoses, this.session, limitWarnings,
+    );
   }
 
   /**
@@ -1944,6 +1952,14 @@ export class Assembly {
       mateMetadata,
     );
 
+    // Issue #537 — advisory out-of-limits warnings for body-tree joint poses
+    // beyond their declared limitsDeg/limitsMm. Computed here (after the
+    // capture-time pose-shape validation in `solvedAssembly` has run) and
+    // folded into the warn-mode `scene.warnings` aggregate below. The pose is
+    // still applied; these never throw (they stay severity 'warning', so the
+    // 'error'-mode error-find skips them and the 'off' branch drops them).
+    const limitWarnings = checkPoseLimits(this.joints, poses, this.session);
+
     // Mode resolution: explicit opts win; otherwise read the env override
     // (T10 sets this from `kernelcad evaluate`). Default for everything else
     // is `'warn'` — never breaking, never silent.
@@ -2097,6 +2113,7 @@ export class Assembly {
         const aggregated: readonly SceneDiagnostic[] = [
           ...result.diagnostics,
           ...envelopeDiagnostics,
+          ...limitWarnings,
         ];
         return this.makeScene(sceneShape, aggregated, mateT);
       },
@@ -2252,6 +2269,13 @@ export class SolvedKinematics {
   private readonly poses: Record<string, number | [number, number, number]>;
   private readonly joints: readonly AssemblyJointStored[];
   private readonly session: CaptureSession;
+  /**
+   * Issue #537 — advisory out-of-limits diagnostics for poses that exceed a
+   * joint's declared `limitsDeg`/`limitsMm`. Always present (possibly empty).
+   * Propagated onto `toScene().warnings` so the snapshot Scene reports them
+   * identically to `solvedModel(...)`.
+   */
+  readonly warnings: readonly SceneDiagnostic[];
 
   /**
    * Process-scoped warn-once flag for the deprecated `.toShape()` alias.
@@ -2276,6 +2300,7 @@ export class SolvedKinematics {
     worldT: Map<FeatureId, Transform>,
     poses: Record<string, number | [number, number, number]>,
     session: CaptureSession,
+    warnings: readonly SceneDiagnostic[] = [],
   ) {
     this.assemblyName = assemblyName;
     this.partsByName = new Map(parts.map(p => [p.name, p]));
@@ -2283,6 +2308,7 @@ export class SolvedKinematics {
     this.poses = poses;
     this.joints = joints;
     this.session = session;
+    this.warnings = Object.freeze([...warnings]);
     Object.freeze(this);
   }
 
@@ -2401,6 +2427,10 @@ export class SolvedKinematics {
           'invalid-args.scene.compound-not-supported-on-snapshot — call Assembly.solvedModel(poses).toCompound() for a Scene whose lowerer preserves per-part identity.',
         );
       },
+      undefined, // sourceFeatureId — snapshot Scene has no upstream feature.
+      undefined, // mates — snapshot Scene does not carry the mate graph.
+      // Issue #537 — propagate out-of-limits warnings onto the snapshot Scene.
+      this.warnings,
     );
   }
 
@@ -2467,6 +2497,56 @@ function isValidJointLimits(value: [number, number]): boolean {
     value.every((n) => typeof n === 'number' && Number.isFinite(n)) &&
     value[0] < value[1]
   );
+}
+
+/**
+ * Issue #537 — advisory out-of-limits check for the body-tree joint poses
+ * passed to `Assembly.solve()` / `Assembly.solvedModel()`.
+ *
+ * For each revolute / prismatic joint that declares `limitsDeg` / `limitsMm`,
+ * resolves the supplied pose to a numeric value (snapshot via the param table)
+ * and emits one `kinematic.pose.out-of-limits` WARNING when the value falls
+ * outside the closed `[min, max]` range. The pose is still applied by FK — the
+ * diagnostic is advisory, closing the false-pass gap where a knee with
+ * `limitsDeg:[-150,0]` posed to `+140` was accepted silently.
+ *
+ * Skips: joints with no declared limits, fixed joints, ball joints, joints with
+ * no pose supplied, and any pose that cannot be resolved to a finite number
+ * (shape errors are surfaced by the throwing validators upstream).
+ *
+ * Pure: joints + poses in, diagnostics out — shared by both solve() and
+ * solvedModel() so the two surfaces report identically.
+ */
+function checkPoseLimits(
+  joints: readonly AssemblyJointStored[],
+  poses: Poses,
+  session: CaptureSession,
+): ValidatorDiagnostic[] {
+  const out: ValidatorDiagnostic[] = [];
+  for (const j of joints) {
+    if (j.kind !== 'revolute' && j.kind !== 'prismatic') continue;
+    const limits = j.kind === 'revolute' ? j.limitsDeg : j.limitsMm;
+    if (limits === undefined) continue;
+    const raw = poses[j.name];
+    if (raw === undefined || Array.isArray(raw)) continue;
+    if (!isParamRef(raw) && typeof raw !== 'number') continue;
+    const value = currentValue(raw as Editable<number>, session.paramTable);
+    if (typeof value !== 'number' || !Number.isFinite(value)) continue;
+    const [min, max] = limits;
+    if (value >= min && value <= max) continue;
+    const unit = j.kind === 'revolute' ? '°' : 'mm';
+    const field = j.kind === 'revolute' ? 'limitsDeg' : 'limitsMm';
+    out.push({
+      code: 'kinematic.pose.out-of-limits',
+      severity: 'warning',
+      message: `joint '${j.name}' pose ${value}${unit} exceeds declared ${field} [${min}, ${max}]`,
+      hint: `invalid-args.kinematic.pose-out-of-limits — clamp '${j.name}' to [${min}, ${max}], or widen ${field} on the joint if the mechanism is intended to travel that far.`,
+      mateName: j.name,
+      pose: value,
+      limits,
+    });
+  }
+  return out;
 }
 
 function isScalarCouplingMate(type: MateType): boolean {

--- a/src/modeling/mates/validator.ts
+++ b/src/modeling/mates/validator.ts
@@ -90,6 +90,7 @@ export type ValidatorDiagnosticCode = Extract<
   | 'assembly.joint.not-visible'
   | 'assembly.mate.not-physically-realized'
   | 'assembly.workspace.unreachable'
+  | 'kinematic.pose.out-of-limits'
 >;
 
 export interface ValidatorDiagnostic {

--- a/src/shared/diagnostics/registry.ts
+++ b/src/shared/diagnostics/registry.ts
@@ -1993,6 +1993,19 @@ export const DIAGNOSTIC_REGISTRY = {
     description:
       'A revolute/prismatic joint pose passed to assembly.solve() or assembly.solvedModel() exceeds the closed limitsDeg/limitsMm range declared on that joint; the pose is still applied (advisory warning, not a hard failure).',
   },
+  'kinematic.mounting-holes.no-coverage': {
+    hintTemplate:
+      'The mounting-hole consistency check found no fastened mates to examine, so a green result verifies nothing. Add at least one arm.mate(..., \'fastened\') between connectors bound to face-center holes, or stop relying on this gate for fastener coverage.',
+    nextAction: {
+      kind: 'rewrite-feature',
+      guidance:
+        'add a fastened mate between connectors bound to face-center holes so the mounting-hole gate has something to verify',
+    },
+    defaultSeverity: 'info',
+    group: 'kinematic',
+    description:
+      'checkMountingHoleConsistency ran on an assembly with zero fastened mates; nothing was checked, so the otherwise-green result is vacuous (no coverage).',
+  },
 
   // Slice Q (Query DSL) — Q3 evaluator codes (7 of the v1 11-code core;
   // remaining 4 ship in Q4/Q5/Q7 alongside their evaluator entry points).

--- a/src/shared/diagnostics/registry.ts
+++ b/src/shared/diagnostics/registry.ts
@@ -1980,6 +1980,19 @@ export const DIAGNOSTIC_REGISTRY = {
     description:
       'A fastened mate binds two connectors whose hole diameters disagree beyond the diameter-match tolerance; the underlying assembly.mounting-hole.mismatch code also fires from the v0.7.4 substrate.',
   },
+  'kinematic.pose.out-of-limits': {
+    hintTemplate:
+      'A pose value supplied to assembly.solve()/solvedModel() falls outside the joint\'s declared limitsDeg/limitsMm. Clamp the pose into the declared range, or widen the joint limits if the mechanism is intended to travel that far.',
+    nextAction: {
+      kind: 'rewrite-feature',
+      guidance:
+        'clamp the joint pose into the declared limits, or widen limitsDeg/limitsMm on the joint if the travel is intended',
+    },
+    defaultSeverity: 'warn',
+    group: 'kinematic',
+    description:
+      'A revolute/prismatic joint pose passed to assembly.solve() or assembly.solvedModel() exceeds the closed limitsDeg/limitsMm range declared on that joint; the pose is still applied (advisory warning, not a hard failure).',
+  },
 
   // Slice Q (Query DSL) — Q3 evaluator codes (7 of the v1 11-code core;
   // remaining 4 ship in Q4/Q5/Q7 alongside their evaluator entry points).

--- a/src/shared/diagnostics/registry.ts
+++ b/src/shared/diagnostics/registry.ts
@@ -1993,7 +1993,7 @@ export const DIAGNOSTIC_REGISTRY = {
     description:
       'A revolute/prismatic joint pose passed to assembly.solve() or assembly.solvedModel() exceeds the closed limitsDeg/limitsMm range declared on that joint; the pose is still applied (advisory warning, not a hard failure).',
   },
-  'kinematic.mounting-holes.no-coverage': {
+  'kinematic.mounting-hole.no-coverage': {
     hintTemplate:
       'The mounting-hole consistency check found no fastened mates to examine, so a green result verifies nothing. Add at least one arm.mate(..., \'fastened\') between connectors bound to face-center holes, or stop relying on this gate for fastener coverage.',
     nextAction: {

--- a/tests/integration/lowering/coloredPosedAssembly.test.ts
+++ b/tests/integration/lowering/coloredPosedAssembly.test.ts
@@ -1,0 +1,177 @@
+// tests/integration/lowering/coloredPosedAssembly.test.ts
+//
+// Regression coverage for issue #538: "no path yields a POSED assembly with
+// per-part COLOR that also renders."
+//
+// On develop the supported colored + posed RENDER path is to return the
+// reactive `Assembly.solvedModel(poses)` Scene directly. Its lowerer emits a
+// SceneBackend whose parts carry BOTH the FK-posed `worldTransform` and the
+// per-part `color` walked from each source shape; the meshing fan-out
+// (`meshFeaturesPerFeature` — the actual render mesh source) turns that into
+// one colored, posed FeatureMesh per part.
+//
+// These tests use the public body-tree `assembly.revolute()` joint (issue
+// #535) rather than a connector/mate so the regression matches the exact
+// authoring surface reported on #538. They pin:
+//   1. solvedModel(poses) render path: per-part color preserved AND the posed
+//      child part's WORLD geometry moves vs the rest pose (not the static
+//      rest pose the deployed/older server rendered).
+//   2. solvedModel(poses).toCompound() export path: lowers to a posed
+//      TopoDS_Compound (bbox reflects the pose) preserving per-part topological
+//      identity — the supported single-Shape posed export for STEP/downstream.
+//   3. Documented non-paths: solve(poses).toScene() is a snapshot Scene with
+//      no upstream feature (renders the chain tail, not a posed scene) and
+//      .toScene().toCompound() throws a hint pointing at solvedModel(...).
+//
+// Together (1)+(2) resolve the core of #538; (3) locks in the guard rails.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { initOcct, OcctBackend } from '../../../src/kernel/backends/occt/occtBackend';
+import { runScript } from '../../../src/modeling/runtime/runScript';
+import { meshFeaturesPerFeature, type FeatureMesh } from '../../../src/modeling/capture/featureMeshing';
+import { RecomputeEngine } from '../../../src/modeling/compute/recomputeEngine';
+import { OcctLowerer } from '../../../src/modeling/backends/occt/occtLowerer';
+import { Scene } from '../../../src/modeling/validation/scene';
+import { KernelError } from '../../../src/shared/intent/kernelError';
+
+beforeAll(async () => { await initOcct(); });
+
+/** Apply a column-major 4x4 (FeatureMesh.transform) to a local-frame point. */
+function applyMat4(m: readonly number[] | undefined, p: readonly [number, number, number]): [number, number, number] {
+  if (!m) return [p[0], p[1], p[2]];
+  const [x, y, z] = p;
+  return [
+    m[0] * x + m[4] * y + m[8] * z + m[12],
+    m[1] * x + m[5] * y + m[9] * z + m[13],
+    m[2] * x + m[6] * y + m[10] * z + m[14],
+  ];
+}
+
+/** World-space AABB of a fanned FeatureMesh: local verts pushed through the
+ *  viewport-side `transform` (where the pose lives for body-tree joints). */
+function worldBbox(fm: FeatureMesh): { min: [number, number, number]; max: [number, number, number] } {
+  const min: [number, number, number] = [Infinity, Infinity, Infinity];
+  const max: [number, number, number] = [-Infinity, -Infinity, -Infinity];
+  for (const f of fm.faces) {
+    const v = f.vertices;
+    for (let i = 0; i < v.length; i += 3) {
+      const w = applyMat4(fm.transform, [v[i], v[i + 1], v[i + 2]]);
+      for (let k = 0; k < 3; k++) {
+        if (w[k] < min[k]) min[k] = w[k];
+        if (w[k] > max[k]) max[k] = w[k];
+      }
+    }
+  }
+  return { min, max };
+}
+
+// Two-part body-tree arm: a fixed colored base and a colored link driven by a
+// single revolute about +Z at the shoulder. The link extends +X in its local
+// frame, so a 90° shoulder pose swings it to +Y in world space.
+const armScript = (shoulderDeg: number) => `
+  const arm = assembly('robot');
+  const base = arm.part('base', box(20, 20, 10).color('plate'));
+  const link = arm.part('link', box(60, 8, 8).translate(30, 0, 0).color('beam'));
+  arm.revolute('shoulder', base, link, { axis: [0, 0, 1], origin: [0, 0, 5] });
+  return arm.solvedModel({ shoulder: ${shoulderDeg} });
+`;
+
+describe('issue #538 — colored + posed assembly export', () => {
+  it('solvedModel(poses) renders per-part color AND the joint pose (not the rest pose)', async () => {
+    const rest = await runScript({ code: armScript(0), fileName: 'rest.kcad.ts' });
+    const posed = await runScript({ code: armScript(90), fileName: 'posed.kcad.ts' });
+
+    // Both lower into the SceneBackend mesh fan-out (the render path).
+    expect(rest.records[rest.records.length - 1].kind).toBe('solvedAssembly');
+    const meshRest = await meshFeaturesPerFeature(rest.records);
+    const meshPosed = await meshFeaturesPerFeature(posed.records);
+    expect(meshRest.failedFeatureIds).toEqual([]);
+    expect(meshPosed.failedFeatureIds).toEqual([]);
+
+    // (a) COLORED: each part fans out to its own FeatureMesh carrying the
+    //     per-part color walked from the source shape.
+    const baseRest = meshRest.features.find((f) => f.assemblyPartName === 'base');
+    const linkRest = meshRest.features.find((f) => f.assemblyPartName === 'link');
+    const linkPosed = meshPosed.features.find((f) => f.assemblyPartName === 'link');
+    expect(baseRest?.color).toBe('plate');
+    expect(linkRest?.color).toBe('beam');
+    expect(linkPosed?.color).toBe('beam');
+
+    // (b) POSED: the link's WORLD geometry actually moves. At rest the link
+    //     spans +X (≈[30,90]); at 90° about +Z it swings to span +Y (≈[30,90])
+    //     with X collapsing near the joint. A static-rest-pose render (the
+    //     deployed/older server bug) would leave these identical.
+    const bbRest = worldBbox(linkRest!);
+    const bbPosed = worldBbox(linkPosed!);
+    expect(bbRest.max[0]).toBeGreaterThan(80);   // rest: extends far in +X
+    expect(bbPosed.max[1]).toBeGreaterThan(80);  // posed: extends far in +Y
+    expect(bbPosed.max[0]).toBeLessThan(40);     // posed: X extent collapsed
+    expect(Math.abs(bbPosed.max[0] - bbRest.max[0])).toBeGreaterThan(40);
+  });
+
+  it('solvedModel(poses).toCompound() lowers to a posed TopoDS_Compound (per-part identity preserved)', async () => {
+    const compoundScript = (shoulderDeg: number) => `
+      const arm = assembly('robot');
+      const base = arm.part('base', box(20, 20, 10).color('plate'));
+      const link = arm.part('link', box(60, 8, 8).translate(30, 0, 0).color('beam'));
+      arm.revolute('shoulder', base, link, { axis: [0, 0, 1], origin: [0, 0, 5] });
+      return (await arm.solvedModel({ shoulder: ${shoulderDeg} })).toCompound();
+    `;
+    const lower = async (deg: number) => {
+      const { records } = await runScript({ code: compoundScript(deg), fileName: 'c.kcad.ts' });
+      const engine = new RecomputeEngine(new OcctLowerer());
+      const r = await engine.run(records);
+      const last = records[records.length - 1];
+      expect(last.kind).toBe('assemblyExport');
+      expect(r.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+      return r.shapes.get(last.id) as OcctBackend;
+    };
+
+    const rest = await lower(0);
+    const posed = await lower(90);
+    expect(rest).toBeInstanceOf(OcctBackend);
+    expect(posed).toBeInstanceOf(OcctBackend);
+
+    // Compound (not fused): volume = sum of the two part volumes, unchanged
+    // by the rigid pose — identity is preserved, geometry isn't merged.
+    expect(rest.volume()).toBeCloseTo(posed.volume(), 3);
+
+    // The pose is baked into the exported geometry: the link's far end moves
+    // from +X at rest to +Y when posed 90°.
+    const bbRest = rest.boundingBox();
+    const bbPosed = posed.boundingBox();
+    expect(bbRest.max[0]).toBeGreaterThan(80);
+    expect(bbPosed.max[1]).toBeGreaterThan(80);
+    expect(bbPosed.max[0]).toBeLessThan(40);
+  });
+
+  it('solve(poses).toScene() is a non-rendering snapshot; .toCompound() points to solvedModel', async () => {
+    // Snapshot Scene from the in-script FK handle. It has NO upstream feature
+    // id, so returning it from a script renders the chain tail (an
+    // assemblyJoint record), not a posed multi-part scene — hence the "empty
+    // server-side render" on #538. The supported render path is to return
+    // solvedModel(poses) directly (test 1). Documented, not a defect.
+    const { records, returnValue } = await runScript({
+      code: `
+        const arm = assembly('robot');
+        const base = arm.part('base', box(20, 20, 10).color('plate'));
+        const link = arm.part('link', box(60, 8, 8).translate(30, 0, 0).color('beam'));
+        arm.revolute('shoulder', base, link, { axis: [0, 0, 1], origin: [0, 0, 5] });
+        return arm.solve({ shoulder: 90 }).toScene();
+      `,
+      fileName: 'snapshot.kcad.ts',
+    });
+    const scene = returnValue as Scene;
+    expect(scene).toBeInstanceOf(Scene);
+    expect(scene.__sourceFeatureId()).toBeUndefined();
+    expect(records[records.length - 1].kind).not.toBe('solvedAssembly');
+
+    // toCompound() on the snapshot throws with a hint pointing at the
+    // supported posed-export path.
+    let captured: unknown;
+    try { scene.toCompound(); } catch (e) { captured = e; }
+    expect(captured).toBeInstanceOf(KernelError);
+    expect((captured as KernelError).hint).toContain('compound-not-supported-on-snapshot');
+    expect((captured as KernelError).hint).toContain('solvedModel(poses).toCompound()');
+  });
+});

--- a/tests/unit/assemblies/solvedJointPoseLimits.test.ts
+++ b/tests/unit/assemblies/solvedJointPoseLimits.test.ts
@@ -1,0 +1,104 @@
+// tests/unit/assemblies/solvedJointPoseLimits.test.ts
+//
+// Issue #537 — `Assembly.solve()` / `Assembly.solvedModel()` used to silently
+// accept revolute/prismatic joint poses BEYOND the declared limitsDeg/limitsMm
+// (a false-pass risk: a knee with limitsDeg:[-150,0] posed to +140 was
+// accepted with no warning). The fix emits an advisory
+// `kinematic.pose.out-of-limits` WARNING; the pose is still applied.
+//
+// These tests assert the diagnostic fires (naming joint/value/limit), stays
+// silent for in-range poses, and skips joints with no declared limits.
+
+import { describe, it, expect } from 'vitest';
+import { CaptureSession } from '../../../src/modeling/capture/captureSession';
+import { createApi } from '../../../src/modeling/api';
+
+describe('Issue #537 — joint pose out-of-limits diagnostic', () => {
+  const setup = () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('leg');
+    const thigh = arm.part('thigh', kcad.box(10, 10, 10));
+    const shin = arm.part('shin', kcad.box(10, 10, 10), { at: [0, 0, 10] });
+    return { session, kcad, arm, thigh, shin };
+  };
+
+  it('solve(): warns when a revolute pose exceeds limitsDeg, naming joint/value/limit', () => {
+    const { arm, thigh, shin } = setup();
+    arm.revolute('knee', thigh, shin, { axis: [0, 1, 0], origin: [0, 0, 0], limitsDeg: [-150, 0] });
+
+    const solved = arm.solve({ knee: 140 });
+    // Pose is still applied (advisory, not a hard failure).
+    expect(solved.value('knee')).toBe(140);
+
+    const diag = solved.warnings.find((w) => w.code === 'kinematic.pose.out-of-limits');
+    expect(diag).toBeDefined();
+    expect(diag!.severity).toBe('warning');
+    expect(diag!.message).toContain("knee");
+    expect(diag!.message).toContain('140');
+    expect(diag!.message).toContain('limitsDeg');
+    expect(diag!.message).toContain('[-150, 0]');
+    // The snapshot Scene carries the same warning.
+    expect(
+      solved.toScene().warnings.some((w) => w.code === 'kinematic.pose.out-of-limits'),
+    ).toBe(true);
+  });
+
+  it('solve(): no diagnostic when the pose is WITHIN limits', () => {
+    const { arm, thigh, shin } = setup();
+    arm.revolute('knee', thigh, shin, { axis: [0, 1, 0], origin: [0, 0, 0], limitsDeg: [-150, 0] });
+
+    const solved = arm.solve({ knee: -30 });
+    expect(solved.warnings.some((w) => w.code === 'kinematic.pose.out-of-limits')).toBe(false);
+  });
+
+  it('solve(): no diagnostic for a joint with NO declared limits', () => {
+    const { arm, thigh, shin } = setup();
+    arm.revolute('knee', thigh, shin, { axis: [0, 1, 0], origin: [0, 0, 0] });
+
+    const solved = arm.solve({ knee: 9999 });
+    expect(solved.warnings.some((w) => w.code === 'kinematic.pose.out-of-limits')).toBe(false);
+  });
+
+  it('solve(): warns when a prismatic pose exceeds limitsMm', () => {
+    const { arm, thigh, shin } = setup();
+    arm.prismatic('slide', thigh, shin, { axis: [0, 0, 1], origin: [0, 0, 0], limitsMm: [0, 50] });
+
+    const solved = arm.solve({ slide: 75 });
+    expect(solved.value('slide')).toBe(75);
+    const diag = solved.warnings.find((w) => w.code === 'kinematic.pose.out-of-limits');
+    expect(diag).toBeDefined();
+    expect(diag!.message).toContain('slide');
+    expect(diag!.message).toContain('75');
+    expect(diag!.message).toContain('limitsMm');
+    expect(diag!.message).toContain('[0, 50]');
+  });
+
+  it('solvedModel(): out-of-limits pose surfaces on scene.warnings (default warn mode)', async () => {
+    const { arm, thigh, shin } = setup();
+    arm.revolute('knee', thigh, shin, { axis: [0, 1, 0], origin: [0, 0, 0], limitsDeg: [-150, 0] });
+
+    const scene = await arm.solvedModel({ knee: 140 });
+    const diag = scene.warnings.find((w) => w.code === 'kinematic.pose.out-of-limits');
+    expect(diag).toBeDefined();
+    expect(diag!.message).toContain('knee');
+    expect(diag!.message).toContain('140');
+    expect(diag!.message).toContain('[-150, 0]');
+  });
+
+  it('solvedModel(): no out-of-limits diagnostic for an in-range pose', async () => {
+    const { arm, thigh, shin } = setup();
+    arm.revolute('knee', thigh, shin, { axis: [0, 1, 0], origin: [0, 0, 0], limitsDeg: [-150, 0] });
+
+    const scene = await arm.solvedModel({ knee: -30 });
+    expect(scene.warnings.some((w) => w.code === 'kinematic.pose.out-of-limits')).toBe(false);
+  });
+
+  it('solvedModel(): validate:"off" suppresses the out-of-limits warning', async () => {
+    const { arm, thigh, shin } = setup();
+    arm.revolute('knee', thigh, shin, { axis: [0, 1, 0], origin: [0, 0, 0], limitsDeg: [-150, 0] });
+
+    const scene = await arm.solvedModel({ knee: 140 }, { validate: 'off' });
+    expect(scene.warnings.some((w) => w.code === 'kinematic.pose.out-of-limits')).toBe(false);
+  });
+});

--- a/tests/unit/diagnostics/codes.test.ts
+++ b/tests/unit/diagnostics/codes.test.ts
@@ -32,8 +32,11 @@ describe('diagnostic catalogue invariants', () => {
     //   gate: the over-budget BREP pose-sweep skip is now a LOUD structured
     //   diagnostic instead of a silent console.warn). = 237.
     // + 1 tool.trace-from-image.trace-timeout (forward-ported: pure-JS tracer hard per-call timeout). = 238.
-    expect(DIAGNOSTIC_CODES).toHaveLength(238);
-    expect(new Set(DIAGNOSTIC_CODES).size).toBe(238);
+    // + 1 kinematic.pose.out-of-limits (#537 — advisory warning when a
+    //   solve()/solvedModel() pose value exceeds a joint's declared
+    //   limitsDeg/limitsMm; the pose is still applied). = 239.
+    expect(DIAGNOSTIC_CODES).toHaveLength(239);
+    expect(new Set(DIAGNOSTIC_CODES).size).toBe(239);
   });
 
   it('every code has a non-empty hint template', () => {

--- a/tests/unit/diagnostics/codes.test.ts
+++ b/tests/unit/diagnostics/codes.test.ts
@@ -35,7 +35,7 @@ describe('diagnostic catalogue invariants', () => {
     // + 1 kinematic.pose.out-of-limits (#537 — advisory warning when a
     //   solve()/solvedModel() pose value exceeds a joint's declared
     //   limitsDeg/limitsMm; the pose is still applied). = 239.
-    // + 1 kinematic.mounting-holes.no-coverage (#541 — info diagnostic when
+    // + 1 kinematic.mounting-hole.no-coverage (#541 — info diagnostic when
     //   checkMountingHoleConsistency examined zero fastened mates, so the
     //   green result verifies nothing). = 240.
     expect(DIAGNOSTIC_CODES).toHaveLength(240);

--- a/tests/unit/diagnostics/codes.test.ts
+++ b/tests/unit/diagnostics/codes.test.ts
@@ -35,8 +35,11 @@ describe('diagnostic catalogue invariants', () => {
     // + 1 kinematic.pose.out-of-limits (#537 — advisory warning when a
     //   solve()/solvedModel() pose value exceeds a joint's declared
     //   limitsDeg/limitsMm; the pose is still applied). = 239.
-    expect(DIAGNOSTIC_CODES).toHaveLength(239);
-    expect(new Set(DIAGNOSTIC_CODES).size).toBe(239);
+    // + 1 kinematic.mounting-holes.no-coverage (#541 — info diagnostic when
+    //   checkMountingHoleConsistency examined zero fastened mates, so the
+    //   green result verifies nothing). = 240.
+    expect(DIAGNOSTIC_CODES).toHaveLength(240);
+    expect(new Set(DIAGNOSTIC_CODES).size).toBe(240);
   });
 
   it('every code has a non-empty hint template', () => {

--- a/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
+++ b/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
@@ -163,7 +163,7 @@ describe('every diagnostic code emitted in src/ is in the catalogue', () => {
     //  +  1 tool.trace-from-image.trace-timeout (forward-ported) = 238.
     //  +  1 kinematic.pose.out-of-limits (#537 — advisory warning when a
     //       solve()/solvedModel() pose exceeds a joint's declared limits) = 239.
-    //  +  1 kinematic.mounting-holes.no-coverage (#541 — info diagnostic when
+    //  +  1 kinematic.mounting-hole.no-coverage (#541 — info diagnostic when
     //       checkMountingHoleConsistency examined zero fastened mates) = 240.
     expect(catalogue.size).toBe(240);
   });

--- a/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
+++ b/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
@@ -163,7 +163,9 @@ describe('every diagnostic code emitted in src/ is in the catalogue', () => {
     //  +  1 tool.trace-from-image.trace-timeout (forward-ported) = 238.
     //  +  1 kinematic.pose.out-of-limits (#537 — advisory warning when a
     //       solve()/solvedModel() pose exceeds a joint's declared limits) = 239.
-    expect(catalogue.size).toBe(239);
+    //  +  1 kinematic.mounting-holes.no-coverage (#541 — info diagnostic when
+    //       checkMountingHoleConsistency examined zero fastened mates) = 240.
+    expect(catalogue.size).toBe(240);
   });
 
   it('no emit site uses a code outside the catalogue', () => {

--- a/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
+++ b/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
@@ -161,7 +161,9 @@ describe('every diagnostic code emitted in src/ is in the catalogue', () => {
     //  +  1 mechanism.unverified-budget-exceeded (this PR — T3 over-budget
     //       BREP pose-sweep skip is now a LOUD structured diagnostic) = 237.
     //  +  1 tool.trace-from-image.trace-timeout (forward-ported) = 238.
-    expect(catalogue.size).toBe(238);
+    //  +  1 kinematic.pose.out-of-limits (#537 — advisory warning when a
+    //       solve()/solvedModel() pose exceeds a joint's declared limits) = 239.
+    expect(catalogue.size).toBe(239);
   });
 
   it('no emit site uses a code outside the catalogue', () => {

--- a/tests/unit/diagnostics/kinematicCodes.test.ts
+++ b/tests/unit/diagnostics/kinematicCodes.test.ts
@@ -23,7 +23,7 @@ const KINEMATIC_CODES = [
   'kinematic.pose.out-of-limits',
   // #541 — info diagnostic when checkMountingHoleConsistency examined zero
   // fastened mates, so the green result verifies nothing.
-  'kinematic.mounting-holes.no-coverage',
+  'kinematic.mounting-hole.no-coverage',
 ] as const;
 
 // Per the cumulative-findings discipline (item #56), every nextAction kind

--- a/tests/unit/diagnostics/kinematicCodes.test.ts
+++ b/tests/unit/diagnostics/kinematicCodes.test.ts
@@ -1,8 +1,9 @@
 // tests/unit/diagnostics/kinematicCodes.test.ts
 //
 // Per-code shape gate for the kinematic-grounding slice (T1).
-// Asserts the 9 K1-K9 codes are registered with non-empty hint + valid
-// nextAction + group: 'kinematic' + severity in the canonical set.
+// Asserts the kinematic.* codes (K1-K9 plus #537 pose.out-of-limits) are
+// registered with non-empty hint + valid nextAction + group: 'kinematic' +
+// severity in the canonical set.
 
 import { describe, it, expect } from 'vitest';
 import { DIAGNOSTIC_REGISTRY } from '../../../src/shared/diagnostics/registry';
@@ -17,6 +18,9 @@ const KINEMATIC_CODES = [
   'kinematic.load.beam-not-applicable',
   'kinematic.no-material-declared',
   'kinematic.mounting-hole.diameter-mismatch',
+  // #537 — advisory warning when a solve()/solvedModel() pose exceeds a
+  // joint's declared limitsDeg/limitsMm.
+  'kinematic.pose.out-of-limits',
 ] as const;
 
 // Per the cumulative-findings discipline (item #56), every nextAction kind
@@ -37,7 +41,7 @@ const CANONICAL_NEXT_ACTION_KINDS = new Set([
 ]);
 
 describe('kinematic-grounding diagnostic codes', () => {
-  it('registers exactly 9 kinematic.* codes', () => {
+  it('registers exactly 10 kinematic.* codes', () => {
     const kinCodes = Object.keys(DIAGNOSTIC_REGISTRY).filter((c) =>
       c.startsWith('kinematic.'),
     );

--- a/tests/unit/diagnostics/kinematicCodes.test.ts
+++ b/tests/unit/diagnostics/kinematicCodes.test.ts
@@ -21,6 +21,9 @@ const KINEMATIC_CODES = [
   // #537 — advisory warning when a solve()/solvedModel() pose exceeds a
   // joint's declared limitsDeg/limitsMm.
   'kinematic.pose.out-of-limits',
+  // #541 — info diagnostic when checkMountingHoleConsistency examined zero
+  // fastened mates, so the green result verifies nothing.
+  'kinematic.mounting-holes.no-coverage',
 ] as const;
 
 // Per the cumulative-findings discipline (item #56), every nextAction kind
@@ -41,7 +44,7 @@ const CANONICAL_NEXT_ACTION_KINDS = new Set([
 ]);
 
 describe('kinematic-grounding diagnostic codes', () => {
-  it('registers exactly 10 kinematic.* codes', () => {
+  it('registers exactly 11 kinematic.* codes', () => {
     const kinCodes = Object.keys(DIAGNOSTIC_REGISTRY).filter((c) =>
       c.startsWith('kinematic.'),
     );

--- a/tests/unit/kinematic/beamMaterials.test.ts
+++ b/tests/unit/kinematic/beamMaterials.test.ts
@@ -82,7 +82,9 @@ describe('resolveMaterialProps — T6.2', () => {
       youngsModulusGPa: 200,
     });
     expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.missingField).toBe('yieldStressMPa');
+    if (!r.ok && r.reason === 'missing-custom-field') {
+      expect(r.missingField).toBe('yieldStressMPa');
+    }
   });
 
   it('refuses custom without youngsModulusGPa', () => {
@@ -91,7 +93,23 @@ describe('resolveMaterialProps — T6.2', () => {
       yieldStressMPa: 300,
     });
     expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.missingField).toBe('youngsModulusGPa');
+    if (!r.ok && r.reason === 'missing-custom-field') {
+      expect(r.missingField).toBe('youngsModulusGPa');
+    }
+  });
+
+  it('returns unknown-material (no throw) for a bare/typo SKU not in the catalog', () => {
+    // Issue #540 part A: a value that is neither 'custom' nor a catalog key
+    // must not crash reading yieldStressPa off an undefined catalog row.
+    const r = resolveMaterialProps({
+      material: 'aluminum-6061' as never,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok && r.reason === 'unknown-material') {
+      expect(r.material).toBe('aluminum-6061');
+    } else {
+      throw new Error('expected unknown-material failure');
+    }
   });
 
   it('honours catalog override of density / modulus when the agent passes it', () => {

--- a/tests/unit/kinematic/checkLoadCapacity.test.ts
+++ b/tests/unit/kinematic/checkLoadCapacity.test.ts
@@ -24,6 +24,33 @@ import { beforeAll } from 'vitest';
 import { initOcct } from '../../../src/kernel/backends/occt/occtBackend';
 import { checkLoadCapacity } from '../../../src/kinematic/checkLoadCapacity';
 import { buildCantileverBracket } from './fixtures/cantileverBracket';
+import { CaptureSession } from '../../../src/modeling/capture/captureSession';
+import { createApi } from '../../../src/modeling/api';
+import type { AssemblyCrossSection } from '../../../src/modeling/capture/assembly';
+
+/** Build a cantilever anchored by a single directly-registered revolute
+ *  joint (no mate) — issue #540 part B. Returns the assembly + the loaded
+ *  part name. */
+function buildJointAnchoredCantilever(): {
+  arm: ReturnType<ReturnType<typeof createApi>['assembly']>;
+  partName: 'cantilever';
+} {
+  const session = new CaptureSession();
+  const kc = createApi({ session });
+  const arm = kc.assembly('joint-cantilever');
+  const cs: AssemblyCrossSection = {
+    kind: 'rectangle',
+    widthMm: 50,
+    heightMm: 5,
+    lengthMm: 200,
+  };
+  const wall = arm.part('wall', kc.box(40, 40, 40, true));
+  const beam = arm.part('cantilever', kc.box(200, 50, 5, true).translate(100, 0, 0), {
+    crossSection: cs,
+  });
+  arm.revolute('rootJoint', wall, beam, { axis: [0, 1, 0], origin: [0, 0, 0] });
+  return { arm, partName: 'cantilever' };
+}
 
 describe('checkLoadCapacity — T6 closed-form Euler-Bernoulli', () => {
   beforeAll(async () => {
@@ -135,6 +162,49 @@ describe('checkLoadCapacity — T6 closed-form Euler-Bernoulli', () => {
     expect(r.ok).toBe(true);
     expect(r.elements[0]!.yieldPa).toBe(6e8);
     expect(r.elements[0]!.safetyFactor).toBeCloseTo(600 / 48, 2);
+  });
+
+  it('unknown material SKU → clean K8 diagnostic naming the bad material, no throw', async () => {
+    // Issue #540 part A: a typo / bare SKU like 'aluminum-6061' must not
+    // crash on an undefined catalog row — the check returns and the
+    // diagnostic names the offending value.
+    const { arm, partName } = buildCantileverBracket();
+    const r = await checkLoadCapacity(
+      arm,
+      { [partName]: { force: [0, 0, 50] } },
+      { materials: { [partName]: { material: 'aluminum-6061' as never } } },
+    );
+    expect(r.source).toBe('local');
+    expect(r.elements).toHaveLength(0);
+    expect(r.failures).toHaveLength(0);
+    const k8 = r.diagnostics.find(
+      (d) => d.code === 'kinematic.no-material-declared',
+    );
+    expect(k8).toBeDefined();
+    expect(k8?.severity).toBe('error');
+    expect(k8?.element).toBe(partName);
+    expect(k8?.message).toContain('aluminum-6061');
+    expect(k8?.message).toContain('steel|aluminum|pla|abs|pet');
+  });
+
+  it('part anchored by a single revolute joint (no mate) → computed SF (issue #540 part B)', async () => {
+    const { arm, partName } = buildJointAnchoredCantilever();
+    const r = await checkLoadCapacity(
+      arm,
+      { [partName]: { force: [0, 0, 50] } },
+      { materials: { [partName]: { material: 'steel' } } },
+    );
+    expect(r.ok).toBe(true);
+    expect(r.elements).toHaveLength(1);
+    const el = r.elements[0]!;
+    expect(el.partName).toBe(partName);
+    expect(el.safetyFactor).toBeCloseTo(5.208, 2);
+    expect(r.safetyFactor).toBeCloseTo(5.208, 2);
+    // It must NOT be reported as "no declared mate".
+    const notApplicable = r.diagnostics.find(
+      (d) => d.code === 'kinematic.load.beam-not-applicable',
+    );
+    expect(notApplicable).toBeUndefined();
   });
 
   it('mode: stub re-exports the v0.7.4 substrate (joint-load magnitude)', async () => {

--- a/tests/unit/kinematic/checkMountingHoleConsistency.test.ts
+++ b/tests/unit/kinematic/checkMountingHoleConsistency.test.ts
@@ -45,6 +45,50 @@ describe('kc.kinematic.checkMountingHoleConsistency', () => {
     expect(r.ok).toBe(true);
     expect(r.mismatches).toHaveLength(0);
     expect(r.diagnostics).toHaveLength(0);
+    // #541 — a real interface was examined, so the green is not vacuous and
+    // no no-coverage note fires.
+    expect(r.checked).toBeGreaterThanOrEqual(1);
+    expect(
+      r.diagnostics.some(
+        (d) => d.code === 'kinematic.mounting-holes.no-coverage',
+      ),
+    ).toBe(false);
+  });
+
+  it('#541 reports zero coverage instead of a vacuous green when there are no fastened mates', async () => {
+    const { kc, arm } = makeArm();
+    // Two parts, no fastened mate between them — nothing for the gate to check.
+    const a = kc
+      .box(20, 20, 5)
+      .hole('top', { u: 0, v: 0, diameter: 5, depth: 'through' });
+    const b = kc
+      .box(20, 20, 5)
+      .hole('bottom', { u: 0, v: 0, diameter: 5, depth: 'through' });
+    arm.part('a', a).connector('h', {
+      type: 'frame',
+      origin: { kind: 'topology', query: { kind: 'face-center', name: 'top' } },
+    });
+    arm.part('b', b).connector('h', {
+      type: 'frame',
+      origin: {
+        kind: 'topology',
+        query: { kind: 'face-center', name: 'bottom' },
+      },
+    });
+
+    const r = await kc.kinematic.checkMountingHoleConsistency(arm);
+    expect(r.source).toBe('local');
+    // Still ok:true (no mismatch), but `checked` and the diagnostic make the
+    // zero-coverage case detectable — a green is not mistaken for "verified".
+    expect(r.checked).toBe(0);
+    expect(r.mismatches).toHaveLength(0);
+    const noCoverage = r.diagnostics.filter(
+      (d) => d.code === 'kinematic.mounting-holes.no-coverage',
+    );
+    expect(noCoverage).toHaveLength(1);
+    expect(noCoverage[0].severity).toBe('info');
+    expect(noCoverage[0].source).toBe('local');
+    expect(noCoverage[0].message).toContain('nothing was checked');
   });
 
   it('flags diameter mismatch with a translated diagnostic envelope', async () => {
@@ -74,6 +118,7 @@ describe('kc.kinematic.checkMountingHoleConsistency', () => {
     const r = await kc.kinematic.checkMountingHoleConsistency(arm);
     expect(r.source).toBe('local');
     expect(r.ok).toBe(false);
+    expect(r.checked).toBeGreaterThanOrEqual(1);
     expect(r.mismatches.length).toBeGreaterThanOrEqual(1);
     expect(r.mismatches[0].mateName).toBe('screw');
     expect(r.diagnostics.length).toBeGreaterThanOrEqual(1);

--- a/tests/unit/kinematic/checkMountingHoleConsistency.test.ts
+++ b/tests/unit/kinematic/checkMountingHoleConsistency.test.ts
@@ -50,7 +50,7 @@ describe('kc.kinematic.checkMountingHoleConsistency', () => {
     expect(r.checked).toBeGreaterThanOrEqual(1);
     expect(
       r.diagnostics.some(
-        (d) => d.code === 'kinematic.mounting-holes.no-coverage',
+        (d) => d.code === 'kinematic.mounting-hole.no-coverage',
       ),
     ).toBe(false);
   });
@@ -83,7 +83,7 @@ describe('kc.kinematic.checkMountingHoleConsistency', () => {
     expect(r.checked).toBe(0);
     expect(r.mismatches).toHaveLength(0);
     const noCoverage = r.diagnostics.filter(
-      (d) => d.code === 'kinematic.mounting-holes.no-coverage',
+      (d) => d.code === 'kinematic.mounting-hole.no-coverage',
     );
     expect(noCoverage).toHaveLength(1);
     expect(noCoverage[0].severity).toBe('info');

--- a/tests/unit/kinematic/checkReachableMultiDof.test.ts
+++ b/tests/unit/kinematic/checkReachableMultiDof.test.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// tests/unit/kinematic/checkReachableMultiDof.test.ts
+//
+// Regression for issue #539: numeric inverse kinematics must actuate EVERY
+// revolute DOF in the chain, not just the first joint. The deployed server
+// (older build) only ever moved joint1 of a 3-DOF serial leg, hit the
+// iteration cap, and reported clearly reachable targets as unreachable.
+//
+// These tests lock in the correct multi-DOF behaviour on a 3-DOF leg:
+//   base --j1(roll, axis x)--> coxa --j2(pitch, axis y)--> femur
+//        --j3(knee pitch, axis y)--> tibia --(fixed)--> foot (tip)
+//
+// The foot at rest hangs straight down at (0, 0, -(Lf+Lt)). A target with a
+// non-zero X component is unreachable by j1 alone (rolling about the world X
+// axis keeps the foot in the X=0 plane), so the solver MUST flex j2/j3.
+//
+// The helper-level path is exercised through a minimal stub arm (the same
+// pattern as forwardKinematics.test.ts) so the kinematic solvers are tested
+// without standing up a CaptureSession + Shape graph; both checkReachable
+// (dispatcher) and solveNumeric (DLS core) are driven directly.
+
+import { describe, it, expect } from 'vitest';
+import { solveNumeric } from '../../../src/kinematic/inverseKinematicsNumeric';
+import { checkReachable } from '../../../src/kinematic/checkReachable';
+import type {
+  Assembly,
+  AssemblyJointStored,
+  AssemblyPartStored,
+} from '../../../src/modeling/capture/assembly';
+
+const Lf = 100; // femur length
+const Lt = 100; // tibia length
+
+function part(id: string, name: string): AssemblyPartStored {
+  return { id, name } as unknown as AssemblyPartStored;
+}
+
+/** Build a 3-DOF serial leg as a minimal stub arm. */
+function makeLeg(): Assembly {
+  const parts: AssemblyPartStored[] = [
+    part('p_base', 'base'),
+    part('p_coxa', 'coxa'),
+    part('p_femur', 'femur'),
+    part('p_tibia', 'tibia'),
+    part('p_foot', 'foot'),
+  ];
+  const joints: AssemblyJointStored[] = [
+    {
+      name: 'j1', kind: 'revolute', parentPartId: 'p_base', childPartId: 'p_coxa',
+      axis: [1, 0, 0], origin: [0, 0, 0], limitsDeg: [-90, 90],
+    },
+    {
+      name: 'j2', kind: 'revolute', parentPartId: 'p_coxa', childPartId: 'p_femur',
+      axis: [0, 1, 0], origin: [0, 0, 0], limitsDeg: [-90, 90],
+    },
+    {
+      name: 'j3', kind: 'revolute', parentPartId: 'p_femur', childPartId: 'p_tibia',
+      axis: [0, 1, 0], origin: [0, 0, -Lf], limitsDeg: [-150, 150],
+    },
+    {
+      name: 'jfoot', kind: 'fixed', parentPartId: 'p_tibia', childPartId: 'p_foot',
+      origin: [0, 0, -Lt],
+    },
+  ] as unknown as AssemblyJointStored[];
+
+  return {
+    __parts: () => parts,
+    __joints: () => joints,
+  } as unknown as Assembly;
+}
+
+describe('checkReachable — numeric IK uses all chain DOFs (issue #539)', () => {
+  it('solveNumeric flexes j2/j3 to reach a target off the roll plane', () => {
+    const arm = makeLeg();
+    // Forward + up from the rest foot at (0,0,-200): requires pitch flexion.
+    const res = solveNumeric(
+      arm,
+      'foot',
+      { position: [60, 0, -150], positionToleranceMm: 0.5 },
+      {},
+      200,
+    );
+
+    expect(res.converged).toBe(true);
+    expect(res.positionErrorMm).toBeLessThan(0.5);
+    // The downstream pitch joints carry the solution, not j1 alone.
+    expect(Math.abs(res.poses.j2 as number)).toBeGreaterThan(1);
+    expect(Math.abs(res.poses.j3 as number)).toBeGreaterThan(1);
+    // j1 (roll about world X) cannot produce the +X reach, so it stays ~0.
+    expect(Math.abs(res.poses.j1 as number)).toBeLessThan(1e-6);
+  });
+
+  it('checkReachable (dispatcher) reports a reachable off-plane target as reachable', async () => {
+    const arm = makeLeg();
+    const r = await checkReachable(arm, {
+      tipLink: 'foot',
+      target: { position: [60, 0, -150] },
+    });
+
+    expect(r.ok).toBe(true);
+    expect(r.pose).toBeDefined();
+    expect(Math.abs(r.pose!.j2 as number)).toBeGreaterThan(1);
+    expect(Math.abs(r.pose!.j3 as number)).toBeGreaterThan(1);
+    expect(r.diagnostics).toHaveLength(0);
+  });
+
+  it('does not regress the rest pose to "unreachable"', async () => {
+    const arm = makeLeg();
+    // The rest foot sits exactly at (0,0,-(Lf+Lt)); the seed pose satisfies it.
+    const r = await checkReachable(arm, {
+      tipLink: 'foot',
+      target: { position: [0, 0, -(Lf + Lt)] },
+    });
+    expect(r.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes a batch of joint/kinematic-check issues surfaced while building a 12-DOF quadruped to stress-test the assembly verification checks.

## Code fixes
- **Closes #535** — restore public `assembly.revolute(name, a, b, {axis, origin, limitsDeg})`, mirroring `prismatic()`/`ball()`. Revolute was the only common joint missing from the public surface; the internals already supported it.
- **Closes #537** — `solve()`/`solvedModel()` now emit a `kinematic.pose.out-of-limits` warning when a pose exceeds the joint's declared `limitsDeg`/`limitsMm` (was silently accepted — a false-pass risk). Advisory; does not change pose application.
- **Closes #540** — load-capacity: (a) an unknown material SKU now returns a clean diagnostic instead of crashing with `reading 'yieldStressPa'`; (b) parts anchored by a single directly-registered joint (not only a mate) are now cantilever-eligible, so jointed mechanisms get a safety factor.
- **Closes #541** — mounting-holes now reports `checked` count + a `kinematic.mounting-hole.no-coverage` diagnostic when there are zero fastened mates, instead of a vacuous green pass.
- **Closes #536** — posing a non-drivable name (e.g. a revolute *mate*) via `solve()` now throws a clear `feature.invalid-args` pointing to `assembly.revolute(...)`, instead of the cryptic `reading 'kind'` TypeError.

## Regression tests only (already correct on `develop`)
- **Refs #539** — numeric IK already uses all chain DOFs and converges on `develop`; added a multi-DOF regression test. (The reported single-joint behavior was the stale deployed build.)
- **Refs #538** — `solvedModel(poses)` already renders posed + per-part colored on `develop`; added a regression test + a doc note that `solve().toScene()` snapshots are for analysis, not rendering.

## Notes
- These issues were originally observed against the **deployed** `mcp.kernelcad.com` server, which is an older build — #536/#538/#539 were already fixed on `develop`. Recommend redeploying the server so the live MCP picks up the rest.
- Behavior change worth a release note (#540): a part anchored by both a mate and a body-tree joint now counts 2 anchors → `beam-not-applicable` (the single-anchor limitation applied consistently). 152/152 regression tests pass.

## Verification
- `tsc -b --noEmit` clean.
- Per-fix scoped vitest green; broad regression `vitest run tests/unit/assemblies tests/unit/kinematic tests/unit/diagnostics` = 152/152.
- Independent whole-branch review: clean, merge-ready (no Critical/Important).
