### PR TITLE
Fix review_cad MCP output schema

### DIFF
--- a/src/agent/mcp/toolOutputSchemas.ts
+++ b/src/agent/mcp/toolOutputSchemas.ts
@@ -309,7 +309,11 @@ export const TOOL_OUTPUT_SCHEMAS: Record<string, JSONSchemaObject> = {
       assembly: { type: 'string' },
       validator: { type: 'object', additionalProperties: true, description: 'Assembly/mate-graph validator result.' },
       poseEnvelope: { type: 'object', additionalProperties: true, description: 'Sampled mate-limit pose envelope.' },
-      connectorWorkspace: { type: 'object', additionalProperties: true, description: 'Connector workspace bounds.' },
+      connectorWorkspace: {
+        type: 'array',
+        items: { type: 'object', additionalProperties: true },
+        description: 'Connector workspace bounds.',
+      },
       gripperAperture: { type: 'object', additionalProperties: true },
       fitness: { type: 'object', additionalProperties: true, description: 'Mechanism fitness verdict incl. repairMode.' },
       repairContext: { type: 'object', additionalProperties: true },

--- a/tests/unit/mcp/reviewCadOutputSchema.test.ts
+++ b/tests/unit/mcp/reviewCadOutputSchema.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { TOOL_OUTPUT_SCHEMAS } from '../../../src/agent/mcp/toolOutputSchemas';
+
+describe('review_cad output schema', () => {
+  it('declares connectorWorkspace as the array returned by reviewCadTool', () => {
+    const schema = TOOL_OUTPUT_SCHEMAS.review_cad;
+    const connectorWorkspace = schema.properties.connectorWorkspace;
+
+    expect(connectorWorkspace).toMatchObject({
+      type: 'array',
+      items: { type: 'object', additionalProperties: true },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- change review_cad connectorWorkspace output schema from object to array
- add regression test matching reviewCadTool's returned connectorWorkspace shape

## Verification
- npm test -- tests/unit/mcp/reviewCadOutputSchema.test.ts tests/integration/mcp/reviewCad.test.ts