### PR TITLE
Require sign-in for the Studio again (user collection); MCP exempt

### DIFF
--- a/docs/superpowers/specs/2026-06-28-studio-auth-gate-design.md
+++ b/docs/superpowers/specs/2026-06-28-studio-auth-gate-design.md
@@ -3,24 +3,6 @@
 Date: 2026-06-28
 Branch: `feat/studio-auth-gate` (off `develop`)
 
-## Update 2026-06-28 — narrowed to cost-protection (agent-only)
-
-The full-Studio wall below was shipped first, then narrowed per a clarified
-policy: anonymous users are blocked only from services that incur inference
-**cost** for us, not from the editor itself. Net behavior now:
-
-- `/` and `/studio` are NOT gated — anonymous users can open the editor and
-  view/hand-edit (no cost to us). The `StudioAuthGate` wrapper was removed.
-- The cost-bearing in-app agent stays gated: `StudioShell` hides the AgentRail +
-  toggle when there is no session. The header `UserMenu` offers the sign-in
-  entry point ("Sign in to use the agent and save projects").
-- `/generate` already required sign-in before generating (`handleSubmit` opens
-  the sign-in modal for anon) — unchanged.
-- MCP-driven builds are intentionally free (bring-your-own-model, no cost to us)
-  and remain fully open; they surface results as anonymous `/p/<slug>` links.
-
-The sections below describe the original full-Studio gate for history.
-
 ## Problem
 
 The authoring Web Studio is wide open. Anyone can load `/` or `/studio`, edit

--- a/docs/superpowers/specs/2026-06-28-studio-auth-gate-design.md
+++ b/docs/superpowers/specs/2026-06-28-studio-auth-gate-design.md
@@ -3,6 +3,15 @@
 Date: 2026-06-28
 Branch: `feat/studio-auth-gate` (off `develop`)
 
