### PR TITLE
fix: route Tripo GLB urls through the API asset relay

### DIFF
--- a/src/funnel/hooks/useTextTo3dPreview.test.ts
+++ b/src/funnel/hooks/useTextTo3dPreview.test.ts
@@ -24,6 +24,22 @@ describe('useTextTo3dPreview', () => {
     expect(result.current.phase).toMatchObject({ state: 'done', glbUrl: 'https://t/out.glb' });
   });
 
+  it('rewrites Tripo glb urls through the API asset relay', async () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com');
+    const glb = 'https://tripo-data.rg1.data.tripo3d.com/a/model.glb?sig=x';
+    vi.spyOn(client, 'startPreview').mockResolvedValue(
+      sseResponse(`event: preview_done\ndata: ${JSON.stringify({ glbUrl: glb, costUsd: null, taskId: 't2' })}\n\n`),
+    );
+    const { result } = renderHook(() => useTextTo3dPreview());
+    await act(async () => { await result.current.submit('a bracket'); });
+    await waitFor(() => expect(result.current.phase.state).toBe('done'));
+    expect(result.current.phase).toMatchObject({
+      state: 'done',
+      glbUrl: `https://api.example.com/api/v1/preview/asset?src=${encodeURIComponent(glb)}`,
+    });
+    vi.unstubAllEnvs();
+  });
+
   it('maps 402 to the upgrade state', async () => {
     vi.spyOn(client, 'startPreview').mockResolvedValue(new Response('{"error":"not_paid"}', { status: 402 }));
     const { result } = renderHook(() => useTextTo3dPreview());

--- a/src/funnel/hooks/useTextTo3dPreview.ts
+++ b/src/funnel/hooks/useTextTo3dPreview.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 import { useCallback, useState } from 'react';
-import { parsePreviewStream, startPreview } from '../lib/previewClient';
+import { parsePreviewStream, proxiedAssetUrl, startPreview } from '../lib/previewClient';
 
 export type PreviewPhase =
   | { state: 'idle' }
@@ -33,7 +33,7 @@ export function useTextTo3dPreview() {
     }
     for await (const e of parsePreviewStream(res.body)) {
       if (e.kind === 'status') setPhase({ state: 'running', progress: e.progress });
-      else if (e.kind === 'preview_done') { setPhase({ state: 'done', glbUrl: e.glbUrl, costUsd: e.costUsd }); return; }
+      else if (e.kind === 'preview_done') { setPhase({ state: 'done', glbUrl: proxiedAssetUrl(e.glbUrl), costUsd: e.costUsd }); return; }
       else if (e.kind === 'error') { setPhase({ state: 'error', code: e.code, message: e.message }); return; }
     }
     setPhase({ state: 'error', code: 'stream_closed', message: 'Connection closed before the preview finished.' });

--- a/src/funnel/lib/previewClient.ts
+++ b/src/funnel/lib/previewClient.ts
@@ -69,3 +69,21 @@ export async function startPreview(prompt: string): Promise<Response> {
   }
   return fetch(`${base}/api/v1/preview/text-to-3d`, { method: 'POST', headers, body: JSON.stringify({ prompt }) });
 }
+
+/**
+ * Tripo's CDN allows localhost origins but sends no CORS headers for real
+ * domains, so <model-viewer> cannot fetch the signed GLB directly in prod.
+ * Route Tripo asset URLs through the API's relay (which our CORS covers);
+ * anything else passes through untouched.
+ */
+export function proxiedAssetUrl(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  if (!parsed.hostname.endsWith('.data.tripo3d.com')) return url;
+  const base = import.meta.env.VITE_API_BASE_URL;
+  return `${base}/api/v1/preview/asset?src=${encodeURIComponent(url)}`;
+}

--- a/src/funnel/lib/proxiedAssetUrl.test.ts
+++ b/src/funnel/lib/proxiedAssetUrl.test.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { proxiedAssetUrl } from './previewClient';
+
+beforeEach(() => vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com'));
+afterEach(() => vi.unstubAllEnvs());
+
+describe('proxiedAssetUrl', () => {
+  it('rewrites Tripo CDN URLs through the API asset relay (their CDN blocks real origins)', () => {
+    const glb = 'https://tripo-data.rg1.data.tripo3d.com/a/b/model.glb?Policy=x&Signature=y';
+    expect(proxiedAssetUrl(glb)).toBe(
+      `https://api.example.com/api/v1/preview/asset?src=${encodeURIComponent(glb)}`,
+    );
+  });
+
+  it('leaves non-Tripo URLs untouched', () => {
+    expect(proxiedAssetUrl('https://cdn.example.com/x.glb')).toBe('https://cdn.example.com/x.glb');
+  });
+
+  it('leaves unparseable strings untouched', () => {
+    expect(proxiedAssetUrl('not a url')).toBe('not a url');
+  });
+});


### PR DESCRIPTION
Companion to [kernelCAD-server #88](https://github.com/w1ne/kernelCAD-server/pull/88). Tripo's CDN allows localhost origins but sends **no CORS headers for real domains**, so the unified-UI live verification showed the preview completing but the viewer rendering black (CORS block in console).

`proxiedAssetUrl()` rewrites `*.data.tripo3d.com` GLB urls to `${VITE_API_BASE_URL}/api/v1/preview/asset?src=…`; non-Tripo urls pass through. 4 new tests; typecheck + studio/funnel suites green.

**Merge order: server #88 must deploy first** — this PR points the viewer at the new route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)