### PR TITLE
fix: Build-as-CAD generates fresh instead of editing starter code

### DIFF
--- a/src/studio/StudioGenerate.test.tsx
+++ b/src/studio/StudioGenerate.test.tsx
@@ -22,7 +22,8 @@ vi.mock('../funnel/hooks/useTextTo3dPreview', () => ({
   useTextTo3dPreview: () => ({ phase: previewPhase, submit: previewSubmit }),
 }));
 
-vi.mock('./context/CodeContext', () => ({ useCode: () => ({ code: '', setCode: vi.fn() }) }));
+let mockCode = '';
+vi.mock('./context/CodeContext', () => ({ useCode: () => ({ code: mockCode, setCode: vi.fn() }) }));
 vi.mock('./context/GeometryContext', () => ({ useGeometry: () => ({ executeGeometry: vi.fn() }) }));
 vi.mock('../funnel/hooks/useModelViewer', () => ({ useModelViewer: () => {} }));
 
@@ -31,6 +32,7 @@ import { StudioGenerate } from './StudioGenerate';
 beforeEach(() => {
   vi.clearAllMocks();
   previewPhase = { state: 'idle' };
+  mockCode = '';
 });
 afterEach(() => cleanup());
 
@@ -62,6 +64,17 @@ describe('StudioGenerate — unified prompt', () => {
   });
 
   it('Build-as-CAD feeds the concept prompt into the agent submit', () => {
+    const { rerender } = render(<StudioGenerate />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'a hex planter' } });
+    fireEvent.click(screen.getByRole('button', { name: /3d concept/i }));
+    previewPhase = { state: 'done', glbUrl: 'https://t/x.glb', costUsd: null };
+    rerender(<StudioGenerate />);
+    fireEvent.click(screen.getByRole('button', { name: /build as parametric cad/i }));
+    expect(generationSubmit).toHaveBeenCalledWith('a hex planter', undefined);
+  });
+
+  it('Build-as-CAD is a FRESH generation even when the editor holds code (not an edit of it)', () => {
+    mockCode = 'const base = box(60, 40, 5); return base;';
     const { rerender } = render(<StudioGenerate />);
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'a hex planter' } });
     fireEvent.click(screen.getByRole('button', { name: /3d concept/i }));

--- a/src/studio/StudioGenerate.tsx
+++ b/src/studio/StudioGenerate.tsx
@@ -80,7 +80,13 @@ const StudioGenerateInner: React.FC = () => {
 
     const buildConceptAsCad = () => {
         if (!conceptPrompt || busy) return;
-        runAgent(conceptPrompt);
+        // Fresh generation, never an edit: framing the concept prompt as an
+        // edit of whatever happens to sit in the editor (often the untouched
+        // starter sample) lets the model return that code unchanged. The
+        // review diff still uses the current editor code as its baseline, so
+        // nothing is overwritten without the user accepting.
+        setBaseline(code);
+        void submit(conceptPrompt, undefined);
     };
 
     const accept = () => {


### PR DESCRIPTION
Live test of the concept→CAD pipeline (from #565): with the untouched starter sample in the editor, Build-as-CAD framed the request as an EDIT of that sample — and the model returned it byte-identical, titled "Wall-Mount Bracket for 30mm Sensor". ✓ verified only means "it builds".

Fix: Build-as-CAD always submits the concept prompt as a **fresh generation** (`submit(conceptPrompt, undefined)`). The review diff still baselines against current editor code, so the user's work is never replaced without an explicit accept. The plain Build button keeps its edit-mode behavior.

New test pins it: editor holding code → Build-as-CAD still submits `(prompt, undefined)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)