### PR TITLE
fix(text3d): clean 503 'unavailable' state + extract shared useModelViewer

### DIFF
--- a/src/funnel/components/GallerySection.tsx
+++ b/src/funnel/components/GallerySection.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import { useEffect, useRef, useState, type RefObject } from 'react';
+import { useModelViewer } from '../hooks/useModelViewer';
 
 interface GalleryAuthor {
   handle: string;
@@ -29,30 +30,8 @@ interface GalleryJson {
   entries: GalleryEntry[];
 }
 
-const MODEL_VIEWER_CDN =
-  'https://cdn.jsdelivr.net/npm/@google/model-viewer/dist/model-viewer.min.js';
-
-/** Lazy-load the model-viewer web component only after a tile needs it. Match the
- * static landing page's CDN script-tag approach — keeps it out of the main
- * Vite bundle (the npm package is ~1MB minified) and shares the CDN cache
- * with any other page on kernelcad.com that loads it. */
-function useModelViewer(enabled: boolean): void {
-  useEffect(() => {
-    if (!enabled) return;
-    if (typeof window === 'undefined') return;
-    if (window.customElements?.get('model-viewer')) return;
-    if (document.querySelector(`script[src="${MODEL_VIEWER_CDN}"]`)) return;
-    const script = document.createElement('script');
-    script.type = 'module';
-    script.src = MODEL_VIEWER_CDN;
-    script.onerror = () => {
-      // Graceful degrade — tiles fall back to the <model-viewer> poster
-      // attribute, which renders as an <img> until the script registers
-      // the custom element.
-    };
-    document.head.appendChild(script);
-  }, [enabled]);
-}
+// useModelViewer (lazy CDN load of the <model-viewer> web component) is shared
+// with the Studio 3D-concept preview — see ../hooks/useModelViewer.
 
 function useNearViewport<T extends Element>(): [RefObject<T | null>, boolean, () => void] {
   const ref = useRef<T>(null);

--- a/src/funnel/hooks/useModelViewer.ts
+++ b/src/funnel/hooks/useModelViewer.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { useEffect } from 'react';
+
+export const MODEL_VIEWER_CDN =
+  'https://cdn.jsdelivr.net/npm/@google/model-viewer/dist/model-viewer.min.js';
+
+/**
+ * Lazy-load the `<model-viewer>` web component only when a consumer actually
+ * needs it. Matches the static landing page's CDN script-tag approach — keeps
+ * the ~1MB npm package out of the main Vite bundle and shares the CDN cache
+ * with any other page on kernelcad.com that loads it. Shared by the funnel
+ * gallery tiles and the Studio 3D-concept preview.
+ *
+ * Graceful degrade: if the script fails (offline, CSP) the element falls back
+ * to its `poster` attribute, rendering as an `<img>` until/unless the custom
+ * element registers.
+ */
+export function useModelViewer(enabled: boolean): void {
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined') return;
+    if (window.customElements?.get('model-viewer')) return;
+    if (document.querySelector(`script[src="${MODEL_VIEWER_CDN}"]`)) return;
+    const script = document.createElement('script');
+    script.type = 'module';
+    script.src = MODEL_VIEWER_CDN;
+    try {
+      document.head.appendChild(script);
+    } catch {
+      // Graceful degrade in test/SSR environments where head injection is unavailable.
+    }
+  }, [enabled]);
+}

--- a/src/funnel/hooks/useTextTo3dPreview.test.ts
+++ b/src/funnel/hooks/useTextTo3dPreview.test.ts
@@ -30,4 +30,11 @@ describe('useTextTo3dPreview', () => {
     await act(async () => { await result.current.submit('x'); });
     expect(result.current.phase.state).toBe('upgrade');
   });
+
+  it('maps 503 (no provider key) to the unavailable state, not an error', async () => {
+    vi.spyOn(client, 'startPreview').mockResolvedValue(new Response('{"error":"feature_unavailable"}', { status: 503 }));
+    const { result } = renderHook(() => useTextTo3dPreview());
+    await act(async () => { await result.current.submit('x'); });
+    expect(result.current.phase.state).toBe('unavailable');
+  });
 });

--- a/src/funnel/hooks/useTextTo3dPreview.ts
+++ b/src/funnel/hooks/useTextTo3dPreview.ts
@@ -7,7 +7,8 @@ export type PreviewPhase =
   | { state: 'running'; progress: number }
   | { state: 'done'; glbUrl: string; costUsd: number | null }
   | { state: 'error'; code: string; message: string }
