### PR TITLE
Route design loop through review pipeline

### DIFF
--- a/src/agent/mcp/tools/designLoop.ts
+++ b/src/agent/mcp/tools/designLoop.ts
@@ -5,7 +5,12 @@ import { dirname, relative, resolve } from 'node:path';
 import type { GripperApertureRequest } from '../../../modeling/mates/gripperAperture';
 import type { MechanismFitnessResult } from '../../../modeling/mates/mechanismFitness';
 import type { ContactGraphResult } from '../../../modeling/runtime/contactGraph';
-import { reviewCadTool, type RepairContext, type ReviewCadInput, type ReviewCadOutput } from './reviewCad';
+import {
+  runReviewPipeline,
+  type RepairContext,
+  type ReviewCadInput,
+  type ReviewCadOutput,
+} from '../../review/reviewPipeline';
 
 export interface DesignLoopAttemptInput {
   id?: string;
@@ -180,7 +185,7 @@ export async function designLoopTool(input: DesignLoopInput): Promise<DesignLoop
       samplesPerMate: input.samplesPerMate,
       combinatorial: input.combinatorial,
     };
-    const review = await reviewCadTool(reviewInput);
+    const review = await runReviewPipeline(reviewInput);
     const source = attempt.code ?? (attempt.file !== undefined ? await readFile(attempt.file, 'utf-8') : '');
     const attemptResult = toAttemptResult({
       id,

--- a/tests/unit/mcp/designLoopEnvelopeOptions.test.ts
+++ b/tests/unit/mcp/designLoopEnvelopeOptions.test.ts
@@ -1,14 +1,20 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { MechanismFitnessResult } from '../../../src/modeling/mates/mechanismFitness';
-import type { ReviewCadInput, ReviewCadOutput } from '../../../src/agent/mcp/tools/reviewCad';
+import type { ReviewCadInput, ReviewCadOutput } from '../../../src/agent/review/reviewPipeline';
 
-const mockReviewCadTool = vi.fn<(input: ReviewCadInput) => Promise<ReviewCadOutput>>();
+const runReviewPipeline = vi.fn<(input: ReviewCadInput) => Promise<ReviewCadOutput>>();
 
-vi.mock('../../../src/agent/mcp/tools/reviewCad', () => ({
-  reviewCadTool: (input: ReviewCadInput) => mockReviewCadTool(input),
-}));
+vi.mock('../../../src/agent/review/reviewPipeline', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/agent/review/reviewPipeline')>(
+    '../../../src/agent/review/reviewPipeline',
+  );
+  return {
+    ...actual,
+    runReviewPipeline: (input: ReviewCadInput) => runReviewPipeline(input),
+  };
+});
 
