### PR TITLE
feat(loop): ground floating-geometry & object-count gates in geometry (release port)

### DIFF
--- a/src/agent/mcp/tools/designLoop.ts
+++ b/src/agent/mcp/tools/designLoop.ts
@@ -4,6 +4,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, relative, resolve } from 'node:path';
 import type { GripperApertureRequest } from '../../../modeling/mates/gripperAperture';
 import type { MechanismFitnessResult } from '../../../modeling/mates/mechanismFitness';
+import type { ContactGraphResult } from '../../../modeling/runtime/contactGraph';
 import { reviewCadTool, type RepairContext, type ReviewCadInput, type ReviewCadOutput } from './reviewCad';
 
 export interface DesignLoopAttemptInput {
@@ -74,6 +75,56 @@ export interface DesignLoopOutput {
   outputRecordPath?: string;
   recordUrl?: string;
   nextActionPrompt?: string;
+  convergence?: ConvergenceStall;
+}
+
+export interface ConvergenceStall {
+  /** True when successive failing attempts repeat the same failure signature
+   *  — the loop is not converging and needs a different strategy, not one
+   *  more nudge. */
+  readonly escalate: boolean;
+  /** How many trailing attempts shared the repeated failure signature. */
+  readonly repeatCount: number;
+  /** Human-readable escalation reason for the repair prompt. */
+  readonly reason: string;
+}
+
+/**
+ * Detect a non-converging loop: two or more trailing failing attempts that
+ * share an identical failure signature (repair mode + the set of unresolved
+ * review-fact codes). Returns undefined when the loop is making progress, the
+ * final attempt passed, or there is only one attempt. No silent caps — the
+ * caller surfaces this so an agent stops nudging a design that keeps failing
+ * the same way and instead changes strategy.
+ */
+export function detectConvergenceStall(
+  attempts: readonly DesignLoopAttemptResult[],
+): ConvergenceStall | undefined {
+  if (attempts.length < 2) return undefined;
+  const last = attempts[attempts.length - 1];
+  if (last.ok) return undefined;
+
+  const signature = (a: DesignLoopAttemptResult): string =>
+    `${a.repairMode ?? 'unknown'}::${[...a.reviewFacts.map((f) => f.code)].sort().join(',')}`;
+
+  const target = signature(last);
+  let repeatCount = 0;
+  for (let i = attempts.length - 1; i >= 0; i--) {
+    if (signature(attempts[i]) !== target) break;
+    repeatCount++;
+  }
+  if (repeatCount < 2) return undefined;
+
+  const mode = last.repairMode ?? 'unknown';
+  return {
+    escalate: true,
+    repeatCount,
+    reason:
+      `Loop stalled: ${repeatCount} consecutive attempts failed with the same ${mode} signature ` +
+      `and identical unresolved facts (${last.reviewFacts.map((f) => f.code).join(', ') || 'none'}). ` +
+      `Local nudges are not converging — change strategy: redesign the affected module from the original ` +
+      `goal, or explicitly justify and allow-list a warning code if the flagged geometry has a real physical role.`,
+  };
 }
 
 interface BuildRecordStep {
@@ -147,6 +198,7 @@ export async function designLoopTool(input: DesignLoopInput): Promise<DesignLoop
   }
 
   const finalPass = attempts.find((attempt) => attempt.ok);
+  const convergence = detectConvergenceStall(attempts);
   const record = buildRecord(input, attempts);
   const outputRecordPath = input.outputRecordPath !== undefined
     ? resolve(input.outputRecordPath)
@@ -164,7 +216,10 @@ export async function designLoopTool(input: DesignLoopInput): Promise<DesignLoop
     record,
     outputRecordPath,
     ...(outputRecordPath !== undefined ? { recordUrl: publicRecordUrl(outputRecordPath) } : {}),
-    nextActionPrompt: finalPass === undefined ? attempts.at(-1)?.nextActionPrompt : undefined,
+    ...(convergence !== undefined ? { convergence } : {}),
+    nextActionPrompt: finalPass === undefined
+      ? [convergence?.reason, attempts.at(-1)?.nextActionPrompt].filter(Boolean).join('\n\n')
+      : undefined,
   };
 }
 