+## Current decision (2026-06-28, latest)
+
+The full-Studio gate described below is the live behavior: signing in is required
+to enter `/` and `/studio`, to **collect users** (lead-gen), not only for cost.
+The only exemption is MCP — clients connecting via the MCP server authenticate
+through its own OAuth and are never sent to the web sign-in wall; MCP-produced
+builds surface as anonymous `/p/<slug>` links, which stay viewable. (A brief
+agent-only loosening, PR #557, was reverted to restore this gate.)
+
 ## Problem
 
 The authoring Web Studio is wide open. Anyone can load `/` or `/studio`, edit

--- a/src/funnel/hooks/useSession.ts
+++ b/src/funnel/hooks/useSession.ts
@@ -39,8 +39,8 @@ export function useSession(): SessionState {
  * no-ops inside the effect when `isAuthConfigured()` is false, returning
  * `{ session: null, loading: false }` immediately. Use this in components
  * that mount regardless of whether Supabase env vars are present (e.g.
- * StudioShell and the /p, /g viewer routes) so plain local dev and env-less
- * embed hosts do not throw.
+ * StudioShell, StudioAuthGate) so plain local dev and env-less embed hosts
+ * do not throw.
  */
 export function useOptionalSession(): SessionState {
   const [state, setState] = useState<SessionState>({

--- a/src/studio/StudioAuthGate.tsx
+++ b/src/studio/StudioAuthGate.tsx
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import React from 'react';
+import { useOptionalSession } from '../funnel/hooks/useSession';
+import { isAuthConfigured } from '../funnel/lib/supabaseClient';
+import { SignInModal } from '../funnel/components/SignInModal';
+
+/**
+ * Gates the authoring Studio (`/`, `/studio`). Anonymous users get the existing
+ * sign-in window, forced open, over an inert background — they cannot reach the
+ * editor until a Supabase session exists. Read-only viewer routes (`/p`, `/g`)
+ * are NOT wrapped in this gate.
+ *
+ * When Supabase env vars are absent (plain local dev, env-less embed hosts),
+ * the gate is bypassed and children render immediately so the CAD viewer works
+ * without auth.
+ */
+export function StudioAuthGate({ children }: { children: React.ReactNode }): React.JSX.Element {
+  const authConfigured = isAuthConfigured();
+  const { session, loading } = useOptionalSession();
+
+  if (!authConfigured) return <>{children}</>;
+
+  if (loading) {
+    return (
+      <div
+        data-testid="studio-auth-splash"
+        className="min-h-screen bg-vellum"
+        aria-busy="true"
+      />
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="min-h-screen bg-vellum">
+        <SignInModal
+          open
+          onClose={() => {}}
+          dismissable={false}
+          title="Sign in to open kernelCAD Studio"
+          description="kernelCAD Studio is where you build and edit models. Sign in to continue."
+          footer={false}
+        />
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/studio/__tests__/StudioAuthGate.test.tsx
+++ b/src/studio/__tests__/StudioAuthGate.test.tsx
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// @vitest-environment jsdom
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { StudioAuthGate } from '../StudioAuthGate';
+
+const mockSession = vi.fn();
+vi.mock('../../funnel/hooks/useSession', () => ({
+  useOptionalSession: () => mockSession(),
+}));
+
+const mockIsAuthConfigured = vi.fn(() => true);
+vi.mock('../../funnel/lib/supabaseClient', () => ({
+  isAuthConfigured: () => mockIsAuthConfigured(),
+}));
+
+afterEach(() => cleanup());
+
+describe('StudioAuthGate', () => {
+  it('shows splash while loading', () => {
+    mockIsAuthConfigured.mockReturnValue(true);
+    mockSession.mockReturnValue({ session: null, loading: true });
+    render(<StudioAuthGate><div>EDITOR</div></StudioAuthGate>);
+    expect(screen.queryByText('EDITOR')).toBeNull();
+    expect(screen.getByTestId('studio-auth-splash')).toBeInTheDocument();
+  });
+
+  it('shows non-dismissable sign-in window when anonymous', () => {
+    mockIsAuthConfigured.mockReturnValue(true);
+    mockSession.mockReturnValue({ session: null, loading: false });
+    render(<StudioAuthGate><div>EDITOR</div></StudioAuthGate>);
+    expect(screen.queryByText('EDITOR')).toBeNull();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Close')).toBeNull();
+    expect(screen.queryByText(/5 free generations/)).toBeNull();
+  });
+
+  it('renders children when signed in', () => {
+    mockIsAuthConfigured.mockReturnValue(true);
+    mockSession.mockReturnValue({ session: { user: { id: 'u1' } }, loading: false });
+    render(<StudioAuthGate><div>EDITOR</div></StudioAuthGate>);
+    expect(screen.getByText('EDITOR')).toBeInTheDocument();
+  });
+
+  it('renders children when auth is not configured', () => {
+    mockIsAuthConfigured.mockReturnValue(false);
+    mockSession.mockReturnValue({ session: null, loading: false });
+    render(<StudioAuthGate><div>EDITOR</div></StudioAuthGate>);
+    expect(screen.getByText('EDITOR')).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});

--- a/src/studio/routes/__tests__/studioRouteGate.test.tsx
+++ b/src/studio/routes/__tests__/studioRouteGate.test.tsx
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// The route components are thin wrappers; assert they compose StudioAuthGate
+// around <App/> rather than rendering <App/> bare.
+const read = (p: string) =>
+  readFileSync(fileURLToPath(new URL(p, import.meta.url)), 'utf8');
+
+describe('authoring routes are gated', () => {
+  it('index route wraps App in StudioAuthGate', () => {
+    const src = read('../index.tsx');
+    expect(src).toMatch(/StudioAuthGate/);
+    expect(src).toMatch(/<StudioAuthGate>\s*<App\s*\/>\s*<\/StudioAuthGate>/);
+  });
+  it('studio route wraps App in StudioAuthGate', () => {
+    const src = read('../studio.tsx');
+    expect(src).toMatch(/StudioAuthGate/);
+    expect(src).toMatch(/<StudioAuthGate>\s*<App\s*\/>\s*<\/StudioAuthGate>/);
+  });
+});

--- a/src/studio/routes/index.tsx
+++ b/src/studio/routes/index.tsx
@@ -2,14 +2,16 @@
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import { createFileRoute } from '@tanstack/react-router';
 import App from '../App';
+import { StudioAuthGate } from '../StudioAuthGate';
 
 export const Route = createFileRoute('/')({
   component: StudioHome,
 });
 
-// The Studio editor is open to anonymous users (viewing and hand-editing cost
-// us nothing). The cost-bearing in-app agent is gated behind sign-in inside
-// StudioShell; the header UserMenu offers the sign-in entry point.
 function StudioHome() {
-  return <App />;
+  return (
+    <StudioAuthGate>
+      <App />
+    </StudioAuthGate>
+  );
 }

--- a/src/studio/routes/studio.tsx
+++ b/src/studio/routes/studio.tsx
@@ -2,12 +2,16 @@
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import { createFileRoute } from '@tanstack/react-router';
 import App from '../App';
+import { StudioAuthGate } from '../StudioAuthGate';
 
 export const Route = createFileRoute('/studio')({
   component: StudioRoute,
 });
 
-// Open to anonymous users; the cost-bearing agent is gated inside StudioShell.
 function StudioRoute() {
-  return <App />;
+  return (
+    <StudioAuthGate>
+      <App />
+    </StudioAuthGate>
+  );
 }

--- a/tests/e2e/studio-gate.spec.ts
+++ b/tests/e2e/studio-gate.spec.ts
@@ -1,16 +1,10 @@
 // tests/e2e/studio-gate.spec.ts
 import { test, expect } from '@playwright/test';
 
-// Cost-protection model: the Studio editor is OPEN to anonymous users (viewing
-// and hand-editing cost us nothing). Only the in-app agent (our paid inference)
-// is gated. So an anonymous visitor reaches the editor — NOT a forced sign-in
-// wall — and sees a "Sign in" entry point but no agent rail.
-test('anonymous user can open /studio editor; no forced sign-in wall', async ({ page }) => {
+test('anonymous user hitting /studio sees the sign-in window, not the editor', async ({ page }) => {
   await page.goto('/studio');
-  // No forced, non-dismissable sign-in modal blocks the editor.
-  await expect(page.getByText(/Sign in to open kernelCAD Studio/i)).toHaveCount(0);
-  // A sign-in affordance is available in the header to unlock the agent.
-  await expect(page.getByRole('button', { name: /sign in/i }).first()).toBeVisible();
-  // The cost-bearing agent rail is not present for an anonymous user.
-  await expect(page.getByLabelText('Agent rail')).toHaveCount(0);
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await expect(page.getByText(/Sign in to open kernelCAD Studio/i)).toBeVisible();
+  // Non-dismissable: no close control.
+  await expect(page.getByLabelText('Close')).toHaveCount(0);
 });


### PR DESCRIPTION
## Why

Reinstate the sign-in wall on the Studio to **start collecting users** (lead-gen). Signing in is required to enter the Studio; the only exemption is MCP, which authenticates through its own OAuth and should never hit the web wall. This reverts the brief agent-only loosening (#557) and restores the gate from #556.

## What changed

- **`/` and `/studio` require sign-in again** — `StudioAuthGate` is restored: an anonymous visitor gets the existing `SignInModal` forced open (non-dismissable) and cannot reach the editor until signed in.
- **MCP stays exempt** — the MCP server authenticates via its own OAuth (independent of the web Supabase session); MCP-produced builds surface as anonymous `/p/<slug>` links, which remain viewable. The MCP-independence guard test still enforces no coupling.
- **`/p` and `/g` viewing stays anonymous** — so shared/MCP build links keep working without an account.

## Net policy after this PR

| Surface | Anonymous | |
|---|---|---|
| `/studio`, `/` editor | **sign-in required** | collect users |
| MCP-driven builds | open | own OAuth, never walled |
| `/p`, `/g` model viewing | open | shared/MCP links stay viewable |

## Implementation

Reverts the merge of #557 (`git revert -m 1`), restoring `StudioAuthGate.tsx`, its tests, the route wrapping, and the e2e spec asserting the forced sign-in window. Unrelated `develop` changes are untouched.

## Testing

- `tsc -b` clean; 0 lint errors; full `src/studio` + `src/funnel` + MCP-guard suites pass.
- e2e `tests/e2e/studio-gate.spec.ts` asserts anon `/studio` shows the forced sign-in window with no close control (runs in CI).
