### PR TITLE
feat(billing): PhotoAI-style /pricing page

### DIFF
--- a/src/funnel/components/PricingTiers.test.tsx
+++ b/src/funnel/components/PricingTiers.test.tsx
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { PricingTiers } from './PricingTiers';
+
+afterEach(cleanup);
+
+describe('PricingTiers', () => {
+  it('calls onSelect with the paid tier id when its Subscribe button is clicked', () => {
+    const onSelect = vi.fn();
+    render(<PricingTiers onSelect={onSelect} onFree={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /subscribe to standard/i }));
+    expect(onSelect).toHaveBeenCalledWith('standard');
+  });
+
+  it('calls onFree when the free tier CTA is clicked', () => {
+    const onFree = vi.fn();
+    render(<PricingTiers onSelect={vi.fn()} onFree={onFree} />);
+    fireEvent.click(screen.getByRole('button', { name: /get started with free/i }));
+    expect(onFree).toHaveBeenCalled();
+  });
+
+  it('marks the active tier as the current plan instead of offering to subscribe', () => {
+    const onSelect = vi.fn();
+    render(<PricingTiers currentPlan="pro" currentTier="standard" onSelect={onSelect} onFree={vi.fn()} />);
+    // The Standard card is the user's current plan.
+    expect(screen.getByRole('button', { name: /current plan \(standard\)/i })).toBeDefined();
+    // And clicking it does nothing (disabled).
+    fireEvent.click(screen.getByRole('button', { name: /current plan \(standard\)/i }));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('highlights Standard as the most popular tier', () => {
+    render(<PricingTiers onSelect={vi.fn()} onFree={vi.fn()} />);
+    expect(screen.getByText(/most popular/i)).toBeDefined();
+  });
+});

--- a/src/funnel/components/PricingTiers.tsx
+++ b/src/funnel/components/PricingTiers.tsx
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { CheckCircle2 } from 'lucide-react';
+import type { PaidTier, PlanTier } from '../lib/apiClient';
+
+/**
+ * PhotoAI-style pricing tiers (dark cards, huge prices, green check-circles,
+ * colored emoji feature badges, an orange gradient CTA, and a highlighted
+ * "Most popular" tier). Data-driven so copy is easy to tune.
+ */
+
+type BadgeColor = 'emerald' | 'violet' | 'amber' | 'sky' | 'slate';
+
+interface Feature {
+  text: string;
+  emoji?: string;
+  /** Render the label as a colored pill (PhotoAI's standout-feature style). */
+  badge?: BadgeColor;
+  /** Small muted note after the feature, e.g. "coming soon". */
+  note?: string;
+}
+
+interface Tier {
+  /** Display name. */
+  name: string;
+  /** Checkout tier id; null for the free tier. */
+  tier: PaidTier | null;
+  price: string;
+  period: string;
+  blurb: string;
+  /** "Everything in X, plus:" divider label. */
+  inherits?: string;
+  popular?: boolean;
+  features: Feature[];
+}
+
+const TIERS: Tier[] = [
+  {
+    name: 'Free',
+    tier: null,
+    price: '$0',
+    period: 'forever',
+    blurb: 'Model and view in the browser, and bring your own agent over MCP.',
+    features: [
+      { text: '5 generations / month' },
+      { text: 'Full 3D editor & viewer' },
+      { text: 'MCP access — bring your own agent', emoji: '🔌', badge: 'sky' },
+      { text: 'STEP / STL export' },
+      { text: 'Public share links' },
+    ],
+  },
+  {
+    name: 'Standard',
+    tier: 'standard',
+    price: '$20',
+    period: 'per month',
+    popular: true,
+    blurb: 'Unlimited hosted generation and the parametric build agent.',
+    inherits: 'Free',
+    features: [
+      { text: 'Unlimited generations', emoji: '♾️', badge: 'emerald' },
+      { text: 'Build as parametric CAD (mesh-conditioned)', emoji: '🧠', badge: 'violet' },
+      { text: 'Image → 3D concept previews', emoji: '🖼️', badge: 'amber' },
+      { text: 'Priority generation', emoji: '⚡' },
+      { text: 'Commercial use license' },
+    ],
+  },
+  {
+    name: 'Pro',
+    tier: 'pro',
+    price: '$100',
+    period: 'per month',
+    blurb: 'For teams sharing a workspace and a single bill.',
+    inherits: 'Standard',
+    features: [
+      { text: 'Team seats & shared projects', emoji: '👥', note: 'coming soon' },
+      { text: 'Centralized billing', emoji: '🧾', note: 'coming soon' },
+      { text: 'Priority support', emoji: '🎧' },
+    ],
+  },
+];
+
+const BADGE_CLASS: Record<BadgeColor, string> = {
+  emerald: 'bg-emerald-500/15 text-emerald-300',
+  violet: 'bg-violet-500/15 text-violet-300',
+  amber: 'bg-amber-500/15 text-amber-300',
+  sky: 'bg-sky-500/15 text-sky-300',
+  slate: 'bg-slate-500/15 text-slate-300',
+};
+
+export interface PricingTiersProps {
+  /** Current plan tier ('free' | 'pro') to render a "Current plan" state. */
+  currentPlan?: PlanTier;
+  /** Which paid tier is active, when currentPlan === 'pro'. */
+  currentTier?: PaidTier | null;
+  /** Fired when a paid tier's Subscribe button is clicked. */
+  onSelect: (tier: PaidTier) => void;
+  /** Fired when the free tier CTA is clicked. */
+  onFree: () => void;
+  /** Disables the CTAs while a checkout redirect is being fetched. */
+  busy?: boolean;
+}
+
+function FeatureRow({ f }: { f: Feature }) {
+  return (
+    <li className="flex items-start gap-2.5">
+      <CheckCircle2 size={16} className="mt-0.5 shrink-0 text-emerald-500" />
+      <span className="text-sm text-gray-200 leading-snug">
+        {f.badge ? (
+          <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${BADGE_CLASS[f.badge]}`}>
+            {f.emoji && <span>{f.emoji}</span>}
+            {f.text}
+          </span>
+        ) : (
+          <>
+            {f.emoji && <span className="mr-1">{f.emoji}</span>}
+            {f.text}
+          </>
+        )}
+        {f.note && <span className="ml-1.5 text-[11px] uppercase tracking-wide text-gray-500">{f.note}</span>}
+      </span>
+    </li>
+  );
+}
+
+export function PricingTiers({ currentPlan, currentTier, onSelect, onFree, busy = false }: PricingTiersProps) {
+  const isCurrent = (t: Tier): boolean => {
+    if (t.tier === null) return currentPlan === 'free' || currentPlan === undefined ? currentPlan === 'free' : false;
+    return currentPlan === 'pro' && (currentTier ?? 'standard') === t.tier;
+  };
+
+  return (
+    <div className="grid grid-cols-1 gap-5 md:grid-cols-3">
+      {TIERS.map(t => {
+        const current = isCurrent(t);
+        const highlight = t.popular;
+        return (
+          <section
+            key={t.name}
+            aria-label={`${t.name} plan`}
+            className={`relative flex flex-col rounded-2xl border p-6 ${
+              highlight
+                ? 'border-orange-500/60 bg-[#17151a]'
+                : 'border-[#26262b] bg-[#141416]'
+            }`}
+          >
+            {highlight && (
+              <span className="absolute -top-3 left-6 rounded-full bg-gradient-to-r from-orange-500 to-red-500 px-3 py-0.5 text-xs font-semibold text-white shadow">
+                Most popular
+              </span>
+            )}
+
+            <h3 className="text-2xl font-bold text-white">{t.name}</h3>
+            <div className="mt-2 flex items-end gap-2">
+              <span className="text-5xl font-extrabold tracking-tight text-white">{t.price}</span>
+              <span className="mb-1.5 text-sm text-gray-400">{t.period}</span>
+            </div>
+            <p className="mt-3 min-h-[40px] text-sm text-gray-400">{t.blurb}</p>
+
+            {t.tier === null ? (
+              <button
+                type="button"
+                onClick={onFree}
+                disabled={current}
+                aria-label={current ? 'Current plan (Free)' : 'Get started with Free'}
+                className="mt-5 w-full rounded-lg bg-[#26262b] py-3 text-sm font-semibold text-white transition-colors hover:bg-[#31313a] disabled:cursor-default disabled:opacity-60"
+              >
+                {current ? 'Current plan' : 'Get started'}
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => onSelect(t.tier as PaidTier)}
+                disabled={current || busy}
+                aria-label={current ? `Current plan (${t.name})` : `Subscribe to ${t.name}`}
+                className={`mt-5 w-full rounded-lg py-3 text-sm font-semibold text-white transition-colors disabled:cursor-default disabled:opacity-70 ${
+                  highlight
+                    ? 'bg-gradient-to-r from-orange-500 to-red-500 hover:from-orange-400 hover:to-red-400'
+                    : 'bg-[#26262b] hover:bg-[#31313a]'
+                }`}
+              >
+                {current ? 'Current plan' : busy ? 'Loading…' : 'Subscribe →'}
+              </button>
+            )}
+
+            <ul className="mt-6 space-y-3">
+              {t.inherits && (
+                <li className="text-sm font-medium text-gray-300 underline decoration-dotted underline-offset-4">
+                  ← Everything in {t.inherits}, plus:
+                </li>
+              )}
+              {t.features.map((f, i) => (
+                <FeatureRow key={i} f={f} />
+              ))}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/studio/routes/billing.tsx
+++ b/src/studio/routes/billing.tsx
@@ -5,7 +5,6 @@ import { useEffect, useState } from 'react';
 import { useSession } from '../../funnel/hooks/useSession';
 import { getSupabase } from '../../funnel/lib/supabaseClient';
 import {
-  createCheckoutSession,
   fetchMyPlan,
   openBillingPortal,
   type MyPlan,
@@ -55,16 +54,9 @@ function BillingPage() {
     navigate({ to: '/billing', search: {}, replace: true });
   };
 
-  const handleUpgrade = async () => {
-    setBillingBusy(true);
-    setBillingErr(null);
-    try {
-      const { url } = await createCheckoutSession();
-      window.location.href = url;
-    } catch (e) {
-      setBillingErr(e instanceof Error ? e.message : String(e));
-      setBillingBusy(false);
-    }
+  // Free users pick a tier on the dedicated /pricing comparison page.
+  const handleUpgrade = () => {
+    navigate({ to: '/pricing' });
   };
 
   const handleManage = async () => {
@@ -119,7 +111,12 @@ function BillingPage() {
       </header>
 
       <section className="px-6 py-10 max-w-2xl mx-auto">
-        <h1 className="font-serif text-3xl font-medium text-ink">Usage &amp; billing</h1>
+        <div className="flex items-baseline justify-between gap-4">
+          <h1 className="font-serif text-3xl font-medium text-ink">Usage &amp; billing</h1>
+          <a href="/pricing" className="font-mono text-xs text-blueprint hover:text-ink no-underline shrink-0">
+            Compare all plans →
+          </a>
+        </div>
         <p className="text-ink-soft mt-2 mb-8">
           Your plan, generation usage, and payment settings.
         </p>

--- a/src/studio/routes/pricing.tsx
+++ b/src/studio/routes/pricing.tsx
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+import { useOptionalSession } from '../../funnel/hooks/useSession';
+import { createCheckoutSession, fetchMyPlan, type MyPlan, type PaidTier } from '../../funnel/lib/apiClient';
+import { PricingTiers } from '../../funnel/components/PricingTiers';
+
+export const Route = createFileRoute('/pricing')({
+  component: PricingPage,
+});
+
+function PricingPage() {
+  const { session } = useOptionalSession();
+  const navigate = useNavigate();
+  const [plan, setPlan] = useState<MyPlan | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (session) fetchMyPlan().then(setPlan).catch(() => {});
+  }, [session]);
+
+  const handleSelect = async (tier: PaidTier) => {
+    if (!session) {
+      navigate({ to: '/signin', search: { next: '/pricing' } });
+      return;
+    }
+    setBusy(true);
+    setErr(null);
+    try {
+      const { url } = await createCheckoutSession(tier);
+      window.location.href = url;
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+      setBusy(false);
+    }
+  };
+
+  const handleFree = () => {
+    navigate({ to: session ? '/' : '/signin', ...(session ? {} : { search: { next: '/' } }) });
+  };
+
+  return (
+    <main className="min-h-screen bg-[#0b0b0d] text-white font-sans">
+      {/* Nav */}
+      <header className="flex items-center justify-between px-6 py-4">
+        <a href="/" className="flex items-center gap-2 font-serif text-base font-medium no-underline text-white">
+          <svg className="w-4 h-4 text-white" viewBox="0 0 84 84" fill="none" aria-label="kernelCAD">
+            <path d="M 14,12 L 26,12 L 26,34 Q 26,36 27.5,34.5 L 46,12 L 60,12 L 36,40 Q 35,42 36,44 L 60,72 L 46,72 L 27.5,49.5 Q 26,48 26,50 L 26,72 L 14,72 Z" fill="currentColor"/>
+          </svg>
+          <span>kernel<span className="text-blue-400">CAD</span></span>
+        </a>
+        <a
+          href={session ? '/billing' : '/signin'}
+          className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-300 hover:text-white no-underline transition-colors"
+        >
+          {session ? 'Billing' : 'Log in'}
+        </a>
+      </header>
+
+      <section className="mx-auto max-w-5xl px-6 pb-20 pt-10">
+        <h1 className="text-center font-serif text-5xl font-bold tracking-tight">Pricing</h1>
+        <p className="mx-auto mt-4 max-w-xl text-center text-gray-400">
+          Start free. Upgrade when you want unlimited generations and the parametric build agent.
+        </p>
+
+        {/* Billing cadence — monthly only for now (mirrors the PhotoAI toggle). */}
+        <div className="mt-8 flex items-center justify-center">
+          <div className="inline-flex rounded-full bg-[#141416] p-1 ring-1 ring-[#26262b]">
+            <span className="rounded-full bg-[#2a2a30] px-4 py-1.5 text-sm font-medium text-white">Monthly</span>
+            <span className="cursor-not-allowed rounded-full px-4 py-1.5 text-sm text-gray-500" title="Yearly billing coming soon">
+              Yearly · soon
+            </span>
+          </div>
+        </div>
+
+        {err && (
+          <p className="mt-6 text-center font-mono text-xs text-red-400">Checkout error: {err}</p>
+        )}
+
+        <div className="mt-12">
+          <PricingTiers
+            currentPlan={plan?.plan}
+            currentTier={plan?.tier}
+            onSelect={handleSelect}
+            onFree={handleFree}
+            busy={busy}
+          />
+        </div>
+
+        <p className="mt-10 text-center text-xs text-gray-500">
+          Prices in USD. Cancel anytime. Failed generations don't count against your quota.
+        </p>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
Copies the PhotoAI pricing layout for kernelCAD's plans, per request.

## What

- **New `/pricing` page** (dark, PhotoAI-style): centered "Pricing" heading, Monthly/Yearly·soon toggle, three tier cards side-by-side, big bold prices, green check-circles, colored emoji feature badges, a highlighted **Most popular** tier with an orange gradient **Subscribe →**, and "← Everything in X, plus:" dividers.
- **`PricingTiers` component** — data-driven so copy is easy to tune. Real kernelCAD tiers: **Free $0 / Standard $20 (Most popular) / Pro $100**. Wired to `createCheckoutSession(tier)`; renders "Current plan" for the active tier. Pro's team features are honestly marked **coming soon** (Phase 2, not built). Monthly only — no yearly Stripe prices exist.
- **`/billing`**: the free-tier upgrade now routes to `/pricing` to compare, plus a "Compare all plans →" link.

## Verification

- `PricingTiers.test.tsx` (4 tests): onSelect fires the right tier, free CTA fires onFree, active tier shows "Current plan" (disabled), Standard is Most popular. `tsc -b` + lint clean; `vite build` succeeds.
- Rendered locally and screenshotted (dev server) — matches the PhotoAI reference: dark cards, prices, badges, most-popular highlight, Subscribe CTA. Will re-check on the develop preview once deployed.

Note: kept to the real 3 tiers and honest features (no invented yearly pricing or unbuilt features presented as live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)