### PR TITLE
feat(studio): show validity repair workflow state

### DIFF
--- a/src/studio/StudioGenerate.tsx
+++ b/src/studio/StudioGenerate.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { DiffEditor } from '@monaco-editor/react';
 import { useGeneration } from '../funnel/hooks/useGeneration';
 import type { GenerateEvent } from '../funnel/lib/generateClient';
@@ -10,7 +10,7 @@ import { ConceptResult } from './components/ConceptResult';
 import { useCode } from './context/CodeContext';
 import { useGeometry } from './context/GeometryContext';
 import { useFeatureSelection } from './hooks/useFeatureSelection';
-import { useShellStore } from './store/useShellStore';
+import { useShellStore, shellStore } from './store/useShellStore';
 
 /** Web-only gate. No hooks here, so the conditional return is safe. */
 export const StudioGenerate: React.FC = () => {
@@ -38,7 +38,7 @@ const StudioGenerateInner: React.FC = () => {
     const currentCode = code ?? '';
     const { executeGeometry } = useGeometry();
     const { selectedFeatureId } = useFeatureSelection();
-    const { agentDraftPrompt, agentDraftPromptVersion } = useShellStore();
+    const { agentDraftPrompt, agentDraftPromptVersion, agentRepairWorkflow } = useShellStore();
     const [editedPrompt, setEditedPrompt] = useState('');
     const [acknowledgedDraftVersion, setAcknowledgedDraftVersion] = useState(-1);
     // The generationId we've already accepted/rejected — gates the review panel
@@ -73,6 +73,11 @@ const StudioGenerateInner: React.FC = () => {
 
     const steps = useMemo(() => events.map(stepLabel).filter(Boolean) as string[], [events]);
 
+    useEffect(() => {
+        if (phase.state !== 'error' || agentRepairWorkflow?.state !== 'running') return;
+        shellStore.setAgentRepairWorkflow({ ...agentRepairWorkflow, state: 'drafted' });
+    }, [agentRepairWorkflow, phase.state]);
+
     const runAgent = (text: string) => {
         // Edit mode: hand the agent the current model so it iterates instead of
         // replacing. Empty editor → fresh generation.
@@ -89,6 +94,14 @@ const StudioGenerateInner: React.FC = () => {
         const trimmed = prompt.trim();
         if (!trimmed || busy) return;
         const agentPrompt = selectedFeatureId === null ? trimmed : `Edit selected target "${selectedFeatureId}": ${trimmed}`;
+        if (
+            agentRepairWorkflow != null &&
+            agentRepairWorkflow.state === 'drafted' &&
+            agentRepairWorkflow.promptText === trimmed &&
+            agentRepairWorkflow.targetId === selectedFeatureId
+        ) {
+            shellStore.setAgentRepairWorkflow({ ...agentRepairWorkflow, state: 'running' });
+        }
         runAgent(agentPrompt);
     };
 

--- a/src/studio/__tests__/StudioGenerate.test.tsx
+++ b/src/studio/__tests__/StudioGenerate.test.tsx
@@ -26,6 +26,16 @@ const mockSelection = vi.hoisted(() => ({
 const mockShell = vi.hoisted(() => ({
     agentDraftPrompt: null as string | null,
     agentDraftPromptVersion: 0,
+    agentRepairWorkflow: null as {
+        cardId: string;
+        code: string;
+        promptText: string;
+        targetId: string | null;
+        promptSource: 'review' | 'fallback';
+        validityFingerprint: string;
+        state: 'drafted' | 'running';
+    } | null,
+    setAgentRepairWorkflow: vi.fn(),
 }));
 
 vi.mock('../agentAvailability', () => ({
@@ -55,7 +65,11 @@ vi.mock('../store/useShellStore', () => ({
     useShellStore: () => ({
         agentDraftPrompt: mockShell.agentDraftPrompt,
         agentDraftPromptVersion: mockShell.agentDraftPromptVersion,
+        agentRepairWorkflow: mockShell.agentRepairWorkflow,
     }),
+    shellStore: {
+        setAgentRepairWorkflow: mockShell.setAgentRepairWorkflow,
+    },
 }));
 
 import { StudioGenerate } from '../StudioGenerate';
@@ -69,6 +83,8 @@ beforeEach(() => {
     mockSelection.selectedFeatureId = null;
     mockShell.agentDraftPrompt = null;
     mockShell.agentDraftPromptVersion = 0;
+    mockShell.agentRepairWorkflow = null;
+    mockShell.setAgentRepairWorkflow.mockReset();
 });
 
 afterEach(() => cleanup());
@@ -104,6 +120,81 @@ describe('StudioGenerate', () => {
         expect(mockGeneration.submit).toHaveBeenCalledWith(
             'Edit selected target "hinge-pin": add 2 mm clearance',
         );
+    });
+
+    it('marks the active repair workflow running when the drafted prompt is submitted', () => {
+        mockSelection.selectedFeatureId = 'output-horn';
+        mockShell.agentDraftPrompt = 'Fix assembly.part.floating: output-horn floats Action: add a mate';
+        mockShell.agentDraftPromptVersion = 1;
+        mockShell.agentRepairWorkflow = {
+            cardId: 'diagnostic:assembly.part.floating:output-horn:0',
+            code: 'assembly.part.floating',
+            promptText: 'Fix assembly.part.floating: output-horn floats Action: add a mate',
+            targetId: 'output-horn',
+            promptSource: 'fallback',
+            validityFingerprint: 'before',
+            state: 'drafted',
+        };
+        render(<StudioGenerate />);
+
+        const prompt = screen.getByLabelText('Generate prompt');
+        fireEvent.submit(prompt.closest('form')!);
+
+        expect(mockShell.setAgentRepairWorkflow).toHaveBeenCalledWith({
+            ...mockShell.agentRepairWorkflow,
+            state: 'running',
+        });
+        expect(mockGeneration.submit).toHaveBeenCalledWith(
+            'Edit selected target "output-horn": Fix assembly.part.floating: output-horn floats Action: add a mate',
+        );
+    });
+
+    it('does not mark a drafted repair running when the selected target changed', () => {
+        mockSelection.selectedFeatureId = 'hinge-pin';
+        mockShell.agentDraftPrompt = 'Fix assembly.part.floating: output-horn floats Action: add a mate';
+        mockShell.agentDraftPromptVersion = 1;
+        mockShell.agentRepairWorkflow = {
+            cardId: 'diagnostic:assembly.part.floating:output-horn:0',
+            code: 'assembly.part.floating',
+            promptText: 'Fix assembly.part.floating: output-horn floats Action: add a mate',
+            targetId: 'output-horn',
+            promptSource: 'fallback',
+            validityFingerprint: 'before',
+            state: 'drafted',
+        };
+        render(<StudioGenerate />);
+
+        const prompt = screen.getByLabelText('Generate prompt');
+        fireEvent.submit(prompt.closest('form')!);
+
+        expect(mockShell.setAgentRepairWorkflow).not.toHaveBeenCalled();
+        expect(mockGeneration.submit).toHaveBeenCalledWith(
+            'Edit selected target "hinge-pin": Fix assembly.part.floating: output-horn floats Action: add a mate',
+        );
+    });
+
+    it('rolls a running repair workflow back to drafted when generation errors', () => {
+        mockGeneration.phase = {
+            state: 'error',
+            code: 'network',
+            message: 'stream failed',
+        };
+        mockShell.agentRepairWorkflow = {
+            cardId: 'diagnostic:assembly.part.floating:output-horn:0',
+            code: 'assembly.part.floating',
+            promptText: 'Fix assembly.part.floating: output-horn floats Action: add a mate',
+            targetId: 'output-horn',
+            promptSource: 'fallback',
+            validityFingerprint: 'before',
+            state: 'running',
+        };
+
+        render(<StudioGenerate />);
+
+        expect(mockShell.setAgentRepairWorkflow).toHaveBeenCalledWith({
+            ...mockShell.agentRepairWorkflow,
+            state: 'drafted',
+        });
     });
 
     it('loads the agent draft prompt into the textarea', () => {

--- a/src/studio/__tests__/shellStore.test.ts
+++ b/src/studio/__tests__/shellStore.test.ts
@@ -22,6 +22,7 @@ describe('ShellStore', () => {
         expect(typeof s.agentRailOpen).toBe('boolean');
         expect(s.agentDraftPrompt).toBeNull();
         expect(s.agentDraftPromptVersion).toBe(0);
+        expect(s.agentRepairWorkflow).toBeNull();
         expect(s.previousValidity).toBeNull();
         expect(s.currentValidity).toBeNull();
     });
@@ -92,6 +93,33 @@ describe('ShellStore', () => {
         expect(listener).toHaveBeenCalledTimes(3);
         expect(store.getSnapshot().agentDraftPrompt).toBeNull();
         expect(store.getSnapshot().agentDraftPromptVersion).toBe(2);
+    });
+
+    it('setAgentRepairWorkflow tracks the active validity repair workflow', () => {
+        store = new ShellStore();
+        const listener = vi.fn();
+        store.subscribe(listener);
+        const workflow = {
+            cardId: 'diagnostic:assembly.part.floating:output-horn:0',
+            code: 'assembly.part.floating',
+            promptText: 'Fix assembly.part.floating',
+            targetId: 'output-horn',
+            promptSource: 'fallback' as const,
+            validityFingerprint: 'before',
+            state: 'drafted' as const,
+        };
+
+        store.setAgentRepairWorkflow(workflow);
+        expect(store.getSnapshot().agentRepairWorkflow).toBe(workflow);
+
+        store.setAgentRepairWorkflow({ ...workflow, state: 'running' });
+        expect(store.getSnapshot().agentRepairWorkflow?.state).toBe('running');
+
+        store.setAgentRepairWorkflow(null);
+        store.setAgentRepairWorkflow(null);
+
+        expect(listener).toHaveBeenCalledTimes(3);
+        expect(store.getSnapshot().agentRepairWorkflow).toBeNull();
     });
 
     it('publishValidity rotates current → previous', () => {

--- a/src/studio/__tests__/tabs/ValidityTab.test.tsx
+++ b/src/studio/__tests__/tabs/ValidityTab.test.tsx
@@ -219,8 +219,183 @@ describe('ValidityTab', () => {
             'Fix assembly.part.floating: output-horn floats Action: add a mate to output-horn',
         );
         expect(shellStore.getSnapshot().agentRailOpen).toBe(true);
+        expect(shellStore.getSnapshot().agentRepairWorkflow).toMatchObject({
+            cardId: 'diagnostic:assembly.part.floating:output-horn:0',
+            code: 'assembly.part.floating',
+            promptText: 'Fix assembly.part.floating: output-horn floats Action: add a mate to output-horn',
+            targetId: 'output-horn',
+            state: 'drafted',
+        });
         expect(mockSelectFeature).toHaveBeenCalledTimes(1);
         expect(mockSelectFeature).toHaveBeenCalledWith('output-horn');
+    });
+
+    it('labels the active suggestion card as drafted after Use prompt', () => {
+        const diag: ValidatorDiagnostic = {
+            code: 'assembly.part.floating',
+            severity: 'error',
+            message: 'output-horn floats',
+            hint: 'add a mate to output-horn',
+            partName: 'output-horn',
+        };
+
+        mockUseRecomputeResult.mockReturnValue(
+            withValidity(makeValidity('error', [diag], 1, 0)),
+        );
+
+        render(<ValidityTab />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Use prompt' }));
+
+        const card = screen.getByTestId('validity-suggestion-card');
+        expect(card.getAttribute('data-workflow-state')).toBe('drafted');
+        expect(card.textContent).toContain('Drafted');
+    });
+
+    it('labels the active suggestion card as running when Studio Generate submits the drafted prompt', () => {
+        const diag: ValidatorDiagnostic = {
+            code: 'assembly.part.floating',
+            severity: 'error',
+            message: 'output-horn floats',
+            hint: 'add a mate to output-horn',
+            partName: 'output-horn',
+        };
+
+        mockUseRecomputeResult.mockReturnValue(
+            withValidity(makeValidity('error', [diag], 1, 0)),
+        );
+
+        const { rerender } = render(<ValidityTab />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Use prompt' }));
+        const workflow = shellStore.getSnapshot().agentRepairWorkflow;
+        shellStore.setAgentRepairWorkflow(workflow == null ? null : { ...workflow, state: 'running' });
+        rerender(<ValidityTab />);
+
+        const card = screen.getByTestId('validity-suggestion-card');
+        expect(card.getAttribute('data-workflow-state')).toBe('running');
+        expect(card.textContent).toContain('Running');
+    });
+
+    it('marks the drafted card still failing after a recheck with the same diagnostic', () => {
+        const diag: ValidatorDiagnostic = {
+            code: 'assembly.part.floating',
+            severity: 'error',
+            message: 'output-horn floats',
+            hint: 'add a mate to output-horn',
+            partName: 'output-horn',
+        };
+        const firstResult = withValidity(makeValidity('error', [diag], 1, 0));
+        const secondResult = withValidity(makeValidity('error', [
+            { ...diag, message: 'output-horn still floats' },
+        ], 1, 0));
+        mockUseRecomputeResult.mockReturnValue(firstResult);
+        const { rerender } = render(<ValidityTab />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Use prompt' }));
+        const workflow = shellStore.getSnapshot().agentRepairWorkflow;
+        shellStore.setAgentRepairWorkflow(workflow == null ? null : { ...workflow, state: 'running' });
+        mockUseRecomputeResult.mockReturnValue(secondResult);
+        rerender(<ValidityTab />);
+
+        const card = screen.getByTestId('validity-suggestion-card');
+        expect(card.getAttribute('data-workflow-state')).toBe('still-failing');
+        expect(card.textContent).toContain('Rechecked');
+        expect(card.textContent).toContain('Still failing');
+    });
+
+    it('does not mark drafted cards rechecked before the repair has been submitted', () => {
+        const diag: ValidatorDiagnostic = {
+            code: 'assembly.part.floating',
+            severity: 'error',
+            message: 'output-horn floats',
+            hint: 'add a mate to output-horn',
+            partName: 'output-horn',
+        };
+        mockUseRecomputeResult.mockReturnValue(
+            withValidity(makeValidity('error', [diag], 1, 0)),
+        );
+        const { rerender } = render(<ValidityTab />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Use prompt' }));
+        mockUseRecomputeResult.mockReturnValue(
+            withValidity(makeValidity('error', [
+                { ...diag, message: 'output-horn wording changed' },
+            ], 1, 0)),
+        );
+        rerender(<ValidityTab />);
+
+        const card = screen.getByTestId('validity-suggestion-card');
+        expect(card.getAttribute('data-workflow-state')).toBe('drafted');
+        expect(card.textContent).toContain('Drafted');
+        expect(card.textContent).not.toContain('Still failing');
+        expect(screen.queryByTestId('validity-suggestion-workflow-summary')).toBeNull();
+    });
+
+    it('keeps a compact fixed recheck summary when the drafted card disappears', () => {
+        const diag: ValidatorDiagnostic = {
+            code: 'assembly.part.floating',
+            severity: 'error',
+            message: 'output-horn floats',
+            hint: 'add a mate to output-horn',
+            partName: 'output-horn',
+        };
+
+        mockUseRecomputeResult.mockReturnValue(
+            withValidity(makeValidity('error', [diag], 1, 0)),
+        );
+        const { rerender } = render(<ValidityTab />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Use prompt' }));
+        const workflow = shellStore.getSnapshot().agentRepairWorkflow;
+        shellStore.setAgentRepairWorkflow(workflow == null ? null : { ...workflow, state: 'running' });
+        mockUseRecomputeResult.mockReturnValue(
+            withValidity(makeValidity('solved', [], 1, 1)),
+        );
+        rerender(<ValidityTab />);
+
+        const summary = screen.getByTestId('validity-suggestion-workflow-summary');
+        expect(summary.getAttribute('data-workflow-state')).toBe('fixed');
+        expect(summary.textContent).toContain('Rechecked');
+        expect(summary.textContent).toContain('Fixed');
+    });
+
+    it('does not report fixed when the same failure remains outside the visible card limit', () => {
+        const diag: ValidatorDiagnostic = {
+            code: 'assembly.part.floating',
+            severity: 'error',
+            message: 'output-horn floats',
+            hint: 'add a mate to output-horn',
+            partName: 'output-horn',
+        };
+
+        mockUseRecomputeResult.mockReturnValue(
+            withValidity(makeValidity('error', [diag], 1, 0)),
+        );
+        const { rerender } = render(<ValidityTab />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Use prompt' }));
+        const workflow = shellStore.getSnapshot().agentRepairWorkflow;
+        shellStore.setAgentRepairWorkflow(workflow == null ? null : { ...workflow, state: 'running' });
+        mockUseRecomputeResult.mockReturnValue({
+            ...withValidity(makeValidity('error', [
+                { ...diag, message: 'output-horn still floats' },
+            ], 1, 0)),
+            mechanismBanner: {
+                entries: [
+                    { code: 'mechanism.disconnect', message: 'drive chain disconnected', hint: 'connect drive' },
+                    { code: 'mechanism.orphan-part', message: 'orphan part', hint: 'add mate' },
+                    { code: 'mechanism.no-actuator', message: 'no actuator', hint: 'add actuator' },
+                ],
+            },
+        });
+        rerender(<ValidityTab />);
+
+        const summary = screen.getByTestId('validity-suggestion-workflow-summary');
+        expect(summary.getAttribute('data-workflow-state')).toBe('still-failing');
+        expect(summary.textContent).toContain('Rechecked');
+        expect(summary.textContent).toContain('Still failing');
+        expect(summary.textContent).not.toContain('Fixed');
     });
 
     it('renders fallback prompt preview and source on a suggestion card', () => {

--- a/src/studio/store/shellStore.ts
+++ b/src/studio/store/shellStore.ts
@@ -28,11 +28,24 @@ export interface StagedEdit {
     readonly source?: { kind: 'agent' | 'human' | 'test'; label?: string };
 }
 
+export type AgentRepairWorkflowState = 'drafted' | 'running';
+
+export interface AgentRepairWorkflow {
+    readonly cardId: string;
+    readonly code: string;
+    readonly promptText: string;
+    readonly targetId: SelectedFeatureId;
+    readonly promptSource: 'review' | 'fallback';
+    readonly validityFingerprint: string;
+    readonly state: AgentRepairWorkflowState;
+}
+
 export interface ShellState {
     readonly selectedFeatureId: SelectedFeatureId;
     readonly agentRailOpen: boolean;
     readonly agentDraftPrompt: string | null;
     readonly agentDraftPromptVersion: number;
+    readonly agentRepairWorkflow: AgentRepairWorkflow | null;
     readonly inspectorOpen: boolean;
     readonly previousValidity: ValidatorResult | null;
     readonly currentValidity: ValidatorResult | null;
@@ -82,6 +95,7 @@ const INITIAL_STATE: ShellState = {
     agentRailOpen: Boolean(import.meta.env?.VITE_API_BASE_URL),
     agentDraftPrompt: null,
     agentDraftPromptVersion: 0,
+    agentRepairWorkflow: null,
     inspectorOpen: true,
     previousValidity: null,
     currentValidity: null,
@@ -137,6 +151,12 @@ export class ShellStore {
                     ? this.state.agentDraftPromptVersion
                     : this.state.agentDraftPromptVersion + 1,
         };
+        this.emit();
+    };
+
+    setAgentRepairWorkflow = (workflow: AgentRepairWorkflow | null): void => {
+        if (this.state.agentRepairWorkflow === workflow) return;
+        this.state = { ...this.state, agentRepairWorkflow: workflow };
         this.emit();
     };
 

--- a/src/studio/tabs/ValidityTab.tsx
+++ b/src/studio/tabs/ValidityTab.tsx
@@ -9,7 +9,8 @@ import {
     buildValiditySuggestions,
     type ValiditySuggestionCard,
 } from '../adapters/validitySuggestions';
-import { shellStore } from '../store/shellStore';
+import { useShellStore, shellStore } from '../store/useShellStore';
+import type { AgentRepairWorkflow } from '../store/shellStore';
 
 /**
  * Always-visible inspector view of the validator result. Peer to the
@@ -19,6 +20,7 @@ import { shellStore } from '../store/shellStore';
 export function ValidityTab(): JSX.Element {
     const { validity, mechanismBanner, suggestedRepairPrompt, repairEvidence } = useRecomputeResult();
     const { selectFeature } = useFeatureSelection();
+    const { agentRepairWorkflow } = useShellStore();
 
     if (validity === null) {
         return (
@@ -38,6 +40,20 @@ export function ValidityTab(): JSX.Element {
         mechanismBanner,
         suggestedRepairPrompt,
         repairEvidence,
+    });
+    const validityFingerprint = fingerprintValidity({
+        status,
+        diagnostics,
+        mechanismBanner,
+    });
+    const workflowView = resolveWorkflowView({
+        workflow: agentRepairWorkflow,
+        suggestionCards,
+        failureStillPresent:
+            agentRepairWorkflow == null
+                ? false
+                : workflowFailureStillPresent(agentRepairWorkflow, diagnostics, mechanismBanner),
+        validityFingerprint,
     });
 
     return (
@@ -64,6 +80,8 @@ export function ValidityTab(): JSX.Element {
                         <SuggestionCard
                             key={card.id}
                             card={card}
+                            workflowState={workflowView.cardStates.get(card.id) ?? null}
+                            validityFingerprint={validityFingerprint}
                             onSelect={
                                 card.targetId == null
                                     ? undefined
@@ -72,6 +90,9 @@ export function ValidityTab(): JSX.Element {
                         />
                     ))}
                 </div>
+            )}
+            {workflowView.summary != null && (
+                <WorkflowSummary summary={workflowView.summary} />
             )}
             {diagnostics.length > 0 && (
                 <ul
@@ -93,9 +114,13 @@ export function ValidityTab(): JSX.Element {
 
 function SuggestionCard({
     card,
+    workflowState,
+    validityFingerprint,
     onSelect,
 }: {
     card: ValiditySuggestionCard;
+    workflowState: SuggestionWorkflowState | null;
+    validityFingerprint: string;
     onSelect?: () => void;
 }): JSX.Element {
     const className =
@@ -104,6 +129,15 @@ function SuggestionCard({
         event.stopPropagation();
         onSelect?.();
         shellStore.setAgentDraftPrompt(card.promptText);
+        shellStore.setAgentRepairWorkflow({
+            cardId: card.id,
+            code: card.code,
+            promptText: card.promptText,
+            targetId: card.targetId,
+            promptSource: card.promptSource,
+            validityFingerprint,
+            state: 'drafted',
+        });
         shellStore.setAgentRailOpen(true);
     };
 
@@ -114,6 +148,7 @@ function SuggestionCard({
             data-code={card.code}
             data-kind={card.kind}
             data-prompt-source={card.promptSource}
+            data-workflow-state={workflowState ?? undefined}
         >
             <div className="flex items-center gap-2">
                 <span
@@ -126,6 +161,9 @@ function SuggestionCard({
                     <span className="ml-auto max-w-[8rem] truncate text-[11px] text-gray-300" title={card.targetLabel}>
                         {card.targetLabel}
                     </span>
+                )}
+                {workflowState != null && (
+                    <WorkflowBadge state={workflowState} />
                 )}
             </div>
             <div className="mt-1 text-[11px] text-gray-400">{card.evidence}</div>
@@ -163,6 +201,155 @@ function SuggestionCard({
             </div>
         </div>
     );
+}
+
+type SuggestionWorkflowState = 'drafted' | 'running' | 'still-failing';
+
+type WorkflowSummaryState = 'fixed' | 'still-failing';
+
+function WorkflowBadge({ state }: { state: SuggestionWorkflowState }): JSX.Element {
+    const label = state === 'still-failing' ? 'Rechecked · Still failing' : workflowLabel(state);
+    return (
+        <span
+            className={`rounded border px-1.5 py-0.5 text-[10px] ${workflowBadgeClass(state)}`}
+            data-testid="validity-suggestion-workflow-badge"
+        >
+            {label}
+        </span>
+    );
+}
+
+function WorkflowSummary({
+    summary,
+}: {
+    summary: { state: WorkflowSummaryState; code: string };
+}): JSX.Element {
+    const fixed = summary.state === 'fixed';
+    return (
+        <div
+            className={`mx-3 mb-2 rounded border px-2 py-1 text-[11px] ${fixed ? 'border-emerald-900/50 bg-emerald-950/30 text-emerald-200' : 'border-red-900/50 bg-red-950/30 text-red-200'}`}
+            data-testid="validity-suggestion-workflow-summary"
+            data-workflow-state={summary.state}
+        >
+            Rechecked · {fixed ? 'Fixed' : 'Still failing'} {summary.code}
+        </div>
+    );
+}
+
+function workflowLabel(state: SuggestionWorkflowState): string {
+    switch (state) {
+        case 'drafted':
+            return 'Drafted';
+        case 'running':
+            return 'Running';
+        case 'still-failing':
+            return 'Still failing';
+    }
+}
+
+function workflowBadgeClass(state: SuggestionWorkflowState): string {
+    switch (state) {
+        case 'drafted':
+            return 'border-blue-800/70 bg-blue-950/40 text-blue-200';
+        case 'running':
+            return 'border-amber-800/70 bg-amber-950/40 text-amber-200';
+        case 'still-failing':
+            return 'border-red-800/70 bg-red-950/40 text-red-200';
+    }
+}
+
+function resolveWorkflowView(input: {
+    workflow: AgentRepairWorkflow | null;
+    suggestionCards: ReadonlyArray<ValiditySuggestionCard>;
+    failureStillPresent: boolean;
+    validityFingerprint: string;
+}): {
+    cardStates: Map<string, SuggestionWorkflowState>;
+    summary: { state: WorkflowSummaryState; code: string } | null;
+} {
+    const cardStates = new Map<string, SuggestionWorkflowState>();
+    const { workflow } = input;
+    if (workflow == null) return { cardStates, summary: null };
+
+    const matchingCard = input.suggestionCards.find((card) => cardMatchesWorkflow(card, workflow));
+    const rechecked =
+        workflow.state === 'running' &&
+        input.validityFingerprint !== workflow.validityFingerprint;
+    if (!rechecked && matchingCard != null) {
+        cardStates.set(matchingCard.id, workflow.state);
+        return { cardStates, summary: null };
+    }
+
+    if (matchingCard != null) {
+        cardStates.set(matchingCard.id, 'still-failing');
+        return { cardStates, summary: null };
+    }
+
+    if (rechecked && input.failureStillPresent) {
+        return { cardStates, summary: { state: 'still-failing', code: workflow.code } };
+    }
+
+    if (rechecked) {
+        return { cardStates, summary: { state: 'fixed', code: workflow.code } };
+    }
+
+    return { cardStates, summary: null };
+}
+
+function cardMatchesWorkflow(card: ValiditySuggestionCard, workflow: AgentRepairWorkflow): boolean {
+    if (card.id === workflow.cardId) return true;
+    return card.code === workflow.code && card.targetId === workflow.targetId;
+}
+
+function workflowFailureStillPresent(
+    workflow: AgentRepairWorkflow,
+    diagnostics: ReadonlyArray<ValidatorDiagnostic>,
+    mechanismBanner: {
+        readonly entries: ReadonlyArray<{
+            readonly code: string;
+            readonly message: string;
+            readonly hint: string;
+        }>;
+    } | null,
+): boolean {
+    if (mechanismBanner?.entries.some((entry) => entry.code === workflow.code) === true) {
+        return true;
+    }
+    return diagnostics.some((diagnostic) => (
+        diagnostic.code === workflow.code &&
+        diagnosticTargetId(diagnostic) === workflow.targetId
+    ));
+}
+
+function fingerprintValidity(input: {
+    status: ValidatorStatus;
+    diagnostics: ReadonlyArray<ValidatorDiagnostic>;
+    mechanismBanner: {
+        readonly entries: ReadonlyArray<{
+            readonly code: string;
+            readonly message: string;
+            readonly hint: string;
+        }>;
+    } | null;
+}): string {
+    return JSON.stringify({
+        status: input.status,
+        mechanism: input.mechanismBanner?.entries.map((entry) => ({
+            code: entry.code,
+            message: entry.message,
+            hint: entry.hint,
+        })) ?? [],
+        diagnostics: input.diagnostics.map((diagnostic) => ({
+            code: diagnostic.code,
+            severity: diagnostic.severity,
+            message: diagnostic.message,
+            hint: diagnostic.hint,
+            partName: diagnostic.partName,
+            mateName: diagnostic.mateName,
+            partA: diagnostic.partA,
+            partB: diagnostic.partB,
+        })),
+    });
 }
 
 function RepairEvidenceBlock({
@@ -297,6 +484,13 @@ function diagnosticTargetLabel(d: ValidatorDiagnostic): string | null {
     if (d.partName) return d.partName;
     if (d.mateName) return d.mateName;
     if (d.partA && d.partB) return `${d.partA} ↔ ${d.partB}`;
+    if (d.partA) return d.partA;
+    return null;
+}
+
+function diagnosticTargetId(d: ValidatorDiagnostic): string | null {
+    if (d.partName) return d.partName;
+    if (d.mateName) return d.mateName;
     if (d.partA) return d.partA;
     return null;
 }


### PR DESCRIPTION
## Summary
- add a shell-store workflow record for active Validity repair cards
- show Drafted, Running, Rechecked/Fixed, and Rechecked/Still failing states in Validity cards/summaries
- guard against false recheck labels before a submitted run, target changes, hidden still-present failures, and failed agent submissions

## Verification
- npm test -- --run src/studio/__tests__/shellStore.test.ts src/studio/__tests__/tabs/ValidityTab.test.tsx src/studio/__tests__/StudioGenerate.test.tsx
- npm run typecheck
- npm run build:studio
- npm run lint (passes with existing unused-disable warnings outside touched files)