### PR TITLE
Move naming contracts into shared

### DIFF
--- a/src/kernel/naming/query.ts
+++ b/src/kernel/naming/query.ts
@@ -16,6 +16,9 @@
 
 import type { OcctBackend } from '../backends/occt/occtBackend';
 import type { FeatureRecord } from '../../shared/intent/featureRecord';
+import type { QueryAst, QueryKind } from '../../shared/naming/queryAst';
+
+export type { GeometryType, QueryAst, QueryKind } from '../../shared/naming/queryAst';
 
 /** Internal: evaluator delegates injected by `queryEvaluator.ts` after its
  *  module init finishes. The chainables read this table at call time so the
@@ -46,9 +49,6 @@ export function __installQueryStringifier(fn: (q: Query<unknown>) => string): vo
   __formatQueryAsString = fn;
 }
 
-/** Discriminator for the entity kind a Query addresses. */
-export type QueryKind = 'face' | 'edge' | 'vertex' | 'connector' | 'part' | 'solid';
-
 /** Phantom type markers for static type narrowing. The markers are NEVER
  *  materialised at runtime; the runtime discriminator is `Query.target`.
  *  Phantoms exist purely so TS rejects `fillet({ edges: faceQuery })` at
@@ -63,29 +63,6 @@ export type SolidMarker = { readonly _solid: unique symbol };
 export type EntityMarker =
   | FaceMarker | EdgeMarker | VertexMarker
   | ConnectorMarker | PartMarker | SolidMarker;
-
-export type GeometryType =
-  | 'PLANE' | 'CYLINDER' | 'CONE' | 'SPHERE' | 'TORUS'
-  | 'BSPLINE_SURFACE' | 'LINE' | 'CIRCLE' | 'BSPLINE_CURVE' | 'OTHER';
-
-/** The Query AST. Serializable; structurally equal under round-trip. */
-export type QueryAst =
-  | { op: 'nothing' }
-  | { op: 'everything'; kind: QueryKind }
-  | { op: 'createdBy'; id: string; kind?: QueryKind }
-  | { op: 'ownedByPart'; query: QueryAst }
-  | { op: 'ownerPart'; query: QueryAst }
-  | { op: 'union'; queries: QueryAst[] }
-  | { op: 'intersection'; queries: QueryAst[] }
-  | { op: 'subtraction'; a: QueryAst; b: QueryAst }
-  | { op: 'containsPoint'; query: QueryAst; point: [number, number, number] }
-  | { op: 'closestTo'; query: QueryAst; point: [number, number, number]; k?: number }
-  | { op: 'geometryType'; query: QueryAst; geomType: GeometryType }
-  | { op: 'entityFilter'; query: QueryAst; kind: QueryKind }
-  | { op: 'withLabel'; query: QueryAst; label: string }
-  | { op: 'withFeatureName'; query: QueryAst; name: string }
-  | { op: 'nthElement'; query: QueryAst; index: number }
-  | { op: 'fromString'; ref: string };
 
 /** A resolved entity carries the OCCT handle, the canonical @kc[...] ref
  *  (so diagnostic prose stays compact), and a snapshot for cite-by-geometry. */

--- a/src/kernel/naming/uniquenessValidator.ts
+++ b/src/kernel/naming/uniquenessValidator.ts
@@ -2,60 +2,12 @@
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // src/kernel/naming/uniquenessValidator.ts
 //
-// Capture-time enforcement that names emitted by user code (face labels,
-// part names, connector names, feature names) can round-trip through the
-// @kc[...] topology-ref grammar. Names that fail this check would otherwise
-// produce ambiguous or unparseable refs at the resolver — fail fast at
-// capture time instead.
-//
-// Internal-only. Surfacing this contract through SKILL.md / MCP tool docs
-// ships with F-surface (Task F5).
+// Compatibility re-export for existing kernel/modeling callers. The shared
+// topology-ref name contract lives in src/shared/naming/topoRefName.ts so
+// shared manifests can validate connector names without importing kernel.
 