@@ -195,6 +250,7 @@ function toAttemptResult(input: {
       hint: diagnostic.hint,
     })),
     ...scriptQualityFacts(input.source, input.allowReviewWarnings),
+    ...geometryReviewFacts(input.review.geometry, input.allowReviewWarnings),
     ...visualReviewFacts(input.requireVisualReview, input.visualReview, input.allowReviewWarnings),
   ];
   const functional = input.review.ok;
@@ -338,6 +394,33 @@ function scriptQualityFacts(
     severity: 'warning',
     message: `Script uses ${boxCount} box primitives and ${boxUnionCount} box unions; this often produces visually arbitrary cuboid fragments instead of an explainable mechanical load path.`,
     hint: 'quality.box-fragment-clutter — replace decorative cuboids with continuous brackets, cylinders/shafts/bearing washers, or fewer purpose-named bodies. Each visible sub-shape should have an obvious role in the mechanism.',
+  }];
+}
+
+/**
+ * Deterministic floating-geometry gate.
+ *
+ * The visual `no-stray-or-floating-geometry` / `main-object-count` checks are
+ * graded on the agent's own prose. This grades them on the geometry: the
+ * contact-graph analysis (dfm surface-distance sweep → connected components)
+ * reports how many disconnected bodies the scene actually contains and which
+ * parts are the stray islands. Any floating body is a warning the loop cannot
+ * be talked out of. It is allow-listable only by its explicit named code,
+ * because a genuinely multi-body deliverable is occasionally intended.
+ */
+export function geometryReviewFacts(
+  geometry: ContactGraphResult | undefined,
+  allowReviewWarnings: readonly string[],
+): Array<{ code: string; severity: string; message: string; hint?: string }> {
+  const code = 'assembly.geometry.floating-body';
+  if (geometry === undefined || geometry.floatingParts.length === 0) return [];
+  if (allowReviewWarnings.includes(code)) return [];
+  const parts = geometry.floatingParts.join(', ');
+  return [{
+    code,
+    severity: 'warning',
+    message: `Deterministic contact graph found ${geometry.objectCount} disconnected bodies; parts float free of the main body (gap > ${geometry.gapMm} mm): ${parts}.`,
+    hint: 'geometry.floating-body — the named parts have no surface contact or near-contact with the main body. Move or extend them so they seat against the structure they belong to (mate-graph connectivity is not geometric contact), then rerun review_cad. Allow-list assembly.geometry.floating-body only when the design is genuinely meant to ship as separate bodies.',
   }];
 }
 

--- a/src/agent/mcp/tools/reviewCad.ts
+++ b/src/agent/mcp/tools/reviewCad.ts
@@ -30,6 +30,7 @@ import { validateAssemblyWithMates } from '../../../modeling/mates/validator';
 import type { InterferencePair } from '../../../modeling/runtime/detectInterferences';
 import { detectInterferences } from '../../../modeling/runtime/detectInterferences';
 import { isSceneBackend } from '../../../kernel/backends/sceneBackend';
+import { analyzeContactGraph, type ContactGraphResult } from '../../../modeling/runtime/contactGraph';
 import type { BuiltModel } from '../../../modeling/buildModel';
 import { clearActiveMcpSession, setActiveMcpSession } from '../activeSession';
 
@@ -114,6 +115,11 @@ export type ReviewCadOutput =
       /** Structured failure list when `mechanism === 'broken'`. Empty
        *  otherwise. */
       mechanismFailures: readonly CompilerDiagnostic[];
+      /** Deterministic geometric contact graph of the returned scene:
+       *  distinct connected bodies and floating/disconnected parts. Drives
+       *  the design-loop's floating-geometry gate. Undefined when the scene
+       *  could not be analyzed. */
+      geometry?: ContactGraphResult;
     }
   | {
       ok: false;
@@ -142,6 +148,9 @@ export type ReviewCadOutput =
        *  where no assembly reached the probe. */
       mechanism?: MechanismVerdict;
       mechanismFailures?: readonly CompilerDiagnostic[];
+      /** Deterministic geometric contact graph (see the `ok: true` variant).
+       *  Present whenever a scene was built, even when `ok: false`. */
+      geometry?: ContactGraphResult;
     };
 
 type ReviewDiagnostic =
