### PR TITLE
Fix landing app navigation prompts

### DIFF
--- a/scripts/staticGalleryLanding.test.ts
+++ b/scripts/staticGalleryLanding.test.ts
@@ -63,7 +63,7 @@ describe('static gallery landing page', () => {
   it('places the prompt handoff before the built-with-kernelCAD gallery', () => {
     const html = readFileSync(path.resolve(__dirname, '../site/index.html'), 'utf8');
 
-    expect(html).toContain('action="https://app.kernelcad.com/generate"');
+    expect(html).toContain('action="/app/generate"');
     expect(html).toContain('name="prompt"');
     expect(html).toContain('Describe the part you want');
 

--- a/site/index.html
+++ b/site/index.html
@@ -113,7 +113,7 @@
         <span class="section-kicker">Start with words</span>
         <h2 class="prompt-handoff-headline">Describe the part you want.</h2>
       </div>
-      <form class="prompt-handoff-form" action="https://app.kernelcad.com/generate" method="GET">
+      <form class="prompt-handoff-form" action="/app/generate" method="GET" autocomplete="off">
         <label class="sr-only" for="prompt-input">CAD prompt</label>
         <textarea
           id="prompt-input"
@@ -121,6 +121,7 @@
           rows="3"
           placeholder="60x40x5 mm bracket with 4 M3 mounting holes"
           required
+          autocomplete="off"
         ></textarea>
         <button class="btn btn-primary" type="submit">Generate in app</button>
       </form>
@@ -380,8 +381,10 @@
           `;
           tile.__entry = entry;
           armGalleryTileUpgrade(tile, entry, galleryCacheKey);
+          tile.querySelector('.tile-studio-link')?.addEventListener('pointerdown', clearPromptDraftBeforeNavigation);
           tile.querySelector('.tile-studio-link')?.addEventListener('click', (event) => {
             event.stopPropagation();
+            clearPromptDraftBeforeNavigation();
           });
           tile.addEventListener('click', () => {
             upgradeGalleryTile(tile, entry, galleryCacheKey);
@@ -427,7 +430,16 @@
           dialog.querySelector('.lightbox-stage').textContent = '';
           dialog.close();
         }
+        function clearPromptDraftBeforeNavigation() {
+          const form = document.querySelector('.prompt-handoff-form');
+          if (!(form instanceof HTMLFormElement)) return;
+          form.reset();
+        }
         closeBtn.addEventListener('click', closeLightbox);
+        studioLink.addEventListener('pointerdown', clearPromptDraftBeforeNavigation);
+        studioLink.addEventListener('click', clearPromptDraftBeforeNavigation);
+        appLink.addEventListener('pointerdown', clearPromptDraftBeforeNavigation);
+        appLink.addEventListener('click', clearPromptDraftBeforeNavigation);
         dialog.addEventListener('click', (e) => {
           if (e.target === dialog) closeLightbox();
         });

--- a/site/scripts/build-gallery.test.ts
+++ b/site/scripts/build-gallery.test.ts
@@ -34,7 +34,7 @@ describe('buildGallery', () => {
     expect(out.entries[0].posterUrl).toBe('/gallery/fixture-build/poster.jpg');
     expect(out.entries[0].modelUrl).toBe('/gallery/fixture-build/model.glb');
     expect(out.entries[0].promptUrl).toBe('/gallery/fixture-build/prompt.md');
-    expect(out.entries[0].studioUrl).toBe('https://app.kernelcad.com/studio?gallery=fixture-build');
+    expect(out.entries[0].studioUrl).toBe('/app/studio?gallery=fixture-build');
     expect(out.entries[0].sourceUrl).toBe('/gallery/fixture-build/source.kcad.ts');
     expect(out.entries[0].scriptPath).toBe('simple-box.kcad.ts');
 

--- a/site/scripts/build-gallery.ts
+++ b/site/scripts/build-gallery.ts
@@ -47,7 +47,7 @@ interface PublishedEntry extends Omit<GalleryEntry, 'video' | 'codeLocal'> {
 // spice-dispenser carousel under it (~452 KB). Next lever if tiles ever grow:
 // mesh quantization / Draco.
 const GLB_SIZE_HARD_CAP = 500_000;
-const STUDIO_ORIGIN = 'https://app.kernelcad.com';
+const STUDIO_BASE_PATH = '/app';
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 /**
  * Builds the `ScriptReviewSummary` the hosted Studio consumes (see
@@ -145,7 +145,7 @@ export async function buildGallery(opts: BuildGalleryOptions): Promise<void> {
       ? entry.codeLocal.split(path.sep).join('/')
       : null;
     const studioUrl = entry.source === 'curated'
-      ? `${STUDIO_ORIGIN}/studio?gallery=${encodeURIComponent(entry.slug)}`
+      ? `${STUDIO_BASE_PATH}/studio?gallery=${encodeURIComponent(entry.slug)}`
       : entry.appUrl;
 
     copyFileSync(srcVideo, dstVideo);

--- a/src/funnel/components/PromptBox.tsx
+++ b/src/funnel/components/PromptBox.tsx
@@ -26,7 +26,7 @@ export function PromptBox({ onSubmit, disabled, examples = DEFAULT_EXAMPLES, ini
   }
 
   return (
-    <form onSubmit={handleSubmit} className="w-full max-w-2xl mx-auto">
+    <form onSubmit={handleSubmit} className="w-full max-w-2xl mx-auto" autoComplete="off">
       <label htmlFor="prompt" className="sr-only">CAD prompt</label>
       <textarea
         id="prompt"
@@ -35,6 +35,7 @@ export function PromptBox({ onSubmit, disabled, examples = DEFAULT_EXAMPLES, ini
         rows={3}
         disabled={disabled}
         placeholder="Describe the part you want…"
+        autoComplete="off"
         className="w-full rounded-lg bg-white border border-rule text-ink p-4 text-base placeholder:text-ink-faint focus:border-blueprint focus:outline-none disabled:opacity-50 font-sans"
       />
       <div className="mt-3 flex flex-wrap items-center justify-between gap-2">

--- a/tests/funnel/PromptBox.test.tsx
+++ b/tests/funnel/PromptBox.test.tsx
@@ -38,4 +38,14 @@ describe('PromptBox', () => {
     const btn = screen.getByRole('button', { name: /Generating/i }) as HTMLButtonElement;
     expect(btn.disabled).toBe(true);
   });
+
+  it('disables browser autocomplete for prompt draft fields', () => {
+    render(<PromptBox onSubmit={() => {}} />);
+
+    const form = screen.getByLabelText(/CAD prompt/).closest('form');
+    const textarea = screen.getByLabelText(/CAD prompt/) as HTMLTextAreaElement;
+
+    expect(form?.getAttribute('autocomplete')).toBe('off');
+    expect(textarea.autocomplete).toBe('off');
+  });
 });

--- a/tests/unit/site/landingNavigation.test.ts
+++ b/tests/unit/site/landingNavigation.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+describe('landing page app navigation', () => {
+  const html = () => readFileSync(path.resolve(__dirname, '../../../site/index.html'), 'utf8');
+
+  it('keeps prompt handoff same-origin and disables browser draft restoration', () => {
+    const source = html();
+
+    expect(source).toContain('class="prompt-handoff-form" action="/app/generate" method="GET" autocomplete="off"');
+    expect(source).toContain('name="prompt"');
+    expect(source).toContain('autocomplete="off"');
+    expect(source).not.toContain('action="https://app.kernelcad.com/generate"');
+  });
+
+  it('clears prompt draft state before gallery app navigation', () => {
+    const source = html();
+
+    expect(source).toContain('function clearPromptDraftBeforeNavigation()');
+    expect(source).toContain("tile.querySelector('.tile-studio-link')?.addEventListener('pointerdown', clearPromptDraftBeforeNavigation)");
+    expect(source).toContain("tile.querySelector('.tile-studio-link')?.addEventListener('click'");
+    expect(source).toContain("studioLink.addEventListener('pointerdown', clearPromptDraftBeforeNavigation)");
+    expect(source).toContain("appLink.addEventListener('pointerdown', clearPromptDraftBeforeNavigation)");
+  });
+});


### PR DESCRIPTION
## Summary
- Keep landing prompt handoff on same-origin `/app/generate` and disable browser autocomplete draft restoration.
- Generate curated gallery Studio links as same-origin `/app/studio?...` paths instead of cross-origin `app.kernelcad.com` URLs.
- Clear the landing prompt form before gallery Studio/app navigation.

## Root Cause
The deployed landing page still navigated from `kernelcad.com` to `app.kernelcad.com` for prompt handoff and live-build Studio links. On mobile/in-app browsers that can surface a browser-level leave-site confirmation even when the user only focused the prompt and typed nothing.

## Test Plan
- `npx vitest run tests/unit/site/landingNavigation.test.ts tests/funnel/PromptBox.test.tsx site/scripts/build-gallery.test.ts scripts/staticGalleryLanding.test.ts`