### PR TITLE
fix(sweep): prevent stack overflow when a path is passed as the sweep rail

### DIFF
--- a/src/modeling/capture/sketch.ts
+++ b/src/modeling/capture/sketch.ts
@@ -55,6 +55,55 @@ export type { SketchCommand };
  * match the advertised array. This guards agent discoverability — methods
  * not in `list_api` are invisible to MCP clients.
  */
+
+/**
+ * Validate a `sweep` rail argument. The rail must be a `Vec3[]` — an array of
+ * `[x, y, z]` numeric points. Without this guard, passing a `path()` /
+ * `PathBuilder` / `Sketch` (the natural mistake, since profiles are paths)
+ * stored a live capture object into `metadata.rail`; the capture layer then
+ * walked it during `collectParamRefs` and blew the stack with an opaque
+ * "Maximum call stack size exceeded". Fail fast with a recoverable diagnostic
+ * that names the fix instead.
+ */
+function validateSweepRail(rail: unknown): void {
+  const looksLikePathOrSketch =
+    rail !== null &&
+    typeof rail === 'object' &&
+    !Array.isArray(rail) &&
+    ('id' in (rail as object) || 'commands' in (rail as object) || 'moveTo' in (rail as object));
+  if (looksLikePathOrSketch) {
+    throw new KernelError(
+      'feature.invalid-args',
+      'sweep(rail): rail must be a Vec3[] (array of [x, y, z] points), not a path()/Sketch.',
+      undefined,
+      "invalid-args.sweep.rail — pass explicit points, e.g. [[0,0,0],[40,0,0],[40,0,30]], or sample a curve with helix(...). To sweep along a 2D profile, build the rail points directly; the profile you call .sweep() on stays a path().",
+    );
+  }
+  if (!Array.isArray(rail) || rail.length < 2) {
+    throw new KernelError(
+      'feature.invalid-args',
+      `sweep(rail): rail must be a Vec3[] with at least 2 points; got ${Array.isArray(rail) ? `${rail.length} point(s)` : typeof rail}.`,
+      undefined,
+      'invalid-args.sweep.rail — pass at least 2 points, e.g. [[0,0,0],[40,0,0],[40,0,30]].',
+    );
+  }
+  for (let i = 0; i < rail.length; i++) {
+    const p = rail[i] as unknown;
+    const ok =
+      Array.isArray(p) &&
+      p.length === 3 &&
+      p.every((c) => typeof c === 'number' && Number.isFinite(c));
+    if (!ok) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `sweep(rail): rail[${i}] must be a [x, y, z] triple of finite numbers; got ${JSON.stringify(p)}.`,
+        undefined,
+        'invalid-args.sweep.rail — every rail point is three finite numbers, e.g. [40, 0, 30]. ParamRefs are not allowed in a rail; resolve them to numbers first.',
+      );
+    }
+  }
+}
+
 export class Sketch {
   readonly id: FeatureId;
   private session: CaptureSession;
@@ -159,6 +208,7 @@ export class Sketch {
     } = {},
   ): Shape {
     const faceLabels = validateFaceLabels(opts?.faceLabels, 'sweep');
+    validateSweepRail(rail);
     const transitionMode = opts.transitionMode ?? 'right';
     const spine = opts.spine ?? 'polyline';
     return this.session.createShape({

--- a/src/modeling/capture/sweepRailValidation.test.ts
+++ b/src/modeling/capture/sweepRailValidation.test.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/modeling/capture/sweepRailValidation.test.ts
+//
+// Regression: `Sketch.sweep(rail)` used to blow the stack with an opaque
+// "Maximum call stack size exceeded" when a `path()`/PathBuilder/Sketch was
+// passed as the rail (the natural mistake — profiles are paths). The rail
+// object carries a back-reference to the session, whose `records` array holds
+// the freshly-registered sweep record, so `collectParamRefs` walked
+// session → records → record → metadata.rail → session forever.
+//
+// Two complementary guards are asserted here:
+//   1. `collectParamRefs` tolerates cyclic graphs (root robustness).
+//   2. `Sketch.sweep` rejects a non-Vec3[] rail with a recoverable
+//      `feature.invalid-args` diagnostic instead of a RangeError.
+
+import { describe, it, expect } from 'vitest';
+import { CaptureSession } from './captureSession';
+import { createApi } from '../api';
+import { KernelError } from '../../shared/intent/kernelError';
+import { collectParamRefs } from '../../shared/runtime/resolveParams';
+
+function makeApi() {
+  const session = new CaptureSession();
+  return createApi({ session });
+}
+
+function squareProfile(kcad: ReturnType<typeof createApi>) {
+  return kcad.path().moveTo(0, 0).lineTo(6, 0).lineTo(6, 6).lineTo(0, 6).close();
+}
+
+describe('collectParamRefs — cycle safety', () => {
+  it('terminates on a self-referential object instead of overflowing the stack', () => {
+    const a: Record<string, unknown> = { keep: 'x' };
+    a.self = a; // direct cycle
+    const b: Record<string, unknown> = { a };
+    a.b = b; // mutual cycle
+    expect(() => collectParamRefs(a)).not.toThrow();
+    expect(collectParamRefs(a) instanceof Set).toBe(true);
+  });
+});
+
+describe('Sketch.sweep — rail validation', () => {
+  it('throws a recoverable feature.invalid-args (not a stack overflow) for a path() rail', () => {
+    const kcad = makeApi();
+    const profile = squareProfile(kcad);
+    const railPath = kcad.path().moveTo(40, 20).lineTo(70, 25).lineTo(70, 70).lineTo(40, 75);
+    let caught: unknown;
+    try {
+      // @ts-expect-error — deliberately passing a PathBuilder where Vec3[] is expected
+      profile.sweep(railPath);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(KernelError);
+    expect((caught as KernelError).code).toBe('feature.invalid-args');
+    expect((caught as Error).message).not.toMatch(/call stack/i);
+  });
+
+  it('rejects a too-short rail with feature.invalid-args', () => {
+    const kcad = makeApi();
+    const profile = squareProfile(kcad);
+    expect(() => profile.sweep([[0, 0, 0]])).toThrow(KernelError);
+  });
+
+  it('accepts a valid Vec3[] rail at capture time', () => {
+    const kcad = makeApi();
+    const profile = squareProfile(kcad);
+    expect(() => profile.sweep([[40, 20, 0], [70, 25, 0], [70, 70, 0], [40, 75, 0]])).not.toThrow();
+  });
+});

--- a/src/shared/runtime/resolveParams.ts
+++ b/src/shared/runtime/resolveParams.ts
@@ -146,14 +146,24 @@ function walkResolve(node: unknown, table: ParamTable): unknown {
 
 export function collectParamRefs(blob: unknown): Set<string> {
   const refs = new Set<string>();
-  walkCollect(blob, refs);
+  walkCollect(blob, refs, new WeakSet<object>());
   return refs;
 }
 
-function walkCollect(node: unknown, refs: Set<string>): void {
+// `seen` breaks reference cycles. Capture-layer objects (PathBuilder, Sketch,
+// Shape) hold a back-reference to the session, whose `records` array contains
+// the very feature whose metadata we are walking — so an object that lands in
+// metadata (e.g. a PathBuilder mistakenly passed as a sweep rail) would recurse
+// session → records → record → metadata → object forever and blow the stack.
+// A visited set bounds the walk; param refs are still collected exactly once.
+function walkCollect(node: unknown, refs: Set<string>, seen: WeakSet<object>): void {
   if (node === null || node === undefined) return;
+  if (typeof node === 'object') {
+    if (seen.has(node)) return;
+    seen.add(node);
+  }
   if (Array.isArray(node)) {
-    for (const item of node) walkCollect(item, refs);
+    for (const item of node) walkCollect(item, refs, seen);
     return;
   }
   if (typeof node !== 'object') return;
@@ -167,5 +177,5 @@ function walkCollect(node: unknown, refs: Set<string>): void {
     return;
   }
   const obj = node as Record<string, unknown>;
-  for (const k of Object.keys(obj)) walkCollect(obj[k], refs);
+  for (const k of Object.keys(obj)) walkCollect(obj[k], refs, seen);
 }


### PR DESCRIPTION
Clean rebuild of #548 on current `develop`. The original branch also carried an unrelated stack of pure-js-tracer / opencv-removal commits that conflicted with `develop`; this PR is just the self-contained sweep-rail fix (`sketch.ts`, `resolveParams.ts`, and a new `sweepRailValidation.test.ts`). 4/4 tests pass on `develop`. Closes #548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)