### PR TITLE
feat(studio): show staged edit context

### DIFF
--- a/src/studio/StagedEditSlot.tsx
+++ b/src/studio/StagedEditSlot.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import { useCallback, useState } from 'react';
-import { Check, X } from 'lucide-react';
+import { Check, RotateCcw, X } from 'lucide-react';
 import { useShellStore, shellStore } from './store/useShellStore';
 import { useWorkbench } from './context/WorkbenchContext';
 import type { StagedEdit } from './store/shellStore';
@@ -84,6 +84,50 @@ function PlaceholderBody() {
     );
 }
 
+function StagedEditContextDetails({ edit }: { edit: StagedEdit }) {
+    const context = edit.context;
+    if (context == null && edit.source?.label == null) return null;
+
+    const prompt = context?.promptText.trim();
+    const target = context?.selectedFeatureId ?? null;
+    const workflow = context?.repairWorkflow ?? null;
+
+    return (
+        <div
+            className="min-w-0 rounded border border-[#252a33] bg-[#111318] px-2 py-1.5 text-[10px] text-gray-400 space-y-1 break-words"
+            data-testid="staged-edit-context"
+        >
+            {edit.source?.label && (
+                <div className="min-w-0">
+                    <span className="text-gray-500">Source:</span> {edit.source.kind} · {edit.source.label}
+                </div>
+            )}
+            {prompt && (
+                <div className="line-clamp-2 min-w-0" title={prompt}>
+                    <span className="text-gray-500">Prompt:</span> {prompt}
+                </div>
+            )}
+            {context != null && (
+                <div className="flex min-w-0 flex-wrap gap-x-2 gap-y-1">
+                    <span className="min-w-0">
+                        <span className="text-gray-500">Target:</span> {target ?? 'whole model'}
+                    </span>
+                    {workflow != null && (
+                        <span className="min-w-0">
+                            <span className="text-gray-500">Workflow:</span> {workflow.promptSource} repair
+                        </span>
+                    )}
+                    {context.generationId && (
+                        <span className="min-w-0">
+                            <span className="text-gray-500">Generation:</span> {context.generationId}
+                        </span>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
 export function StagedEditSlot() {
     const { stagedEdit } = useShellStore();
     const { code, setCode } = useWorkbench();
@@ -111,6 +155,23 @@ export function StagedEditSlot() {
         shellStore.clearStagedEdit();
     }, []);
 
+    const handleRerunPrompt = useCallback(() => {
+        const context = stagedEdit?.context;
+        if (context == null) return;
+
+        const prompt = context.promptText.trim();
+        if (!prompt) return;
+
+        shellStore.setSelectedFeatureId(context.selectedFeatureId);
+        shellStore.setAgentDraftPrompt(prompt);
+        shellStore.setAgentRepairWorkflow(
+            context.repairWorkflow == null ? null : { ...context.repairWorkflow, state: 'drafted' }
+        );
+        shellStore.setAgentRailOpen(true);
+        shellStore.clearStagedEdit();
+        setStaleWarning(null);
+    }, [stagedEdit]);
+
     return (
         <div className="p-3 flex flex-col gap-2" data-testid="staged-edit-slot">
             <div className="uppercase tracking-wide text-[10px] text-gray-500">
@@ -127,18 +188,27 @@ export function StagedEditSlot() {
                     >
                         "{stagedEdit.intent}"
                     </div>
+                    <StagedEditContextDetails edit={stagedEdit} />
                     <DiffCard edit={stagedEdit} />
-                    {stagedEdit.source?.label && (
-                        <div className="text-[10px] text-gray-500">
-                            {stagedEdit.source.kind} · {stagedEdit.source.label}
-                        </div>
-                    )}
                     {visibleStaleWarning != null && (
                         <div
-                            className="rounded border border-amber-800/70 bg-amber-950/40 px-2 py-1 text-[10px] text-amber-200"
+                            className="rounded border border-amber-800/70 bg-amber-950/40 px-2 py-1 text-[10px] text-amber-200 space-y-1.5"
                             data-testid="staged-edit-stale-warning"
+                            role="alert"
+                            aria-live="polite"
+                            aria-atomic="true"
                         >
-                            {visibleStaleWarning}
+                            <div>{visibleStaleWarning}</div>
+                            {stagedEdit.context?.promptText.trim() && (
+                                <button
+                                    type="button"
+                                    onClick={handleRerunPrompt}
+                                    data-testid="staged-edit-rerun-prompt"
+                                    className="inline-flex items-center gap-1 rounded border border-amber-700/70 bg-amber-900/30 px-2 py-1 text-[10px] text-amber-100 hover:bg-amber-900/50"
+                                >
+                                    <RotateCcw className="h-3 w-3" /> Rerun prompt
+                                </button>
+                            )}
                         </div>
                     )}
                     <div className="flex gap-2">

--- a/src/studio/__tests__/StagedEditSlot.test.tsx
+++ b/src/studio/__tests__/StagedEditSlot.test.tsx
@@ -103,4 +103,93 @@ describe('StagedEditSlot', () => {
         const { getByText } = render(<StagedEditSlot />);
         expect(getByText(/agent.*set_param_value/i)).toBeDefined();
     });
+
+    it('renders captured generation context for staged agent edits', () => {
+        shellStore.proposeStagedEdit({
+            id: 'e-context',
+            intent: 'Repair output horn',
+            fromCode: 'return box(10);',
+            toCode: 'return box(20);',
+            source: { kind: 'agent', label: 'Studio Generate' },
+            context: {
+                promptText: 'Fix assembly.part.floating: output-horn floats Action: add a mate',
+                selectedFeatureId: 'output-horn',
+                repairWorkflow: {
+                    cardId: 'diagnostic:assembly.part.floating:output-horn:0',
+                    code: 'assembly.part.floating',
+                    promptText: 'Fix assembly.part.floating: output-horn floats Action: add a mate',
+                    targetId: 'output-horn',
+                    promptSource: 'review',
+                    validityFingerprint: 'before',
+                    state: 'running',
+                },
+                generationId: 'gen-context',
+            },
+        });
+
+        const { getByTestId } = render(<StagedEditSlot />);
+        const context = getByTestId('staged-edit-context');
+
+        expect(context.textContent).toContain('Studio Generate');
+        expect(context.textContent).toContain('output-horn');
+        expect(context.textContent).toContain('review repair');
+        expect(context.textContent).toContain('gen-context');
+        expect(context.textContent).toContain('Fix assembly.part.floating');
+    });
+
+    it('stale conflicts can rerun the captured prompt without applying code', () => {
+        shellStore.setSelectedFeatureId('old-target');
+        shellStore.setAgentRailOpen(false);
+        shellStore.setAgentRepairWorkflow({
+            cardId: 'diagnostic:old',
+            code: 'assembly.part.floating',
+            promptText: 'Old diagnostic prompt',
+            targetId: 'old-target',
+            promptSource: 'review',
+            validityFingerprint: 'old',
+            state: 'running',
+        });
+        shellStore.proposeStagedEdit({
+            id: 'e-rerun',
+            intent: 'Repair output horn',
+            fromCode: 'return box(10);',
+            toCode: 'return box(20);',
+            context: {
+                promptText: 'Fix output-horn floating mate',
+                selectedFeatureId: 'output-horn',
+                repairWorkflow: null,
+                generationId: 'gen-rerun',
+            },
+        });
+        workbenchCode = 'return box(15);';
+
+        const { getByTestId } = render(<StagedEditSlot />);
+        fireEvent.click(getByTestId('staged-edit-approve'));
+        fireEvent.click(getByTestId('staged-edit-rerun-prompt'));
+
+        const snapshot = shellStore.getSnapshot();
+        expect(setCodeMock).not.toHaveBeenCalled();
+        expect(snapshot.stagedEdit).toBeNull();
+        expect(snapshot.agentRailOpen).toBe(true);
+        expect(snapshot.agentDraftPrompt).toBe('Fix output-horn floating mate');
+        expect(snapshot.selectedFeatureId).toBe('output-horn');
+        expect(snapshot.agentRepairWorkflow).toBeNull();
+    });
+
+    it('stale conflicts omit rerun prompt when no prompt context exists', () => {
+        shellStore.proposeStagedEdit({
+            id: 'e-no-rerun',
+            intent: 'Manual edit',
+            fromCode: 'return box(10);',
+            toCode: 'return box(20);',
+        });
+        workbenchCode = 'return box(15);';
+
+        const { getByRole, getByTestId, queryByTestId } = render(<StagedEditSlot />);
+        fireEvent.click(getByTestId('staged-edit-approve'));
+
+        expect(getByTestId('staged-edit-stale-warning').textContent).toContain('changed since this edit was staged');
+        expect(getByRole('alert')).toBe(getByTestId('staged-edit-stale-warning'));
+        expect(queryByTestId('staged-edit-rerun-prompt')).toBeNull();
+    });
 });


### PR DESCRIPTION
## Summary
- Render staged edit source, prompt, target, workflow, and generation id in the review slot.
- Add stale-conflict Rerun prompt recovery that reopens the agent rail without applying stale code.
- Clear stale repair workflow state when rerunning prompt-only staged edits and announce stale warnings.

## Test Plan
- npm test -- --run src/studio/__tests__/StagedEditSlot.test.tsx src/studio/__tests__/StudioGenerate.test.tsx
- npm run typecheck
- npm run build:studio
- npm run lint
- git diff --check

## Review
- Subagent review found stale agentRepairWorkflow contamination on rerun; fixed with a regression assertion.
