### PR TITLE
ci: auto-deploy kernelcad.com on merge to develop

### DIFF
--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -1,0 +1,61 @@
+name: Deploy kernelcad.com (on merge to develop)
+
+# The kernelcad.com marketing site is built + deployed by a workflow in the
+# PRIVATE kernelCAD-server repo (deploy-kernelcad-com.yml), which keeps the
+# Cloudflare project name and build details out of this public repo. That
+# workflow was manual-only (workflow_dispatch), so the live site lagged merged
+# source until someone remembered to run it.
+#
+# This workflow closes that gap: every push to develop — which, per branch
+# protection (required checks: lint, build-and-checks, test), means a PR that
+# passed CI was merged — automatically triggers the marketing deploy against the
+# freshly-merged develop. app.kernelcad.com already auto-deploys on develop push
+# (deploy-cloudflare.yml); this gives kernelcad.com the same behaviour.
+#
+# ONE-TIME SETUP (only a repo admin can do this):
+#   Add a repo secret MARKETING_DEPLOY_TOKEN = a fine-grained PAT (or GitHub App
+#   token) with "Actions: Read and write" permission on w1ne/kernelCAD-server.
+#   The default GITHUB_TOKEN cannot trigger workflows in another repository.
+#
+# Note: develop's branch protection does not enforce admins, so a direct admin
+# push that bypasses a PR would deploy without a fresh CI run. Normal PR merges
+# always pass CI first. Manual re-deploys remain available via workflow_dispatch
+# here or directly in kernelCAD-server.
+
+on:
+  push:
+    branches: [develop]
+    paths-ignore:
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+      - 'CHANGELOG.md'
+      - 'LICENSE'
+      - 'RELEASE_NOTES.md'
+      - 'docs/**'
+      - 'doc/**'
+      - 'archive/**'
+  workflow_dispatch:
+
+concurrency:
+  # Never run two marketing deploys at once; let an in-flight one finish so we
+  # don't cancel a deploy that's mid-publish.
+  group: deploy-marketing
+  cancel-in-progress: false
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger kernelcad.com marketing deploy (private kernelCAD-server)
+        env:
+          GH_TOKEN: ${{ secrets.MARKETING_DEPLOY_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::MARKETING_DEPLOY_TOKEN is not set. Add a fine-grained PAT with Actions: read/write on w1ne/kernelCAD-server so this repo can trigger the marketing deploy."
+            exit 1
+          fi
+          gh workflow run deploy-kernelcad-com.yml \
+            --repo w1ne/kernelCAD-server \
+            --ref main \
+            -f web_ref=develop
+          echo "Dispatched deploy-kernelcad-com.yml (web_ref=develop) in kernelCAD-server."


### PR DESCRIPTION
## Problem
The kernelcad.com marketing deploy (`deploy-kernelcad-com.yml` in the private **kernelCAD-server**) is `workflow_dispatch`-only. So the live marketing site lags merged source until someone runs it manually — which is how a merged pricing fix sat un-deployed and looked "not fixed".

## Fix
A `develop`-push-triggered workflow here that dispatches that deploy. Since develop's branch protection requires `lint` + `build-and-checks` + `test`, a push to develop = a PR that **passed CI was merged** → this fires on *merge + CI pass*. `app.kernelcad.com` already auto-deploys on develop push; `kernelcad.com` now matches. `workflow_dispatch` kept for manual re-deploys.

## Why trigger cross-repo instead of moving the deploy here
The deploy + Cloudflare credentials + Pages bindings stay **owned by the private server repo** (its existing "single-owned marketing deploy" design, so public-repo pushes can't overwrite the marketing project). This public repo only *asks* it to run.

## ⚠️ One-time setup (repo admin)
Add repo secret **`MARKETING_DEPLOY_TOKEN`** = a fine-grained PAT with **Actions: Read and write** on `w1ne/kernelCAD-server`. The default `GITHUB_TOKEN` can't trigger workflows in another repo. Until it's set, the job fails loudly with a clear message (no silent no-op).

Note: develop protection doesn't enforce admins, so a direct admin push bypassing a PR would deploy without a fresh CI run; normal PR merges always pass CI first.