### PR TITLE
feat(pricing): Free/Standard/Team tiers + monthly/yearly toggle

### DIFF
--- a/src/funnel/components/PricingTiers.test.tsx
+++ b/src/funnel/components/PricingTiers.test.tsx
@@ -8,32 +8,47 @@ import { PricingTiers } from './PricingTiers';
 afterEach(cleanup);
 
 describe('PricingTiers', () => {
-  it('calls onSelect with the paid tier id when its Subscribe button is clicked', () => {
+  it('calls onSelect with the tier and the current period when Subscribe is clicked', () => {
     const onSelect = vi.fn();
-    render(<PricingTiers onSelect={onSelect} onFree={vi.fn()} />);
+    render(<PricingTiers period="monthly" onSelect={onSelect} onFree={vi.fn()} />);
     fireEvent.click(screen.getByRole('button', { name: /subscribe to standard/i }));
-    expect(onSelect).toHaveBeenCalledWith('standard');
+    expect(onSelect).toHaveBeenCalledWith('standard', 'monthly');
+  });
+
+  it('passes the yearly period through to onSelect', () => {
+    const onSelect = vi.fn();
+    render(<PricingTiers period="yearly" onSelect={onSelect} onFree={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /subscribe to team/i }));
+    expect(onSelect).toHaveBeenCalledWith('pro', 'yearly');
+  });
+
+  it('shows the yearly total and "2 months free" when period is yearly', () => {
+    render(<PricingTiers period="yearly" onSelect={vi.fn()} onFree={vi.fn()} />);
+    expect(screen.getByText(/\$200\/year — 2 months free/i)).toBeDefined();
   });
 
   it('calls onFree when the free tier CTA is clicked', () => {
     const onFree = vi.fn();
-    render(<PricingTiers onSelect={vi.fn()} onFree={onFree} />);
+    render(<PricingTiers period="monthly" onSelect={vi.fn()} onFree={onFree} />);
     fireEvent.click(screen.getByRole('button', { name: /get started with free/i }));
     expect(onFree).toHaveBeenCalled();
   });
 
   it('marks the active tier as the current plan instead of offering to subscribe', () => {
     const onSelect = vi.fn();
-    render(<PricingTiers currentPlan="pro" currentTier="standard" onSelect={onSelect} onFree={vi.fn()} />);
-    // The Standard card is the user's current plan.
+    render(<PricingTiers period="monthly" currentPlan="pro" currentTier="standard" onSelect={onSelect} onFree={vi.fn()} />);
     expect(screen.getByRole('button', { name: /current plan \(standard\)/i })).toBeDefined();
-    // And clicking it does nothing (disabled).
     fireEvent.click(screen.getByRole('button', { name: /current plan \(standard\)/i }));
     expect(onSelect).not.toHaveBeenCalled();
   });
 
+  it('renders a Team tier for enterprises', () => {
+    render(<PricingTiers period="monthly" onSelect={vi.fn()} onFree={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /subscribe to team/i })).toBeDefined();
+  });
+
   it('highlights Standard as the most popular tier', () => {
-    render(<PricingTiers onSelect={vi.fn()} onFree={vi.fn()} />);
+    render(<PricingTiers period="monthly" onSelect={vi.fn()} onFree={vi.fn()} />);
     expect(screen.getByText(/most popular/i)).toBeDefined();
   });
 });

--- a/src/funnel/components/PricingTiers.tsx
+++ b/src/funnel/components/PricingTiers.tsx
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import { CheckCircle2 } from 'lucide-react';
-import type { PaidTier, PlanTier } from '../lib/apiClient';
+import type { BillingPeriod, PaidTier, PlanTier } from '../lib/apiClient';
 
 /**
  * PhotoAI-style pricing tiers (dark cards, huge prices, green check-circles,
  * colored emoji feature badges, an orange gradient CTA, and a highlighted
- * "Most popular" tier). Data-driven so copy is easy to tune.
+ * "Most popular" tier). Data-driven so copy is easy to tune. Supports a
+ * monthly/yearly billing toggle (yearly = 2 months free).
  */
 
 type BadgeColor = 'emerald' | 'violet' | 'amber' | 'sky' | 'slate';
