### PR TITLE
Landing: replace prompt section with a pricing section

### DIFF
--- a/scripts/staticGalleryLanding.test.ts
+++ b/scripts/staticGalleryLanding.test.ts
@@ -60,17 +60,25 @@ describe('static gallery landing page', () => {
     expect(readme).not.toContain('build-demo.ts && node site/scripts/render-brand.mjs');
   });
 
-  it('places the prompt handoff before the built-with-kernelCAD gallery', () => {
+  it('places the pricing section before the built-with-kernelCAD gallery', () => {
     const html = readFileSync(path.resolve(__dirname, '../site/index.html'), 'utf8');
 
-    expect(html).toContain('action="/app/generate"');
-    expect(html).toContain('name="prompt"');
-    expect(html).toContain('Describe the part you want');
+    // Pricing section (mirrors app.kernelcad.com/pricing): Standard + Enterprise.
+    expect(html).toContain('class="pricing"');
+    expect(html).toContain('>Standard<');
+    expect(html).toContain('>Enterprise<');
+    // Standard deep-links to the app pricing page; Enterprise is contact-sales.
+    expect(html).toContain('href="https://app.kernelcad.com/pricing"');
+    expect(html).toContain('mailto:support@kernelcad.com');
 
-    const promptIdx = html.indexOf('class="prompt-handoff"');
+    // The old "Describe the part you want" prompt handoff is gone.
+    expect(html).not.toContain('class="prompt-handoff"');
+    expect(html).not.toContain('Describe the part you want');
+
+    const pricingIdx = html.indexOf('class="pricing"');
     const galleryIdx = html.indexOf('class="gallery"');
-    expect(promptIdx).toBeGreaterThan(-1);
-    expect(galleryIdx).toBeGreaterThan(promptIdx);
+    expect(pricingIdx).toBeGreaterThan(-1);
+    expect(galleryIdx).toBeGreaterThan(pricingIdx);
   });
 
   it('renders gallery tiles as posters before upgrading them to rotating model-viewer elements', () => {

--- a/site/index.html
+++ b/site/index.html
@@ -107,23 +107,41 @@
       </div>
     </section>
 
-    <section class="prompt-handoff" aria-label="Generate a CAD model from a prompt">
-      <div class="prompt-handoff-copy">
-        <span class="section-kicker">Start with words</span>
-        <h2 class="prompt-handoff-headline">Describe the part you want.</h2>
+    <section class="pricing" id="pricing" aria-label="Pricing">
+      <div class="pricing-head">
+        <span class="section-kicker">Pricing</span>
+        <h2 class="pricing-headline">Simple pricing. Unlimited parts.</h2>
+        <p class="pricing-sub">Unlimited hosted generation and the parametric build agent. Cancel anytime.</p>
       </div>
-      <form class="prompt-handoff-form" action="/app/generate" method="GET" autocomplete="off">
-        <label class="sr-only" for="prompt-input">CAD prompt</label>
-        <textarea
-          id="prompt-input"
-          name="prompt"
-          rows="3"
-          placeholder="60x40x5 mm bracket with 4 M3 mounting holes"
-          required
-          autocomplete="off"
-        ></textarea>
-        <button class="btn btn-primary" type="submit">Generate in app</button>
-      </form>
+      <div class="pricing-grid">
+        <article class="price-card price-card--featured">
+          <span class="price-badge">Most popular</span>
+          <h3 class="price-name">Standard</h3>
+          <p class="price-amount"><span class="price-num">$20</span><span class="price-per">/ month</span></p>
+          <p class="price-blurb">Unlimited hosted generation and the parametric build agent.</p>
+          <a class="btn btn-primary price-cta" href="https://app.kernelcad.com/pricing">Subscribe</a>
+          <ul class="price-features">
+            <li>Unlimited generations</li>
+            <li>Build as parametric CAD (mesh-conditioned)</li>
+            <li>Image &rarr; 3D concept previews</li>
+            <li>STEP / STL export &amp; MCP access</li>
+            <li>Commercial use license</li>
+          </ul>
+        </article>
+        <article class="price-card">
+          <h3 class="price-name">Enterprise</h3>
+          <p class="price-amount"><span class="price-num">Custom</span><span class="price-per">let&rsquo;s talk</span></p>
+          <p class="price-blurb">Seats, one invoice, and a security review for your whole team.</p>
+          <a class="btn btn-secondary price-cta" href="mailto:support@kernelcad.com?subject=kernelCAD%20for%20teams">Contact sales</a>
+          <ul class="price-features">
+            <li>Everything in Standard, plus:</li>
+            <li>Team seats &amp; shared projects</li>
+            <li>Centralized billing &amp; invoicing</li>
+            <li>SSO / SAML</li>
+            <li>Priority support &amp; onboarding</li>
+          </ul>
+        </article>
+      </div>
     </section>
 
     <section class="gallery" id="gallery" hidden>

--- a/site/style.css
+++ b/site/style.css
@@ -240,6 +240,78 @@ body {
   justify-content: center;
 }
 
+/* PRICING */
+.pricing { margin: 0 0 88px; }
+.pricing-head { margin-bottom: 28px; }
+.pricing-headline {
+  font-family: 'Source Serif 4', Georgia, serif;
+  font-size: clamp(30px, 4vw, 46px);
+  font-weight: 500;
+  line-height: 1.02;
+  margin: 0 0 12px;
+}
+.pricing-sub { color: var(--ink-soft); font-size: 16px; line-height: 1.5; max-width: 520px; margin: 0; }
+.pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+  align-items: start;
+}
+.price-card {
+  position: relative;
+  border: 1px solid var(--rule);
+  border-radius: 14px;
+  background: var(--paper);
+  padding: 26px 24px;
+  display: flex;
+  flex-direction: column;
+}
+.price-card--featured {
+  border-color: var(--blueprint);
+  box-shadow: 0 0 0 1px var(--blueprint);
+}
+.price-badge {
+  position: absolute;
+  top: -11px;
+  left: 24px;
+  background: var(--blueprint);
+  color: #FFF;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 999px;
+}
+.price-name {
+  font-family: 'Source Serif 4', Georgia, serif;
+  font-size: 24px;
+  font-weight: 500;
+  margin: 0 0 6px;
+}
+.price-amount { display: flex; align-items: baseline; gap: 8px; margin: 0 0 12px; }
+.price-num { font-family: 'Source Serif 4', Georgia, serif; font-size: 44px; font-weight: 500; line-height: 1; }
+.price-per { color: var(--ink-faint); font-size: 14px; }
+.price-blurb { color: var(--ink-soft); font-size: 14px; line-height: 1.45; margin: 0 0 20px; min-height: 40px; }
+.price-cta { justify-content: center; width: 100%; box-sizing: border-box; }
+.price-features { list-style: none; margin: 22px 0 0; padding: 0; display: grid; gap: 11px; }
+.price-features li {
+  position: relative;
+  padding-left: 24px;
+  color: var(--ink-soft);
+  font-size: 14px;
+  line-height: 1.4;
+}
+.price-features li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 1px;
+  width: 16px;
+  height: 16px;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Ccircle cx='12' cy='12' r='12' fill='%231E5FA8'/%3E%3Cpath fill='white' d='M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4z'/%3E%3C/svg%3E") no-repeat center / 16px 16px;
+}
+
 /* CODE */
 .code-block { margin: 0 0 100px; max-width: 720px; margin-left: auto; margin-right: auto; }
 .code-label {
@@ -355,6 +427,8 @@ body {
   .capability { border-right: 0; border-bottom: 1px solid var(--rule); }
   .capability:last-child { border-bottom: 0; }
   .prompt-handoff { grid-template-columns: 1fr; margin-bottom: 60px; }
+  .pricing-grid { grid-template-columns: 1fr; }
+  .pricing { margin-bottom: 60px; }
   .code { font-size: 12px; padding: 20px; }
   .footer { flex-direction: column; gap: 12px; }
   .signup { margin: 40px 0 60px; padding: 24px 18px; }

--- a/tests/unit/site/landingNavigation.test.ts
+++ b/tests/unit/site/landingNavigation.test.ts
@@ -6,13 +6,15 @@ import path from 'node:path';
 describe('landing page app navigation', () => {
   const html = () => readFileSync(path.resolve(__dirname, '../../../site/index.html'), 'utf8');
 
-  it('keeps prompt handoff same-origin and disables browser draft restoration', () => {
+  it('links the landing pricing CTAs to the app and sales, not a generate form', () => {
     const source = html();
 
-    expect(source).toContain('class="prompt-handoff-form" action="/app/generate" method="GET" autocomplete="off"');
-    expect(source).toContain('name="prompt"');
-    expect(source).toContain('autocomplete="off"');
-    expect(source).not.toContain('action="https://app.kernelcad.com/generate"');
+    // Standard → app pricing page (real checkout lives there); Enterprise → sales.
+    expect(source).toContain('href="https://app.kernelcad.com/pricing"');
+    expect(source).toContain('href="mailto:support@kernelcad.com');
+    // The prompt-handoff form was replaced by the pricing section.
+    expect(source).not.toContain('class="prompt-handoff-form"');
+    expect(source).not.toContain('action="/app/generate"');
   });
 
   it('clears prompt draft state before gallery app navigation', () => {


### PR DESCRIPTION
Swap the 'Describe the part you want' prompt-handoff block on the marketing landing (`site/index.html`) for a **pricing section** mirroring app.kernelcad.com/pricing:

- **Standard $20** (Most popular) + **Enterprise** (Custom → Contact sales)
- Styled in the site's light/vellum theme (blueprint check-circles, matches existing cards)
- Standard CTA deep-links to `app.kernelcad.com/pricing`; Enterprise CTA opens `mailto:support@kernelcad.com`
- Removed form is safely no-op'd by the existing `clearPromptDraftBeforeNavigation` guard (`instanceof HTMLFormElement` check)
- Mobile: pricing grid collapses to one column

Static marketing page only — no app/runtime code touched.