### PR TITLE
feat(studio): record staged edit outcomes

### DIFF
--- a/src/studio/StagedEditSlot.tsx
+++ b/src/studio/StagedEditSlot.tsx
@@ -4,7 +4,7 @@ import { useCallback, useState } from 'react';
 import { Check, RotateCcw, X } from 'lucide-react';
 import { useShellStore, shellStore } from './store/useShellStore';
 import { useWorkbench } from './context/WorkbenchContext';
-import type { StagedEdit } from './store/shellStore';
+import type { AppliedEditHistoryEntry, StagedEdit } from './store/shellStore';
 
 // Slice 1.5: real body. Reads stagedEdit from the shell store. When
 // populated, renders the intent, a minimal line-by-line diff, and
@@ -128,8 +128,89 @@ function StagedEditContextDetails({ edit }: { edit: StagedEdit }) {
     );
 }
 
+function AppliedEditHistory({ entries }: { entries: readonly AppliedEditHistoryEntry[] }) {
+    if (entries.length === 0) return null;
+
+    return (
+        <div
+            className="mt-1 border-t border-[#252a33] pt-2 space-y-1"
+            data-testid="applied-edit-history"
+            aria-label="Recent staged edit outcomes"
+        >
+            <div className="uppercase tracking-wide text-[10px] text-gray-500">
+                Recent edits
+            </div>
+            {entries.map((entry) => {
+                const metadata = formatHistoryMetadata(entry);
+                return (
+                    <div
+                        key={entry.id}
+                        className="min-w-0 rounded border border-[#252a33] bg-[#111318] px-2 py-1.5 text-[10px] text-gray-400 space-y-1"
+                    >
+                        <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+                            <span className="font-medium text-gray-200">{formatOutcome(entry.outcome)}</span>
+                            <span className="font-mono text-emerald-300">
+                                +{entry.addedLines} / -{entry.removedLines}
+                            </span>
+                            {entry.recheckStatus !== 'not-applicable' && (
+                                <span className="text-gray-500">{formatRecheckStatus(entry.recheckStatus)}</span>
+                            )}
+                        </div>
+                        <div className="line-clamp-1 text-gray-300" title={entry.intent}>
+                            {entry.intent}
+                        </div>
+                        {entry.promptText && (
+                            <div className="line-clamp-2 break-words text-gray-500">{entry.promptText}</div>
+                        )}
+                        {metadata.length > 0 && (
+                            <div className="line-clamp-1 break-words text-gray-500">
+                                {metadata.join(' · ')}
+                            </div>
+                        )}
+                    </div>
+                );
+            })}
+        </div>
+    );
+}
+
+function formatHistoryMetadata(entry: AppliedEditHistoryEntry): string[] {
+    const metadata: string[] = [];
+    if (entry.sourceLabel) metadata.push(entry.sourceLabel);
+    if (entry.selectedFeatureId) metadata.push(entry.selectedFeatureId);
+    if (entry.repairPromptSource) metadata.push(`${entry.repairPromptSource} repair`);
+    if (entry.generationId) metadata.push(entry.generationId);
+    return metadata;
+}
+
+function formatOutcome(outcome: AppliedEditHistoryEntry['outcome']): string {
+    switch (outcome) {
+        case 'approved':
+            return 'Approved';
+        case 'rejected':
+            return 'Rejected';
+        case 'rerun':
+            return 'Rerun';
+    }
+}
+
+function formatRecheckStatus(status: AppliedEditHistoryEntry['recheckStatus']): string {
+    switch (status) {
+        case 'pending-recheck':
+            return 'pending recheck';
+        case 'rechecked-solved':
+            return 'rechecked solved';
+        case 'rechecked-issues':
+            return 'rechecked issues';
+        case 'recheck-error':
+            return 'recheck error';
+        case 'not-applicable':
+            return '';
+    }
+}
+
 export function StagedEditSlot() {
-    const { stagedEdit } = useShellStore();
+    const { stagedEdit, appliedEditHistory } = useShellStore();
     const { code, setCode } = useWorkbench();
     const [staleWarning, setStaleWarning] = useState<{ editId: string; message: string } | null>(null);
     const visibleStaleWarning =
@@ -147,16 +228,21 @@ export function StagedEditSlot() {
             return;
         }
         setCode(stagedEdit.toCode);
+        shellStore.recordStagedEditOutcome(stagedEdit, 'approved');
         shellStore.clearStagedEdit();
     }, [code, stagedEdit, setCode]);
 
     const handleReject = useCallback(() => {
+        if (stagedEdit != null) {
+            shellStore.recordStagedEditOutcome(stagedEdit, 'rejected');
+        }
         setStaleWarning(null);
         shellStore.clearStagedEdit();
-    }, []);
+    }, [stagedEdit]);
 
     const handleRerunPrompt = useCallback(() => {
-        const context = stagedEdit?.context;
+        if (stagedEdit == null) return;
+        const context = stagedEdit.context;
         if (context == null) return;
 
         const prompt = context.promptText.trim();
@@ -168,6 +254,7 @@ export function StagedEditSlot() {
             context.repairWorkflow == null ? null : { ...context.repairWorkflow, state: 'drafted' }
         );
         shellStore.setAgentRailOpen(true);
+        shellStore.recordStagedEditOutcome(stagedEdit, 'rerun');
         shellStore.clearStagedEdit();
         setStaleWarning(null);
     }, [stagedEdit]);