-import { KernelError } from '../../shared/intent/kernelError';
-
-/** Characters reserved by the @kc[...] grammar. None may appear inside a
- *  name segment. The set is fixed by spec §3.1 (separators) + §3.1 reserved
- *  chars + the grammar wrapper (`@`, `[`, `]`). */
-export const RESERVED_TOPO_REF_CHARS = [
-  '.', '/', '[', ']', '@', '#', '*', '?', ',',
-] as const;
-
-/** Regex form of the name grammar — alpha-leading, alnum + dash + underscore. */
-export const TOPO_REF_NAME_REGEX = /^[A-Za-z][A-Za-z0-9_-]*$/;
-
-/**
- * Throw KernelError('feature.invalid-args') if `name` is not safe to embed
- * in a `@kc[owner/kind/name]` topology reference.
- *
- * `scope` is a human-readable category used in the error message
- * ('face-label', 'part-name', 'connector-name', 'feature-name',
- * 'wrap-geom-name').
- *
- * `featureId` (optional) attaches to the thrown error for diagnostic plumbing.
- */
-export function assertTopoRefSafeName(
-  name: string,
-  scope: 'face-label' | 'part-name' | 'connector-name' | 'feature-name' | 'wrap-geom-name',
-  featureId?: string,
-): void {
-  if (typeof name !== 'string' || name.length === 0) {
-    throw new KernelError(
-      'feature.invalid-args',
-      `${scope} must be a non-empty string; got ${JSON.stringify(name)}.`,
-      featureId,
-      `Use a non-empty identifier matching ${TOPO_REF_NAME_REGEX.source}.`,
-    );
-  }
-  if (!TOPO_REF_NAME_REGEX.test(name)) {
-    const offenders = RESERVED_TOPO_REF_CHARS.filter((c) => name.includes(c));
-    const reason = offenders.length > 0
-      ? `contains reserved character(s): ${offenders.map((c) => `'${c}'`).join(', ')}`
-      : `does not match ${TOPO_REF_NAME_REGEX.source} (must start with a letter; subsequent chars must be letters, digits, dash, or underscore)`;
-    throw new KernelError(
-      'feature.invalid-args',
-      `${scope} '${name}' is not a valid topology-ref name: ${reason}.`,
-      featureId,
-      `Rename to an identifier matching ${TOPO_REF_NAME_REGEX.source}; the disallowed characters are reserved by the @kc[owner/kind/name] grammar.`,
-    );
-  }
-}
+export {
+  assertTopoRefSafeName,
+  RESERVED_TOPO_REF_CHARS,
+  TOPO_REF_NAME_REGEX,
+} from '../../shared/naming/topoRefName';

--- a/src/shared/intent/types.ts
+++ b/src/shared/intent/types.ts
@@ -81,7 +81,7 @@ export type FaceRef =
   // Q8 — Query DSL value (kc.q.face(...) etc). Serialized as the AST so
   // the FeatureRecord stays JSON-round-trippable; the lowerer dispatches
   // through the Q3 evaluator at consume time.
-  | { kind: 'queryDsl'; queryAst: import('../../kernel/naming/query').QueryAst; queryTarget: import('../../kernel/naming/query').QueryKind | 'any'; lenient?: boolean };
+  | { kind: 'queryDsl'; queryAst: import('../naming/queryAst').QueryAst; queryTarget: import('../naming/queryAst').QueryKind | 'any'; lenient?: boolean };
 
 export type EdgeRef =
   | { kind: 'tracked'; edgeName: string; selector: 'edge'|'start'|'end'|'midpoint' }
@@ -93,7 +93,7 @@ export type EdgeRef =
   | { kind: 'segment'; segmentId: string }
   | { kind: 'segments'; segmentIds: string[] }
   // Q8 — Query DSL value (kc.q.edge(...) etc).
-  | { kind: 'queryDsl'; queryAst: import('../../kernel/naming/query').QueryAst; queryTarget: import('../../kernel/naming/query').QueryKind | 'any'; lenient?: boolean };
+  | { kind: 'queryDsl'; queryAst: import('../naming/queryAst').QueryAst; queryTarget: import('../naming/queryAst').QueryKind | 'any'; lenient?: boolean };
 
 export type VertexRef =
   | { kind: 'tracked'; vertexName: string }

--- a/src/shared/naming/queryAst.ts
+++ b/src/shared/naming/queryAst.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/shared/naming/queryAst.ts
+//
+// Serializable Query DSL contracts. Runtime query values, evaluators, and
+// OCCT-facing scene types stay in src/kernel/naming/query.ts.
+
+/** Discriminator for the entity kind a Query addresses. */
+export type QueryKind = 'face' | 'edge' | 'vertex' | 'connector' | 'part' | 'solid';
+
+export type GeometryType =
+  | 'PLANE' | 'CYLINDER' | 'CONE' | 'SPHERE' | 'TORUS'
+  | 'BSPLINE_SURFACE' | 'LINE' | 'CIRCLE' | 'BSPLINE_CURVE' | 'OTHER';
+
+/** The Query AST. Serializable; structurally equal under round-trip. */
+export type QueryAst =
+  | { op: 'nothing' }
+  | { op: 'everything'; kind: QueryKind }
+  | { op: 'createdBy'; id: string; kind?: QueryKind }
+  | { op: 'ownedByPart'; query: QueryAst }
+  | { op: 'ownerPart'; query: QueryAst }
+  | { op: 'union'; queries: QueryAst[] }
+  | { op: 'intersection'; queries: QueryAst[] }
+  | { op: 'subtraction'; a: QueryAst; b: QueryAst }
+  | { op: 'containsPoint'; query: QueryAst; point: [number, number, number] }
+  | { op: 'closestTo'; query: QueryAst; point: [number, number, number]; k?: number }
+  | { op: 'geometryType'; query: QueryAst; geomType: GeometryType }
+  | { op: 'entityFilter'; query: QueryAst; kind: QueryKind }
+  | { op: 'withLabel'; query: QueryAst; label: string }
+  | { op: 'withFeatureName'; query: QueryAst; name: string }
+  | { op: 'nthElement'; query: QueryAst; index: number }
+  | { op: 'fromString'; ref: string };

