### PR TITLE
fix(studio): close project manager after creating a project

### DIFF
--- a/src/studio/components/Dialogs/ProjectManagerDialog.test.tsx
+++ b/src/studio/components/Dialogs/ProjectManagerDialog.test.tsx
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import ProjectManagerDialog from './ProjectManagerDialog';
+
+const createProject = vi.fn(() => 'new-id');
+const openProject = vi.fn();
+
+vi.mock('../../context/ProjectContext', () => ({
+    useProject: () => ({
+        projects: [
+            { id: 'old-1', name: 'Old Project', lastUpdated: '2026-06-01T00:00:00.000Z' },
+        ],
+        activeProjectId: 'old-1',
+        openProject,
+        createProject,
+        deleteProject: vi.fn(),
+        renameActiveProject: vi.fn(),
+    }),
+}));
+
+afterEach(() => {
+    cleanup();
+    createProject.mockClear();
+    openProject.mockClear();
+});
+
+describe('ProjectManagerDialog', () => {
+    it('closes the dialog after creating a new project', () => {
+        const onClose = vi.fn();
+        render(<ProjectManagerDialog isOpen={true} onClose={onClose} />);
+
+        fireEvent.click(screen.getByText('Create New Project'));
+
+        expect(createProject).toHaveBeenCalled();
+        // Creating a project makes it active and should reveal the canvas,
+        // exactly like Switch/Open do. Leaving the dialog open strands the
+        // user on the project list so it looks like nothing happened.
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    it('closes the dialog when switching projects', () => {
+        const onClose = vi.fn();
+        render(<ProjectManagerDialog isOpen={true} onClose={onClose} />);
+
+        // Sanity check that the sibling action already closes the dialog.
+        fireEvent.click(screen.getByText('Old Project'));
+
+        expect(openProject).toHaveBeenCalledWith('old-1');
+        expect(onClose).toHaveBeenCalled();
+    });
+});

--- a/src/studio/components/Dialogs/ProjectManagerDialog.tsx
+++ b/src/studio/components/Dialogs/ProjectManagerDialog.tsx
@@ -57,7 +57,10 @@ export default function ProjectManagerDialog({ isOpen, onClose }: ProjectManager
                 {/* Content */}
                 <div className="flex-1 overflow-y-auto p-6 space-y-4">
                     <button
-                        onClick={() => createProject()}
+                        onClick={() => {
+                            createProject();
+                            onClose();
+                        }}
                         className="w-full py-3 border-2 border-dashed border-[#333] hover:border-blue-500/50 hover:bg-blue-500/5 flex items-center justify-center gap-2 rounded-xl text-gray-400 hover:text-blue-400 transition-all group"
                     >
                         <Plus size={20} className="group-hover:scale-110 transition-transform" />


### PR DESCRIPTION
Creating a new project from the Project Manager left the dialog open over the canvas, so the user was stranded on the project list with the old project still shown — it looked like nothing happened. Every other action in the dialog (Switch/Open) closes it; Create New Project did not.

Mirror the sibling handlers: close the dialog after `createProject()`.

Adds `ProjectManagerDialog.test.tsx` asserting create-closes-dialog (the regression) plus a passing switch-closes-dialog control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)