### PR TITLE
feat: enable in-Studio agent UI in the prod web build

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -44,6 +44,10 @@ jobs:
           VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
           # GitHub OAuth provider is registered and enabled in Supabase Auth.
           VITE_GITHUB_AUTH_ENABLED: 'true'
+          # Paid launch 2026-07-02: server-side ENABLE_IN_APP_AGENT is on and
+          # billing is live; without this build flag inAppAgentEnabled() hides
+          # the whole StudioGenerate UI (agent prompt + 3D concept preview).
+          VITE_ENABLE_IN_APP_AGENT: 'true'
         run: npm run build
 
       - name: Deploy to Cloudflare Pages (kernelcad-app)


### PR DESCRIPTION
Server-side paid launch is live (kernelCAD-server #87 + Stripe prices + `ENABLE_IN_APP_AGENT=true` on the box), but `inAppAgentEnabled()` (src/studio/agentAvailability.ts) also requires build-time `VITE_ENABLE_IN_APP_AGENT='true'` — which the Cloudflare Pages build never set. Result: app.kernelcad.com hides the agent prompt **and** the paid 3D concept preview panel, so nobody can reach the features they'd pay for.

One-line build-env addition. Verified the full flow locally against prod API (paid demo user): prompt → Tripo → GLB rendered in the rail, 20 credits/preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)