### PR TITLE
feat(studio): link edit rechecks to script fingerprints

### DIFF
--- a/src/studio/__tests__/StagedEditSlot.test.tsx
+++ b/src/studio/__tests__/StagedEditSlot.test.tsx
@@ -4,7 +4,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render } from '@testing-library/react';
 import { StagedEditSlot } from '../StagedEditSlot';
-import { shellStore } from '../store/shellStore';
+import { fingerprintStudioScript, shellStore } from '../store/shellStore';
 
 const setCodeMock = vi.fn();
 let workbenchCode = '';
@@ -61,6 +61,9 @@ describe('StagedEditSlot', () => {
         expect(setCodeMock).toHaveBeenCalledTimes(1);
         expect(setCodeMock).toHaveBeenCalledWith(toCode);
         expect(shellStore.getSnapshot().stagedEdit).toBeNull();
+        expect(shellStore.getSnapshot().appliedEditHistory[0]).toMatchObject({
+            approvedScriptFingerprint: fingerprintStudioScript(toCode),
+        });
         expect(getByTestId('applied-edit-history').textContent).toContain('Approved');
         expect(getByTestId('applied-edit-history').textContent).toContain('demo');
         expect(getByTestId('applied-edit-history').textContent).toContain('Studio Generate');

--- a/src/studio/__tests__/shellStore.test.ts
+++ b/src/studio/__tests__/shellStore.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { ShellStore } from '../store/shellStore';
+import { fingerprintStudioScript, ShellStore } from '../store/shellStore';
 import type { ValidatorResult } from '../../modeling/mates/validator';
 
 function makeValidity(status: ValidatorResult['status']): ValidatorResult {
@@ -261,6 +261,7 @@ describe('ShellStore', () => {
             addedLines: 2,
             removedLines: 1,
             recheckStatus: 'pending-recheck',
+            approvedScriptFingerprint: fingerprintStudioScript(edit.toCode),
         });
 
         for (let i = 0; i < 8; i++) {
@@ -273,24 +274,37 @@ describe('ShellStore', () => {
         expect(history.at(-1)?.editId).toBe('e-2');
     });
 
-    it('publishValidity updates only pending approved ledger entries', () => {
+    it('publishValidity updates only pending approved ledger entries with matching script fingerprints', () => {
         store = new ShellStore();
         const approved = { id: 'approved', intent: 'approved', fromCode: 'a', toCode: 'b' };
         const rejected = { id: 'rejected', intent: 'rejected', fromCode: 'a', toCode: 'b' };
         store.recordStagedEditOutcome(approved, 'approved');
         store.recordStagedEditOutcome(rejected, 'rejected');
 
-        store.publishValidity(makeValidity('warning'));
+        store.publishValidity(makeValidity('warning'), { scriptFingerprint: fingerprintStudioScript('unrelated') });
         expect(store.getSnapshot().appliedEditHistory[0]).toMatchObject({
             editId: 'rejected',
             recheckStatus: 'not-applicable',
         });
         expect(store.getSnapshot().appliedEditHistory[1]).toMatchObject({
             editId: 'approved',
-            recheckStatus: 'rechecked-issues',
+            recheckStatus: 'pending-recheck',
         });
 
         store.publishValidity(makeValidity('solved'));
+        expect(store.getSnapshot().appliedEditHistory[1]).toMatchObject({
+            editId: 'approved',
+            recheckStatus: 'pending-recheck',
+        });
+
+        store.publishValidity(makeValidity('warning'), { scriptFingerprint: fingerprintStudioScript(approved.toCode) });
+        expect(store.getSnapshot().appliedEditHistory[1]).toMatchObject({
+            editId: 'approved',
+            recheckStatus: 'rechecked-issues',
+            recheckedScriptFingerprint: fingerprintStudioScript(approved.toCode),
+        });
+
+        store.publishValidity(makeValidity('solved'), { scriptFingerprint: fingerprintStudioScript(approved.toCode) });
         expect(store.getSnapshot().appliedEditHistory[1]).toMatchObject({
             editId: 'approved',
             recheckStatus: 'rechecked-issues',
@@ -298,7 +312,7 @@ describe('ShellStore', () => {
 
         store = new ShellStore();
         store.recordStagedEditOutcome(approved, 'approved');
-        store.publishValidity(makeValidity('solved'));
+        store.publishValidity(makeValidity('solved'), { scriptFingerprint: fingerprintStudioScript(approved.toCode) });
         expect(store.getSnapshot().appliedEditHistory[0]).toMatchObject({
             editId: 'approved',
             recheckStatus: 'rechecked-solved',
@@ -306,10 +320,29 @@ describe('ShellStore', () => {
 
         store = new ShellStore();
         store.recordStagedEditOutcome(approved, 'approved');
-        store.publishValidity(makeValidity('error'));
+        store.publishValidity(makeValidity('error'), { scriptFingerprint: fingerprintStudioScript(approved.toCode) });
         expect(store.getSnapshot().appliedEditHistory[0]).toMatchObject({
             editId: 'approved',
             recheckStatus: 'recheck-error',
+        });
+    });
+
+    it('updates matching ledger rechecks without rotating identical validity references', () => {
+        store = new ShellStore();
+        const approved = { id: 'approved', intent: 'approved', fromCode: 'a', toCode: 'b' };
+        const validity = makeValidity('solved');
+        store.recordStagedEditOutcome(approved, 'approved');
+
+        store.publishValidity(validity, { scriptFingerprint: fingerprintStudioScript('unrelated') });
+        expect(store.getSnapshot().previousValidity).toBeNull();
+        expect(store.getSnapshot().currentValidity).toBe(validity);
+
+        store.publishValidity(validity, { scriptFingerprint: fingerprintStudioScript(approved.toCode) });
+        expect(store.getSnapshot().previousValidity).toBeNull();
+        expect(store.getSnapshot().currentValidity).toBe(validity);
+        expect(store.getSnapshot().appliedEditHistory[0]).toMatchObject({
+            editId: 'approved',
+            recheckStatus: 'rechecked-solved',
         });
     });
 });

--- a/src/studio/__tests__/useRecomputeResult.test.tsx
+++ b/src/studio/__tests__/useRecomputeResult.test.tsx
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // @vitest-environment happy-dom
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import type { FeatureRecord } from '../../shared/intent/featureRecord';
 import type { ScriptReviewSummary } from '../context/GeometryContext';
 import type { SerializedParamEntry } from '../../shared/runtime/paramTable';
+import { fingerprintStudioScript, shellStore } from '../store/shellStore';
 
 const workbenchValue: {
+    code: string;
     geometries: never[];
     featureRecords: FeatureRecord[];
     recomputeMs: number;
@@ -15,6 +17,7 @@ const workbenchValue: {
     scriptParams: SerializedParamEntry[];
     updateParam?: (edits: { name: string; value: number | boolean }[]) => Promise<void>;
 } = {
+    code: '',
     geometries: [],
     featureRecords: [],
     recomputeMs: 0,
@@ -27,6 +30,17 @@ vi.mock('../context/WorkbenchContext', () => ({
 }));
 
 describe('useRecomputeResult — Slice 1.2 data wiring', () => {
+    beforeEach(() => {
+        shellStore.reset();
+        workbenchValue.code = '';
+        workbenchValue.geometries = [];
+        workbenchValue.featureRecords = [];
+        workbenchValue.recomputeMs = 0;
+        workbenchValue.scriptReview = null;
+        workbenchValue.scriptParams = [];
+        workbenchValue.updateParam = undefined;
+    });
+
     it('passes featureRecords through unchanged', async () => {
         const records: FeatureRecord[] = [
             {
@@ -265,5 +279,29 @@ describe('useRecomputeResult — Slice 1.2 data wiring', () => {
         expect(result.current.updateParam).toBe(updateParam);
         await result.current.updateParam?.([{ name: 'w', value: 70 }]);
         expect(updateParam).toHaveBeenCalledWith([{ name: 'w', value: 70 }]);
+    });
+
+    it('publishes validity with the current workbench code fingerprint', async () => {
+        const approvedCode = 'const part = box(20);\nreturn part;';
+        shellStore.recordStagedEditOutcome(
+            {
+                id: 'approved-from-hook',
+                intent: 'approved from hook',
+                fromCode: 'return box(10);',
+                toCode: approvedCode,
+            },
+            'approved',
+        );
+        workbenchValue.code = approvedCode;
+        workbenchValue.scriptReview = { ok: true, diagnostics: [] };
+
+        const { useRecomputeResult } = await import('../hooks/useRecomputeResult');
+        renderHook(() => useRecomputeResult());
+
+        expect(shellStore.getSnapshot().appliedEditHistory[0]).toMatchObject({
+            editId: 'approved-from-hook',
+            recheckStatus: 'rechecked-solved',
+            recheckedScriptFingerprint: fingerprintStudioScript(approvedCode),
+        });
     });
 });

--- a/src/studio/hooks/useRecomputeResult.ts
+++ b/src/studio/hooks/useRecomputeResult.ts
@@ -6,7 +6,7 @@ import { reviewToValidity, reviewToMechanismBanner } from '../adapters/reviewToV
 import { serializedParamsToTable } from '../adapters/serializedParamsToTable';
 import { reviewDiagnosticsToCompiler } from '../adapters/reviewDiagnosticsToCompiler';
 import { extractJointSnapshots } from '../adapters/featureRecordsToMates';
-import { shellStore } from '../store/shellStore';
+import { fingerprintStudioScript, shellStore } from '../store/shellStore';
 import type { ScriptReviewSummary } from '../context/GeometryContext';
 import type { StudioRecomputeResult, StudioRepairEvidence } from '../types';
 
@@ -80,12 +80,16 @@ export function useRecomputeResult(): StudioRecomputeResult {
         () => extractJointSnapshots(workbench.featureRecords ?? [], paramTable),
         [workbench.featureRecords, paramTable],
     );
+    const scriptFingerprint = useMemo(
+        () => fingerprintStudioScript(workbench.code ?? ''),
+        [workbench.code],
+    );
 
     // Publish validity into the shell store so BottomDrawer +
     // ValidityDeltaHeader see the delta (current ↔ previous).
     useEffect(() => {
-        shellStore.publishValidity(validity);
-    }, [validity]);
+        shellStore.publishValidity(validity, { scriptFingerprint });
+    }, [scriptFingerprint, validity]);
 
     const updateParam = (workbench as { updateParam?: StudioRecomputeResult['updateParam'] }).updateParam;
     const setGeometryTransformOverride =

--- a/src/studio/store/shellStore.ts
+++ b/src/studio/store/shellStore.ts
@@ -36,6 +36,7 @@ export interface StagedEdit {
 }
 
 export type StagedEditOutcome = 'approved' | 'rejected' | 'rerun';
+export type StudioScriptFingerprint = `script:${number}:${string}:${string}`;
 export type AppliedEditRecheckStatus =
     | 'not-applicable'
     | 'pending-recheck'
@@ -56,6 +57,12 @@ export interface AppliedEditHistoryEntry {
     readonly addedLines: number;
     readonly removedLines: number;
     readonly recheckStatus: AppliedEditRecheckStatus;
+    readonly approvedScriptFingerprint?: StudioScriptFingerprint;
+    readonly recheckedScriptFingerprint?: StudioScriptFingerprint;
+}
+
+export interface PublishValidityOptions {
+    readonly scriptFingerprint?: StudioScriptFingerprint;
 }
 
 export type AgentRepairWorkflowState = 'drafted' | 'running';
@@ -166,6 +173,21 @@ function countChangedNonEmptyLines(from: string, to: string): { addedLines: numb
         if (right?.trim()) addedLines++;
     }
     return { addedLines, removedLines };
+}
+
+export function fingerprintStudioScript(code: string): StudioScriptFingerprint {
+    const normalized = code.replace(/\r\n?/g, '\n');
+    let fnv = 0x811c9dc5;
+    let djb = 0x1505;
+    for (let i = 0; i < normalized.length; i++) {
+        const char = normalized.charCodeAt(i);
+        fnv ^= char;
+        fnv = Math.imul(fnv, 0x01000193);
+        djb = Math.imul(djb, 33) ^ char;
+    }
+    return `script:${normalized.length}:${(fnv >>> 0).toString(16).padStart(8, '0')}:${(djb >>> 0)
+        .toString(16)
+        .padStart(8, '0')}`;
 }
 
 export class ShellStore {
@@ -330,15 +352,20 @@ export class ShellStore {
     /**
      * Publish a new validator result. Rotates current → previous so the
      * `<ValidityDelta>` component can diff the two without storing its own
-     * history. Identity check on the validity reference: republishing the
-     * same `ValidatorResult` is a no-op.
+     * history. Republishing the same `ValidatorResult` only updates ledger
+     * recheck evidence; it does not rotate the validity delta pair.
      */
-    publishValidity = (next: ValidatorResult | null): void => {
-        if (this.state.currentValidity === next) return;
+    publishValidity = (next: ValidatorResult | null, options: PublishValidityOptions = {}): void => {
         const appliedEditHistory =
             next == null
                 ? this.state.appliedEditHistory
-                : this.updateNewestPendingApprovedRecheck(next);
+                : this.updateNewestPendingApprovedRecheck(next, options.scriptFingerprint);
+        if (this.state.currentValidity === next) {
+            if (appliedEditHistory === this.state.appliedEditHistory) return;
+            this.state = { ...this.state, appliedEditHistory };
+            this.emit();
+            return;
+        }
         this.state = {
             ...this.state,
             previousValidity: this.state.currentValidity,
@@ -366,6 +393,7 @@ export class ShellStore {
             ...(context?.promptText ? { promptText: context.promptText } : {}),
             ...(workflow?.promptSource ? { repairPromptSource: workflow.promptSource } : {}),
             ...(context?.generationId ? { generationId: context.generationId } : {}),
+            ...(outcome === 'approved' ? { approvedScriptFingerprint: fingerprintStudioScript(edit.toCode) } : {}),
         };
         this.state = {
             ...this.state,
@@ -398,9 +426,16 @@ export class ShellStore {
         this.emit();
     };
 
-    private updateNewestPendingApprovedRecheck(next: ValidatorResult): readonly AppliedEditHistoryEntry[] {
+    private updateNewestPendingApprovedRecheck(
+        next: ValidatorResult,
+        scriptFingerprint: StudioScriptFingerprint | undefined,
+    ): readonly AppliedEditHistoryEntry[] {
+        if (scriptFingerprint == null) return this.state.appliedEditHistory;
         const index = this.state.appliedEditHistory.findIndex(
-            (entry) => entry.outcome === 'approved' && entry.recheckStatus === 'pending-recheck'
+            (entry) =>
+                entry.outcome === 'approved' &&
+                entry.recheckStatus === 'pending-recheck' &&
+                entry.approvedScriptFingerprint === scriptFingerprint
         );
         if (index < 0) return this.state.appliedEditHistory;
         const recheckStatus: AppliedEditRecheckStatus =
@@ -410,7 +445,11 @@ export class ShellStore {
                     ? 'recheck-error'
                     : 'rechecked-issues';
         const nextHistory = [...this.state.appliedEditHistory];
-        nextHistory[index] = { ...nextHistory[index], recheckStatus };
+        nextHistory[index] = {
+            ...nextHistory[index],
+            recheckStatus,
+            recheckedScriptFingerprint: scriptFingerprint,
+        };
         return nextHistory;
     }
 


### PR DESCRIPTION
## Summary
- add deterministic Studio script fingerprints for approved staged edit code
- require matching validity fingerprints before updating pending approved ledger entries
- publish validity with the current workbench code fingerprint from useRecomputeResult

## Reliability notes
- missing or mismatched validity fingerprints leave approved entries pending
- same ValidatorResult reference can update ledger evidence without rotating previous/current validity
- fingerprint stores line-normalized script length plus two independent 32-bit hashes, not full source text

## Test Plan
- npm test -- --run src/studio/__tests__/shellStore.test.ts src/studio/__tests__/StagedEditSlot.test.tsx src/studio/__tests__/useRecomputeResult.test.tsx
- npm run typecheck
- git diff --check
- npm run build:studio
- npm run lint (passes with existing unused-disable warnings outside this slice)

Private docs: w1ne/kernelCAD-private@78cabae