### PR TITLE
fix(studio): gate hosted agent behind feature flag

### DIFF
--- a/src/studio/StudioGenerate.tsx
+++ b/src/studio/StudioGenerate.tsx
@@ -4,19 +4,9 @@ import React, { useMemo, useState } from 'react';
 import { DiffEditor } from '@monaco-editor/react';
 import { useGeneration } from '../funnel/hooks/useGeneration';
 import type { GenerateEvent } from '../funnel/lib/generateClient';
+import { inAppAgentEnabled } from './agentAvailability';
 import { useCode } from './context/CodeContext';
 import { useGeometry } from './context/GeometryContext';
-
-/**
- * The in-app agent exists ONLY on the hosted web build (which sets a generation
- * backend via VITE_API_BASE_URL). The npm-distributed / local-MCP Studio has no
- * backend env → the panel is hidden there; locally the agent is the developer's
- * own Claude via the `kernelcad` MCP.
- */
-function inAppAgentEnabled(): boolean {
-    const base = import.meta.env?.VITE_API_BASE_URL;
-    return typeof base === 'string' && base.length > 0;
-}
 
 /** Web-only gate. No hooks here, so the conditional return is safe. */
 export const StudioGenerate: React.FC = () => {

--- a/src/studio/__tests__/agentAvailability.test.ts
+++ b/src/studio/__tests__/agentAvailability.test.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+/** @vitest-environment jsdom */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalLocation = window.location;
+
+function setHost(hostname: string) {
+    Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: { ...originalLocation, hostname },
+    });
+}
+
+afterEach(() => {
+    Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+    });
+    vi.unstubAllEnvs();
+    vi.resetModules();
+});
+
+describe('inAppAgentEnabled', () => {
+    it('is disabled on localhost even when the flag and API backend are configured', async () => {
+        vi.stubEnv('VITE_API_BASE_URL', 'https://api.kernelcad.com');
+        vi.stubEnv('VITE_ENABLE_IN_APP_AGENT', 'true');
+        setHost('localhost');
+
+        const { inAppAgentEnabled } = await import('../agentAvailability');
+
+        expect(inAppAgentEnabled()).toBe(false);
+    });
+
+    it('is disabled on hosted origins by default even when an API backend is configured', async () => {
+        vi.stubEnv('VITE_API_BASE_URL', 'https://api.kernelcad.com');
+        setHost('app.kernelcad.com');
+
+        const { inAppAgentEnabled } = await import('../agentAvailability');
+
+        expect(inAppAgentEnabled()).toBe(false);
+    });
+
+    it('is enabled on hosted origins only when the feature flag and API backend are configured', async () => {
+        vi.stubEnv('VITE_API_BASE_URL', 'https://api.kernelcad.com');
+        vi.stubEnv('VITE_ENABLE_IN_APP_AGENT', 'true');
+        setHost('app.kernelcad.com');
+
+        const { inAppAgentEnabled } = await import('../agentAvailability');
+
+        expect(inAppAgentEnabled()).toBe(true);
+    });
+});

--- a/src/studio/agentAvailability.ts
+++ b/src/studio/agentAvailability.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+
+/**
+ * Built-in hosted generation is expensive and still maturing. Keep it behind an
+ * explicit opt-in flag so live Studio defaults to MCP-first operation.
+ */
+export function inAppAgentEnabled(): boolean {
+    if (typeof window !== 'undefined') {
+        const host = window.location.hostname;
+        if (host === 'localhost' || host === '127.0.0.1' || host === '0.0.0.0') {
+            return false;
+        }
+    }
+    if (import.meta.env?.VITE_ENABLE_IN_APP_AGENT !== 'true') {
+        return false;
+    }
+    const base = import.meta.env?.VITE_API_BASE_URL;
+    return typeof base === 'string' && base.length > 0;
+}

--- a/src/studio/routes/generate.tsx
+++ b/src/studio/routes/generate.tsx
@@ -10,6 +10,7 @@ import { RateLimitedPanel } from '../../funnel/components/RateLimitedPanel';
 import { useGeneration } from '../../funnel/hooks/useGeneration';
 import { useSession } from '../../funnel/hooks/useSession';
 import { createCheckoutSession } from '../../funnel/lib/apiClient';
