### PR TITLE
funnel: model 'gate_failed' generation status/error code

### DIFF
--- a/src/funnel/lib/apiClient.ts
+++ b/src/funnel/lib/apiClient.ts
@@ -5,7 +5,8 @@ import type { Artifact } from './generateClient';
 
 export interface GenerationRow {
   id: string;
-  status: 'running' | 'done' | 'eval_failed' | 'llm_failed' | 'timeout';
+  // 'gate_failed' is the live server status; 'eval_failed' kept for historical rows.
+  status: 'running' | 'done' | 'gate_failed' | 'eval_failed' | 'llm_failed' | 'timeout';
   code: string | null;
   prompt: string;
   suggestions: string[];

--- a/src/funnel/lib/generateClient.ts
+++ b/src/funnel/lib/generateClient.ts
@@ -22,7 +22,7 @@ export type GenerateEvent =
   | { kind: 'tool_call'; name: string; args: unknown }
   | { kind: 'tool_result'; name: string; ok: boolean }
   | { kind: 'done'; artifact: Artifact; generationId: string; anonId: string; durationMs: number }
-  | { kind: 'error'; code: 'llm_failed' | 'eval_failed' | 'timeout'; message: string; generationId: string };
+  | { kind: 'error'; code: 'llm_failed' | 'gate_failed' | 'eval_failed' | 'timeout'; message: string; generationId: string };
 
 /**
  * Parse a Server-Sent Events stream from POST /api/v1/generate into typed events.
@@ -102,7 +102,7 @@ function mapToEvent(name: string, p: Record<string, unknown>): GenerateEvent | n
     case 'error':
       return {
         kind: 'error',
-        code: p.code as 'llm_failed' | 'eval_failed' | 'timeout',
+        code: p.code as 'llm_failed' | 'gate_failed' | 'eval_failed' | 'timeout',
         message: asString(p.message),
         generationId: asString(p.generationId),
       };


### PR DESCRIPTION
The kernelCAD-server build pipeline emits `gate_failed` (SSE `error` code + persisted `gen_status`) when a generated model fails the build-blocking gates — it was renamed server-side from the legacy `eval_failed` (migration `20260604`), but the funnel client was never updated. So a gate failure reached the browser as an unmodeled code: the message still rendered, but the typed contract was wrong.

Adds `gate_failed` to `GenerationRow.status` and the `GenerateEvent` error union (+ the SSE parse cast). Keeps `eval_failed` for historical persisted rows. Type-only widening; tsc clean, 61 funnel tests pass.

Pairs with kernelCAD-server#73.