-  | { state: 'upgrade' };
+  | { state: 'upgrade' }
+  | { state: 'unavailable' };
 
 export function useTextTo3dPreview() {
   const [phase, setPhase] = useState<PreviewPhase>({ state: 'idle' });
@@ -21,9 +22,11 @@ export function useTextTo3dPreview() {
       setPhase({ state: 'error', code: 'network', message: err instanceof Error ? err.message : String(err) });
       return;
     }
-    // 401 = anonymous (sign in), 402 = signed-in free user (upgrade), 403/503 also
-    // surface as an actionable state. Both 401/402 route to the same upgrade panel.
+    // 401 = anonymous (sign in), 402 = signed-in free user — both route to the
+    // upgrade panel. 503 = the server has no provider key yet (feature dark) —
+    // surface a quiet "unavailable" state, not a raw error.
     if (res.status === 401 || res.status === 402) { setPhase({ state: 'upgrade' }); return; }
+    if (res.status === 503) { setPhase({ state: 'unavailable' }); return; }
     if (!res.ok || !res.body) {
       setPhase({ state: 'error', code: `http_${res.status}`, message: await res.text().catch(() => `HTTP ${res.status}`) });
       return;

--- a/src/studio/components/PreviewConceptPanel.test.tsx
+++ b/src/studio/components/PreviewConceptPanel.test.tsx
@@ -30,6 +30,15 @@ describe('PreviewConceptPanel', () => {
     expect(screen.getByText(/upgrade/i)).toBeInTheDocument();
   });
 
+  it('shows a quiet "not available" state on unavailable, with no prompt input', () => {
+    vi.spyOn(hook, 'useTextTo3dPreview').mockReturnValue({ phase: { state: 'unavailable' }, submit: vi.fn() });
+    render(<PreviewConceptPanel />);
+    expect(screen.getByText(/not available yet/i)).toBeInTheDocument();
+    // The input is hidden so the user can't retry into a wall.
+    expect(screen.queryByPlaceholderText(/describe/i)).toBeNull();
+    expect(screen.queryByRole('button', { name: /generate concept/i })).toBeNull();
+  });
+
   it('calls submit with the typed prompt', () => {
     const submit = vi.fn();
     vi.spyOn(hook, 'useTextTo3dPreview').mockReturnValue({ phase: { state: 'idle' }, submit });

--- a/src/studio/components/PreviewConceptPanel.tsx
+++ b/src/studio/components/PreviewConceptPanel.tsx
@@ -1,22 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useTextTo3dPreview } from '../../funnel/hooks/useTextTo3dPreview';
-
-const MODEL_VIEWER_CDN = 'https://cdn.jsdelivr.net/npm/@google/model-viewer/dist/model-viewer.min.js';
-
-/** Lazy-load the model-viewer web component (keeps the ~1MB pkg out of the main bundle).
- *  Mirrors useModelViewer in GallerySection.tsx. */
-function useModelViewer(enabled: boolean): void {
-  useEffect(() => {
-    if (!enabled || typeof window === 'undefined') return;
-    if (window.customElements?.get('model-viewer')) return;
-    if (document.querySelector(`script[src="${MODEL_VIEWER_CDN}"]`)) return;
-    const s = document.createElement('script');
-    s.type = 'module'; s.src = MODEL_VIEWER_CDN;
-    try { document.head.appendChild(s); } catch { /* graceful degrade in test/SSR envs */ }
-  }, [enabled]);
-}
+import { useModelViewer } from '../../funnel/hooks/useModelViewer';
 
 export function PreviewConceptPanel() {
   const { phase, submit } = useTextTo3dPreview();
@@ -24,6 +10,18 @@ export function PreviewConceptPanel() {
   const busy = phase.state === 'running';
 
   useModelViewer(phase.state === 'done');
+
+  // The feature is dark until the server has a provider key (503). Render a
+  // quiet "not available" state instead of a scary red error, and hide the
+  // input so the user can't keep retrying into a wall.
+  if (phase.state === 'unavailable') {
+    return (
+      <section aria-label="Generate concept preview" className="flex flex-col gap-2 border-t border-[#2a2e38] pt-3 mt-1">
+        <div className="uppercase tracking-wide text-[10px] text-gray-500">3D Concept Preview</div>
+        <p className="text-[11px] text-gray-500">Not available yet — coming soon.</p>
+      </section>
+    );
+  }
 
   return (
     <section aria-label="Generate concept preview" className="flex flex-col gap-2 border-t border-[#2a2e38] pt-3 mt-1">


### PR DESCRIPTION
Two fast-follows from the text-to-3D preview final review (PR #562).

## 1. Clean `unavailable` state on 503 (UX)
Before: if the server has no `TRIPO_API_KEY` yet (feature dark → `503 feature_unavailable`), the Studio panel showed `Preview failed: {"error":"feature_unavailable"}` — a raw-JSON error. Now `503` maps to a quiet `unavailable` phase: the panel renders "Not available yet — coming soon." and hides the prompt input so users can't retry into a wall. (Cost invariant unaffected — server still 503s with no spend.)

## 2. Extract shared `useModelViewer` (DRY)
The lazy-CDN `<model-viewer>` loader was duplicated in `GallerySection.tsx` and `PreviewConceptPanel.tsx`. Extracted to `src/funnel/hooks/useModelViewer.ts`; both import it.

## Tests
7/7 pass (hook 3/3 incl. new 503→unavailable; panel 4/4 incl. new unavailable-render). Full `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)