### PR TITLE
studio: in-editor agentic loop (edit model, diff + accept/reject, verified)

### DIFF
--- a/src/funnel/hooks/useGeneration.test.ts
+++ b/src/funnel/hooks/useGeneration.test.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+const startGeneration = vi.fn();
+const parseSseStream = vi.fn();
+
+vi.mock('../lib/generateClient', () => ({
+  startGeneration: (...a: unknown[]) => startGeneration(...a),
+  parseSseStream: (...a: unknown[]) => parseSseStream(...a),
+}));
+
+import { useGeneration } from './useGeneration';
+
+async function* yieldDone() {
+  yield { kind: 'generation', generationId: 'g1', anonId: 'a1' };
+  yield { kind: 'done', generationId: 'g1', anonId: 'a1', artifact: { title: 'T', code: 'return box(1,1,1);', parameters: [], suggestions: [] } };
+}
+
+describe('useGeneration edit mode', () => {
+  beforeEach(() => {
+    startGeneration.mockReset();
+    parseSseStream.mockReset();
+    startGeneration.mockResolvedValue({ ok: true, body: {} } as Response);
+    parseSseStream.mockReturnValue(yieldDone());
+  });
+
+  it('forwards currentCode to startGeneration when editing', async () => {
+    const { result } = renderHook(() => useGeneration());
+    await act(async () => {
+      await result.current.submit('add a hole', 'return box(20,20,20);');
+    });
+    expect(startGeneration).toHaveBeenCalledWith({ prompt: 'add a hole', currentCode: 'return box(20,20,20);' });
+    await waitFor(() => expect(result.current.phase.state).toBe('done'));
+  });
+
+  it('omits currentCode for a fresh generation', async () => {
+    const { result } = renderHook(() => useGeneration());
+    await act(async () => {
+      await result.current.submit('a 20mm cube');
+    });
+    expect(startGeneration).toHaveBeenCalledWith({ prompt: 'a 20mm cube', currentCode: undefined });
+  });
+});

