### PR TITLE
Paywall UI: $20/$100 plans + surface the agent-mode quota wall

### DIFF
--- a/src/funnel/components/PlanCard.tsx
+++ b/src/funnel/components/PlanCard.tsx
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
-import type { PlanTier } from '../lib/apiClient';
+import type { PlanTier, PaidTier } from '../lib/apiClient';
 
 export interface PlanCardProps {
   plan: PlanTier;
+  /** Which paid plan, when plan === 'pro' ('standard' $20 | 'pro' $100). */
+  tier?: PaidTier | null;
   generationsRemaining: number;
   /** ISO date string for the end of the current billing period (pro only). */
   currentPeriodEnd: string | null;
@@ -29,6 +31,7 @@ export interface PlanCardProps {
  */
 export function PlanCard({
   plan,
+  tier,
   generationsRemaining,
   currentPeriodEnd,
   onUpgrade,
@@ -36,6 +39,8 @@ export function PlanCard({
   busy = false,
 }: PlanCardProps) {
   if (plan === 'pro') {
+    const planName = tier === 'pro' ? 'Pro plan' : 'Standard plan';
+    const planPrice = tier === 'pro' ? '$100/mo' : '$20/mo';
     const renewsCopy = currentPeriodEnd
       ? `renews ${new Date(currentPeriodEnd).toLocaleDateString()}`
       : 'active subscription';
@@ -46,7 +51,7 @@ export function PlanCard({
       >
         <div>
           <p className="font-serif font-medium text-ink text-base">
-            Pro plan <span className="text-blueprint">·</span> $12/mo
+            {planName} <span className="text-blueprint">·</span> {planPrice}
           </p>
           <p className="font-mono text-[11px] text-ink-faint mt-1.5 tracking-wide">
             {renewsCopy}
@@ -83,7 +88,7 @@ export function PlanCard({
         disabled={busy}
         className="rounded-md bg-blueprint px-4 py-2 font-mono text-xs tracking-wide text-white hover:bg-ink transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
       >
-        {busy ? 'Loading…' : 'Upgrade to Pro — $12/mo'}
+        {busy ? 'Loading…' : 'Upgrade — $20/mo'}
       </button>
     </section>
   );

--- a/src/funnel/components/RateLimitedPanel.tsx
+++ b/src/funnel/components/RateLimitedPanel.tsx
@@ -25,7 +25,7 @@ export function RateLimitedPanel({
   const buttonCopy = authenticated
     ? busy
       ? 'Loading…'
-      : 'Upgrade to Pro — $12/mo'
+      : 'Upgrade — $20/mo'
     : 'Sign in to upgrade';
   return (
     <div
@@ -36,7 +36,7 @@ export function RateLimitedPanel({
         You've used your free generations this month
       </p>
       <p className="text-sm text-ink-soft mt-2">
-        Upgrade to Pro to keep generating — $12/mo, cancel anytime.
+        Upgrade to keep generating — $20/mo, cancel anytime.
       </p>
       <div className="mt-4">
         <button

--- a/src/funnel/components/RateLimitedPanel.tsx
+++ b/src/funnel/components/RateLimitedPanel.tsx
@@ -33,10 +33,14 @@ export function RateLimitedPanel({
       className="mt-6 mx-auto max-w-2xl rounded-lg border border-blueprint bg-vellum-soft p-5 text-ink text-left"
     >
       <p className="font-serif font-medium text-lg">
-        You've used your free generations this month
+        {authenticated
+          ? "You've used your free generations this month"
+          : 'Sign in to build with the agent'}
       </p>
       <p className="text-sm text-ink-soft mt-2">
-        Upgrade to keep generating — $20/mo, cancel anytime.
+        {authenticated
+          ? 'Upgrade to keep generating — $20/mo, cancel anytime.'
+          : 'The build agent is free to start once you sign in — 5 builds a month, no card needed.'}
       </p>
       <div className="mt-4">
         <button

--- a/src/funnel/hooks/useGeneration.ts
+++ b/src/funnel/hooks/useGeneration.ts
@@ -44,7 +44,9 @@ export function useGeneration() {
     if (!res.ok) {
       setPhase({
         state: 'error',
-        code: res.status === 429 ? 'rate_limited' : `http_${res.status}`,
+        // 429 = anonymous IP limit; 402 = signed-in monthly quota exhausted.
+        // Both surface the same "upgrade to keep generating" panel.
+        code: res.status === 429 || res.status === 402 ? 'rate_limited' : `http_${res.status}`,
         message: await res.text().catch(() => `HTTP ${res.status}`),
       });
       return;

--- a/src/funnel/hooks/useGeneration.ts
+++ b/src/funnel/hooks/useGeneration.ts
@@ -44,9 +44,11 @@ export function useGeneration() {
     if (!res.ok) {
       setPhase({
         state: 'error',
-        // 429 = anonymous IP limit; 402 = signed-in monthly quota exhausted.
-        // Both surface the same "upgrade to keep generating" panel.
-        code: res.status === 429 || res.status === 402 ? 'rate_limited' : `http_${res.status}`,
+        // Agent mode requires a connected account. 401 = anonymous (must sign
+        // in); 402 = signed-in but monthly quota exhausted (must upgrade); 429 =
+        // legacy rate limit. All route to the same panel, which shows "sign in"
+        // vs "upgrade" based on whether there's a session.
+        code: res.status === 401 || res.status === 402 || res.status === 429 ? 'rate_limited' : `http_${res.status}`,
         message: await res.text().catch(() => `HTTP ${res.status}`),
       });
       return;

--- a/src/funnel/lib/apiClient.ts
+++ b/src/funnel/lib/apiClient.ts
@@ -197,8 +197,13 @@ export async function listMyProjects(): Promise<ProjectRow[]> {
 
 export type PlanTier = 'free' | 'pro';
 
+/** The two paid plans. 'standard' = $20/mo solo, 'pro' = $100/mo team. */
+export type PaidTier = 'standard' | 'pro';
+
 export interface MyPlan {
   plan: PlanTier;
+  /** Which paid plan, when plan === 'pro'; null on free. */
+  tier?: PaidTier | null;
   generationsRemaining: number;
   currentPeriodEnd: string | null;
 }
@@ -217,9 +222,10 @@ export async function fetchMyPlan(): Promise<MyPlan> {
 }
 
 /** POST /api/v1/billing/create-checkout — returns a Stripe Checkout URL
- * the caller should redirect to (window.location.href = url). */
-export async function createCheckoutSession(): Promise<CheckoutSession> {
-  return authedFetch<CheckoutSession>('POST', '/api/v1/billing/create-checkout');
+ * the caller should redirect to (window.location.href = url). `tier` selects
+ * the plan ($20 Standard by default; 'pro' for the $100 team plan). */
+export async function createCheckoutSession(tier: PaidTier = 'standard'): Promise<CheckoutSession> {
+  return authedFetch<CheckoutSession>('POST', '/api/v1/billing/create-checkout', { tier });
 }
 
 /** POST /api/v1/billing/portal — returns a Stripe Customer Portal URL

--- a/src/funnel/lib/generateClient.ts
+++ b/src/funnel/lib/generateClient.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { getSupabase, isAuthConfigured } from './supabaseClient';
 export interface Artifact {
   title: string;
   code: string;
@@ -120,9 +121,22 @@ export interface GenerateRequest {
 
 export async function startGeneration(req: GenerateRequest): Promise<Response> {
   const base = import.meta.env.VITE_API_BASE_URL;
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  // Agent mode requires a connected account (every run lands against a plan), so
+  // forward the Supabase session token when there is one. Without it the server
+  // returns 401 and the UI prompts sign-in. Guarded so an env-less/local build
+  // (no auth) doesn't throw — it just sends no token.
+  if (isAuthConfigured()) {
+    try {
+      const { data: { session } } = await getSupabase().auth.getSession();
+      if (session?.access_token) headers['Authorization'] = `Bearer ${session.access_token}`;
+    } catch {
+      // no session / auth unavailable → anonymous → server will 401
+    }
+  }
   return fetch(`${base}/api/v1/generate`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     body: JSON.stringify(req),
   });
 }

--- a/src/studio/StudioShell.tsx
+++ b/src/studio/StudioShell.tsx
@@ -46,10 +46,16 @@ export function StudioShell() {
     const enableAgentRail = embed.enableAgentRail ?? true;
     const authConfigured = isAuthConfigured();
     const { session } = useOptionalSession();
-    // When auth is not configured (local dev, env-less embed), preserve
-    // pre-branch behavior and follow enableAgentRail directly. When auth is
-    // configured, require a live session before enabling the agent rail.
-    const agentEnabled = enableAgentRail && (!authConfigured || !!session);
+    // The in-Studio agent talks to the hosted, auth'd, metered backend
+    // (api.kernelcad.com /api/v1/generate), so it only belongs in the real
+    // hosted app for a signed-in user. It is therefore hidden when:
+    //   - auth is not configured (local dev / env-less embed) — no backend to
+    //     drive it and nothing to meter against; and
+    //   - the host disables it (embed / MCP-driven shells pass enableAgentRail
+    //     = false, e.g. proto.cat) or there is no live session.
+    // (`open_in_studio` / `/p/<slug>` review pages additionally hide it via
+    // viewerMode below.)
+    const agentEnabled = enableAgentRail && authConfigured && !!session;
     const enableConnect = embed.enableConnect ?? true;
     const { viewerMode } = useStudioChrome();
     const handleToggleMarkingMode = useCallback(() => {

--- a/src/studio/__tests__/agentRailVisibility.test.tsx
+++ b/src/studio/__tests__/agentRailVisibility.test.tsx
@@ -62,7 +62,7 @@ vi.mock('../../funnel/hooks/useSession', () => ({
 }));
 
 vi.mock('../../funnel/lib/supabaseClient', () => ({
-    isAuthConfigured: () => true,
+    isAuthConfigured: vi.fn(() => true),
 }));
 
 vi.mock('../components/Layout/Header', () => ({ Header: () => <div data-testid="header" /> }));
@@ -78,19 +78,21 @@ vi.mock('../components/Layout/StatusBar', () => ({
 }));
 
 import { StudioShell } from '../StudioShell';
+import { isAuthConfigured } from '../../funnel/lib/supabaseClient';
+
+const mockIsAuthConfigured = vi.mocked(isAuthConfigured);
 
 afterEach(() => cleanup());
 
 beforeEach(() => {
     agentRailOpen = true;
     sessionState = { session: null, loading: false };
+    mockIsAuthConfigured.mockReturnValue(true);
 });
 
 describe('agent rail visibility by session state', () => {
+    // agentEnabled = enableAgentRail && authConfigured && !!session
     it('hides the agent rail when auth is configured but no session exists', () => {
-        // isAuthConfigured() → true, session → null
-        // agentEnabled = enableAgentRail && (!authConfigured || !!session)
-        //              = true && (false || false) = false → rail NOT rendered
         sessionState = { session: null, loading: false };
 
         render(<StudioShell />);
@@ -99,12 +101,21 @@ describe('agent rail visibility by session state', () => {
     });
 
     it('shows the agent rail when auth is configured and a session exists', () => {
-        // isAuthConfigured() → true, session → {user:{id:'u1'}}
-        // agentEnabled = true && (false || true) = true, agentRailOpen = true → rail rendered
         sessionState = { session: { user: { id: 'u1' } }, loading: false };
 
         render(<StudioShell />);
 
         expect(screen.queryByLabelText('Agent rail')).not.toBeNull();
+    });
+
+    it('hides the agent rail in local dev (auth not configured), even with a session', () => {
+        // Local run: no Supabase env → isAuthConfigured() false. The in-Studio
+        // agent has no hosted/metered backend locally, so the rail stays hidden.
+        mockIsAuthConfigured.mockReturnValue(false);
+        sessionState = { session: { user: { id: 'u1' } }, loading: false };
+
+        render(<StudioShell />);
+
+        expect(screen.queryByLabelText('Agent rail')).toBeNull();
     });
 });

--- a/src/studio/__tests__/agentSessionGate.test.tsx
+++ b/src/studio/__tests__/agentSessionGate.test.tsx
@@ -14,7 +14,9 @@ describe('agent rail requires a session', () => {
     expect(src).toMatch(/useOptionalSession/);
   });
   it('derives agentEnabled from session and gates the rail with it', () => {
-    expect(src).toMatch(/const\s+agentEnabled\s*=\s*enableAgentRail\s*&&\s*\(!authConfigured\s*\|\|\s*!!session\)/);
+    // Agent mode requires a configured-auth backend AND a live session, so the
+    // rail is hidden locally (no auth) and in MCP/embed shells (enableAgentRail=false).
+    expect(src).toMatch(/const\s+agentEnabled\s*=\s*enableAgentRail\s*&&\s*authConfigured\s*&&\s*!!session/);
     expect(src).toMatch(/agentEnabled\s*&&\s*agentRailOpen\s*&&\s*!viewerMode\s*&&\s*<AgentRail/);
   });
 });

--- a/src/studio/routes/me.tsx
+++ b/src/studio/routes/me.tsx
@@ -3,6 +3,7 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 import { useSession } from '../../funnel/hooks/useSession';
+import { getSupabase } from '../../funnel/lib/supabaseClient';
 import {
   createCheckoutSession,
   fetchMyPlan,
@@ -130,7 +131,20 @@ function MePage() {
           </svg>
           <span>kernel<span className="text-blueprint">CAD</span></span>
         </a>
-        <span className="font-mono text-xs text-ink-soft tracking-wide">{session.user.email}</span>
+        <div className="flex items-center gap-4">
+          <span className="font-mono text-xs text-ink-soft tracking-wide">{session.user.email}</span>
+          <button
+            type="button"
+            onClick={() => {
+              // onAuthStateChange clears the session; the !session effect above
+              // then redirects to /signin.
+              void getSupabase().auth.signOut();
+            }}
+            className="rounded-md border border-rule px-3 py-1.5 font-mono text-xs tracking-wide text-ink-soft hover:border-ink hover:text-ink transition-colors"
+          >
+            Sign out
+          </button>
+        </div>
       </header>
 
       <section className="px-6 py-10 max-w-4xl mx-auto">

--- a/src/studio/routes/me.tsx
+++ b/src/studio/routes/me.tsx
@@ -176,6 +176,7 @@ function MePage() {
         {plan && (
           <PlanCard
             plan={plan.plan}
+            tier={plan.tier}
             generationsRemaining={plan.generationsRemaining}
             currentPeriodEnd={plan.currentPeriodEnd}
             onUpgrade={handleUpgrade}

--- a/tests/funnel/PlanCard.test.tsx
+++ b/tests/funnel/PlanCard.test.tsx
@@ -20,7 +20,7 @@ describe('PlanCard', () => {
 
     expect(screen.getByText(/Free plan/i)).toBeDefined();
     expect(screen.getByText(/3 generations remaining/i)).toBeDefined();
-    const btn = screen.getByRole('button', { name: /Upgrade to Pro/i });
+    const btn = screen.getByRole('button', { name: /Upgrade/i });
     fireEvent.click(btn);
     expect(onUpgrade).toHaveBeenCalledTimes(1);
   });
@@ -43,6 +43,7 @@ describe('PlanCard', () => {
     render(
       <PlanCard
         plan="pro"
+        tier="pro"
         generationsRemaining={9999}
         currentPeriodEnd="2026-06-15T00:00:00.000Z"
         onUpgrade={() => {}}

--- a/tests/funnel/RateLimitedPanel.test.tsx
+++ b/tests/funnel/RateLimitedPanel.test.tsx
@@ -11,7 +11,7 @@ describe('RateLimitedPanel', () => {
     render(<RateLimitedPanel authenticated onUpgrade={onUpgrade} />);
 
     expect(screen.getByText(/used your free generations/i)).toBeDefined();
-    const btn = screen.getByRole('button', { name: /Upgrade to Pro/i });
+    const btn = screen.getByRole('button', { name: /Upgrade/i });
     fireEvent.click(btn);
     expect(onUpgrade).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary

Web half of the agent-mode paywall (server side: kernelCAD-server #80).

- **402 → upgrade panel.** A signed-in user who exhausts the monthly free agent-build cap gets HTTP 402 `quota_exceeded` from `/api/v1/generate`; `useGeneration` now maps it to the same upgrade panel as the anonymous 429 rate limit.
- **Tier-aware checkout.** `createCheckoutSession(tier)` posts the chosen plan (default $20 Standard); `/me/plan` returns the active `tier` and `PlanCard` renders Standard ($20) vs Pro ($100).
- **Copy fix.** Stale `$12/mo` → `$20`/`$100` in `PlanCard` + `RateLimitedPanel`.

## Tests
Funnel component + hook + apiClient + studio-route suites pass (35). `tsc -b` clean (the deploy build, which the test gate alone doesn't run).

## Note
Viewing and manual editing stay free/anonymous; only the in-Studio build **agent** is metered. The $100 Pro **team** features are a later phase — the UI primary CTA is the $20 plan; $100 is purchasable via the tier param and shown correctly once subscribed.