### PR TITLE
fix(gallery): "Open in Studio" points at app origin, not a dead /app path

### DIFF
--- a/site/scripts/build-gallery.test.ts
+++ b/site/scripts/build-gallery.test.ts
@@ -34,7 +34,7 @@ describe('buildGallery', () => {
     expect(out.entries[0].posterUrl).toBe('/gallery/fixture-build/poster.jpg');
     expect(out.entries[0].modelUrl).toBe('/gallery/fixture-build/model.glb');
     expect(out.entries[0].promptUrl).toBe('/gallery/fixture-build/prompt.md');
-    expect(out.entries[0].studioUrl).toBe('/app/studio?gallery=fixture-build');
+    expect(out.entries[0].studioUrl).toBe('https://app.kernelcad.com/studio?gallery=fixture-build');
     expect(out.entries[0].sourceUrl).toBe('/gallery/fixture-build/source.kcad.ts');
     expect(out.entries[0].scriptPath).toBe('simple-box.kcad.ts');
 

--- a/site/scripts/build-gallery.ts
+++ b/site/scripts/build-gallery.ts
@@ -47,7 +47,12 @@ interface PublishedEntry extends Omit<GalleryEntry, 'video' | 'codeLocal'> {
 // spice-dispenser carousel under it (~452 KB). Next lever if tiles ever grow:
 // mesh quantization / Draco.
 const GLB_SIZE_HARD_CAP = 500_000;
-const STUDIO_BASE_PATH = '/app';
+// The gallery is served from the marketing site (kernelcad.com); the hosted
+// Studio lives on a separate origin (app.kernelcad.com, deployed at base `/`).
+// "Open in Studio" must therefore be an absolute cross-origin URL — a relative
+// `/app/...` path resolves against kernelcad.com, which has no such route and
+// silently 404s. Keep this in sync with the absolute app links in site/*.html.
+const STUDIO_ORIGIN = 'https://app.kernelcad.com';
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 /**
  * Builds the `ScriptReviewSummary` the hosted Studio consumes (see
@@ -145,7 +150,7 @@ export async function buildGallery(opts: BuildGalleryOptions): Promise<void> {
       ? entry.codeLocal.split(path.sep).join('/')
       : null;
     const studioUrl = entry.source === 'curated'
-      ? `${STUDIO_BASE_PATH}/studio?gallery=${encodeURIComponent(entry.slug)}`
+      ? `${STUDIO_ORIGIN}/studio?gallery=${encodeURIComponent(entry.slug)}`
       : entry.appUrl;
 
     copyFileSync(srcVideo, dstVideo);


### PR DESCRIPTION
Curated gallery tiles built their "Open in Studio" link as a relative `/app/studio?gallery=<slug>` path. The gallery is served from the marketing site (kernelcad.com), so that resolves to `kernelcad.com/app/studio` — a route that does not exist, so the link silently 404s and nothing opens. The hosted Studio is on `app.kernelcad.com` (base `/`), where `/studio` reads `?gallery=`.

Restore the absolute app origin (pre-regression behaviour): `https://app.kernelcad.com/studio?gallery=<slug>`, matching every other app link on the marketing site. The build-gallery test now asserts the working absolute URL so it cannot silently regress again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)