--- a/src/shared/naming/topoRefName.ts
+++ b/src/shared/naming/topoRefName.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/shared/naming/topoRefName.ts
+//
+// Shared topology-ref name grammar. Used by shared manifests and re-exported
+// by kernel/naming for existing runtime callers.
+
+import { KernelError } from '../intent/kernelError';
+
+/** Characters reserved by the @kc[...] grammar. None may appear inside a
+ *  name segment. The set is fixed by spec §3.1 (separators) + §3.1 reserved
+ *  chars + the grammar wrapper (`@`, `[`, `]`). */
+export const RESERVED_TOPO_REF_CHARS = [
+  '.', '/', '[', ']', '@', '#', '*', '?', ',',
+] as const;
+
+/** Regex form of the name grammar — alpha-leading, alnum + dash + underscore. */
+export const TOPO_REF_NAME_REGEX = /^[A-Za-z][A-Za-z0-9_-]*$/;
+
+/**
+ * Throw KernelError('feature.invalid-args') if `name` is not safe to embed
+ * in a `@kc[owner/kind/name]` topology reference.
+ *
+ * `scope` is a human-readable category used in the error message
+ * ('face-label', 'part-name', 'connector-name', 'feature-name',
+ * 'wrap-geom-name').
+ *
+ * `featureId` (optional) attaches to the thrown error for diagnostic plumbing.
+ */
+export function assertTopoRefSafeName(
+  name: string,
+  scope: 'face-label' | 'part-name' | 'connector-name' | 'feature-name' | 'wrap-geom-name',
+  featureId?: string,
+): void {
+  if (typeof name !== 'string' || name.length === 0) {
+    throw new KernelError(
+      'feature.invalid-args',
+      `${scope} must be a non-empty string; got ${JSON.stringify(name)}.`,
+      featureId,
+      `Use a non-empty identifier matching ${TOPO_REF_NAME_REGEX.source}.`,
+    );
+  }
+  if (!TOPO_REF_NAME_REGEX.test(name)) {
+    const offenders = RESERVED_TOPO_REF_CHARS.filter((c) => name.includes(c));
+    const reason = offenders.length > 0
+      ? `contains reserved character(s): ${offenders.map((c) => `'${c}'`).join(', ')}`
+      : `does not match ${TOPO_REF_NAME_REGEX.source} (must start with a letter; subsequent chars must be letters, digits, dash, or underscore)`;
+    throw new KernelError(
+      'feature.invalid-args',
+      `${scope} '${name}' is not a valid topology-ref name: ${reason}.`,
+      featureId,
+      `Rename to an identifier matching ${TOPO_REF_NAME_REGEX.source}; the disallowed characters are reserved by the @kc[owner/kind/name] grammar.`,
+    );
+  }
+}

--- a/src/shared/parts/connectorManifest.ts
+++ b/src/shared/parts/connectorManifest.ts
@@ -8,7 +8,7 @@
 // collide with the @kc[...] grammar fails AT BUILD TIME, not at runtime.
 
 import { readFileSync } from 'node:fs';
-import { assertTopoRefSafeName } from '../../kernel/naming';
+import { assertTopoRefSafeName } from '../naming/topoRefName';
 
 export type ConnectorType = 'frame' | 'axis';
 

--- a/tests/unit/architecture/sharedBoundary.test.ts
+++ b/tests/unit/architecture/sharedBoundary.test.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '../../..');
+const SHARED_ROOT = join(ROOT, 'src/shared');
+
+const FORBIDDEN_LAYER_IMPORT = /(?:from\s+['"]|import\(\s*['"])(?:\.\.\/)+(?:kernel|modeling|authoring|agent|studio)\//;
+
+function walk(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      walk(full, acc);
+    } else if (/\.[cm]?tsx?$/.test(entry)) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+describe('shared architecture boundary', () => {
+  it('keeps src/shared free of imports into higher runtime layers', () => {
+    const offenders = walk(SHARED_ROOT)
+      .filter(file => FORBIDDEN_LAYER_IMPORT.test(readFileSync(file, 'utf8')))
+      .map(file => relative(ROOT, file));
+
+    expect(
+      offenders,
+      `src/shared must stay a leaf; move serializable contracts into shared instead:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- move serializable query AST contracts into src/shared/naming/queryAst.ts
- move topology-ref name validation into src/shared/naming/topoRefName.ts with kernel compatibility re-exports
- update shared intent/connector manifest code so src/shared no longer imports src/kernel
- add a focused shared-boundary guard test

## Verification
- npm test -- tests/unit/architecture/sharedBoundary.test.ts src/shared/parts/connectorManifest.test.ts src/kernel/naming/uniquenessValidator.test.ts src/kernel/naming/index.test.ts src/kernel/naming/query.test.ts src/kernel/naming/queryConstructors.test.ts src/kernel/naming/parseQuery.test.ts
- npm test -- src/kernel/naming/queryComposition.test.ts
- npm run typecheck
- ./node_modules/.bin/depcruise --config .dependency-cruiser.cjs src --output-type err (still exits nonzero for unrelated existing violations; no shared-stays-leaf entries remain)

## Review
- independent code-review subagent: no findings