-// Imported after the mock so designLoopTool's reviewCadTool reference is the mock.
+// Imported after the mock so designLoopTool's review-pipeline reference is the mock.
 import { designLoopTool } from '../../../src/agent/mcp/tools/designLoop';
 
 function cleanFitness(): MechanismFitnessResult {
@@ -45,8 +51,8 @@ function cleanReviewOutput(): ReviewCadOutput {
 
 describe('design_loop envelope-option pass-through', () => {
   it('designLoopTool forwards samplesPerMate per attempt', async () => {
-    mockReviewCadTool.mockReset();
-    mockReviewCadTool.mockResolvedValue(cleanReviewOutput());
+    runReviewPipeline.mockReset();
+    runReviewPipeline.mockResolvedValue(cleanReviewOutput());
 
     await designLoopTool({
       goal: 'Test samplesPerMate plumbing.',
@@ -55,14 +61,14 @@ describe('design_loop envelope-option pass-through', () => {
       attempts: [{ id: '01', title: 'attempt-1', code: 'return undefined;' }],
     });
 
-    expect(mockReviewCadTool).toHaveBeenCalledTimes(1);
-    const reviewInput = mockReviewCadTool.mock.calls[0]?.[0];
+    expect(runReviewPipeline).toHaveBeenCalledTimes(1);
+    const reviewInput = runReviewPipeline.mock.calls[0]?.[0];
     expect(reviewInput?.samplesPerMate).toBe(5);
   });
 
   it('designLoopTool forwards combinatorial per attempt', async () => {
-    mockReviewCadTool.mockReset();
-    mockReviewCadTool.mockResolvedValue(cleanReviewOutput());
+    runReviewPipeline.mockReset();
+    runReviewPipeline.mockResolvedValue(cleanReviewOutput());
 
     await designLoopTool({
       goal: 'Test combinatorial plumbing.',
@@ -71,8 +77,8 @@ describe('design_loop envelope-option pass-through', () => {
       attempts: [{ id: '01', title: 'attempt-1', code: 'return undefined;' }],
     });
 
-    expect(mockReviewCadTool).toHaveBeenCalledTimes(1);
-    const reviewInput = mockReviewCadTool.mock.calls[0]?.[0];
+    expect(runReviewPipeline).toHaveBeenCalledTimes(1);
+    const reviewInput = runReviewPipeline.mock.calls[0]?.[0];
     expect(reviewInput?.combinatorial).toBe(true);
   });
 });

--- a/tests/unit/mcp/designLoopNextActionPrompt.test.ts
+++ b/tests/unit/mcp/designLoopNextActionPrompt.test.ts
@@ -1,14 +1,20 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { MechanismFitnessResult } from '../../../src/modeling/mates/mechanismFitness';
-import type { ReviewCadInput, ReviewCadOutput } from '../../../src/agent/mcp/tools/reviewCad';
+import type { ReviewCadInput, ReviewCadOutput } from '../../../src/agent/review/reviewPipeline';
 
-const mockReviewCadTool = vi.fn<(input: ReviewCadInput) => Promise<ReviewCadOutput>>();
+const runReviewPipeline = vi.fn<(input: ReviewCadInput) => Promise<ReviewCadOutput>>();
 
-vi.mock('../../../src/agent/mcp/tools/reviewCad', () => ({
-  reviewCadTool: (input: ReviewCadInput) => mockReviewCadTool(input),
-}));
+vi.mock('../../../src/agent/review/reviewPipeline', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/agent/review/reviewPipeline')>(
+    '../../../src/agent/review/reviewPipeline',
+  );
+  return {
+    ...actual,
+    runReviewPipeline: (input: ReviewCadInput) => runReviewPipeline(input),
+  };
+});
 
-// Imported after the mock so designLoopTool's reviewCadTool reference is the mock.
+// Imported after the mock so designLoopTool's review-pipeline reference is the mock.
 import { designLoopTool } from '../../../src/agent/mcp/tools/designLoop';
 
 function failingFitness(): MechanismFitnessResult {
@@ -106,8 +112,8 @@ function cleanReviewOutput(): ReviewCadOutput {
 
 describe('design_loop nextActionPrompt rendering from RepairContext', () => {
   it('nextActionPrompt cites blockingReasons from RepairContext on failure', async () => {
-    mockReviewCadTool.mockReset();
-    mockReviewCadTool.mockResolvedValue(failingReviewOutput());
+    runReviewPipeline.mockReset();
+    runReviewPipeline.mockResolvedValue(failingReviewOutput());
 
     const result = await designLoopTool({
       goal: 'Test hinge widening repair flow.',
@@ -122,8 +128,8 @@ describe('design_loop nextActionPrompt rendering from RepairContext', () => {
   });
 
   it('nextActionPrompt cites top diagnostics with suggestedDelta when present', async () => {
-    mockReviewCadTool.mockReset();
-    mockReviewCadTool.mockResolvedValue(failingReviewOutput());
+    runReviewPipeline.mockReset();
+    runReviewPipeline.mockResolvedValue(failingReviewOutput());
 
     const result = await designLoopTool({
       goal: 'Test hinge widening repair flow.',
@@ -137,9 +143,9 @@ describe('design_loop nextActionPrompt rendering from RepairContext', () => {
   });
 
   it('nextActionPrompt does not duplicate suggestedRepairPrompt verbatim', async () => {
-    mockReviewCadTool.mockReset();
+    runReviewPipeline.mockReset();
     const review = failingReviewOutput();
-    mockReviewCadTool.mockResolvedValue(review);
+    runReviewPipeline.mockResolvedValue(review);
 
     const result = await designLoopTool({
       goal: 'Test hinge widening repair flow.',
@@ -156,8 +162,8 @@ describe('design_loop nextActionPrompt rendering from RepairContext', () => {
   });
 
   it('nextActionPrompt happy path still says "no interferences" on ok:true', async () => {
-    mockReviewCadTool.mockReset();
-    mockReviewCadTool.mockResolvedValue(cleanReviewOutput());
+    runReviewPipeline.mockReset();
+    runReviewPipeline.mockResolvedValue(cleanReviewOutput());
 
     const result = await designLoopTool({
       goal: 'Test clean pass.',
@@ -173,8 +179,8 @@ describe('design_loop nextActionPrompt rendering from RepairContext', () => {
   });
 
   it('does not allow allowReviewWarnings to suppress required visual evidence gates', async () => {
-    mockReviewCadTool.mockReset();
-    mockReviewCadTool.mockResolvedValue(cleanReviewOutput());
+    runReviewPipeline.mockReset();
+    runReviewPipeline.mockResolvedValue(cleanReviewOutput());
 
     const result = await designLoopTool({
       goal: 'Require screenshot-backed visual review for a release model.',

--- a/tests/unit/mcp/designLoopReviewPipeline.test.ts
+++ b/tests/unit/mcp/designLoopReviewPipeline.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ReviewCadInput, ReviewCadOutput } from '../../../src/agent/review/reviewPipeline';
+
+const runReviewPipeline = vi.fn<(input: ReviewCadInput) => Promise<ReviewCadOutput>>();
+
+vi.mock('../../../src/agent/review/reviewPipeline', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/agent/review/reviewPipeline')>(
+    '../../../src/agent/review/reviewPipeline',
+  );
+  return {
+    ...actual,
+    runReviewPipeline: (input: ReviewCadInput) => runReviewPipeline(input),
+  };
+});
+
+vi.mock('../../../src/agent/mcp/tools/reviewCad', () => ({
+  reviewCadTool: () => {
+    throw new Error('design_loop should use runReviewPipeline, not reviewCadTool');
+  },
+}));
+
+import { designLoopTool } from '../../../src/agent/mcp/tools/designLoop';
+
+function cleanReviewOutput(): ReviewCadOutput {
+  return {
+    ok: true,
+    featureCount: 1,
+    diagnostics: [],
+    assembly: 'clean',
+    validator: { status: 'ok', diagnostics: [], partCount: 1, jointCount: 0 },
+    fitness: {
+      functional: true,
+      repairMode: 'none',
+      repairDirective: 'No repair needed. Preserve the current design and rerun review_cad after changes.',
+      passedChecks: ['validator-no-errors'],
+      blockingReasons: [],
+      mechanismSummary: {
+        sampleCount: 0,
+        interferenceCount: 0,
+        trackedConnectorCount: 0,
+      },
+    },
+    repairContext: {
+      blockingReasons: [],
+      topDiagnostics: [],
+      preserveInterfaces: [],
+      designGoal: '',
+    },
+  };
+}
+
+describe('design_loop review boundary', () => {
+  it('uses the shared review pipeline instead of the MCP review_cad adapter', async () => {
+    runReviewPipeline.mockResolvedValueOnce(cleanReviewOutput());
+
+    await expect(designLoopTool({
+      goal: 'Keep design loop off the MCP adapter.',
+      requireVisualReview: false,
+      attempts: [{ id: '01', title: 'clean', code: 'return undefined;' }],
+    })).resolves.toMatchObject({ ok: true, finalAttemptId: '01' });
+
+    expect(runReviewPipeline).toHaveBeenCalledTimes(1);
+    expect(runReviewPipeline.mock.calls[0]?.[0]).toMatchObject({
+      code: 'return undefined;',
+      designGoal: 'Keep design loop off the MCP adapter.',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- make design_loop call runReviewPipeline directly instead of the MCP review_cad adapter
- update design_loop unit mocks to target the shared review pipeline boundary
- add a boundary test that fails if design_loop regresses back to reviewCadTool

## Verification
- PATH=/home/andrii/.nvm/versions/node/v22.22.0/bin:$PATH npm run typecheck
- PATH=/home/andrii/.nvm/versions/node/v22.22.0/bin:$PATH npm test -- tests/unit/mcp/designLoopReviewPipeline.test.ts tests/unit/mcp/designLoopEnvelopeOptions.test.ts tests/unit/mcp/designLoopNextActionPrompt.test.ts tests/integration/mcp/designLoop.test.ts tests/integration/mcp/designLoop-interference.test.ts tests/integration/mcp/reviewCad.test.ts tests/unit/mcp/reviewCadAdapter.test.ts
- independent reviewer subagent: no blocking runtime issues; public review_cad adapter contract preserved

No public docs were added or changed.