@@ -14,21 +15,21 @@ type BadgeColor = 'emerald' | 'violet' | 'amber' | 'sky' | 'slate';
 interface Feature {
   text: string;
   emoji?: string;
-  /** Render the label as a colored pill (PhotoAI's standout-feature style). */
   badge?: BadgeColor;
-  /** Small muted note after the feature, e.g. "coming soon". */
   note?: string;
 }
 
 interface Tier {
-  /** Display name. */
   name: string;
   /** Checkout tier id; null for the free tier. */
   tier: PaidTier | null;
-  price: string;
-  period: string;
+  /** Monthly sticker price, e.g. '$20'. */
+  monthly: string;
+  /** Total billed once per year, e.g. '$200' (2 months free). Null = free. */
+  yearly: string | null;
+  /** Effective per-month price when billed yearly, e.g. '$16.67'. */
+  yearlyPerMonth?: string;
   blurb: string;
-  /** "Everything in X, plus:" divider label. */
   inherits?: string;
   popular?: boolean;
   features: Feature[];
@@ -38,8 +39,8 @@ const TIERS: Tier[] = [
   {
     name: 'Free',
     tier: null,
-    price: '$0',
-    period: 'forever',
+    monthly: '$0',
+    yearly: '$0',
     blurb: 'Model and view in the browser, and bring your own agent over MCP.',
     features: [
       { text: '5 generations / month' },
@@ -52,8 +53,9 @@ const TIERS: Tier[] = [
   {
     name: 'Standard',
     tier: 'standard',
-    price: '$20',
-    period: 'per month',
+    monthly: '$20',
+    yearly: '$200',
+    yearlyPerMonth: '$16.67',
     popular: true,
     blurb: 'Unlimited hosted generation and the parametric build agent.',
     inherits: 'Free',
@@ -66,15 +68,17 @@ const TIERS: Tier[] = [
     ],
   },
   {
-    name: 'Pro',
+    name: 'Team',
     tier: 'pro',
-    price: '$100',
-    period: 'per month',
-    blurb: 'For teams sharing a workspace and a single bill.',
+    monthly: '$100',
+    yearly: '$1000',
+    yearlyPerMonth: '$83.33',
+    blurb: 'For teams and enterprises sharing a workspace and a single bill.',
     inherits: 'Standard',
     features: [
       { text: 'Team seats & shared projects', emoji: '👥', note: 'coming soon' },
-      { text: 'Centralized billing', emoji: '🧾', note: 'coming soon' },
+      { text: 'Centralized billing & invoicing', emoji: '🧾', note: 'coming soon' },
+      { text: 'SSO / SAML', emoji: '🔐', note: 'coming soon' },
       { text: 'Priority support', emoji: '🎧' },
     ],
   },
@@ -89,12 +93,14 @@ const BADGE_CLASS: Record<BadgeColor, string> = {
 };
 
 export interface PricingTiersProps {
+  /** Selected billing cadence. */
+  period: BillingPeriod;
   /** Current plan tier ('free' | 'pro') to render a "Current plan" state. */
   currentPlan?: PlanTier;
   /** Which paid tier is active, when currentPlan === 'pro'. */
   currentTier?: PaidTier | null;
   /** Fired when a paid tier's Subscribe button is clicked. */
-  onSelect: (tier: PaidTier) => void;
+  onSelect: (tier: PaidTier, period: BillingPeriod) => void;
   /** Fired when the free tier CTA is clicked. */
   onFree: () => void;
   /** Disables the CTAs while a checkout redirect is being fetched. */
@@ -123,7 +129,9 @@ function FeatureRow({ f }: { f: Feature }) {
   );
 }
 
-export function PricingTiers({ currentPlan, currentTier, onSelect, onFree, busy = false }: PricingTiersProps) {
+export function PricingTiers({ period, currentPlan, currentTier, onSelect, onFree, busy = false }: PricingTiersProps) {
+  const yearly = period === 'yearly';
+
   const isCurrent = (t: Tier): boolean => {
     if (t.tier === null) return currentPlan === 'free' || currentPlan === undefined ? currentPlan === 'free' : false;
     return currentPlan === 'pro' && (currentTier ?? 'standard') === t.tier;
@@ -134,14 +142,14 @@ export function PricingTiers({ currentPlan, currentTier, onSelect, onFree, busy 
       {TIERS.map(t => {
         const current = isCurrent(t);
         const highlight = t.popular;
+        const paid = t.tier !== null;
+        const showYearly = yearly && paid && !!t.yearly;
         return (
           <section
             key={t.name}
             aria-label={`${t.name} plan`}
             className={`relative flex flex-col rounded-2xl border p-6 ${
-              highlight
-                ? 'border-orange-500/60 bg-[#17151a]'
-                : 'border-[#26262b] bg-[#141416]'
+              highlight ? 'border-orange-500/60 bg-[#17151a]' : 'border-[#26262b] bg-[#141416]'
             }`}
           >
             {highlight && (
@@ -152,9 +160,18 @@ export function PricingTiers({ currentPlan, currentTier, onSelect, onFree, busy 
 
             <h3 className="text-2xl font-bold text-white">{t.name}</h3>
             <div className="mt-2 flex items-end gap-2">
-              <span className="text-5xl font-extrabold tracking-tight text-white">{t.price}</span>
-              <span className="mb-1.5 text-sm text-gray-400">{t.period}</span>
+              <span className="text-5xl font-extrabold tracking-tight text-white">
+                {showYearly ? t.yearlyPerMonth : t.monthly}
+              </span>
+              <span className="mb-1.5 text-sm text-gray-400">
+                {paid ? (showYearly ? '/mo · billed yearly' : 'per month') : t.monthly === '$0' ? 'forever' : ''}
+              </span>
             </div>
+            {showYearly ? (
+              <p className="mt-1 text-xs text-emerald-400">{t.yearly}/year — 2 months free</p>
+            ) : (
+              <p className="mt-1 text-xs text-transparent select-none" aria-hidden="true">.</p>
+            )}
             <p className="mt-3 min-h-[40px] text-sm text-gray-400">{t.blurb}</p>
 
             {t.tier === null ? (
@@ -170,7 +187,7 @@ export function PricingTiers({ currentPlan, currentTier, onSelect, onFree, busy 
             ) : (
               <button
                 type="button"
-                onClick={() => onSelect(t.tier as PaidTier)}
+                onClick={() => onSelect(t.tier as PaidTier, period)}
                 disabled={current || busy}
                 aria-label={current ? `Current plan (${t.name})` : `Subscribe to ${t.name}`}
                 className={`mt-5 w-full rounded-lg py-3 text-sm font-semibold text-white transition-colors disabled:cursor-default disabled:opacity-70 ${

--- a/src/funnel/lib/apiClient.ts
+++ b/src/funnel/lib/apiClient.ts
@@ -200,6 +200,9 @@ export type PlanTier = 'free' | 'pro';
 /** The two paid plans. 'standard' = $20/mo solo, 'pro' = $100/mo team. */
 export type PaidTier = 'standard' | 'pro';
 
+/** Billing cadence. 'yearly' = 2 months free vs monthly. */
+export type BillingPeriod = 'monthly' | 'yearly';
+
 export interface MyPlan {
   plan: PlanTier;
   /** Which paid plan, when plan === 'pro'; null on free. */
@@ -223,9 +226,13 @@ export async function fetchMyPlan(): Promise<MyPlan> {
 
 /** POST /api/v1/billing/create-checkout — returns a Stripe Checkout URL
  * the caller should redirect to (window.location.href = url). `tier` selects
- * the plan ($20 Standard by default; 'pro' for the $100 team plan). */
-export async function createCheckoutSession(tier: PaidTier = 'standard'): Promise<CheckoutSession> {
-  return authedFetch<CheckoutSession>('POST', '/api/v1/billing/create-checkout', { tier });
+ * the plan ($20 Standard by default; 'pro' for the $100 team plan); `period`
+ * selects monthly (default) or yearly (2 months free) billing. */
+export async function createCheckoutSession(
+  tier: PaidTier = 'standard',
+  period: BillingPeriod = 'monthly',
+): Promise<CheckoutSession> {
+  return authedFetch<CheckoutSession>('POST', '/api/v1/billing/create-checkout', { tier, period });
 }
 
 /** POST /api/v1/billing/portal — returns a Stripe Customer Portal URL

--- a/src/studio/routes/pricing.tsx
+++ b/src/studio/routes/pricing.tsx
@@ -3,7 +3,7 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 import { useOptionalSession } from '../../funnel/hooks/useSession';
-import { createCheckoutSession, fetchMyPlan, type MyPlan, type PaidTier } from '../../funnel/lib/apiClient';
+import { createCheckoutSession, fetchMyPlan, type BillingPeriod, type MyPlan, type PaidTier } from '../../funnel/lib/apiClient';
 import { PricingTiers } from '../../funnel/components/PricingTiers';
 
 export const Route = createFileRoute('/pricing')({
@@ -14,6 +14,7 @@ function PricingPage() {
   const { session } = useOptionalSession();
   const navigate = useNavigate();
   const [plan, setPlan] = useState<MyPlan | null>(null);
+  const [period, setPeriod] = useState<BillingPeriod>('monthly');
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
@@ -21,7 +22,7 @@ function PricingPage() {
     if (session) fetchMyPlan().then(setPlan).catch(() => {});
   }, [session]);
 
-  const handleSelect = async (tier: PaidTier) => {
+  const handleSelect = async (tier: PaidTier, selectedPeriod: BillingPeriod) => {
     if (!session) {
       navigate({ to: '/signin', search: { next: '/pricing' } });
       return;
@@ -29,7 +30,7 @@ function PricingPage() {
     setBusy(true);
     setErr(null);
     try {
-      const { url } = await createCheckoutSession(tier);
+      const { url } = await createCheckoutSession(tier, selectedPeriod);
       window.location.href = url;
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e));
@@ -65,13 +66,29 @@ function PricingPage() {
           Start free. Upgrade when you want unlimited generations and the parametric build agent.
         </p>
 
-        {/* Billing cadence — monthly only for now (mirrors the PhotoAI toggle). */}
+        {/* Billing cadence toggle. */}
         <div className="mt-8 flex items-center justify-center">
           <div className="inline-flex rounded-full bg-[#141416] p-1 ring-1 ring-[#26262b]">
-            <span className="rounded-full bg-[#2a2a30] px-4 py-1.5 text-sm font-medium text-white">Monthly</span>
-            <span className="cursor-not-allowed rounded-full px-4 py-1.5 text-sm text-gray-500" title="Yearly billing coming soon">
-              Yearly · soon
-            </span>
+            <button
+              type="button"
+              onClick={() => setPeriod('monthly')}
+              aria-pressed={period === 'monthly'}
+              className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+                period === 'monthly' ? 'bg-[#2a2a30] text-white' : 'text-gray-400 hover:text-white'
+              }`}
+            >
+              Monthly
+            </button>
+            <button
+              type="button"
+              onClick={() => setPeriod('yearly')}
+              aria-pressed={period === 'yearly'}
+              className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+                period === 'yearly' ? 'bg-[#2a2a30] text-white' : 'text-gray-400 hover:text-white'
+              }`}
+            >
+              Yearly <span className="ml-1 text-emerald-400">· 2 months free</span>
+            </button>
           </div>
         </div>
 
@@ -81,6 +98,7 @@ function PricingPage() {
 
         <div className="mt-12">
           <PricingTiers
+            period={period}
             currentPlan={plan?.plan}
             currentTier={plan?.tier}
             onSelect={handleSelect}


### PR DESCRIPTION
Builds on the PhotoAI-style /pricing page (#571): renames the third tier to **Team** (enterprise) and adds a working **Monthly/Yearly** toggle.

## What
- **Tiers:** Free / Standard (Most popular) / **Team** — Team framed for teams & enterprises (seats, shared projects, centralized billing, SSO/SAML; marked *coming soon*, Phase 2).
- **Monthly/Yearly toggle** (2 months free): Standard $200/yr ($16.67/mo), Team $1000/yr ($83.33/mo). `period` threads through `createCheckoutSession(tier, period)`.

## ⚠️ Merge order
Depends on **kernelCAD-server #91** (yearly price support) being deployed AND the yearly Stripe prices being created + env set. If this merges first, the yearly Subscribe button will 400. **Do not merge until server yearly is live.**

## Verification
- `PricingTiers.test.tsx` 7/7 (period passthrough, yearly price display, Team tier, current-plan). tsc + lint clean; build succeeds. Rendered both toggle states locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)