@@ -232,6 +319,7 @@ export function StagedEditSlot() {
                     </div>
                 </>
             )}
+            <AppliedEditHistory entries={appliedEditHistory} />
         </div>
     );
 }

--- a/src/studio/__tests__/StagedEditSlot.test.tsx
+++ b/src/studio/__tests__/StagedEditSlot.test.tsx
@@ -54,12 +54,17 @@ describe('StagedEditSlot', () => {
             intent: 'demo',
             fromCode,
             toCode,
+            source: { kind: 'agent', label: 'Studio Generate' },
         });
         const { getByTestId } = render(<StagedEditSlot />);
         fireEvent.click(getByTestId('staged-edit-approve'));
         expect(setCodeMock).toHaveBeenCalledTimes(1);
         expect(setCodeMock).toHaveBeenCalledWith(toCode);
         expect(shellStore.getSnapshot().stagedEdit).toBeNull();
+        expect(getByTestId('applied-edit-history').textContent).toContain('Approved');
+        expect(getByTestId('applied-edit-history').textContent).toContain('demo');
+        expect(getByTestId('applied-edit-history').textContent).toContain('Studio Generate');
+        expect(getByTestId('applied-edit-history').textContent).toContain('+2 / -1');
     });
 
     it('Approve blocks stale staged edits when the editor changed since proposal', () => {
@@ -71,11 +76,12 @@ describe('StagedEditSlot', () => {
         });
         workbenchCode = 'return box(15);';
 
-        const { getByTestId } = render(<StagedEditSlot />);
+        const { getByTestId, queryByTestId } = render(<StagedEditSlot />);
         fireEvent.click(getByTestId('staged-edit-approve'));
 
         expect(setCodeMock).not.toHaveBeenCalled();
         expect(shellStore.getSnapshot().stagedEdit?.id).toBe('e-stale');
+        expect(queryByTestId('applied-edit-history')).toBeNull();
         expect(getByTestId('staged-edit-stale-warning').textContent).toContain('changed since this edit was staged');
     });
 
