### PR TITLE
site: hero — 'From words to manufacturable geometry'

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Describe what you need and kernelCAD designs the part, checks it holds together, and hands you a file your shop can manufacture." />
-  <meta property="og:title" content="kernelCAD — from a description to a part you can build" />
+  <meta property="og:title" content="kernelCAD — from words to manufacturable geometry" />
   <meta property="og:description" content="Describe what you need. kernelCAD designs the part, checks it holds together, and hands you a file your shop can manufacture." />
   <meta property="og:image" content="https://kernelcad.com/og-image.png" />
   <meta property="og:url" content="https://kernelcad.com" />
@@ -14,7 +14,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,wght@0,500;1,500&family=Inter:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="/style.css?v=2026-07-04-tokentiers" />
-  <title>kernelCAD — from a description to a part you can build</title>
+  <title>kernelCAD — from words to manufacturable geometry</title>
   <!--
     Cloudflare Web Analytics — anonymous beacon (no cookies, no IP storage).
     The token is the public site-token from the Cloudflare Web Analytics
@@ -43,7 +43,7 @@
 
     <header class="hero">
       <div class="hero-copy">
-        <h1 class="headline">From words to a <span class="accent">manufacturable</span> part.</h1>
+        <h1 class="headline">From words to <span class="accent">manufacturable geometry</span>.</h1>
         <p class="subhead">Describe what you need. kernelCAD designs the part, checks it holds together, and hands you a file your shop can manufacture.</p>
         <div class="modes" aria-label="Supported agent surfaces">
           <span class="mode">Claude Desktop</span><span class="sep">·</span>


### PR DESCRIPTION
Sharpens the landing hero to lead with the differentiator (output is *manufacturable geometry*, not triangle soup):

> **From words to manufacturable geometry.**

Updates `<title>` + `og:title` to match. Subhead and inner spec copy unchanged. Copy-guard + landing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)