### PR TITLE
Token-based pricing UI: Basic $19 / Pro $39 / Enterprise

### DIFF
--- a/scripts/staticGalleryLanding.test.ts
+++ b/scripts/staticGalleryLanding.test.ts
@@ -63,11 +63,14 @@ describe('static gallery landing page', () => {
   it('places the pricing section before the built-with-kernelCAD gallery', () => {
     const html = readFileSync(path.resolve(__dirname, '../site/index.html'), 'utf8');
 
-    // Pricing section (mirrors app.kernelcad.com/pricing): Standard + Enterprise.
+    // Pricing section (mirrors app.kernelcad.com/pricing): Basic + Pro + Enterprise.
     expect(html).toContain('class="pricing"');
-    expect(html).toContain('>Standard<');
+    expect(html).toContain('>Basic<');
+    expect(html).toContain('>Pro<');
     expect(html).toContain('>Enterprise<');
-    // Standard deep-links to the app pricing page; Enterprise is contact-sales.
+    expect(html).toContain('5M tokens / month');
+    expect(html).toContain('12M tokens / month');
+    // Basic/Pro deep-link to the app pricing page; Enterprise is contact-sales.
     expect(html).toContain('href="https://app.kernelcad.com/pricing"');
     expect(html).toContain('mailto:support@kernelcad.com');
 

--- a/site/index.html
+++ b/site/index.html
@@ -13,7 +13,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,wght@0,500;1,500&family=Inter:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css?v=2026-07-04-pricing" />
+  <link rel="stylesheet" href="/style.css?v=2026-07-04-tokentiers" />
   <title>kernelCAD — from a description to a part you can build</title>
   <!--
     Cloudflare Web Analytics — anonymous beacon (no cookies, no IP storage).
@@ -110,31 +110,44 @@
     <section class="pricing" id="pricing" aria-label="Pricing">
       <div class="pricing-head">
         <span class="section-kicker">Pricing</span>
-        <h2 class="pricing-headline">Simple pricing. Unlimited parts.</h2>
-        <p class="pricing-sub">Unlimited hosted generation and the parametric build agent. Cancel anytime.</p>
+        <h2 class="pricing-headline">Simple, token-based pricing.</h2>
+        <p class="pricing-sub">A monthly token allowance for the build agent &mdash; a tiny cube costs a sliver, a big assembly costs more. Yearly billing is 2 months free. Cancel anytime.</p>
       </div>
       <div class="pricing-grid">
-        <article class="price-card price-card--featured">
-          <span class="price-badge">Most popular</span>
-          <h3 class="price-name">Standard</h3>
-          <p class="price-amount"><span class="price-num">$20</span><span class="price-per">/ month</span></p>
-          <p class="price-blurb">Unlimited hosted generation and the parametric build agent.</p>
-          <a class="btn btn-primary price-cta" href="https://app.kernelcad.com/pricing">Subscribe</a>
+        <article class="price-card">
+          <h3 class="price-name">Basic</h3>
+          <p class="price-amount"><span class="price-num">$19</span><span class="price-per">/ month</span></p>
+          <p class="price-yearly">or $190/yr &mdash; 2 months free</p>
+          <p class="price-blurb">A generous monthly token allowance for hobby and side-project builds.</p>
+          <a class="btn btn-secondary price-cta" href="https://app.kernelcad.com/pricing">Get Basic</a>
           <ul class="price-features">
-            <li>Unlimited generations</li>
+            <li>5M tokens / month</li>
             <li>Build as parametric CAD (mesh-conditioned)</li>
             <li>Image &rarr; 3D concept previews</li>
             <li>STEP / STL export &amp; MCP access</li>
             <li>Commercial use license</li>
           </ul>
         </article>
+        <article class="price-card price-card--featured">
+          <span class="price-badge">Most popular</span>
+          <h3 class="price-name">Pro</h3>
+          <p class="price-amount"><span class="price-num">$39</span><span class="price-per">/ month</span></p>
+          <p class="price-yearly">or $390/yr &mdash; 2 months free</p>
+          <p class="price-blurb">Almost-unlimited tokens for daily, professional CAD work.</p>
+          <a class="btn btn-primary price-cta" href="https://app.kernelcad.com/pricing">Get Pro</a>
+          <ul class="price-features">
+            <li>12M tokens / month &mdash; almost unlimited</li>
+            <li>Everything in Basic</li>
+            <li>Priority generation</li>
+          </ul>
+        </article>
         <article class="price-card">
           <h3 class="price-name">Enterprise</h3>
           <p class="price-amount"><span class="price-num">Custom</span><span class="price-per">let&rsquo;s talk</span></p>
+          <p class="price-yearly">&nbsp;</p>
           <p class="price-blurb">Seats, one invoice, and a security review for your whole team.</p>
           <a class="btn btn-secondary price-cta" href="mailto:support@kernelcad.com?subject=kernelCAD%20for%20teams">Contact sales</a>
           <ul class="price-features">
-            <li>Everything in Standard, plus:</li>
             <li>Team seats &amp; shared projects</li>
             <li>Centralized billing &amp; invoicing</li>
             <li>SSO / SAML</li>

--- a/site/style.css
+++ b/site/style.css
@@ -253,10 +253,11 @@ body {
 .pricing-sub { color: var(--ink-soft); font-size: 16px; line-height: 1.5; max-width: 520px; margin: 0; }
 .pricing-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 20px;
   align-items: start;
 }
+.price-yearly { color: var(--blueprint); font-size: 12px; margin: 0 0 12px; }
 .price-card {
   position: relative;
   border: 1px solid var(--rule);

--- a/src/funnel/components/PlanCard.tsx
+++ b/src/funnel/components/PlanCard.tsx
@@ -4,67 +4,83 @@ import type { PlanTier, PaidTier } from '../lib/apiClient';
 
 export interface PlanCardProps {
   plan: PlanTier;
-  /** Which paid plan, when plan === 'pro' ('standard' $20 | 'pro' $100). */
+  /** Which paid plan, when plan === 'pro' ('basic' $19 | 'pro' $39). */
   tier?: PaidTier | null;
-  generationsRemaining: number;
+  /** Free plan only: builds left this month (null on paid). */
+  generationsRemaining: number | null;
+  /** Paid plan: monthly token-budget usage. */
+  tokensUsed?: number | null;
+  tokensBudget?: number | null;
   /** ISO date string for the end of the current billing period (pro only). */
   currentPeriodEnd: string | null;
-  /** Fires when the free-tier user clicks "Upgrade to Pro". The parent
-   * should call createCheckoutSession() and window.location.href = url. */
+  /** Fires when the free-tier user clicks "Upgrade". The parent should call
+   * createCheckoutSession() and window.location.href = url. */
   onUpgrade: () => void;
-  /** Fires when the pro user clicks "Manage subscription". The parent
-   * should call openBillingPortal() and window.location.href = url. */
+  /** Fires when the pro user clicks "Manage subscription". The parent should
+   * call openBillingPortal() and window.location.href = url. */
   onManage: () => void;
   /** Disables both buttons while a redirect URL is being fetched. */
   busy?: boolean;
 }
 
+const fmtTokens = (n: number): string =>
+  n >= 1_000_000 ? `${(n / 1_000_000).toFixed(1)}M` : `${Math.round(n / 1000)}k`;
+
 /**
- * Plan + usage card shown above the project grid on /me.
+ * Plan + usage card shown above the project grid on /me and on /billing.
  *
  * Free tier: "Free plan · {N} generations remaining" + Upgrade CTA.
- * Pro tier:  "Pro · renews {date}" + Manage CTA.
- *
- * Styling intentionally matches the existing project-grid card aesthetic
- * (rounded-xl border-rule on white) so it reads as part of the same surface,
- * not a marketing intrusion.
+ * Paid tier: "{Basic|Pro} plan · $X/mo" + a monthly token-usage meter + Manage CTA.
  */
 export function PlanCard({
   plan,
   tier,
   generationsRemaining,
+  tokensUsed,
+  tokensBudget,
   currentPeriodEnd,
   onUpgrade,
   onManage,
   busy = false,
 }: PlanCardProps) {
   if (plan === 'pro') {
-    const planName = tier === 'pro' ? 'Pro plan' : 'Standard plan';
-    const planPrice = tier === 'pro' ? '$100/mo' : '$20/mo';
+    const planName = tier === 'basic' ? 'Basic plan' : 'Pro plan';
+    const planPrice = tier === 'basic' ? '$19/mo' : '$39/mo';
     const renewsCopy = currentPeriodEnd
       ? `renews ${new Date(currentPeriodEnd).toLocaleDateString()}`
       : 'active subscription';
+    const hasMeter = typeof tokensBudget === 'number' && tokensBudget > 0;
+    const used = tokensUsed ?? 0;
+    const pct = hasMeter ? Math.min(100, Math.round((used / tokensBudget!) * 100)) : 0;
     return (
-      <section
-        aria-label="Subscription"
-        className="rounded-xl border border-rule bg-white p-5 flex items-center justify-between gap-4"
-      >
-        <div>
-          <p className="font-serif font-medium text-ink text-base">
-            {planName} <span className="text-blueprint">·</span> {planPrice}
-          </p>
-          <p className="font-mono text-[11px] text-ink-faint mt-1.5 tracking-wide">
-            {renewsCopy}
-          </p>
+      <section aria-label="Subscription" className="rounded-xl border border-rule bg-white p-5">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <p className="font-serif font-medium text-ink text-base">
+              {planName} <span className="text-blueprint">·</span> {planPrice}
+            </p>
+            <p className="font-mono text-[11px] text-ink-faint mt-1.5 tracking-wide">{renewsCopy}</p>
+          </div>
+          <button
+            type="button"
+            onClick={onManage}
+            disabled={busy}
+            className="rounded-md border border-rule px-4 py-2 font-mono text-xs tracking-wide text-ink-soft hover:border-ink hover:text-ink transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {busy ? 'Loading…' : 'Manage subscription'}
+          </button>
         </div>
-        <button
-          type="button"
-          onClick={onManage}
-          disabled={busy}
-          className="rounded-md border border-rule px-4 py-2 font-mono text-xs tracking-wide text-ink-soft hover:border-ink hover:text-ink transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {busy ? 'Loading…' : 'Manage subscription'}
-        </button>
+        {hasMeter && (
+          <div className="mt-4">
+            <div className="flex justify-between font-mono text-[11px] text-ink-faint tracking-wide mb-1.5">
+              <span>{fmtTokens(used)} / {fmtTokens(tokensBudget!)} tokens this month</span>
+              <span>{pct}%</span>
+            </div>
+            <div className="h-1.5 w-full rounded-full bg-vellum-soft overflow-hidden">
+              <div className="h-full rounded-full bg-blueprint" style={{ width: `${pct}%` }} />
+            </div>
+          </div>
+        )}
       </section>
     );
   }
@@ -75,11 +91,9 @@ export function PlanCard({
       className="rounded-xl border border-rule bg-white p-5 flex items-center justify-between gap-4"
     >
       <div>
-        <p className="font-serif font-medium text-ink text-base">
-          Free plan
-        </p>
+        <p className="font-serif font-medium text-ink text-base">Free plan</p>
         <p className="font-mono text-[11px] text-ink-faint mt-1.5 tracking-wide">
-          {generationsRemaining} generation{generationsRemaining === 1 ? '' : 's'} remaining
+          {generationsRemaining ?? 0} generation{(generationsRemaining ?? 0) === 1 ? '' : 's'} remaining
         </p>
       </div>
       <button
@@ -88,7 +102,7 @@ export function PlanCard({
         disabled={busy}
         className="rounded-md bg-blueprint px-4 py-2 font-mono text-xs tracking-wide text-white hover:bg-ink transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
       >
-        {busy ? 'Loading…' : 'Upgrade — $20/mo'}
+        {busy ? 'Loading…' : 'Upgrade — $19/mo'}
       </button>
     </section>
   );

--- a/src/funnel/components/PricingTiers.test.tsx
+++ b/src/funnel/components/PricingTiers.test.tsx
@@ -8,23 +8,36 @@ import { PricingTiers } from './PricingTiers';
 afterEach(cleanup);
 
 describe('PricingTiers', () => {
-  it('calls onSelect with the tier and the current period when Subscribe is clicked', () => {
+  it('calls onSelect with the Basic tier and the current period when Subscribe is clicked', () => {
     const onSelect = vi.fn();
     render(<PricingTiers period="monthly" onSelect={onSelect} onFree={vi.fn()} />);
-    fireEvent.click(screen.getByRole('button', { name: /subscribe to standard/i }));
-    expect(onSelect).toHaveBeenCalledWith('standard', 'monthly');
+    fireEvent.click(screen.getByRole('button', { name: /subscribe to basic/i }));
+    expect(onSelect).toHaveBeenCalledWith('basic', 'monthly');
+  });
+
+  it('calls onSelect with the Pro tier', () => {
+    const onSelect = vi.fn();
+    render(<PricingTiers period="monthly" onSelect={onSelect} onFree={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /subscribe to pro/i }));
+    expect(onSelect).toHaveBeenCalledWith('pro', 'monthly');
   });
 
   it('passes the yearly period through to onSelect', () => {
     const onSelect = vi.fn();
     render(<PricingTiers period="yearly" onSelect={onSelect} onFree={vi.fn()} />);
-    fireEvent.click(screen.getByRole('button', { name: /subscribe to standard/i }));
-    expect(onSelect).toHaveBeenCalledWith('standard', 'yearly');
+    fireEvent.click(screen.getByRole('button', { name: /subscribe to basic/i }));
+    expect(onSelect).toHaveBeenCalledWith('basic', 'yearly');
   });
 
   it('shows the yearly total and "2 months free" when period is yearly', () => {
     render(<PricingTiers period="yearly" onSelect={vi.fn()} onFree={vi.fn()} />);
-    expect(screen.getByText(/\$200\/year — 2 months free/i)).toBeDefined();
+    expect(screen.getByText(/\$190\/year — 2 months free/i)).toBeDefined();
+  });
+
+  it('surfaces the token allowances', () => {
+    render(<PricingTiers period="monthly" onSelect={vi.fn()} onFree={vi.fn()} />);
+    expect(screen.getByText(/5M tokens \/ month/i)).toBeDefined();
+    expect(screen.getByText(/12M tokens \/ month/i)).toBeDefined();
   });
 
   it('offers no Free plan card', () => {
@@ -35,9 +48,9 @@ describe('PricingTiers', () => {
 
   it('marks the active tier as the current plan instead of offering to subscribe', () => {
     const onSelect = vi.fn();
-    render(<PricingTiers period="monthly" currentPlan="pro" currentTier="standard" onSelect={onSelect} onFree={vi.fn()} />);
-    expect(screen.getByRole('button', { name: /current plan \(standard\)/i })).toBeDefined();
-    fireEvent.click(screen.getByRole('button', { name: /current plan \(standard\)/i }));
+    render(<PricingTiers period="monthly" currentPlan="pro" currentTier="basic" onSelect={onSelect} onFree={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /current plan \(basic\)/i })).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /current plan \(basic\)/i }));
     expect(onSelect).not.toHaveBeenCalled();
   });
 
@@ -59,7 +72,7 @@ describe('PricingTiers', () => {
     expect(screen.getByRole('link', { name: /contact sales about enterprise/i })).toBeDefined();
   });
 
-  it('highlights Standard as the most popular tier', () => {
+  it('highlights Pro as the most popular tier', () => {
     render(<PricingTiers period="monthly" onSelect={vi.fn()} onFree={vi.fn()} />);
     expect(screen.getByText(/most popular/i)).toBeDefined();
   });

--- a/src/funnel/components/PricingTiers.tsx
+++ b/src/funnel/components/PricingTiers.tsx
@@ -49,22 +49,35 @@ interface Tier {
 
 const TIERS: Tier[] = [
   {
-    name: 'Standard',
-    tier: 'standard',
-    monthly: '$20',
-    yearly: '$200',
-    yearlyPerMonth: '$16.67',
-    popular: true,
-    blurb: 'Unlimited hosted generation and the parametric build agent.',
+    name: 'Basic',
+    tier: 'basic',
+    monthly: '$19',
+    yearly: '$190',
+    yearlyPerMonth: '$15.83',
+    blurb: 'A generous monthly token allowance for hobby and side-project builds.',
     features: [
+      { text: '5M tokens / month', emoji: '🎟️', badge: 'emerald' },
       { text: 'Full 3D editor & viewer' },
       { text: 'MCP access — bring your own agent', emoji: '🔌', badge: 'sky' },
-      { text: 'STEP / STL export' },
-      { text: 'Unlimited generations', emoji: '♾️', badge: 'emerald' },
       { text: 'Build as parametric CAD (mesh-conditioned)', emoji: '🧠', badge: 'violet' },
       { text: 'Image → 3D concept previews', emoji: '🖼️', badge: 'amber' },
-      { text: 'Priority generation', emoji: '⚡' },
+      { text: 'STEP / STL export' },
       { text: 'Commercial use license' },
+    ],
+  },
+  {
+    name: 'Pro',
+    tier: 'pro',
+    monthly: '$39',
+    yearly: '$390',
+    yearlyPerMonth: '$32.50',
+    popular: true,
+    blurb: 'Almost-unlimited tokens for daily, professional CAD work.',
+    inherits: 'Basic',
+    features: [
+      { text: '12M tokens / month — almost unlimited', emoji: '🚀', badge: 'emerald' },
+      { text: 'Priority generation', emoji: '⚡' },
+      { text: 'Every feature, no build counting' },
     ],
   },
   {
@@ -74,7 +87,7 @@ const TIERS: Tier[] = [
     monthly: 'Custom',
     yearly: null,
     blurb: 'Seats, one invoice, and a security review for your whole team.',
-    inherits: 'Standard',
+    inherits: 'Pro',
     features: [
       { text: 'Team seats & shared projects', emoji: '👥' },
       { text: 'Centralized billing & invoicing', emoji: '🧾' },
@@ -135,11 +148,11 @@ export function PricingTiers({ period, currentPlan, currentTier, onSelect, onFre
   const isCurrent = (t: Tier): boolean => {
     if (t.contact) return false;
     if (t.tier === null) return currentPlan === 'free' || currentPlan === undefined ? currentPlan === 'free' : false;
-    return currentPlan === 'pro' && (currentTier ?? 'standard') === t.tier;
+    return currentPlan === 'pro' && (currentTier ?? 'pro') === t.tier;
   };
 
   return (
-    <div className="mx-auto grid max-w-3xl grid-cols-1 gap-5 md:grid-cols-2">
+    <div className="grid grid-cols-1 gap-5 md:grid-cols-3">
       {TIERS.map(t => {
         const current = isCurrent(t);
         const highlight = t.popular;

--- a/src/funnel/components/RateLimitedPanel.tsx
+++ b/src/funnel/components/RateLimitedPanel.tsx
@@ -25,7 +25,7 @@ export function RateLimitedPanel({
   const buttonCopy = authenticated
     ? busy
       ? 'Loading…'
-      : 'Upgrade — $20/mo'
+      : 'Upgrade — $19/mo'
     : 'Sign in to upgrade';
   return (
     <div
@@ -39,7 +39,7 @@ export function RateLimitedPanel({
       </p>
       <p className="text-sm text-ink-soft mt-2">
         {authenticated
-          ? 'Upgrade to keep generating — $20/mo, cancel anytime.'
+          ? 'Upgrade to keep generating — $19/mo, cancel anytime.'
           : 'The build agent is free to start once you sign in — 5 builds a month, no card needed.'}
       </p>
       <div className="mt-4">

--- a/src/funnel/lib/apiClient.ts
+++ b/src/funnel/lib/apiClient.ts
@@ -197,8 +197,8 @@ export async function listMyProjects(): Promise<ProjectRow[]> {
 
 export type PlanTier = 'free' | 'pro';
 
-/** The two paid plans. 'standard' = $20/mo solo, 'pro' = $100/mo team. */
-export type PaidTier = 'standard' | 'pro';
+/** The two paid plans. 'basic' = $19/mo (5M tokens), 'pro' = $39/mo (12M tokens). */
+export type PaidTier = 'basic' | 'pro';
 
 /** Billing cadence. 'yearly' = 2 months free vs monthly. */
 export type BillingPeriod = 'monthly' | 'yearly';
@@ -207,7 +207,12 @@ export interface MyPlan {
   plan: PlanTier;
   /** Which paid plan, when plan === 'pro'; null on free. */
   tier?: PaidTier | null;
-  generationsRemaining: number;
+  /** Free plan only: builds left this month. Paid plans are token-metered. */
+  generationsRemaining: number | null;
+  /** Paid plans: monthly token budget usage. Null on free. */
+  tokensUsed?: number | null;
+  tokensBudget?: number | null;
+  tokensRemaining?: number | null;
   currentPeriodEnd: string | null;
 }
 
@@ -226,10 +231,10 @@ export async function fetchMyPlan(): Promise<MyPlan> {
 
 /** POST /api/v1/billing/create-checkout — returns a Stripe Checkout URL
  * the caller should redirect to (window.location.href = url). `tier` selects
- * the plan ($20 Standard by default; 'pro' for the $100 team plan); `period`
+ * the plan ($19 Basic by default; 'pro' for the $39 plan); `period`
  * selects monthly (default) or yearly (2 months free) billing. */
 export async function createCheckoutSession(
-  tier: PaidTier = 'standard',
+  tier: PaidTier = 'basic',
   period: BillingPeriod = 'monthly',
 ): Promise<CheckoutSession> {
   return authedFetch<CheckoutSession>('POST', '/api/v1/billing/create-checkout', { tier, period });

--- a/src/studio/routes/billing.tsx
+++ b/src/studio/routes/billing.tsx
@@ -141,6 +141,8 @@ function BillingPage() {
             plan={plan.plan}
             tier={plan.tier}
             generationsRemaining={plan.generationsRemaining}
+            tokensUsed={plan.tokensUsed}
+            tokensBudget={plan.tokensBudget}
             currentPeriodEnd={plan.currentPeriodEnd}
             onUpgrade={handleUpgrade}
             onManage={handleManage}

--- a/src/studio/routes/me.tsx
+++ b/src/studio/routes/me.tsx
@@ -169,13 +169,15 @@ function MePage() {
                 {plan.plan === 'pro'
                   ? plan.tier === 'pro'
                     ? 'Pro plan'
-                    : 'Standard plan'
+                    : 'Basic plan'
                   : 'Free plan'}
               </p>
               <p className="font-mono text-[11px] text-ink-faint mt-1 tracking-wide">
                 {plan.plan === 'pro'
-                  ? 'Unlimited generations'
-                  : `${plan.generationsRemaining} generation${plan.generationsRemaining === 1 ? '' : 's'} remaining`}
+                  ? plan.tokensBudget
+                    ? `${((plan.tokensRemaining ?? 0) / 1_000_000).toFixed(1)}M tokens left this month`
+                    : 'Token-metered plan'
+                  : `${plan.generationsRemaining ?? 0} generation${(plan.generationsRemaining ?? 0) === 1 ? '' : 's'} remaining`}
               </p>
             </div>
             <span className="font-mono text-xs text-blueprint shrink-0">Usage &amp; billing →</span>

--- a/src/studio/routes/pricing.tsx
+++ b/src/studio/routes/pricing.tsx
@@ -63,7 +63,7 @@ function PricingPage() {
       <section className="mx-auto max-w-5xl px-6 pb-20 pt-10">
         <h1 className="text-center font-serif text-5xl font-bold tracking-tight">Pricing</h1>
         <p className="mx-auto mt-4 max-w-xl text-center text-gray-400">
-          Unlimited hosted generation and the parametric build agent. Cancel anytime.
+          A monthly token allowance for the parametric build agent — a tiny cube costs a sliver, a big assembly costs more. Cancel anytime.
         </p>
 
         {/* Billing cadence toggle. */}


### PR DESCRIPTION
Token-based pricing UI to match the server (kernelCAD-server #92).

## /pricing
- **Basic $19** (5M tokens/mo) · **Pro $39** (12M tokens/mo, "almost unlimited", Most popular) · **Enterprise** (contact sales).
- Token-based feature copy; monthly/yearly toggle ($190/$390, 2 months free).
- `PaidTier` = basic/pro; `createCheckoutSession` defaults to basic.

## Usage display
- `PlanCard` shows a monthly **token-usage meter** for paid plans; `$19` upgrade CTA.
- `MyPlan` carries `tokensUsed/tokensBudget/tokensRemaining`; me strip + RateLimitedPanel updated (Standard→Basic, $20→$19).

## Landing
- Marketing pricing section rebuilt to Basic/Pro/Enterprise with yearly sublines (3-col grid; cache-bust bumped). Landing test updated.

Tests: PricingTiers (10) + landing (staticGalleryLanding/landingNavigation) green; typecheck clean.
