### PR TITLE
Fix review_cad output schema on release

### DIFF
--- a/src/agent/mcp/toolOutputSchemas.ts
+++ b/src/agent/mcp/toolOutputSchemas.ts
@@ -293,7 +293,11 @@ export const TOOL_OUTPUT_SCHEMAS: Record<string, JSONSchemaObject> = {
       assembly: { type: 'string' },
       validator: { type: 'object', additionalProperties: true, description: 'Assembly/mate-graph validator result.' },
       poseEnvelope: { type: 'object', additionalProperties: true, description: 'Sampled mate-limit pose envelope.' },
-      connectorWorkspace: { type: 'object', additionalProperties: true, description: 'Connector workspace bounds.' },
+      connectorWorkspace: {
+        type: 'array',
+        items: { type: 'object', additionalProperties: true },
+        description: 'Connector workspace bounds.',
+      },
       gripperAperture: { type: 'object', additionalProperties: true },
       fitness: { type: 'object', additionalProperties: true, description: 'Mechanism fitness verdict incl. repairMode.' },
       repairContext: { type: 'object', additionalProperties: true },

--- a/tests/unit/mcp/reviewCadOutputSchema.test.ts
+++ b/tests/unit/mcp/reviewCadOutputSchema.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { TOOL_OUTPUT_SCHEMAS } from '../../../src/agent/mcp/toolOutputSchemas';
+
+describe('review_cad output schema', () => {
+  it('declares connectorWorkspace as the array returned by reviewCadTool', () => {
+    const schema = TOOL_OUTPUT_SCHEMAS.review_cad;
+    const connectorWorkspace = schema.properties.connectorWorkspace;
+
+    expect(connectorWorkspace).toMatchObject({
+      type: 'array',
+      items: { type: 'object', additionalProperties: true },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- declare review_cad connectorWorkspace output as the array returned by the tool
- add a regression test for the MCP output schema

## Verification
- npm test -- tests/unit/mcp/reviewCadOutputSchema.test.ts tests/integration/mcp/reviewCad.test.ts (passed in dependency-complete checkout)

Needed because kernelCAD-server deploys only vendor commits reachable from the protected release branch.