--- a/src/funnel/hooks/useGeneration.ts
+++ b/src/funnel/hooks/useGeneration.ts
@@ -25,7 +25,7 @@ export function useGeneration() {
   const [phase, setPhase] = useState<GenerationPhase>({ state: 'idle' });
   const [events, setEvents] = useState<GenerateEvent[]>([]);
 
-  const submit = useCallback(async (prompt: string) => {
+  const submit = useCallback(async (prompt: string, currentCode?: string) => {
     setEvents([]);
     setPhase({
       state: 'running',
@@ -34,7 +34,7 @@ export function useGeneration() {
 
     let res: Response;
     try {
-      res = await startGeneration({ prompt });
+      res = await startGeneration({ prompt, currentCode });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       setPhase({ state: 'error', code: 'network', message });

--- a/src/funnel/lib/generateClient.ts
+++ b/src/funnel/lib/generateClient.ts
@@ -113,6 +113,9 @@ function mapToEvent(name: string, p: Record<string, unknown>): GenerateEvent | n
 
 export interface GenerateRequest {
   prompt: string;
+  /** Edit mode: the current editor source the agent should modify (Studio agent
+   *  loop). Omit for a fresh generation (funnel/landing). */
+  currentCode?: string;
 }
 
 export async function startGeneration(req: GenerateRequest): Promise<Response> {

--- a/src/studio/StudioGenerate.tsx
+++ b/src/studio/StudioGenerate.tsx
@@ -1,77 +1,95 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useMemo, useState } from 'react';
+import { DiffEditor } from '@monaco-editor/react';
 import { useGeneration } from '../funnel/hooks/useGeneration';
+import type { GenerateEvent } from '../funnel/lib/generateClient';
 import { useCode } from './context/CodeContext';
 import { useGeometry } from './context/GeometryContext';
 
 /**
- * The in-app generate agent exists ONLY on the hosted web build (which sets a
- * generation backend via VITE_API_BASE_URL). The npm-distributed / local-MCP
- * Studio has no backend env → the box is hidden there; locally the agent is the
- * developer's own Claude via the `kernelcad` MCP.
+ * The in-app agent exists ONLY on the hosted web build (which sets a generation
+ * backend via VITE_API_BASE_URL). The npm-distributed / local-MCP Studio has no
+ * backend env → the panel is hidden there; locally the agent is the developer's
+ * own Claude via the `kernelcad` MCP.
  */
 function inAppAgentEnabled(): boolean {
     const base = import.meta.env?.VITE_API_BASE_URL;
     return typeof base === 'string' && base.length > 0;
 }
 
-/**
- * In-Studio generation. Type a prompt → the hosted agent builds a model and
- * the result drops straight into the Studio editor (the viewer re-runs on code
- * change). No navigation, no sign-in wall — `/api/v1/generate` is anonymous
- * (IP rate-limited); signing in is only needed later to SAVE.
- *
- * This is the "generate directly in Studio" experience: same window, live.
- */
-/**
- * Web-only gate. Locally the agent is the developer's own (Claude via the
- * `kernelcad` MCP); the in-app generate agent exists ONLY on the hosted deploy.
- * This wrapper has no hooks, so the conditional return is safe.
- */
+/** Web-only gate. No hooks here, so the conditional return is safe. */
 export const StudioGenerate: React.FC = () => {
     if (!inAppAgentEnabled()) return null;
     return <StudioGenerateInner />;
 };
 
+/** Human-readable label for a streamed agent event (the live "what it's doing"). */
+function stepLabel(e: GenerateEvent): string | null {
+    switch (e.kind) {
+        case 'status':
+            return e.phase === 'tool_calling' ? 'using tools…' : 'thinking…';
+        case 'tool_call':
+            return `→ ${e.name}`;
+        case 'tool_result':
+            return `${e.ok ? '✓' : '⟳'} ${e.name}`;
+        default:
+            return null;
+    }
+}
+
 const StudioGenerateInner: React.FC = () => {
     const { phase, events, submit } = useGeneration();
-    const { setCode } = useCode();
+    const { code, setCode } = useCode();
     const { executeGeometry } = useGeometry();
     const [prompt, setPrompt] = useState('');
-    const loadedRef = useRef<string | null>(null);
-
-    // When a generation finishes, load the model into the editor AND render it.
-    // setCode updates the editor text; executeGeometry meshes it into the viewer
-    // (on the hosted path setCode alone is a no-op for rendering).
-    useEffect(() => {
-        if (phase.state === 'done' && loadedRef.current !== phase.generationId) {
-            loadedRef.current = phase.generationId;
-            setCode(phase.artifact.code);
-            void executeGeometry(phase.artifact.code);
-        }
-    }, [phase, setCode, executeGeometry]);
+    // The generationId we've already accepted/rejected — gates the review panel
+    // so an applied/dismissed proposal doesn't reappear.
+    const [resolvedId, setResolvedId] = useState<string | null>(null);
+    // The editor source captured at submit time — the "before" side of the diff
+    // (so the diff is stable even though `code` changes once we apply).
+    const [baseline, setBaseline] = useState('');
 
     const busy = phase.state === 'running';
+    // A finished, not-yet-resolved proposal → show the review (diff + accept/reject).
+    const reviewing = phase.state === 'done' && resolvedId !== phase.generationId;
+
+    const steps = useMemo(() => events.map(stepLabel).filter(Boolean) as string[], [events]);
 
     const onSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         const trimmed = prompt.trim();
         if (!trimmed || busy) return;
-        void submit(trimmed);
+        // Edit mode: hand the agent the current model so it iterates instead of
+        // replacing. Empty editor → fresh generation.
+        setBaseline(code);
+        void submit(trimmed, code.trim() ? code : undefined);
     };
+
+    const accept = () => {
+        if (phase.state !== 'done') return;
+        setCode(phase.artifact.code);
+        void executeGeometry(phase.artifact.code);
+        setResolvedId(phase.generationId);
+    };
+    const reject = () => {
+        if (phase.state !== 'done') return;
+        setResolvedId(phase.generationId);
+    };
+
+    const isEdit = baseline.trim().length > 0;
 
     return (
         <div className="p-3 flex flex-col gap-2">
-            <div className="uppercase tracking-wide text-[10px] text-gray-500">Generate</div>
+            <div className="uppercase tracking-wide text-[10px] text-gray-500">Agent</div>
             <form onSubmit={onSubmit} className="flex flex-col gap-2">
                 <textarea
-                    aria-label="Generate prompt"
+                    aria-label="Agent prompt"
                     value={prompt}
                     onChange={(e) => setPrompt(e.target.value)}
                     rows={3}
                     disabled={busy}
-                    placeholder="Describe a part… e.g. a 20mm cube"
+                    placeholder={code.trim() ? 'Edit this model… e.g. add two 4mm mounting holes' : 'Describe a part… e.g. a 20mm cube'}
                     className="w-full rounded bg-[#111] border border-[#2a2e38] text-gray-100 p-2 text-[11px] placeholder:text-gray-600 focus:border-blue-500 focus:outline-none disabled:opacity-50 resize-none font-sans"
                 />
                 <button
@@ -79,20 +97,70 @@ const StudioGenerateInner: React.FC = () => {
                     disabled={busy || !prompt.trim()}
                     className="rounded bg-blue-600 hover:bg-blue-500 text-white px-3 py-1.5 text-[11px] font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                 >
-                    {busy ? 'Generating…' : 'Generate →'}
+                    {busy ? 'Working…' : code.trim() ? 'Edit with agent →' : 'Generate →'}
                 </button>
             </form>
 
-            {phase.state === 'running' && (
-                <div className="text-[10px] text-gray-500 truncate" aria-live="polite">
-                    working — {events.length} events
-                    {phase.lastEvent.kind === 'tool_call' && ` · ${phase.lastEvent.name}`}
-                    {phase.lastEvent.kind === 'status' && ` · ${phase.lastEvent.phase}`}
+            {/* Live plan / tool-calls while the agent works. */}
+            {busy && (
+                <div className="flex flex-col gap-0.5 max-h-28 overflow-auto" aria-live="polite">
+                    {steps.length === 0 && <div className="text-[10px] text-gray-500">starting…</div>}
+                    {steps.slice(-6).map((s, i) => (
+                        <div key={i} className="text-[10px] text-gray-400 truncate font-mono">{s}</div>
+                    ))}
                 </div>
             )}
-            {phase.state === 'done' && (
+
+            {/* Review gate: diff + verified badge + accept/reject. Never auto-applies. */}
+            {reviewing && phase.state === 'done' && (
+                <div className="flex flex-col gap-2">
+                    <div className="flex items-center justify-between">
+                        <div className="text-[10px] text-gray-300 truncate" title={phase.artifact.title}>
+                            {phase.artifact.title}
+                        </div>
+                        <div className="text-[10px] text-green-500 whitespace-nowrap" title="Built and passed the kernel gates">
+                            ✓ verified
+                        </div>
+                    </div>
+                    <div className="rounded overflow-hidden border border-[#2a2e38]" style={{ height: 180 }}>
+                        <DiffEditor
+                            original={baseline}
+                            modified={phase.artifact.code}
+                            language="typescript"
+                            theme="vs-dark"
+                            options={{
+                                readOnly: true,
+                                renderSideBySide: false,
+                                minimap: { enabled: false },
+                                fontSize: 11,
+                                lineNumbers: 'off',
+                                scrollBeyondLastLine: false,
+                                renderOverviewRuler: false,
+                            }}
+                        />
+                    </div>
+                    <div className="flex gap-2">
+                        <button
+                            type="button"
+                            onClick={accept}
+                            className="flex-1 rounded bg-green-600 hover:bg-green-500 text-white px-3 py-1.5 text-[11px] font-medium transition-colors"
+                        >
+                            {isEdit ? 'Apply changes' : 'Use this'}
+                        </button>
+                        <button
+                            type="button"
+                            onClick={reject}
+                            className="flex-1 rounded bg-[#1a1d24] hover:bg-[#222630] text-gray-300 border border-[#2a2e38] px-3 py-1.5 text-[11px] font-medium transition-colors"
+                        >
+                            Discard
+                        </button>
+                    </div>
+                </div>
+            )}
+
+            {phase.state === 'done' && !reviewing && (
                 <div className="text-[10px] text-green-500 truncate" aria-live="polite">
-                    ✓ {phase.artifact.title} — loaded into Studio
+                    ✓ applied — {phase.artifact.title}
                 </div>
             )}
             {phase.state === 'error' && (


### PR DESCRIPTION
Reworks the bare Studio prompt box into a proper agent loop on the hosted gemma agent:

- **Edit the current model** (not just regenerate): sends the editor source as `currentCode`; agent iterates and returns the complete updated script. (pairs with kernelCAD-server#77)
- **Live plan/tool-calls**: streams the agent's steps instead of 'working — N events'.
- **Review gate (no silent overwrite)**: on completion shows a Monaco diff (before vs proposed) with **Apply / Discard** — `setCode` only on Apply. Kills the silent-overwrite anti-pattern.
- **Verified badge**: the `done` event means the kernel gates passed → '✓ verified'.

Backward-compatible: empty editor → fresh generation; the funnel path is unaffected (`submit` currentCode is optional). tsc clean; funnel + new useGeneration edit-mode tests pass.