### PR TITLE
Landing: bump style.css cache-bust for pricing section

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -13,7 +13,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,wght@0,500;1,500&family=Inter:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css?v=2026-05-23-gallery-lightbox-model" />
+  <link rel="stylesheet" href="/style.css?v=2026-07-04-pricing" />
   <title>kernelCAD — from a description to a part you can build</title>
   <!--
     Cloudflare Web Analytics — anonymous beacon (no cookies, no IP storage).


### PR DESCRIPTION
Follow-up to #574. The pricing-section CSS shipped in `site/style.css`, but `site/index.html` still linked `style.css?v=2026-05-23-…`, so the CDN served the **stale** stylesheet under the unchanged URL and the new pricing section rendered unstyled on kernelcad.com. Bump the cache-bust query to `?v=2026-07-04-pricing` so every client fetches the current CSS. One-line change.