@@ -216,6 +225,7 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
   const rawInterferencePairs: InterferencePair[] = wantInterference
     ? safeDetectDefaultPoseInterferences(model, input.epsilonMm3)
     : [];
+  const geometry = safeAnalyzeContactGraph(model);
   const validator = await validateAssemblyWithMates(
     arm,
     wantInterference ? rawInterferencePairs : undefined,
@@ -321,6 +331,7 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
       rawInterferencePairs,
       mechanism,
       mechanismFailures,
+      ...(geometry !== undefined ? { geometry } : {}),
     };
   }
 
@@ -344,7 +355,25 @@ export async function reviewCadTool(input: ReviewCadInput): Promise<ReviewCadOut
     rawInterferencePairs,
     mechanism,
     mechanismFailures,
+    ...(geometry !== undefined ? { geometry } : {}),
   };
+}
+
+/**
+ * Deterministic geometric contact graph of the script's returned scene.
+ * Mirrors safeDetectDefaultPoseInterferences: reads the lowered scene of the
+ * script's return value and never lets a kernel failure sink the whole review
+ * — geometry is simply reported as undefined in that case.
+ */
+function safeAnalyzeContactGraph(model: BuiltModel): ContactGraphResult | undefined {
+  try {
+    const tail = model.rootShape ?? model.tailShape;
+    if (!tail || !isSceneBackend(tail)) return undefined;
+    if (tail.parts.length < 2) return undefined;
+    return analyzeContactGraph(tail);
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/src/modeling/runtime/contactGraph.test.ts
+++ b/src/modeling/runtime/contactGraph.test.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/modeling/runtime/contactGraph.test.ts
+//
+// Deterministic geometric contact graph: counts distinct connected bodies
+// and flags floating/disconnected geometry from the lowered BREP scene,
+// so the design-loop's `main-object-count` and `no-stray-or-floating-geometry`
+// visual checks are grounded in geometry instead of the agent's prose.
+//
+// Bodies are placed by hand (the tendonBodyIntersect.test.ts idiom) so the
+// contact topology is exact and independent of the mate solver.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createApi } from '../api';
+import { CaptureSession } from '../capture/captureSession';
+import { initOcct } from '../../kernel/backends/occt/occtBackend';
+import type { OcctBackend } from '../../kernel/backends/occt/occtBackend';
+import type { SceneBackend } from '../../kernel/backends/sceneBackend';
+import { Transform } from '../../shared/runtime/se3';
+import { analyzeContactGraph } from './contactGraph';
+
+async function box(sx: number, sy: number, sz: number): Promise<OcctBackend> {
+  const session = new CaptureSession();
+  const kcad = createApi({ session });
+  return (await kcad.box(sx, sy, sz, true).lower()) as OcctBackend;
+}
+
+function scene(parts: Record<string, { shape: OcctBackend; at: Transform }>): SceneBackend {
+  return {
+    parts: Object.entries(parts).map(([name, p]) => ({
+      name,
+      shape: p.shape,
+      worldTransform: p.at,
+    })),
+  } as unknown as SceneBackend;
+}
+
+describe('analyzeContactGraph — deterministic object count + floating detection', () => {
+  beforeAll(async () => {
+    await initOcct();
+  });
+
+  it('reports one object when two 20mm boxes abut face-to-face', async () => {
+    const a = await box(20, 20, 20);
+    const b = await box(20, 20, 20);
+    // Centred boxes span ±10; place b at x=20 so its -X face (x=10) meets
+    // a's +X face (x=10): surface contact, zero gap.
+    const s = scene({
+      a: { shape: a, at: Transform.identity() },
+      b: { shape: b, at: Transform.translation(20, 0, 0) },
+    });
+    const result = analyzeContactGraph(s);
+    expect(result.objectCount).toBe(1);
+    expect(result.floatingParts).toEqual([]);
+  });
+
+  it('reports two objects and flags the floating part across an air gap', async () => {
+    const a = await box(20, 20, 20);
+    const b = await box(20, 20, 20);
+    // 30mm apart centre-to-centre → 10mm air gap between faces (> default
+    // contact gap): b is geometrically disconnected even if it were mated.
+    const s = scene({
+      a: { shape: a, at: Transform.identity() },
+      b: { shape: b, at: Transform.translation(30, 0, 0) },
+    });
+    const result = analyzeContactGraph(s);
+    expect(result.objectCount).toBe(2);
+    expect(result.floatingParts).toEqual(['b']);
+  });
+
+  it('groups a touching pair and isolates a distant island', async () => {
+    const a = await box(20, 20, 20);
+    const b = await box(20, 20, 20);
+    const c = await box(20, 20, 20);
+    const s = scene({
+      a: { shape: a, at: Transform.identity() },
+      b: { shape: b, at: Transform.translation(20, 0, 0) }, // touches a
+      c: { shape: c, at: Transform.translation(0, 0, 200) }, // far away
+    });
+    const result = analyzeContactGraph(s);
+    expect(result.objectCount).toBe(2);
+    expect(result.components[0].sort()).toEqual(['a', 'b']);
+    expect(result.floatingParts).toEqual(['c']);
+  });
+});

--- a/src/modeling/runtime/contactGraph.ts
+++ b/src/modeling/runtime/contactGraph.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// Deterministic geometric contact graph over a lowered BREP scene.
+//
+// The design-loop's visual-review checks `main-object-count` and
+// `no-stray-or-floating-geometry` were previously graded by regex over the
+// agent's own prose findings — an agent could pass them by writing the right
+// keywords whether or not the geometry was sound. This computes the same
+// facts from the scene itself: two bodies are "in contact" when their true
+// surface distance is at or below a small gap, connected components of that
+// contact relation are the distinct physical objects, and any component that
+// is not the largest is floating/disconnected geometry.
+//
+// Reuses the exact OCCT surface-distance sweep in `checkClearance`
+// (dfm/clearance.ts) rather than approximating with bounding boxes. Mated and
+// ignored pair-lists are deliberately NOT passed in: a part that is
+// mate-connected in the assembly graph but geometrically floating (an air gap)
+// is exactly the defect this gate exists to catch, so every pair is measured
+// on pure geometry.
+
+import type { SceneBackend } from '../../kernel/backends/sceneBackend';
+import { checkClearance } from './dfm/clearance';
+
+/** Default contact gap (mm). Surfaces within this of each other count as
+ *  touching. Small enough to reject real air gaps, loose enough to absorb
+ *  tessellation/placement noise between parts meant to abut. */
+export const DEFAULT_CONTACT_GAP_MM = 0.5;
+
+export interface ContactGraphResult {
+  /** Number of connected bodies under the contact relation. */
+  readonly objectCount: number;
+  /** Part-name groups, one per connected body, largest (most parts) first. */
+  readonly components: readonly string[][];
+  /** Parts not in the largest component — floating / stray islands. Empty
+   *  when the whole scene is a single connected body. */
+  readonly floatingParts: readonly string[];
+  /** The gap threshold used, for reproducibility in review output. */
+  readonly gapMm: number;
+}
+
+export function analyzeContactGraph(
+  scene: SceneBackend,
+  opts: { gapMm?: number } = {},
+): ContactGraphResult {
+  const gapMm = opts.gapMm ?? DEFAULT_CONTACT_GAP_MM;
+  const names = scene.parts.map((p) => p.name);
+
+  const reports = checkClearance(scene, gapMm, new Set(), new Set());
+  const adj = new Map<string, Set<string>>();
+  for (const name of names) adj.set(name, new Set());
+  for (const r of reports) {
+    // 'violated' = measured surface distance below the gap (incl. contact);
+    // 'interfering' = overlapping volume. Both mean the bodies touch.
+    if (r.status !== 'violated' && r.status !== 'interfering') continue;
+    adj.get(r.a)?.add(r.b);
+    adj.get(r.b)?.add(r.a);
+  }
+
+  const components = connectedComponents(names, adj)
+    .map((set) => [...set].sort())
+    .sort((a, b) => b.length - a.length || (a[0] < b[0] ? -1 : 1));
+
+  const floatingParts = components.slice(1).flat();
+
+  return { objectCount: components.length, components, floatingParts, gapMm };
+}
+
+function connectedComponents(
+  nodes: readonly string[],
+  adj: Map<string, Set<string>>,
+): Set<string>[] {
+  const visited = new Set<string>();
+  const out: Set<string>[] = [];
+  for (const start of nodes) {
+    if (visited.has(start)) continue;
+    const component = new Set<string>();
+    const stack = [start];
+    while (stack.length > 0) {
+      const n = stack.pop()!;
+      if (visited.has(n)) continue;
+      visited.add(n);
+      component.add(n);
+      for (const nb of adj.get(n) ?? []) {
+        if (!visited.has(nb)) stack.push(nb);
+      }
+    }
+    out.push(component);
+  }
+  return out;
+}

--- a/tests/integration/mcp/designLoopGeometryGate.test.ts
+++ b/tests/integration/mcp/designLoopGeometryGate.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// The deterministic floating-geometry gate must override a self-graded visual
+// review. Here the agent hands in a fully-accepted visualReview that claims
+// "no stray or floating geometry" — but the two bodies sit 30 mm apart. The
+// loop must still reject the attempt on geometry, and let an explicit
+// allow-list of the named code through when the separation is intended.
+
+import { describe, expect, it } from 'vitest';
+import { designLoopTool } from '../../../src/agent/mcp/tools/designLoop';
+
+const FLOATING_BODY = `
+  const arm = assembly('rig');
+  arm.part('base', box(10, 10, 10, true))
+    .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+  arm.part('link', box(10, 10, 10, true))
+    .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [40, 0, 0] }, axis: [0, 0, 1] });
+  arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', { limitsDeg: [-90, 90] });
+  return arm.model();
+`;
+
+const acceptedVisualReview = {
+  accepted: true,
+  screenshotPath: '/tmp/rig-iso.png',
+  findings: ['Looks like one clean coherent body from every canonical view.'],
+  checks: [
+    { code: 'main-object-count', passed: true, finding: 'One primary object, not duplicate assemblies.' },
+    { code: 'proportions-match-reference', passed: true, finding: 'Proportions match the requested object closely enough.' },
+    { code: 'required-visible-features', passed: true, finding: 'Required visible features are present, legible, unobstructed, and not covered.' },
+    { code: 'no-stray-or-floating-geometry', passed: true, finding: 'No stray, floating, or unexplained extra geometry is visible; each secondary component is supported by contact or near-contact into the parent body, with no visible air gap.' },
+    { code: 'attachment-plausibility', passed: true, finding: 'Visible brackets and case-band interfaces connect through a load-bearing geometry anchored into the parent case body, seated and exposed with no buried half-inserted hardware.' },
+    { code: 'semantic-orientation-alignment', passed: true, finding: 'Labels and indicators point in deliberate, reference-consistent directions.' },
+    { code: 'device-depth-and-construction', passed: true, finding: 'Side and canonical views show real wall thickness, housing, body layers, and non-facade construction.' },
+    { code: 'canonical-views-physically-coherent', passed: true, finding: 'Canonical views read as one physically coherent object.' },
+  ],
+};
+
+describe('design_loop floating-geometry gate overrides self-graded visual review', () => {
+  it('rejects a floating body despite a fully accepted visual review', { timeout: 60_000 }, async () => {
+    const result = await designLoopTool({
+      goal: 'Build a single connected two-part yaw joint.',
+      attempts: [{ id: '01', title: 'floating', code: FLOATING_BODY, visualReview: acceptedVisualReview }],
+    });
+
+    expect(result.ok).toBe(false);
+    const attempt = result.attempts[0];
+    expect(attempt.reviewFacts.some((f) => f.code === 'assembly.geometry.floating-body')).toBe(true);
+    expect(attempt.nextActionPrompt).toContain('link');
+  });
+
+  it('accepts the same design when the floating-body code is explicitly allow-listed', { timeout: 60_000 }, async () => {
+    const result = await designLoopTool({
+      goal: 'Two intentionally separate bodies staged for later assembly.',
+      allowReviewWarnings: ['assembly.geometry.floating-body'],
+      attempts: [{ id: '01', title: 'staged', code: FLOATING_BODY, visualReview: acceptedVisualReview }],
+    });
+
+    const attempt = result.attempts[0];
+    expect(attempt.reviewFacts.some((f) => f.code === 'assembly.geometry.floating-body')).toBe(false);
+  });
+});

--- a/tests/integration/mcp/reviewCadGeometry.test.ts
+++ b/tests/integration/mcp/reviewCadGeometry.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// review_cad exposes a deterministic geometric contact graph so the design
+// loop can gate floating/disconnected bodies on geometry rather than the
+// agent's prose. The fixture below is the case every OTHER gate misses: a
+// valid revolute mate, no interference, poses in range — yet the two bodies
+// sit 30 mm apart in space (mate-graph connected, geometrically floating).
+
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { initOcct } from '../../../src/kernel/backends/occt/occtBackend';
+import { clearActiveMcpSession } from '../../../src/agent/mcp/activeSession';
+import { reviewCadTool } from '../../../src/agent/mcp/tools/reviewCad';
+
+describe('review_cad geometric contact graph', () => {
+  beforeAll(async () => { await initOcct(); }, 60000);
+  beforeEach(() => { clearActiveMcpSession(); });
+
+  it('flags a mate-connected but geometrically floating body', async () => {
+    const r = await reviewCadTool({
+      code: `
+        const arm = assembly('rig');
+        arm.part('base', box(10, 10, 10, true))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 0, 1] });
+        // link's axis is 40 mm off its own body centre; mating it onto base's
+        // origin translates the whole link body 40 mm away -> a 30 mm air gap.
+        arm.part('link', box(10, 10, 10, true))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [40, 0, 0] }, axis: [0, 0, 1] });
+        arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', { limitsDeg: [-90, 90] });
+        return arm.model();
+      `,
+    });
+
+    expect(r.geometry).toBeDefined();
+    expect(r.geometry?.objectCount).toBe(2);
+    expect(r.geometry?.floatingParts).toContain('link');
+  });
+
+  it('reports a single connected body when parts abut', async () => {
+    const r = await reviewCadTool({
+      code: `
+        const arm = assembly('rig');
+        arm.part('base', box(10, 10, 10, true))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [5, 0, 0] }, axis: [0, 0, 1] });
+        arm.part('link', box(10, 10, 10, true))
+          .connector('axis', { type: 'axis', origin: { kind: 'vec3', value: [-5, 0, 0] }, axis: [0, 0, 1] });
+        arm.mate('yaw', 'base.axis', 'link.axis', 'revolute', { limitsDeg: [-90, 90] });
+        return arm.model();
+      `,
+    });
+
+    expect(r.geometry?.objectCount).toBe(1);
+    expect(r.geometry?.floatingParts).toEqual([]);
+  });
+});

--- a/tests/unit/mcp/designLoopConvergence.test.ts
+++ b/tests/unit/mcp/designLoopConvergence.test.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// Convergence guard: when successive attempts fail the same way, the loop
+// should say so — "topology-redesign attempted N times with no progress" —
+// instead of silently handing back the last attempt's repair prompt as if
+// one more nudge would converge. No silent caps.
+
+import { describe, it, expect } from 'vitest';
+import { detectConvergenceStall } from '../../../src/agent/mcp/tools/designLoop';
+import type { DesignLoopAttemptResult } from '../../../src/agent/mcp/tools/designLoop';
+
+function attempt(
+  id: string,
+  ok: boolean,
+  repairMode: DesignLoopAttemptResult['repairMode'],
+  factCodes: string[],
+): DesignLoopAttemptResult {
+  return {
+    id, title: id, ok, functional: false, qualityOk: ok,
+    featureCount: 1, diagnosticCount: factCodes.length,
+    reviewFacts: factCodes.map((code) => ({ code, severity: 'warning', message: code })),
+    repairMode, passedChecks: [], blockingReasons: [],
+    nextActionPrompt: 'repair',
+  };
+}
+
+describe('detectConvergenceStall', () => {
+  it('returns undefined for a single attempt', () => {
+    expect(detectConvergenceStall([attempt('01', false, 'topology-redesign', ['a'])])).toBeUndefined();
+  });
+
+  it('returns undefined when the final attempt passed', () => {
+    const attempts = [
+      attempt('01', false, 'local-fix', ['a']),
+      attempt('02', true, 'none', []),
+    ];
+    expect(detectConvergenceStall(attempts)).toBeUndefined();
+  });
+
+  it('escalates when the last two attempts share the same failure signature', () => {
+    const attempts = [
+      attempt('01', false, 'topology-redesign', ['assembly.geometry.floating-body']),
+      attempt('02', false, 'topology-redesign', ['assembly.geometry.floating-body']),
+    ];
+    const stall = detectConvergenceStall(attempts);
+    expect(stall?.escalate).toBe(true);
+    expect(stall?.repeatCount).toBe(2);
+    expect(stall?.reason).toContain('topology-redesign');
+  });
+
+  it('does not escalate when each attempt resolves a different fact (progress)', () => {
+    const attempts = [
+      attempt('01', false, 'local-fix', ['a', 'b']),
+      attempt('02', false, 'local-fix', ['a']),
+    ];
+    expect(detectConvergenceStall(attempts)).toBeUndefined();
+  });
+});

--- a/tests/unit/mcp/designLoopGeometryFacts.test.ts
+++ b/tests/unit/mcp/designLoopGeometryFacts.test.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// The design-loop quality gate turns the deterministic geometric contact
+// graph into a review fact: floating/disconnected bodies block acceptance
+// regardless of what the agent's prose visualReview claims. Unlike the
+// hard-blocked visual.* checks, this fact is allow-listable with its explicit
+// named code, because a genuinely multi-body deliverable is sometimes
+// intended and the agent/human can attest to it.
+
+import { describe, it, expect } from 'vitest';
+import { geometryReviewFacts } from '../../../src/agent/mcp/tools/designLoop';
+import type { ContactGraphResult } from '../../../src/modeling/runtime/contactGraph';
+
+const connected: ContactGraphResult = {
+  objectCount: 1,
+  components: [['base', 'arm', 'link']],
+  floatingParts: [],
+  gapMm: 0.5,
+};
+
+const floating: ContactGraphResult = {
+  objectCount: 2,
+  components: [['base', 'arm'], ['bezel']],
+  floatingParts: ['bezel'],
+  gapMm: 0.5,
+};
+
+describe('geometryReviewFacts — deterministic floating-geometry gate', () => {
+  it('returns no facts when geometry was not computed', () => {
+    expect(geometryReviewFacts(undefined, [])).toEqual([]);
+  });
+
+  it('returns no facts when the whole scene is one connected body', () => {
+    expect(geometryReviewFacts(connected, [])).toEqual([]);
+  });
+
+  it('emits a warning naming the floating parts and object count', () => {
+    const facts = geometryReviewFacts(floating, []);
+    expect(facts).toHaveLength(1);
+    expect(facts[0].code).toBe('assembly.geometry.floating-body');
+    expect(facts[0].severity).toBe('warning');
+    expect(facts[0].message).toContain('bezel');
+    expect(facts[0].message).toContain('2');
+  });
+
+  it('can be silenced only by explicitly allow-listing its named code', () => {
+    expect(geometryReviewFacts(floating, ['assembly.geometry.floating-body'])).toEqual([]);
+  });
+});


### PR DESCRIPTION
Release-line port of #581 (merged to `develop`) so the loop improvement can ship to `mcp.kernelcad.com` via the kernelCAD-server vendor pin. Clean cherry-pick of the feature commit; all feature deps (`checkClearance`, `model.rootShape`, `isSceneBackend`) already exist on `release`.

## What
- `analyzeContactGraph` — deterministic geometric contact graph (reuses the OCCT `checkClearance` sweep) → distinct bodies + floating parts.
- `review_cad` exposes `geometry`; `design_loop` blocks floating bodies (`assembly.geometry.floating-body`, allow-listable), replacing the old regex-on-prose grade for `no-stray-or-floating-geometry` / `main-object-count`.
- `detectConvergenceStall` — escalates repeated same-signature failures instead of nudging silently.

## Gate on release
29/29 feature + tripwire tests pass locally on `release`, including `toolRegistry.publicContract` and `toolRegistrySchema` (the new fact is an ad-hoc review-fact code, not a `DIAGNOSTIC_REGISTRY` code, so it does not move the diagnostics count).

Once merged, deploy = bump kernelCAD-server vendor pin to `release` tip via `scripts/bump-vendor-pin.sh`.