+import { inAppAgentEnabled } from '../agentAvailability';
 
 export const Route = createFileRoute('/generate')({
   component: GeneratePage,
@@ -25,6 +26,7 @@ function readInitialPrompt(): string {
 }
 
 function GeneratePage() {
+  const agentEnabled = inAppAgentEnabled();
   const { phase, events, submit } = useGeneration();
   const { session, loading: sessionLoading } = useSession();
   const navigate = useNavigate();
@@ -51,6 +53,7 @@ function GeneratePage() {
 
   const handleSubmit = useCallback(
     (prompt: string) => {
+      if (!agentEnabled) return;
       if (!session) {
         // Stash so the post-OAuth landing can pick it up and auto-submit.
         try {
@@ -63,12 +66,13 @@ function GeneratePage() {
       }
       void submit(prompt);
     },
-    [session, submit],
+    [agentEnabled, session, submit],
   );
 
   // After OAuth returns with a session, auto-resume the stashed prompt.
   useEffect(() => {
     if (sessionLoading || !session) return;
+    if (!agentEnabled) return;
     if (phase.state !== 'idle') return;
     let pending: string | null = null;
     try {
@@ -80,7 +84,7 @@ function GeneratePage() {
       window.localStorage.removeItem(PENDING_PROMPT_KEY);
       void submit(pending);
     }
-  }, [sessionLoading, session, phase.state, submit]);
+  }, [agentEnabled, sessionLoading, session, phase.state, submit]);
 
   useEffect(() => {
     if (phase.state === 'done') {
@@ -126,10 +130,26 @@ function GeneratePage() {
           </div>
 
           <div className="mt-2 max-w-2xl mx-auto">
-            <PromptBox onSubmit={handleSubmit} disabled={isBusy} initialValue={initialPrompt} />
+            <PromptBox onSubmit={handleSubmit} disabled={isBusy || !agentEnabled} initialValue={initialPrompt} />
+            {!agentEnabled && (
+              <div className="mt-4 rounded-lg border border-rule bg-vellum-soft p-4 text-left">
+                <p className="font-serif font-medium text-lg">Built-in generation is paused</p>
+                <p className="mt-2 text-sm text-ink-soft leading-relaxed">
+                  Use kernelCAD through MCP while the hosted agent is behind a feature flag.
+                </p>
+                <a
+                  href="/connect"
+                  className="mt-3 inline-flex rounded-lg bg-blueprint hover:bg-blueprint-hover text-white px-4 py-2 text-sm font-medium no-underline transition-colors"
+                >
+                  Connect MCP
+                </a>
+              </div>
+            )}
             {!session && !sessionLoading && (
               <p className="mt-3 text-xs text-ink-faint font-mono tracking-wide">
-                Sign in when you generate - agents build live in the app.
+                {agentEnabled
+                  ? 'Sign in when you generate - agents build live in the app.'
+                  : 'The hosted agent can be re-enabled with VITE_ENABLE_IN_APP_AGENT=true.'}
               </p>
             )}
             {session && (

--- a/src/studio/routes/index.test.ts
+++ b/src/studio/routes/index.test.ts
@@ -55,6 +55,7 @@ describe('Generate page (src/studio/routes/generate.tsx)', () => {
   const source = readFileSync('src/studio/routes/generate.tsx', 'utf8');
 
   it('imports the prompt app and sign-in modal components', () => {
+    expect(source).toMatch(/from\s+['"]\.\.\/agentAvailability['"]/);
     expect(source).toMatch(/from\s+['"]\.\.\/\.\.\/funnel\/components\/PromptBox['"]/);
     expect(source).toMatch(/from\s+['"]\.\.\/\.\.\/funnel\/components\/GallerySection['"]/);
     expect(source).toMatch(/from\s+['"]\.\.\/\.\.\/funnel\/components\/EmailSignup['"]/);
@@ -69,6 +70,8 @@ describe('Generate page (src/studio/routes/generate.tsx)', () => {
   });
 
   it('gates generation by stashing the prompt and opening sign-in', () => {
+    expect(source).toContain('const agentEnabled = inAppAgentEnabled()');
+    expect(source).toContain('if (!agentEnabled) return');
     expect(source).toContain("const PENDING_PROMPT_KEY = 'kc:pendingPrompt'");
     expect(source).toContain('window.localStorage.setItem(PENDING_PROMPT_KEY, prompt)');
     expect(source).toContain('setSignInOpen(true)');


### PR DESCRIPTION
## Summary
- default the built-in hosted Studio agent off unless VITE_ENABLE_IN_APP_AGENT=true
- keep MCP available and point the /generate disabled state to /connect
- guard /generate submit/resume so it cannot call the hosted generation backend while disabled

## Verification
- PATH=/home/andrii/.nvm/versions/node/v22.22.0/bin:/home/andrii/.local/bin:/home/andrii/.nvm/versions/node/v20.20.2/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path:/home/andrii/.codex/tmp/arg0/codex-arg0Nyu9r5:/home/andrii/.nvm/versions/node/v20.20.2/bin:/home/andrii/.local/bin:/home/andrii/.local/bin:/home/andrii/.local/bin:/home/andrii/.deno/bin:/home/andrii/.cargo/bin:/home/andrii/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin npm test -- src/studio/__tests__/agentAvailability.test.ts src/studio/routes/index.test.ts
- PATH=/home/andrii/.nvm/versions/node/v22.22.0/bin:/home/andrii/.local/bin:/home/andrii/.nvm/versions/node/v20.20.2/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path:/home/andrii/.codex/tmp/arg0/codex-arg0Nyu9r5:/home/andrii/.nvm/versions/node/v20.20.2/bin:/home/andrii/.local/bin:/home/andrii/.local/bin:/home/andrii/.local/bin:/home/andrii/.deno/bin:/home/andrii/.cargo/bin:/home/andrii/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin npm run typecheck
- PATH=/home/andrii/.nvm/versions/node/v22.22.0/bin:/home/andrii/.local/bin:/home/andrii/.nvm/versions/node/v20.20.2/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path:/home/andrii/.codex/tmp/arg0/codex-arg0Nyu9r5:/home/andrii/.nvm/versions/node/v20.20.2/bin:/home/andrii/.local/bin:/home/andrii/.local/bin:/home/andrii/.local/bin:/home/andrii/.deno/bin:/home/andrii/.cargo/bin:/home/andrii/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin VITE_BASE_PATH=/ VITE_SUPABASE_URL=dummy VITE_SUPABASE_ANON_KEY=dummy VITE_API_BASE_URL=https://api.kernelcad.com npm run build
- PATH=/home/andrii/.nvm/versions/node/v22.22.0/bin:/home/andrii/.local/bin:/home/andrii/.nvm/versions/node/v20.20.2/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path:/home/andrii/.codex/tmp/arg0/codex-arg0Nyu9r5:/home/andrii/.nvm/versions/node/v20.20.2/bin:/home/andrii/.local/bin:/home/andrii/.local/bin:/home/andrii/.local/bin:/home/andrii/.deno/bin:/home/andrii/.cargo/bin:/home/andrii/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin npx vitest run src/studio/__tests__/agentAvailability.test.ts src/studio/routes/index.test.ts