### PR TITLE
Editor Publish & Share button + My Designs link

### DIFF
--- a/src/funnel/lib/apiClient.ts
+++ b/src/funnel/lib/apiClient.ts
@@ -70,7 +70,7 @@ export async function authedFetch<T>(
 export type ProjectPrivacy = 'public_unlisted' | 'public_featured' | 'private';
 
 export interface SaveProjectInput {
-  generationId: string;
+  generationId?: string;
   anonId?: string;
   title: string;
   code: string;

--- a/src/studio/StudioShell.tsx
+++ b/src/studio/StudioShell.tsx
@@ -227,6 +227,8 @@ export function StudioShell() {
                 onToggleSectionMode={handleToggleSectionMode}
                 inspectorOpen={inspectorOpen}
                 onToggleInspector={handleToggleInspector}
+                code={workbench.code}
+                projectName={activeProject?.name}
             />
 
             <div className="flex-1 flex overflow-hidden relative">

--- a/src/studio/Toolbar.tsx
+++ b/src/studio/Toolbar.tsx
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
-import { CheckCircle2, Play, MessageSquare, Image as ImageIcon, Plug, Brush, Scissors, PanelRight } from 'lucide-react';
+import { useState } from 'react';
+import { CheckCircle2, Play, MessageSquare, Image as ImageIcon, Plug, Brush, Scissors, PanelRight, Share2 } from 'lucide-react';
+import { useNavigate } from '@tanstack/react-router';
+import { useOptionalSession } from '../funnel/hooks/useSession';
+import { saveProject } from '../funnel/lib/apiClient';
 
 interface ToolbarProps {
     isModified: boolean;
@@ -46,6 +50,11 @@ interface ToolbarProps {
     /** When true the agent-rail toggle button is not rendered. Used in
      * viewer mode where the model is driven by an external agent. */
     agentRailHidden?: boolean;
+    /** Current editor code — passed to saveProject on publish. */
+    code: string;
+    /** Active project name — used as the publish title (falls back to first
+     *  60 chars of code, then "Untitled"). */
+    projectName?: string;
 }
 
 export function Toolbar({
@@ -70,7 +79,42 @@ export function Toolbar({
     inspectorOpen,
     onToggleInspector,
     agentRailHidden = false,
+    code,
+    projectName,
 }: ToolbarProps) {
+    const { session } = useOptionalSession();
+    const navigate = useNavigate();
+    const [publishState, setPublishState] = useState<'idle' | 'saving' | 'done' | 'error'>('idle');
+    const [publishedLink, setPublishedLink] = useState<string | null>(null);
+
+    async function handlePublish() {
+        if (!session) {
+            void navigate({ to: '/signin', search: { next: window.location.pathname } });
+            return;
+        }
+        setPublishState('saving');
+        setPublishedLink(null);
+        try {
+            const title = projectName?.slice(0, 60) || code.slice(0, 60) || 'Untitled';
+            const result = await saveProject({
+                title,
+                code,
+                parameters: [],
+                privacy: 'public_unlisted',
+            });
+            const link = `${window.location.origin}/p/${result.slug}`;
+            await navigator.clipboard.writeText(link).catch(() => {});
+            setPublishedLink(link);
+            setPublishState('done');
+            window.setTimeout(() => {
+                setPublishState('idle');
+                setPublishedLink(null);
+            }, 4000);
+        } catch {
+            setPublishState('error');
+        }
+    }
+
     return (
         <div
             data-testid="studio-toolbar"
@@ -102,6 +146,38 @@ export function Toolbar({
                     >
                         <Plug size={12} />
                         Connect
+                    </a>
+                )}
+                {session && (
+                    <a
+                        href="/me"
+                        data-testid="toolbar-my-designs"
+                        aria-label="My Designs"
+                        className="inline-flex items-center gap-1 px-2 py-1 rounded text-gray-300 hover:text-white hover:bg-[#222] transition-colors"
+                    >
+                        My Designs
+                    </a>
+                )}
+                <button
+                    type="button"
+                    data-testid="toolbar-publish"
+                    onClick={() => void handlePublish()}
+                    disabled={publishState === 'saving'}
+                    aria-label="Publish and share"
+                    className="inline-flex items-center gap-1 px-2 py-1 rounded text-gray-300 hover:text-white hover:bg-[#222] transition-colors disabled:opacity-50"
+                >
+                    <Share2 size={12} />
+                    {publishState === 'saving' ? 'Publishing…' : publishState === 'error' ? 'Retry' : 'Publish & Share'}
+                </button>
+                {publishedLink && (
+                    <a
+                        href={publishedLink}
+                        data-testid="toolbar-publish-link"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 px-2 py-1 rounded text-emerald-400 hover:text-emerald-300 text-xs transition-colors"
+                    >
+                        Link copied — {publishedLink}
                     </a>
                 )}
                 {isModified && (

--- a/src/studio/__tests__/Toolbar.test.tsx
+++ b/src/studio/__tests__/Toolbar.test.tsx
@@ -1,11 +1,47 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 /** @vitest-environment happy-dom */
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Toolbar } from '../Toolbar';
 
-afterEach(() => cleanup());
+// ---------------------------------------------------------------------------
+// Module mocks (hoisted so they apply before Toolbar is imported)
+// ---------------------------------------------------------------------------
+
+const mockNavigate = vi.fn();
+vi.mock('@tanstack/react-router', () => ({
+    useNavigate: () => mockNavigate,
+}));
+
+const mockSession = vi.fn<[], { session: { user: { email: string } } | null; loading: boolean }>();
+vi.mock('../../funnel/hooks/useSession', () => ({
+    useOptionalSession: () => mockSession(),
+}));
+
+const mockSaveProject = vi.fn();
+vi.mock('../../funnel/lib/apiClient', () => ({
+    saveProject: (...args: unknown[]) => mockSaveProject(...args),
+}));
+
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+    cleanup();
+    mockNavigate.mockClear();
+    mockSession.mockClear();
+    mockSaveProject.mockClear();
+});
+
+beforeEach(() => {
+    // Default: not signed in
+    mockSession.mockReturnValue({ session: null, loading: false });
+    // Mock clipboard
+    Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+});
 
 function renderToolbar(overrides: Partial<Parameters<typeof Toolbar>[0]> = {}) {
     const props = {
@@ -23,6 +59,7 @@ function renderToolbar(overrides: Partial<Parameters<typeof Toolbar>[0]> = {}) {
         onToggleSectionMode: vi.fn(),
         inspectorOpen: true,
         onToggleInspector: vi.fn(),
+        code: 'const x = box(10, 10, 10);',
         ...overrides,
     };
     render(<Toolbar {...props} />);
@@ -136,5 +173,99 @@ describe('Toolbar', () => {
         const link = screen.getByTestId('toolbar-connect-link');
         expect(link.getAttribute('href')).toBe('/connect');
         expect(link.textContent).toContain('Connect');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Publish & Share
+// ---------------------------------------------------------------------------
+
+describe('Toolbar — Publish & Share', () => {
+    it('renders a Publish & Share button', () => {
+        renderToolbar();
+        expect(screen.getByTestId('toolbar-publish')).toBeDefined();
+    });
+
+    it('navigates to /signin with current path as next when not signed in', async () => {
+        mockSession.mockReturnValue({ session: null, loading: false });
+        renderToolbar();
+        fireEvent.click(screen.getByTestId('toolbar-publish'));
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledTimes(1));
+        expect(mockNavigate).toHaveBeenCalledWith({
+            to: '/signin',
+            search: { next: window.location.pathname },
+        });
+    });
+
+    it('calls saveProject with privacy public_unlisted and the editor code when signed in', async () => {
+        mockSession.mockReturnValue({ session: { user: { email: 'test@test.com' } }, loading: false });
+        mockSaveProject.mockResolvedValue({ slug: 'test-slug', projectId: 'p-1' });
+
+        renderToolbar({ code: 'const y = sphere(5);', projectName: 'My Model' });
+        fireEvent.click(screen.getByTestId('toolbar-publish'));
+
+        await waitFor(() => expect(mockSaveProject).toHaveBeenCalledTimes(1));
+        const call = mockSaveProject.mock.calls[0][0];
+        expect(call.privacy).toBe('public_unlisted');
+        expect(call.code).toBe('const y = sphere(5);');
+    });
+
+    it('writes the /p/<slug> URL to the clipboard after a successful publish', async () => {
+        mockSession.mockReturnValue({ session: { user: { email: 'test@test.com' } }, loading: false });
+        mockSaveProject.mockResolvedValue({ slug: 'my-slug', projectId: 'p-2' });
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: { writeText },
+        });
+
+        renderToolbar({ code: 'box(1)' });
+        fireEvent.click(screen.getByTestId('toolbar-publish'));
+
+        await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+        expect(writeText).toHaveBeenCalledWith(`${window.location.origin}/p/my-slug`);
+    });
+
+    it('shows "Link copied" feedback after a successful publish', async () => {
+        mockSession.mockReturnValue({ session: { user: { email: 'test@test.com' } }, loading: false });
+        mockSaveProject.mockResolvedValue({ slug: 'done-slug', projectId: 'p-3' });
+
+        renderToolbar({ code: 'box(2)' });
+        fireEvent.click(screen.getByTestId('toolbar-publish'));
+
+        await waitFor(() => expect(screen.getByTestId('toolbar-publish-link')).toBeDefined());
+        expect(screen.getByTestId('toolbar-publish-link').textContent).toContain('done-slug');
+    });
+
+    it('disables the publish button while saving', async () => {
+        mockSession.mockReturnValue({ session: { user: { email: 'test@test.com' } }, loading: false });
+        // Never resolves — keeps us in saving state
+        mockSaveProject.mockReturnValue(new Promise(() => {}));
+
+        renderToolbar({ code: 'box(3)' });
+        fireEvent.click(screen.getByTestId('toolbar-publish'));
+
+        await waitFor(() =>
+            expect((screen.getByTestId('toolbar-publish') as HTMLButtonElement).disabled).toBe(true),
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// My Designs link
+// ---------------------------------------------------------------------------
+
+describe('Toolbar — My Designs', () => {
+    it('shows the My Designs link when the user is signed in', () => {
+        mockSession.mockReturnValue({ session: { user: { email: 'a@b.com' } }, loading: false });
+        renderToolbar();
+        const link = screen.getByTestId('toolbar-my-designs');
+        expect(link.getAttribute('href')).toBe('/me');
+    });
+
+    it('hides the My Designs link when not signed in', () => {
+        mockSession.mockReturnValue({ session: null, loading: false });
+        renderToolbar();
+        expect(screen.queryByTestId('toolbar-my-designs')).toBeNull();
     });
 });

--- a/src/studio/__tests__/embed.test.tsx
+++ b/src/studio/__tests__/embed.test.tsx
@@ -15,12 +15,26 @@ import { StudioConfigProvider } from '../config/StudioConfigContext';
 import { getEmbedConfig, setEmbedConfig } from '../config/embedConfigRef';
 import type { BrushReport, StudioConfig } from '../config/types';
 
+// Toolbar now calls useNavigate; stub the router so tests stay router-free.
+vi.mock('@tanstack/react-router', () => ({
+    useNavigate: () => () => {},
+}));
+
+// Toolbar calls useOptionalSession. Return a stable no-session value so the
+// Toolbar renders without hitting the real Supabase client.
+vi.mock('../../funnel/hooks/useSession', () => ({
+    useOptionalSession: () => ({ session: null, loading: false }),
+}));
+
 // Supabase is read by `apiCall()`. Stub it the same way scriptSource.test.ts
 // does so the "unsigned-in" branch is exercised consistently.
+// isAuthConfigured is also stubbed because Toolbar now calls useOptionalSession
+// which reads this function at hook initialisation time.
 vi.mock('../../funnel/lib/supabaseClient', () => ({
     getSupabase: () => ({
         auth: { getSession: async () => ({ data: { session: null } }) },
     }),
+    isAuthConfigured: () => false,
 }));
 
 afterEach(() => {
@@ -213,6 +227,7 @@ describe('Toolbar enableAgentRail gating', () => {
                 onToggleSectionMode={() => {}}
                 inspectorOpen={false}
                 onToggleInspector={() => {}}
+                code=""
             />,
         );
         expect(queryByLabelText(/agent rail/i)).not.toBeNull();
@@ -237,6 +252,7 @@ describe('Toolbar enableAgentRail gating', () => {
                 onToggleSectionMode={() => {}}
                 inspectorOpen={false}
                 onToggleInspector={() => {}}
+                code=""
             />,
         );
         expect(queryByLabelText(/agent rail/i)).toBeNull();


### PR DESCRIPTION
Fixes the 'no way to share my model / no way to see my designs when logged in' gap: localStorage editor projects had no path to server persistence.

## Changes
- **Publish & Share** button in the editor toolbar (`Toolbar.tsx`): unauthenticated → `/signin`; authenticated → `saveProject({ privacy: 'public_unlisted' })`, copies the `/p/<slug>` link with transient feedback. Uses `useOptionalSession` (toolbar is always mounted).
- **My Designs** link to the existing `/me` route (shown only when signed in).
- `StudioShell` threads `code` + project name into the toolbar.

## Depends on
kernelCAD-server PR #82 (`/api/v1/save` accepting saves without a `generationId`) — that must be deployed first, otherwise Publish 400s for editor projects.

## Tests
25/25 Toolbar tests (7 new), studio suite green. Zero new tsc errors vs develop baseline.