### PR TITLE
site: lead landing hero with the offer, not the tech

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -91,7 +91,7 @@
     <section class="capabilities" aria-label="kernelCAD capabilities">
       <div class="capability">
         <span class="capability-name">Editable Source</span>
-        <span class="capability-copy">.kcad.ts files with params, assemblies, NURBS, SDF, and sheet metal APIs</span>
+        <span class="capability-copy">editable .kcad.ts files with params, assemblies, NURBS, SDF, and sheet metal APIs</span>
       </div>
       <div class="capability">
         <span class="capability-name">review_cad</span>

--- a/site/index.html
+++ b/site/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="kernelCAD — editable .kcad.ts source, deterministic review, OpenCASCADE kernel, MCP server, and standard CAD exports." />
-  <meta property="og:title" content="kernelCAD — CAD for agents" />
-  <meta property="og:description" content="Author editable .kcad.ts, run deterministic review_cad checks, and export STEP/STL." />
+  <meta name="description" content="Describe what you need and kernelCAD designs the part, checks it holds together, and hands you a file your shop can manufacture." />
+  <meta property="og:title" content="kernelCAD — from a description to a part you can build" />
+  <meta property="og:description" content="Describe what you need. kernelCAD designs the part, checks it holds together, and hands you a file your shop can manufacture." />
   <meta property="og:image" content="https://kernelcad.com/og-image.png" />
   <meta property="og:url" content="https://kernelcad.com" />
   <meta name="twitter:card" content="summary_large_image" />
@@ -14,7 +14,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,wght@0,500;1,500&family=Inter:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="/style.css?v=2026-05-23-gallery-lightbox-model" />
-  <title>kernelCAD — CAD for agents</title>
+  <title>kernelCAD — from a description to a part you can build</title>
   <!--
     Cloudflare Web Analytics — anonymous beacon (no cookies, no IP storage).
     The token is the public site-token from the Cloudflare Web Analytics
@@ -43,9 +43,8 @@
 
     <header class="hero">
       <div class="hero-copy">
-        <div class="proof-line">.kcad.ts · review_cad · STEP/STL</div>
-        <h1 class="headline">CAD for <span class="accent">agents</span>.</h1>
-        <p class="subhead">A scriptable CAD runtime for editable .kcad.ts source, deterministic review, and physical part exports.</p>
+        <h1 class="headline">From a description to a part you can <span class="accent">build</span>.</h1>
+        <p class="subhead">Describe what you need. kernelCAD designs the part, checks it holds together, and hands you a file your shop can manufacture.</p>
         <div class="modes" aria-label="Supported agent surfaces">
           <span class="mode">Claude Desktop</span><span class="sep">·</span>
           <span class="mode">Codex</span><span class="sep">·</span>


### PR DESCRIPTION
The landing hero opened with implementation detail — "A scriptable CAD runtime for editable .kcad.ts source, deterministic review, and physical part exports" — plus a `.kcad.ts · review_cad · STEP/STL` proof-line above the headline. That leads with the tech, not the customer outcome.

Replaces it with the benefit-first line from our sales brochure:

> **From a description to a part you can build.**
> Describe what you need. kernelCAD designs the part, checks it holds together, and hands you a file your shop can manufacture.

Also updates `<title>` and the meta/OG description to match. Spec-level language stays in the inner sections.

Note: the marketing site (kernelcad.com) deploys on a `v*` tag, so this ships with the next tagged release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)