@@ -90,6 +96,8 @@ describe('StagedEditSlot', () => {
         fireEvent.click(getByTestId('staged-edit-reject'));
         expect(setCodeMock).not.toHaveBeenCalled();
         expect(shellStore.getSnapshot().stagedEdit).toBeNull();
+        expect(getByTestId('applied-edit-history').textContent).toContain('Rejected');
+        expect(getByTestId('applied-edit-history').textContent).toContain('demo');
     });
 
     it('source label renders when provided', () => {
@@ -174,6 +182,9 @@ describe('StagedEditSlot', () => {
         expect(snapshot.agentDraftPrompt).toBe('Fix output-horn floating mate');
         expect(snapshot.selectedFeatureId).toBe('output-horn');
         expect(snapshot.agentRepairWorkflow).toBeNull();
+        expect(getByTestId('applied-edit-history').textContent).toContain('Rerun');
+        expect(getByTestId('applied-edit-history').textContent).toContain('Fix output-horn floating mate');
+        expect(getByTestId('applied-edit-history').textContent).toContain('gen-rerun');
     });
 
     it('stale conflicts omit rerun prompt when no prompt context exists', () => {

--- a/src/studio/__tests__/shellStore.test.ts
+++ b/src/studio/__tests__/shellStore.test.ts
@@ -229,4 +229,87 @@ describe('ShellStore', () => {
         expect(store.getSnapshot().stagedEdit).toBeNull();
         expect(listener).toHaveBeenCalledTimes(1);
     });
+
+    it('records staged edit outcomes with bounded deterministic diff evidence', () => {
+        store = new ShellStore();
+        const edit = {
+            id: 'e-ledger',
+            intent: 'Repair output horn',
+            fromCode: 'return box(10);\n',
+            toCode: 'const part = box(20);\nreturn part;\n',
+            source: { kind: 'agent' as const, label: 'Studio Generate' },
+            context: {
+                promptText: 'Fix output-horn mate',
+                selectedFeatureId: 'output-horn',
+                repairWorkflow: null,
+                generationId: 'gen-ledger',
+            },
+        };
+
+        store.recordStagedEditOutcome(edit, 'approved');
+
+        const entry = store.getSnapshot().appliedEditHistory[0];
+        expect(entry).toMatchObject({
+            id: 'e-ledger:approved:1',
+            editId: 'e-ledger',
+            outcome: 'approved',
+            intent: 'Repair output horn',
+            sourceLabel: 'Studio Generate',
+            promptText: 'Fix output-horn mate',
+            selectedFeatureId: 'output-horn',
+            generationId: 'gen-ledger',
+            addedLines: 2,
+            removedLines: 1,
+            recheckStatus: 'pending-recheck',
+        });
+
+        for (let i = 0; i < 8; i++) {
+            store.recordStagedEditOutcome({ ...edit, id: `e-${i}`, intent: `edit ${i}` }, 'rejected');
+        }
+
+        const history = store.getSnapshot().appliedEditHistory;
+        expect(history).toHaveLength(6);
+        expect(history[0].editId).toBe('e-7');
+        expect(history.at(-1)?.editId).toBe('e-2');
+    });
+
+    it('publishValidity updates only pending approved ledger entries', () => {
+        store = new ShellStore();
+        const approved = { id: 'approved', intent: 'approved', fromCode: 'a', toCode: 'b' };
+        const rejected = { id: 'rejected', intent: 'rejected', fromCode: 'a', toCode: 'b' };
+        store.recordStagedEditOutcome(approved, 'approved');
+        store.recordStagedEditOutcome(rejected, 'rejected');
+
+        store.publishValidity(makeValidity('warning'));
+        expect(store.getSnapshot().appliedEditHistory[0]).toMatchObject({
+            editId: 'rejected',
+            recheckStatus: 'not-applicable',
+        });
+        expect(store.getSnapshot().appliedEditHistory[1]).toMatchObject({
+            editId: 'approved',
+            recheckStatus: 'rechecked-issues',
+        });
+
+        store.publishValidity(makeValidity('solved'));
+        expect(store.getSnapshot().appliedEditHistory[1]).toMatchObject({
+            editId: 'approved',
+            recheckStatus: 'rechecked-issues',
+        });
+
+        store = new ShellStore();
+        store.recordStagedEditOutcome(approved, 'approved');
+        store.publishValidity(makeValidity('solved'));
+        expect(store.getSnapshot().appliedEditHistory[0]).toMatchObject({
+            editId: 'approved',
+            recheckStatus: 'rechecked-solved',
+        });
+
+        store = new ShellStore();
+        store.recordStagedEditOutcome(approved, 'approved');
+        store.publishValidity(makeValidity('error'));
+        expect(store.getSnapshot().appliedEditHistory[0]).toMatchObject({
+            editId: 'approved',
+            recheckStatus: 'recheck-error',
+        });
+    });
 });

--- a/src/studio/store/shellStore.ts
+++ b/src/studio/store/shellStore.ts
@@ -35,6 +35,29 @@ export interface StagedEdit {
     readonly source?: { kind: 'agent' | 'human' | 'test'; label?: string };
 }
 
+export type StagedEditOutcome = 'approved' | 'rejected' | 'rerun';
+export type AppliedEditRecheckStatus =
+    | 'not-applicable'
+    | 'pending-recheck'
+    | 'rechecked-solved'
+    | 'rechecked-issues'
+    | 'recheck-error';
+
+export interface AppliedEditHistoryEntry {
+    readonly id: string;
+    readonly editId: string;
+    readonly outcome: StagedEditOutcome;
+    readonly intent: string;
+    readonly sourceLabel?: string;
+    readonly promptText?: string;
+    readonly selectedFeatureId: SelectedFeatureId;
+    readonly repairPromptSource?: 'review' | 'fallback';
+    readonly generationId?: string;
+    readonly addedLines: number;
+    readonly removedLines: number;
+    readonly recheckStatus: AppliedEditRecheckStatus;
+}
+
 export type AgentRepairWorkflowState = 'drafted' | 'running';
 
 export interface AgentRepairWorkflow {
@@ -64,6 +87,7 @@ export interface ShellState {
     readonly previousValidity: ValidatorResult | null;
     readonly currentValidity: ValidatorResult | null;
     readonly stagedEdit: StagedEdit | null;
+    readonly appliedEditHistory: readonly AppliedEditHistoryEntry[];
     readonly markingMode: boolean;
     readonly sectionMode: boolean;
     /**
@@ -116,6 +140,7 @@ const INITIAL_STATE: ShellState = {
     previousValidity: null,
     currentValidity: null,
     stagedEdit: null,
+    appliedEditHistory: [],
     markingMode: false,
     sectionMode: false,
     sectionAxesEnabled: { x: false, y: false, z: true },
@@ -125,12 +150,30 @@ const INITIAL_STATE: ShellState = {
 };
 
 type Listener = () => void;
+const MAX_APPLIED_EDIT_HISTORY = 6;
+
+function countChangedNonEmptyLines(from: string, to: string): { addedLines: number; removedLines: number } {
+    const a = from.split('\n');
+    const b = to.split('\n');
+    let addedLines = 0;
+    let removedLines = 0;
+    const max = Math.max(a.length, b.length);
+    for (let i = 0; i < max; i++) {
+        const left = a[i];
+        const right = b[i];
+        if (left === right) continue;
+        if (left?.trim()) removedLines++;
+        if (right?.trim()) addedLines++;
+    }
+    return { addedLines, removedLines };
+}
 
 export class ShellStore {
     // Inspector visibility persists across reloads (mirrors the validity
     // drawer's localStorage pattern); everything else starts from defaults.
     private state: ShellState = { ...INITIAL_STATE, inspectorOpen: readStoredInspectorOpen() };
     private readonly listeners = new Set<Listener>();
+    private appliedEditSequence = 0;
 
     getSnapshot = (): ShellState => this.state;
 
@@ -292,10 +335,41 @@ export class ShellStore {
      */
     publishValidity = (next: ValidatorResult | null): void => {
         if (this.state.currentValidity === next) return;
+        const appliedEditHistory =
+            next == null
+                ? this.state.appliedEditHistory
+                : this.updateNewestPendingApprovedRecheck(next);
         this.state = {
             ...this.state,
             previousValidity: this.state.currentValidity,
             currentValidity: next,
+            appliedEditHistory,
+        };
+        this.emit();
+    };
+
+    recordStagedEditOutcome = (edit: StagedEdit, outcome: StagedEditOutcome): void => {
+        const context = edit.context;
+        const workflow = context?.repairWorkflow;
+        const diff = countChangedNonEmptyLines(edit.fromCode, edit.toCode);
+        const sequence = ++this.appliedEditSequence;
+        const entry: AppliedEditHistoryEntry = {
+            id: `${edit.id}:${outcome}:${sequence}`,
+            editId: edit.id,
+            outcome,
+            intent: edit.intent,
+            selectedFeatureId: context?.selectedFeatureId ?? null,
+            addedLines: diff.addedLines,
+            removedLines: diff.removedLines,
+            recheckStatus: outcome === 'approved' ? 'pending-recheck' : 'not-applicable',
+            ...(edit.source?.label ? { sourceLabel: edit.source.label } : {}),
+            ...(context?.promptText ? { promptText: context.promptText } : {}),
+            ...(workflow?.promptSource ? { repairPromptSource: workflow.promptSource } : {}),
+            ...(context?.generationId ? { generationId: context.generationId } : {}),
+        };
+        this.state = {
+            ...this.state,
+            appliedEditHistory: [entry, ...this.state.appliedEditHistory].slice(0, MAX_APPLIED_EDIT_HISTORY),
         };
         this.emit();
     };
@@ -319,9 +393,26 @@ export class ShellStore {
 
     /** Test helper. Not exposed via React hooks. */
     reset = (): void => {
+        this.appliedEditSequence = 0;
         this.state = INITIAL_STATE;
         this.emit();
     };
+
+    private updateNewestPendingApprovedRecheck(next: ValidatorResult): readonly AppliedEditHistoryEntry[] {
+        const index = this.state.appliedEditHistory.findIndex(
+            (entry) => entry.outcome === 'approved' && entry.recheckStatus === 'pending-recheck'
+        );
+        if (index < 0) return this.state.appliedEditHistory;
+        const recheckStatus: AppliedEditRecheckStatus =
+            next.status === 'solved'
+                ? 'rechecked-solved'
+                : next.status === 'error'
+                    ? 'recheck-error'
+                    : 'rechecked-issues';
+        const nextHistory = [...this.state.appliedEditHistory];
+        nextHistory[index] = { ...nextHistory[index], recheckStatus };
+        return nextHistory;
+    }
 
     private emit(): void {
         for (const listener of this.listeners) listener();


### PR DESCRIPTION
## Summary
- add bounded in-memory applied edit history to the Studio shell store
- record approve/reject/rerun outcomes with prompt, source, target, generation, and changed-line evidence
- render recent edit outcomes under the staged edit controls and update approved entries from validator results

## Test Plan
- npm test -- --run src/studio/__tests__/shellStore.test.ts src/studio/__tests__/StagedEditSlot.test.tsx
- npm run typecheck
- git diff --check
- npm run build:studio
- npm run lint (passes with existing unused-disable warnings outside this slice)

Private docs: w1ne/kernelCAD-private@792663b