### PR TITLE
Reduce GitHub Actions usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,22 +66,20 @@ jobs:
       - name: QC — typecheck + build:cli + cookbook + drift check
         run: npm run qc:build
 
-  # The vitest suite is sharded across parallel runners so the merge gate
-  # stays ~2 min wall-clock instead of one ~12 min monolith. Every test still
-  # runs on every PR — sharding changes distribution, not coverage. The
-  # `test` gate job below is the required branch-protection check; it goes
-  # green only when ALL shards pass.
+  # The vitest suite is sharded across parallel runners so the merge gate stays
+  # responsive. Eight shards keep coverage unchanged while cutting duplicated
+  # checkout/setup/build work compared with the previous 12-runner fanout.
   test-shard:
     runs-on: ubuntu-latest
-    # 15 (not 10) gives headroom for the shard that draws the heavy physics
+    # 20 gives headroom for the shard that draws the heavy physics
     # example-sweep tests (a single example can run ~6 min) so a legitimately
     # slow run is never cancelled mid-test. Setup itself is now near-instant
     # (ffmpeg preinstalled; apt fallback bounded) so this is pure test headroom.
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-cad
@@ -91,8 +89,8 @@ jobs:
       # keeps this fast (~10-15s on hit).
       - name: Build CLI bundle (required by integration tests)
         run: npm run build:cli
-      - name: QC — vitest (shard ${{ matrix.shard }}/12)
-        run: npm test -- --shard=${{ matrix.shard }}/12
+      - name: QC — vitest (shard ${{ matrix.shard }}/8)
+        run: npm test -- --shard=${{ matrix.shard }}/8
 
   # Gate job: carries the required-check name `test` so branch protection is
   # unchanged. if: always() ensures it reports failure (rather than being

--- a/.github/workflows/dist-skills-eval-cron.yml
+++ b/.github/workflows/dist-skills-eval-cron.yml
@@ -1,8 +1,6 @@
-name: dist-skills-eval-cron
+name: dist-skills-eval
 
 on:
-  schedule:
-    - cron: '0 4 * * 1' # Mondays 04:00 UTC
   workflow_dispatch: {}
   # Also runs whenever dist-skills publishes, via repository_dispatch fired
   # by the publish job's "fan-out on success" final step.

--- a/.github/workflows/parts-catalog.yml
+++ b/.github/workflows/parts-catalog.yml
@@ -6,8 +6,8 @@ name: Parts Catalog
 # as kernelCAD's remote source instead of a third-party API.
 
 on:
-  schedule:
-    - cron: '0 4 * * 1' # weekly, Monday 04:00 UTC
+  # Manual because this is a long ingest/deploy job and the catalog does not
+  # need to refresh on every calendar week while Actions quota is tight.
   workflow_dispatch:
     inputs:
       subdir:
@@ -20,7 +20,7 @@ permissions:
 
 concurrency:
   group: parts-catalog
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   ingest-and-deploy:

--- a/.github/workflows/usage-stats.yml
+++ b/.github/workflows/usage-stats.yml
@@ -1,14 +1,12 @@
-name: Usage stats daily report
+name: Usage stats report
 
-# Pulls GitHub traffic + npm download counts daily and appends a row to
+# Pulls GitHub traffic + npm download counts and appends a row to
 # docs/usage/daily.md. Auto-commits to develop. Idempotent: re-running on
 # the same day overwrites the most recent row for that date.
 
 on:
-  schedule:
-    # 03:30 UTC daily — well after midnight in UTC, before working hours
-    # in EU; gives GitHub time to finalize the prior day's traffic counts.
-    - cron: '30 3 * * *'
+  # Manual until the collector is fixed. It failed every scheduled run in the
+  # July billing sample, so running it daily only burns Actions minutes.
   workflow_dispatch:
 
 permissions:
@@ -79,7 +77,7 @@ jobs:
             cat > "$file" <<'EOF'
           # kernelCAD daily usage stats
 
-          Auto-collected by `.github/workflows/usage-stats.yml` daily at 03:30 UTC.
+          Auto-collected by `.github/workflows/usage-stats.yml`.
           GitHub traffic counts cover the last 14 days (rolling). npm downloads cover the prior calendar day.
 
           | Date | Clones (uniq) | Views (uniq) | Stars | Forks | Watchers | npm DL |


### PR DESCRIPTION
## Summary
- reduce CI test shards from 12 to 8 to cut duplicated checkout/setup/build minutes while keeping full test coverage
- pause failing daily usage-stats schedule; keep manual dispatch
- pause weekly dist-skills eval schedule; keep manual and publish-triggered dispatch
- make the long parts catalog refresh manual-only and cancel superseded manual runs

## Context
July billing showed `kernelCAD-web` as the third-largest Actions consumer. Recent runs were dominated by PR CI plus scheduled workflows, including failing scheduled jobs.

## Verification
- Branch compare shows only workflow files changed
- Local `git diff --check` passed for the equivalent workflow edits
- Local Ruby YAML parsing passed for the equivalent workflow edits

GitHub Actions should still validate the workflow changes on this PR branch.