### PR TITLE
feat(studio): header user menu (auth state + sign in/out)

### DIFF
--- a/docs/superpowers/specs/2026-06-28-studio-header-user-menu-design.md
+++ b/docs/superpowers/specs/2026-06-28-studio-header-user-menu-design.md
@@ -1,0 +1,140 @@
+# Studio header user menu — design
+
+Date: 2026-06-28
+Status: approved (design), pending implementation plan
+
+## Problem
+
+The Studio editor (`/` route) shows no authentication state of any kind: no
+sign-in control, no indication of who is signed in, no sign-out. Login does
+exist (Google OAuth via Supabase) and it matters in the Studio for two reasons:
+
+1. The **built-in agent rail** routes its backend calls to the hosted API with
+   the user's Supabase JWT (`src/studio/api/apiBase.ts`). Without a session,
+   the agent has no signed-in capability.
+2. **Saving and sharing private projects** requires an account.
+
+Today a user cannot tell from the editor whether they are signed in, cannot sign
+in from the editor, and cannot sign out. Auth is only surfaced on the funnel
+routes (`/generate`, `/g/$genId`, `/p/$slug`, `/me`). This was reported as the
+confusing experience "there is no login anywhere; I don't even know if I'm
+logged in."
+
+## Goal
+
+Add a single auth control to the Studio header that:
+
+- shows whether the user is signed in,
+- lets a signed-out user sign in with one click (Google OAuth), and
+- lets a signed-in user see which account they are on and sign out.
+
+## Non-goals
+
+- No "My projects" / account-page link in the menu (deferred; `/me` already
+  exists for that).
+- No changes to the funnel routes or to how the agent authenticates.
+- No changes to embed/viewer modes — the Studio `Header` only renders in the
+  full shell, so those modes are unaffected.
+- No new auth provider; reuse the existing Google OAuth flow.
+
+## Components
+
+### 1. `isAuthConfigured()` — `src/funnel/lib/supabaseClient.ts`
+
+A new exported predicate that reports whether `VITE_SUPABASE_URL` and
+`VITE_SUPABASE_ANON_KEY` are both present, **without throwing**.
+
+Rationale: `getSupabase()` throws when the env vars are missing (plain local
+dev). `useSession()` calls `getSupabase()` inside its effect, so a component that
+unconditionally mounts `useSession` would crash on localhost. `isAuthConfigured()`
+lets the menu opt out cleanly before any Supabase call.
+
+```ts
+export function isAuthConfigured(): boolean {
+  return Boolean(import.meta.env.VITE_SUPABASE_URL && import.meta.env.VITE_SUPABASE_ANON_KEY);
+}
+```
+
+`getSupabase()` keeps its current throwing contract — unchanged.
+
+### 2. `UserMenu` — `src/studio/components/Layout/UserMenu.tsx`
+
+Two-layer component so React hook rules stay clean (no conditional hook calls):
+
+- **`UserMenu` (outer):** if `!isAuthConfigured()` → return `null`. Otherwise
+  render `<UserMenuInner />`. This guarantees `useSession()` is only ever called
+  when Supabase is configured.
+- **`UserMenuInner`:** calls `useSession()` and branches:
+  - **loading** (`loading === true`): render `null` (avoids a sign-in →
+    avatar flash on first paint).
+  - **signed out** (`session === null`): render the existing `SignInButton`
+    (`src/funnel/components/SignInButton.tsx`) in a compact header style, label
+    "Sign in", `title="Sign in to use the agent and save projects"`. It already
+    performs one-click Google OAuth with `redirectTo: window.location.href`, so
+    the user returns to the same editor URL.
+  - **signed in:** a round avatar button showing the first letter of
+    `session.user.email` (uppercased). Clicking it toggles a dropdown anchored
+    under the button containing:
+    - the full email address, read-only, and
+    - a **Sign out** item that calls `getSupabase().auth.signOut()`.
+    The dropdown closes on outside click and on `Escape`.
+
+Styling follows the existing dark header toolbar (`bg-[#222]`, `hover:bg-[#333]`,
+`text-gray-300/400`, rounded). The avatar is a ~24px circle to fit the 40px-tall
+header.
+
+### 3. Wiring — `src/studio/components/Layout/Header.tsx`
+
+Render `<UserMenu />` as the last item in the header's right-hand cluster, after
+the STEP/STL export buttons and the computing spinner, preceded by a
+`<div className="h-6 w-px bg-[#333] mx-2" />` divider to match the existing
+section separators.
+
+## Data flow
+
+```
+Header
+  └─ UserMenu
+       ├─ isAuthConfigured() ── false ─▶ null
+       └─ UserMenuInner
+            └─ useSession() ─▶ { session, loading }
+                 ├─ loading       ─▶ null
+                 ├─ no session    ─▶ SignInButton ─▶ supabase.auth.signInWithOAuth(google)
+                 └─ session       ─▶ avatar ▸ dropdown(email, Sign out ─▶ supabase.auth.signOut())
+```
+
+`useSession` already subscribes to `onAuthStateChange`, so the menu updates
+reactively after sign-in/sign-out without manual refresh.
+
+## Error handling
+
+- **Auth not configured (local dev):** menu renders nothing; no crash. This is
+  the same "unsigned-in / local" posture the rest of Studio already assumes.
+- **OAuth start failure:** handled inside the reused `SignInButton` (it alerts
+  and re-enables the button).
+- **Sign-out failure:** wrap `signOut()` in try/catch; on error, surface a
+  lightweight alert and leave the menu in its signed-in state (the
+  `onAuthStateChange` listener is the source of truth for the displayed state).
+
+## Testing
+
+`src/studio/components/Layout/UserMenu.test.tsx` (happy-dom), mocking
+`../../../funnel/hooks/useSession` and `../../../funnel/lib/supabaseClient`:
+
+1. **not configured** → `isAuthConfigured` returns false → component renders
+   nothing.
+2. **loading** → renders nothing.
+3. **signed out** → renders a "Sign in" control.
+4. **signed in** → renders the account email; clicking the avatar then
+   "Sign out" calls `supabase.auth.signOut`.
+5. **dropdown dismissal** → opening then pressing Escape (or clicking outside)
+   closes the dropdown.
+
+Existing `Header` rendering tests (if any) must continue to pass; the menu is
+additive.
+
+## Out-of-scope follow-ups (noted, not built)
+
+- "My projects" link to `/me` in the dropdown.
+- Signed-out affordance inside the agent rail itself ("Sign in to use the
+  agent") — this spec only covers the header control.

--- a/src/funnel/lib/supabaseClient.ts
+++ b/src/funnel/lib/supabaseClient.ts
@@ -4,6 +4,16 @@ import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 let cached: SupabaseClient | null = null;
 
+/**
+ * Reports whether Supabase auth is configured (both env vars present) without
+ * throwing. Components can call this before mounting anything that touches
+ * `getSupabase()`/`useSession()`, which throw when the env vars are missing
+ * (plain local dev).
+ */
+export function isAuthConfigured(): boolean {
+  return Boolean(import.meta.env.VITE_SUPABASE_URL && import.meta.env.VITE_SUPABASE_ANON_KEY);
+}
+
 export function getSupabase(): SupabaseClient {
   if (cached) return cached;
   const url = import.meta.env.VITE_SUPABASE_URL;

--- a/src/studio/components/Layout/Header.tsx
+++ b/src/studio/components/Layout/Header.tsx
@@ -8,6 +8,7 @@ import { formatTooltip, SHORTCUT_HINTS } from '../../../shared/constants/shortcu
 import { useProject } from '../../context/ProjectContext';
 import { useStudioChrome } from '../../context/StudioChromeContext';
 import { useUI } from '../../context/UIContext';
+import UserMenu from './UserMenu';
 
 export function Header() {
     const { headerLeft, headerRight } = useStudioChrome();
@@ -265,6 +266,9 @@ export function Header() {
                     <Download className="w-4 h-4" />
                 </button>
                 {isComputing && <Loader2 className="w-3 h-3 animate-spin text-gray-500" />}
+
+                <div className="h-6 w-px bg-[#333] mx-2" />
+                <UserMenu />
             </div>
             <div className="absolute bottom-0 right-0 p-1 text-[9px] text-gray-700 pointer-events-none opacity-50 font-mono">
                 {typeof (window as unknown as { __COMMIT_HASH__: string }).__COMMIT_HASH__ !== 'undefined'

--- a/src/studio/components/Layout/UserMenu.test.tsx
+++ b/src/studio/components/Layout/UserMenu.test.tsx
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import type { Session } from '@supabase/supabase-js';
+import UserMenu from './UserMenu';
+import { useSession } from '../../../funnel/hooks/useSession';
+import { isAuthConfigured, getSupabase } from '../../../funnel/lib/supabaseClient';
+
+vi.mock('../../../funnel/hooks/useSession', () => ({
+    useSession: vi.fn(),
+}));
+
+const signOut = vi.fn().mockResolvedValue({ error: null });
+
+vi.mock('../../../funnel/lib/supabaseClient', () => ({
+    isAuthConfigured: vi.fn(),
+    getSupabase: vi.fn(() => ({
+        auth: {
+            signOut,
+            signInWithOAuth: vi.fn().mockResolvedValue({ error: null }),
+        },
+    })),
+}));
+
+const mockUseSession = vi.mocked(useSession);
+const mockIsAuthConfigured = vi.mocked(isAuthConfigured);
+
+function fakeSession(email: string): Session {
+    return { user: { email } } as unknown as Session;
+}
+
+beforeEach(() => {
+    mockIsAuthConfigured.mockReturnValue(true);
+    signOut.mockClear();
+});
+
+afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+});
+
+describe('UserMenu', () => {
+    it('renders nothing when auth is not configured', () => {
+        mockIsAuthConfigured.mockReturnValue(false);
+        mockUseSession.mockReturnValue({ session: null, loading: false });
+        const { container } = render(<UserMenu />);
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing while the session is loading', () => {
+        mockUseSession.mockReturnValue({ session: null, loading: true });
+        const { container } = render(<UserMenu />);
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('shows a Sign in control when signed out', () => {
+        mockUseSession.mockReturnValue({ session: null, loading: false });
+        render(<UserMenu />);
+        expect(screen.getByText('Sign in')).toBeDefined();
+    });
+
+    it('shows the account email and signs out when signed in', async () => {
+        mockUseSession.mockReturnValue({ session: fakeSession('jane@example.com'), loading: false });
+        render(<UserMenu />);
+
+        // Avatar shows the uppercased first letter.
+        const avatar = screen.getByTestId('user-menu-avatar');
+        expect(avatar.textContent).toBe('J');
+
+        // Open the dropdown and confirm the email is shown.
+        fireEvent.click(avatar);
+        expect(screen.getByText('jane@example.com')).toBeDefined();
+
+        // Sign out calls the mocked supabase client.
+        fireEvent.click(screen.getByText('Sign out'));
+        expect(getSupabase).toHaveBeenCalled();
+        expect(signOut).toHaveBeenCalled();
+    });
+
+    it('closes the dropdown on Escape', () => {
+        mockUseSession.mockReturnValue({ session: fakeSession('jane@example.com'), loading: false });
+        render(<UserMenu />);
+
+        fireEvent.click(screen.getByTestId('user-menu-avatar'));
+        expect(screen.queryByTestId('user-menu-dropdown')).not.toBeNull();
+
+        fireEvent.keyDown(document, { key: 'Escape' });
+        expect(screen.queryByTestId('user-menu-dropdown')).toBeNull();
+    });
+});

--- a/src/studio/components/Layout/UserMenu.tsx
+++ b/src/studio/components/Layout/UserMenu.tsx
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { useEffect, useRef, useState } from 'react';
+import { useSession } from '../../../funnel/hooks/useSession';
+import { getSupabase, isAuthConfigured } from '../../../funnel/lib/supabaseClient';
+import { SignInButton } from '../../../funnel/components/SignInButton';
+
+/**
+ * Header auth control for the Studio editor.
+ *
+ * Outer layer: opts out cleanly when Supabase auth is not configured (plain
+ * local dev), so `useSession()` is only ever called when a Supabase client can
+ * be created. This keeps React hook rules clean — `UserMenuInner` always calls
+ * its hooks unconditionally.
+ */
+export default function UserMenu() {
+    if (!isAuthConfigured()) return null;
+    return <UserMenuInner />;
+}
+
+function UserMenuInner() {
+    const { session, loading } = useSession();
+    const [open, setOpen] = useState(false);
+    const menuRef = useRef<HTMLDivElement>(null);
+
+    // Close the dropdown on outside click / Escape.
+    useEffect(() => {
+        if (!open) return;
+        const onPointerDown = (e: MouseEvent) => {
+            if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+                setOpen(false);
+            }
+        };
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') setOpen(false);
+        };
+        document.addEventListener('mousedown', onPointerDown);
+        document.addEventListener('keydown', onKeyDown);
+        return () => {
+            document.removeEventListener('mousedown', onPointerDown);
+            document.removeEventListener('keydown', onKeyDown);
+        };
+    }, [open]);
+
+    // Avoid a sign-in → avatar flash on first paint.
+    if (loading) return null;
+
+    if (session === null) {
+        return (
+            <span title="Sign in to use the agent and save projects">
+                <SignInButton className="inline-flex items-center gap-2 rounded bg-[#222] hover:bg-[#333] text-gray-300 hover:text-white px-2 py-1 text-xs font-medium transition-colors">
+                    Sign in
+                </SignInButton>
+            </span>
+        );
+    }
+
+    const email = session.user.email ?? '';
+    const initial = (email.charAt(0) || '?').toUpperCase();
+
+    const handleSignOut = async () => {
+        try {
+            await getSupabase().auth.signOut();
+            // onAuthStateChange in useSession is the source of truth; the menu
+            // updates reactively once the session clears.
+        } catch (err) {
+            alert('Sign-out failed: ' + (err instanceof Error ? err.message : String(err)));
+        }
+        setOpen(false);
+    };
+
+    return (
+        <div className="relative" ref={menuRef} data-testid="user-menu">
+            <button
+                type="button"
+                onClick={() => setOpen((o) => !o)}
+                className="flex items-center justify-center w-6 h-6 rounded-full bg-[#222] hover:bg-[#333] text-gray-300 hover:text-white text-xs font-medium transition-colors"
+                aria-label="Account menu"
+                aria-haspopup="menu"
+                aria-expanded={open}
+                title={email}
+                data-testid="user-menu-avatar"
+            >
+                {initial}
+            </button>
+            {open && (
+                <div
+                    role="menu"
+                    className="absolute right-0 top-full mt-1 w-56 bg-[#1a1a1a] border border-[#333] rounded shadow-lg z-50 py-1"
+                    data-testid="user-menu-dropdown"
+                >
+                    <div className="px-3 py-1.5 text-xs text-gray-400 truncate" data-testid="user-menu-email">
+                        {email}
+                    </div>
+                    <div className="h-px bg-[#333] my-1" />
+                    <button
+                        type="button"
+                        onClick={handleSignOut}
+                        className="w-full text-left px-3 py-1.5 text-xs text-gray-300 hover:text-white hover:bg-[#222] transition-colors"
+                        role="menuitem"
+                    >
+                        Sign out
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
The Studio editor showed no auth state at all: no way to tell if you were signed in, no sign-in, no sign-out. Login matters in the editor — it unlocks the built-in agent (backend calls carry the Supabase JWT) and saving/sharing private projects — but was only surfaced on the funnel routes.

Adds a header user menu:
- `isAuthConfigured()` helper (no-throw env check) so the menu degrades to nothing in local dev where Supabase is unconfigured.
- `UserMenu`: signed-out → one-click Google sign-in (returns to the editor); signed-in → avatar + email + sign out. Dropdown closes on outside-click/Escape.
- Wired into the header right cluster.

Design spec included under `docs/superpowers/specs/`. Unit tests cover unconfigured/loading/signed-out/signed-in/Escape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)