### PR TITLE
feat(studio): pin account menu + separate usage/billing view

### DIFF
--- a/src/studio/components/Layout/Header.tsx
+++ b/src/studio/components/Layout/Header.tsx
@@ -266,8 +266,18 @@ export function Header() {
                     <Download className="w-4 h-4" />
                 </button>
                 {isComputing && <Loader2 className="w-3 h-3 animate-spin text-gray-500" />}
+            </div>
 
-                <div className="h-6 w-px bg-[#333] mx-2" />
+            {/* Account menu — pinned to the right edge so it never scrolls out of
+                the horizontally-scrollable toolbar. It used to be the last item
+                inside the scrolling instrument cluster, so on narrow viewports it
+                slid off-screen (the scrollbar is hidden) and users couldn't find
+                sign-out / billing. */}
+            <div
+                className="sticky right-0 z-20 shrink-0 self-stretch flex items-center gap-2 pl-3 bg-[#111] shadow-[-8px_0_8px_-4px_rgba(0,0,0,0.55)]"
+                data-testid="account-slot"
+            >
+                <div className="h-6 w-px bg-[#333]" />
                 <UserMenu />
             </div>
             <div className="absolute bottom-0 right-0 p-1 text-[9px] text-gray-700 pointer-events-none opacity-50 font-mono">

--- a/src/studio/components/Layout/UserMenu.test.tsx
+++ b/src/studio/components/Layout/UserMenu.test.tsx
@@ -79,6 +79,19 @@ describe('UserMenu', () => {
         expect(signOut).toHaveBeenCalled();
     });
 
+    it('links to the projects and billing pages from the dropdown', () => {
+        mockUseSession.mockReturnValue({ session: fakeSession('jane@example.com'), loading: false });
+        render(<UserMenu />);
+
+        fireEvent.click(screen.getByTestId('user-menu-avatar'));
+
+        const projects = screen.getByRole('menuitem', { name: /your projects/i });
+        expect(projects.getAttribute('href')).toBe('/me');
+
+        const billing = screen.getByRole('menuitem', { name: /usage.*billing/i });
+        expect(billing.getAttribute('href')).toBe('/billing');
+    });
+
     it('closes the dropdown on Escape', () => {
         mockUseSession.mockReturnValue({ session: fakeSession('jane@example.com'), loading: false });
         render(<UserMenu />);

--- a/src/studio/components/Layout/UserMenu.tsx
+++ b/src/studio/components/Layout/UserMenu.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import { useEffect, useRef, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
 import { useSession } from '../../../funnel/hooks/useSession';
 import { getSupabase, isAuthConfigured } from '../../../funnel/lib/supabaseClient';
 import { SignInButton } from '../../../funnel/components/SignInButton';
@@ -74,14 +75,17 @@ function UserMenuInner() {
             <button
                 type="button"
                 onClick={() => setOpen((o) => !o)}
-                className="flex items-center justify-center w-6 h-6 rounded-full bg-[#222] hover:bg-[#333] text-gray-300 hover:text-white text-xs font-medium transition-colors"
+                className="flex items-center gap-1 rounded-full bg-[#2b2b2b] hover:bg-[#3a3a3a] pl-0.5 pr-1.5 py-0.5 text-gray-200 hover:text-white transition-colors ring-1 ring-[#444]"
                 aria-label="Account menu"
                 aria-haspopup="menu"
                 aria-expanded={open}
                 title={email}
                 data-testid="user-menu-avatar"
             >
-                {initial}
+                <span className="flex items-center justify-center w-5 h-5 rounded-full bg-blue-600 text-white text-[11px] font-semibold">
+                    {initial}
+                </span>
+                <ChevronDown size={12} className="text-gray-400" />
             </button>
             {open && (
                 <div
@@ -92,6 +96,21 @@ function UserMenuInner() {
                     <div className="px-3 py-1.5 text-xs text-gray-400 truncate" data-testid="user-menu-email">
                         {email}
                     </div>
+                    <div className="h-px bg-[#333] my-1" />
+                    <a
+                        href="/me"
+                        className="block px-3 py-1.5 text-xs text-gray-300 hover:text-white hover:bg-[#222] no-underline transition-colors"
+                        role="menuitem"
+                    >
+                        Your projects
+                    </a>
+                    <a
+                        href="/billing"
+                        className="block px-3 py-1.5 text-xs text-gray-300 hover:text-white hover:bg-[#222] no-underline transition-colors"
+                        role="menuitem"
+                    >
+                        Usage &amp; billing
+                    </a>
                     <div className="h-px bg-[#333] my-1" />
                     <button
                         type="button"

--- a/src/studio/routes/billing.tsx
+++ b/src/studio/routes/billing.tsx
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+import { useSession } from '../../funnel/hooks/useSession';
+import { getSupabase } from '../../funnel/lib/supabaseClient';
+import {
+  createCheckoutSession,
+  fetchMyPlan,
+  openBillingPortal,
+  type MyPlan,
+} from '../../funnel/lib/apiClient';
+import { PlanCard } from '../../funnel/components/PlanCard';
+
+type CheckoutStatus = 'success' | 'cancel' | undefined;
+
+export const Route = createFileRoute('/billing')({
+  component: BillingPage,
+  validateSearch: (s: Record<string, unknown>): { checkout?: CheckoutStatus } => ({
+    checkout:
+      s.checkout === 'success' || s.checkout === 'cancel'
+        ? (s.checkout as CheckoutStatus)
+        : undefined,
+  }),
+});
+
+/** Human-readable plan name for the usage summary. */
+function planLabel(plan: MyPlan): string {
+  if (plan.plan !== 'pro') return 'Free plan';
+  return plan.tier === 'pro' ? 'Pro plan' : 'Standard plan';
+}
+
+function BillingPage() {
+  const { session, loading } = useSession();
+  const navigate = useNavigate();
+  const { checkout } = Route.useSearch();
+  const [plan, setPlan] = useState<MyPlan | null>(null);
+  const [planErr, setPlanErr] = useState<string | null>(null);
+  const [billingBusy, setBillingBusy] = useState(false);
+  const [billingErr, setBillingErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!loading && !session) {
+      navigate({ to: '/signin', search: { next: '/billing' } });
+    }
+  }, [loading, session, navigate]);
+
+  useEffect(() => {
+    if (session) {
+      fetchMyPlan().then(setPlan).catch(e => setPlanErr(String(e)));
+    }
+  }, [session]);
+
+  const dismissCheckoutBanner = () => {
+    navigate({ to: '/billing', search: {}, replace: true });
+  };
+
+  const handleUpgrade = async () => {
+    setBillingBusy(true);
+    setBillingErr(null);
+    try {
+      const { url } = await createCheckoutSession();
+      window.location.href = url;
+    } catch (e) {
+      setBillingErr(e instanceof Error ? e.message : String(e));
+      setBillingBusy(false);
+    }
+  };
+
+  const handleManage = async () => {
+    setBillingBusy(true);
+    setBillingErr(null);
+    try {
+      const { url } = await openBillingPortal();
+      window.location.href = url;
+    } catch (e) {
+      setBillingErr(e instanceof Error ? e.message : String(e));
+      setBillingBusy(false);
+    }
+  };
+
+  if (loading || !session) {
+    return (
+      <main className="min-h-screen bg-vellum font-sans p-8">
+        <p className="text-ink-faint font-mono text-sm">Loading…</p>
+      </main>
+    );
+  }
+
+  const isPro = plan?.plan === 'pro';
+
+  return (
+    <main className="min-h-screen bg-vellum text-ink font-sans">
+      {/* Nav */}
+      <header className="border-b border-rule px-6 py-3 flex items-center justify-between bg-vellum">
+        <a href="/" className="flex items-center gap-2 font-serif text-base font-medium no-underline text-ink">
+          <svg className="w-4 h-4 text-ink" viewBox="0 0 84 84" fill="none" aria-label="kernelCAD">
+            <path d="M 14,12 L 26,12 L 26,34 Q 26,36 27.5,34.5 L 46,12 L 60,12 L 36,40 Q 35,42 36,44 L 60,72 L 46,72 L 27.5,49.5 Q 26,48 26,50 L 26,72 L 14,72 Z" fill="currentColor"/>
+          </svg>
+          <span>kernel<span className="text-blueprint">CAD</span></span>
+        </a>
+        <div className="flex items-center gap-4">
+          <a href="/me" className="font-mono text-xs text-ink-soft hover:text-ink tracking-wide no-underline">
+            Your projects
+          </a>
+          <span className="font-mono text-xs text-ink-soft tracking-wide hidden sm:inline">{session.user.email}</span>
+          <button
+            type="button"
+            onClick={() => {
+              // onAuthStateChange clears the session; the !session effect above
+              // then redirects to /signin.
+              void getSupabase().auth.signOut();
+            }}
+            className="rounded-md border border-rule px-3 py-1.5 font-mono text-xs tracking-wide text-ink-soft hover:border-ink hover:text-ink transition-colors"
+          >
+            Sign out
+          </button>
+        </div>
+      </header>
+
+      <section className="px-6 py-10 max-w-2xl mx-auto">
+        <h1 className="font-serif text-3xl font-medium text-ink">Usage &amp; billing</h1>
+        <p className="text-ink-soft mt-2 mb-8">
+          Your plan, generation usage, and payment settings.
+        </p>
+
+        {checkout === 'success' && (
+          <div role="status" className="mb-6 rounded-lg border border-blueprint bg-vellum-soft p-4 text-ink relative">
+            <button type="button" onClick={dismissCheckoutBanner} aria-label="Dismiss" className="absolute top-3 right-3 text-ink-faint hover:text-ink font-mono text-sm leading-none">×</button>
+            <p className="font-serif font-medium">You're on Pro</p>
+            <p className="text-sm text-ink-soft mt-1">Subscription active — generate as much as you like.</p>
+          </div>
+        )}
+        {checkout === 'cancel' && (
+          <div role="status" className="mb-6 rounded-lg border border-rule bg-vellum-soft p-4 text-ink relative">
+            <button type="button" onClick={dismissCheckoutBanner} aria-label="Dismiss" className="absolute top-3 right-3 text-ink-faint hover:text-ink font-mono text-sm leading-none">×</button>
+            <p className="font-serif font-medium">Checkout cancelled</p>
+            <p className="text-sm text-ink-soft mt-1">No charge was made. You can upgrade any time from this page.</p>
+          </div>
+        )}
+
+        {plan && (
+          <PlanCard
+            plan={plan.plan}
+            tier={plan.tier}
+            generationsRemaining={plan.generationsRemaining}
+            currentPeriodEnd={plan.currentPeriodEnd}
+            onUpgrade={handleUpgrade}
+            onManage={handleManage}
+            busy={billingBusy}
+          />
+        )}
+        {planErr && !plan && (
+          <p className="text-ink-faint font-mono text-xs">Couldn't load plan info: {planErr}</p>
+        )}
+        {billingErr && (
+          <p className="text-copper font-mono text-xs mt-2">Billing error: {billingErr}</p>
+        )}
+
+        {/* Usage detail */}
+        {plan && (
+          <section aria-label="Usage" className="mt-6 rounded-xl border border-rule bg-white p-5">
+            <h2 className="font-serif text-lg font-medium text-ink">This period</h2>
+            <dl className="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-4">
+              <div>
+                <dt className="font-mono text-[11px] text-ink-faint tracking-wide uppercase">Plan</dt>
+                <dd className="text-ink mt-1">{planLabel(plan)}</dd>
+              </div>
+              <div>
+                <dt className="font-mono text-[11px] text-ink-faint tracking-wide uppercase">Generations</dt>
+                <dd className="text-ink mt-1">
+                  {isPro ? 'Unlimited' : `${plan.generationsRemaining} remaining`}
+                </dd>
+              </div>
+              <div>
+                <dt className="font-mono text-[11px] text-ink-faint tracking-wide uppercase">
+                  {isPro ? 'Renews' : 'Resets'}
+                </dt>
+                <dd className="text-ink mt-1">
+                  {plan.currentPeriodEnd
+                    ? new Date(plan.currentPeriodEnd).toLocaleDateString()
+                    : isPro ? '—' : 'monthly'}
+                </dd>
+              </div>
+            </dl>
+          </section>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/studio/routes/me.tsx
+++ b/src/studio/routes/me.tsx
@@ -5,14 +5,11 @@ import { useEffect, useState } from 'react';
 import { useSession } from '../../funnel/hooks/useSession';
 import { getSupabase } from '../../funnel/lib/supabaseClient';
 import {
-  createCheckoutSession,
   fetchMyPlan,
   listMyProjects,
-  openBillingPortal,
   type MyPlan,
   type ProjectRow,
 } from '../../funnel/lib/apiClient';
-import { PlanCard } from '../../funnel/components/PlanCard';
 
 type CheckoutStatus = 'success' | 'cancel' | undefined;
 
@@ -61,8 +58,6 @@ function MePage() {
   const [projects, setProjects] = useState<ProjectRow[] | null>(null);
   const [plan, setPlan] = useState<MyPlan | null>(null);
   const [planErr, setPlanErr] = useState<string | null>(null);
-  const [billingBusy, setBillingBusy] = useState(false);
-  const [billingErr, setBillingErr] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
   useEffect(() => {
@@ -80,30 +75,6 @@ function MePage() {
 
   const dismissCheckoutBanner = () => {
     navigate({ to: '/me', search: {}, replace: true });
-  };
-
-  const handleUpgrade = async () => {
-    setBillingBusy(true);
-    setBillingErr(null);
-    try {
-      const { url } = await createCheckoutSession();
-      window.location.href = url;
-    } catch (e) {
-      setBillingErr(e instanceof Error ? e.message : String(e));
-      setBillingBusy(false);
-    }
-  };
-
-  const handleManage = async () => {
-    setBillingBusy(true);
-    setBillingErr(null);
-    try {
-      const { url } = await openBillingPortal();
-      window.location.href = url;
-    } catch (e) {
-      setBillingErr(e instanceof Error ? e.message : String(e));
-      setBillingBusy(false);
-    }
   };
 
   if (loading || !session) {
@@ -187,25 +158,32 @@ function MePage() {
           </div>
         )}
 
+        {/* Compact plan summary — full usage & billing lives on /billing. */}
         {plan && (
-          <PlanCard
-            plan={plan.plan}
-            tier={plan.tier}
-            generationsRemaining={plan.generationsRemaining}
-            currentPeriodEnd={plan.currentPeriodEnd}
-            onUpgrade={handleUpgrade}
-            onManage={handleManage}
-            busy={billingBusy}
-          />
+          <a
+            href="/billing"
+            className="flex items-center justify-between gap-4 rounded-xl border border-rule bg-white p-4 no-underline hover:border-ink transition-colors"
+          >
+            <div>
+              <p className="font-serif font-medium text-ink text-sm">
+                {plan.plan === 'pro'
+                  ? plan.tier === 'pro'
+                    ? 'Pro plan'
+                    : 'Standard plan'
+                  : 'Free plan'}
+              </p>
+              <p className="font-mono text-[11px] text-ink-faint mt-1 tracking-wide">
+                {plan.plan === 'pro'
+                  ? 'Unlimited generations'
+                  : `${plan.generationsRemaining} generation${plan.generationsRemaining === 1 ? '' : 's'} remaining`}
+              </p>
+            </div>
+            <span className="font-mono text-xs text-blueprint shrink-0">Usage &amp; billing →</span>
+          </a>
         )}
         {planErr && !plan && (
           <p className="text-ink-faint font-mono text-xs">
             Couldn't load plan info: {planErr}
-          </p>
-        )}
-        {billingErr && (
-          <p className="text-copper font-mono text-xs mt-2">
-            Billing error: {billingErr}
           </p>
         )}
 


### PR DESCRIPTION
## Problem

Two account-UX gaps the user hit while testing paid functionality:

1. **Can't find sign-out in the editor.** The editor toolbar was recently made horizontally scrollable (`bar-scroll-x` → `overflow-x:auto` with a *hidden* scrollbar). The account menu (`UserMenu`) was the last item in that scrolling cluster, so on any window that isn't very wide it scrolled off-screen — and with no visible scrollbar there's no hint it's there. Reported as "the menu is hidden in the instrument panel."
2. **Usage/billing was jammed into the projects page** (`/me`), not a separate view.

## Changes

- **Header:** pull the account menu out of the scrolling instrument cluster into a `sticky right-0` slot pinned to the right edge (with a divider + left shadow), so it's always visible regardless of toolbar overflow.
- **UserMenu:** add a chevron affordance; dropdown now links to **Your projects** (`/me`) and **Usage & billing** (`/billing`) above **Sign out**.
- **New `/billing` route:** dedicated usage & billing view — plan/tier, generations remaining (usage), renewal/reset date, and upgrade/manage (Stripe portal). Reuses the existing tested `PlanCard`.
- **`/me`:** now projects-focused — the full billing card is replaced by a compact plan strip linking to `/billing`; keeps its Sign out and the post-checkout confirmation banner (Stripe still returns to `/me`).

## Verification

- `UserMenu.test.tsx` extended: asserts the dropdown links to `/me` and `/billing`. All Layout/StudioShell/funnel suites pass (40/40).
- `tsc -b` clean; `vite build` succeeds (deploy-safe — the merge gate is vitest-only).
- Route tree regenerates `/billing` via the `prebuild` hook + vite router plugin.

Visual note: browser automation was unavailable in this session (Chrome profile in use), so the sticky-header + `/billing` render should be eyeballed on the develop preview after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)