### PR TITLE
feat(parts): add Cherry MX switch + EC11 rotary encoder to catalog

### DIFF
--- a/scripts/electronics-parts.json
+++ b/scripts/electronics-parts.json
@@ -29,6 +29,16 @@
       "tags": ["mcu", "module", "wifi", "ble", "esp32", "esp32c3", "riscv"]
     },
     {
+      "id": "ic-pdip-16",
+      "name": "PDIP-16 (300 mil, 2.54mm pitch)",
+      "family": "IC package",
+      "mpn": "PDIP-16",
+      "kcad_source": "scripts/parts/authored/ic-pdip-16.kcad.ts",
+      "tags": ["ic", "package", "dip", "pdip", "l293d", "74hc595", "74hc165"],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
       "id": "ic-lqfp-48",
       "name": "LQFP-48 (7x7mm, 0.5mm pitch)",
       "family": "IC package",
@@ -309,14 +319,82 @@
       "attribution": "ConstantinoSchillebeeckx/cherry-mx-switch (github.com/ConstantinoSchillebeeckx/cherry-mx-switch), MIT"
     },
     {
-      "id": "ec11-rotary-encoder",
-      "name": "EC11-class rotary encoder with push switch (Bourns PEC11R, Ø6 shaft)",
+      "id": "rotary-encoder-ec11",
+      "name": "EC11 rotary encoder, 12mm, knurled D-shaft + pushbutton",
       "family": "Encoder",
-      "mpn": "PEC11R-4220F-S0024",
-      "url": "https://raw.githubusercontent.com/ubiqueIoT/rotary-encoder-PEC11R/main/Bourns_-_PEC11R-4220F-S0024.step",
-      "tags": ["encoder", "rotary", "ec11", "pec11r", "bourns", "knob", "switch"],
-      "license": "UNVERIFIED",
-      "attribution": "ubiqueIoT/rotary-encoder-PEC11R (github.com/ubiqueIoT/rotary-encoder-PEC11R) — NO LICENSE FILE in repo; verify permission before redistributing this catalog entry"
+      "mpn": "PEC11R / EC11E",
+      "kcad_source": "scripts/parts/authored/rotary-encoder-ec11.kcad.ts",
+      "tags": ["encoder", "rotary", "rotary encoder", "ec11", "incremental", "quadrature", "knob", "shaft", "d-shaft", "switch", "pushbutton", "panel", "input", "maker"],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "keyswitch-mx",
+      "name": "Cherry MX-compatible keyswitch (14mm plate cutout)",
+      "family": "Switch",
+      "mpn": "MX1A",
+      "kcad_source": "scripts/parts/authored/keyswitch-mx.kcad.ts",
+      "tags": ["keyswitch", "key switch", "cherry", "mx", "cherry mx", "mechanical", "keyboard", "keycap", "switch", "button", "cross stem", "plate", "input", "maker"],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "oled-sh1106-13",
+      "name": "1.3\" SH1106 128x64 I2C OLED module",
+      "family": "Display",
+      "mpn": "1.3in SH1106 OLED",
+      "kcad_source": "scripts/parts/authored/oled-sh1106-13.kcad.ts",
+      "tags": [
+        "oled",
+        "display",
+        "screen",
+        "sh1106",
+        "ssd1306",
+        "i2c",
+        "128x64",
+        "1.3inch",
+        "1.3\"",
+        "monochrome",
+        "module",
+        "maker"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "oled-ssd1327-15",
+      "name": "1.5\" SSD1327 128x128 greyscale OLED module",
+      "family": "Display",
+      "mpn": "1.5in SSD1327 OLED",
+      "kcad_source": "scripts/parts/authored/oled-ssd1327-15.kcad.ts",
+      "tags": [
+        "oled",
+        "display",
+        "screen",
+        "ssd1327",
+        "ssd1351",
+        "spi",
+        "i2c",
+        "128x128",
+        "1.5inch",
+        "1.5\"",
+        "greyscale",
+        "square",
+        "module",
+        "maker"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "tactile-12mm",
+      "name": "12mm tactile pushbutton with round cap (12x12x7.3mm)",
+      "family": "Switch",
+      "mpn": "Omron B3F-4050 + B32-16x0",
+      "kcad_source": "scripts/parts/authored/tactile-12mm.kcad.ts",
+      "tags": ["switch", "button", "tactile", "pushbutton", "12mm", "keycap", "cap", "b3f", "panel", "input", "maker"],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
     }
   ]
 }

--- a/scripts/electronics-parts.json
+++ b/scripts/electronics-parts.json
@@ -297,6 +297,26 @@
       "tags": ["power", "buck", "regulator", "24v", "3v3", "stepdown"],
       "license": "MIT",
       "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "cherry-mx-switch",
+      "name": "Cherry MX keyboard switch (PCB mount, 15.6×15.6mm)",
+      "family": "Switch",
+      "mpn": "Cherry MX",
+      "url": "https://raw.githubusercontent.com/ConstantinoSchillebeeckx/cherry-mx-switch/master/switch.step",
+      "tags": ["switch", "keyboard", "cherry", "mx", "keyswitch", "tactile"],
+      "license": "MIT",
+      "attribution": "ConstantinoSchillebeeckx/cherry-mx-switch (github.com/ConstantinoSchillebeeckx/cherry-mx-switch), MIT"
+    },
+    {
+      "id": "ec11-rotary-encoder",
+      "name": "EC11-class rotary encoder with push switch (Bourns PEC11R, Ø6 shaft)",
+      "family": "Encoder",
+      "mpn": "PEC11R-4220F-S0024",
+      "url": "https://raw.githubusercontent.com/ubiqueIoT/rotary-encoder-PEC11R/main/Bourns_-_PEC11R-4220F-S0024.step",
+      "tags": ["encoder", "rotary", "ec11", "pec11r", "bourns", "knob", "switch"],
+      "license": "UNVERIFIED",
+      "attribution": "ubiqueIoT/rotary-encoder-PEC11R (github.com/ubiqueIoT/rotary-encoder-PEC11R) — NO LICENSE FILE in repo; verify permission before redistributing this catalog entry"
     }
   ]
 }

--- a/scripts/parts/authored/ic-pdip-16.kcad.ts
+++ b/scripts/parts/authored/ic-pdip-16.kcad.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/ic-pdip-16.kcad.ts
+//
+// PDIP-16 — 300-mil plastic dual in-line package, 16 leads.
+//
+// Covers l293d (body 19.80 x 6.35), 74hc595 (19.31 x 6.35) and sn74hc165
+// (19.10 x 6.35): one package, three body lengths within half a millimetre, so
+// a single model serves all three at catalog resolution.
+//
+// These parts were previously pointed at an 'ic-lqfp-48' mesh as a stand-in.
+// That was wrong on every axis — shape (square flatpack vs rectangular DIP),
+// size, and pin count (48 vs 16). TI's own datasheets list no LQFP variant of
+// the L293D at all.
+//
+// Built as an assembly rather than one fused boolean on purpose: booleans drop
+// leaf colors, and the catalog GLB build asserts >= 2 materials ("colors lost").
+// Separate parts keep the black body and tin-plated leads distinguishable.
+
+const BODY_L = 19.8; // JEDEC D, L293D; HC595 19.31 / HC165 19.10 within tolerance
+const BODY_W = 6.35; // JEDEC E1, leads excluded
+const BODY_H = 3.8; // JEDEC A, above the seating plane
+
+// Lead frame fixed by the 300-mil standard — changing these would stop it being
+// a PDIP-16, so they are constants rather than tunables.
+const PITCH = 2.54;
+const ROW_SPACING = 7.62;
+const PINS_PER_SIDE = 8;
+const STANDOFF = 3.3; // JEDEC A1: body underside above the board
+const LEAD_W = 0.5;
+const LEAD_T = 0.25;
+const SHOULDER_INNER_Y = 2.5; // tucks under the body so the joint always overlaps
+
+const BODY_BLACK = '#1c1c1f';
+const LEAD_METAL = '#c8ccd0';
+
+// Body, centred on the origin in X/Y and sitting on its standoff.
+// The pin-1 end notch and dimple are cut here, before the part is coloured, so
+// the indent reads as an indent rather than a separate black blob.
+const notch = cylinder(BODY_H + 1, 1.0, 24).translate(-BODY_L / 2, 0, STANDOFF - 0.5);
+const dimple = cylinder(1.2, 0.55, 20).translate(-BODY_L / 2 + 2.6, -1.7, STANDOFF + BODY_H - 0.5);
+
+const body = box(BODY_L, BODY_W, BODY_H, true)
+  .translate(0, 0, STANDOFF + BODY_H / 2)
+  .subtract(notch)
+  .subtract(dimple)
+  .color(BODY_BLACK);
+
+const asm = assembly('ic-pdip-16');
+asm.part('body', body);
+
+// Leads: a vertical run down to the board, plus a shoulder tucked into the body.
+// A plain loop rather than patternLinear — the pattern API is boolean-union
+// based, which is what we are specifically avoiding here.
+const firstX = -((PINS_PER_SIDE - 1) * PITCH) / 2;
+for (let i = 0; i < PINS_PER_SIDE; i++) {
+  const x = firstX + i * PITCH;
+  for (const side of [-1, 1]) {
+    const tag = side < 0 ? 'a' : 'b';
+    const lead = box(LEAD_W, LEAD_T, STANDOFF + 0.6, true)
+      .translate(x, (side * ROW_SPACING) / 2, (STANDOFF + 0.6) / 2)
+      .color(LEAD_METAL);
+    const shoulder = box(LEAD_W, ROW_SPACING / 2 - SHOULDER_INNER_Y, LEAD_T, true)
+      .translate(x, side * (ROW_SPACING / 4 + SHOULDER_INNER_Y / 2), STANDOFF + 0.5)
+      .color(LEAD_METAL);
+    asm.part(`lead-${tag}${i + 1}`, lead);
+    asm.part(`shoulder-${tag}${i + 1}`, shoulder);
+  }
+}
+
+return asm.model();

--- a/scripts/parts/authored/keyswitch-mx.kcad.ts
+++ b/scripts/parts/authored/keyswitch-mx.kcad.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/keyswitch-mx.kcad.ts
+//
+// Cherry MX-compatible mechanical keyswitch (MX1A series), PCB-mount ("5-pin")
+// with the cross stem. Shown in MX Red colouring; the body geometry is common
+// to the whole MX1A family.
+//
+// DIMENSION SOURCES
+//   Cherry MX1A datasheet : https://www.maltron.com/uploads/6/1/2/5/61250099/mx1a_11nn_data_sheet.pdf
+//   Cherry MX Series (SparkFun copy) : https://cdn.sparkfun.com/datasheets/Components/Switches/MX%20Series.pdf
+//
+//   Plate cutout        0.551 +/-0.002 in = 14.00 +/-0.05 mm SQUARE,
+//                       corner R 0.30 mm max            CONFIRMED (MX1A p.5)
+//                       -- the famous 14 mm figure is real and exact.
+//   Plate thickness     0.06 +/-0.006 in = 1.52 +/-0.15 mm   CONFIRMED (p.5)
+//   Lower housing       0.61 x 0.61 in = 15.6 x 15.6 mm      CONFIRMED (p.1)
+//   Total height,
+//     PCB -> stem top   0.60 in = 15.2 mm  (= 11.6 + 3.6)    CONFIRMED (p.1)
+//   Housing height      0.46 in = 11.6 mm                    CONFIRMED (p.1)
+//   Lower-housing skirt 0.20 in = 5.0 mm                     CONFIRMED (p.1)
+//   Stem above housing  0.14 in = 3.6 mm                     CONFIRMED (p.1)
+//   Height above plate  0.197 +0.012 in = 5.00 +0.30 mm      CONFIRMED (p.2)
+//   Pin length below    0.13 in = 3.30 mm                    CONFIRMED (p.1)
+//   Total travel        0.16 in = 4.06 mm                    CONFIRMED (p.4)
+//   Pretravel           0.08 in = 2.03 mm (linear)           CONFIRMED (p.4)
+//
+//   FOOTPRINT (datasheet grid, 0.05 in = 1.27 mm spacing, origin = centre post):
+//     central post      (0, 0),          hole dia 3.99 mm    CONFIRMED
+//     contact pin 1     (-3.81, +2.54),  hole dia 1.50 mm    CONFIRMED
+//     contact pin 2     (+2.54, +5.08),  hole dia 1.50 mm    CONFIRMED
+//     fixation legs 2x  (+/-5.08, 0),    hole dia 1.70 mm    CONFIRMED
+//     optional LED holes below centre,   hole dia 0.99 mm    CONFIRMED
+//   Note the two contact pins are ASYMMETRIC — that is correct, not a typo.
+//
+// EXPLICITLY UNVERIFIED (do not treat as spec):
+//   - UPPER HOUSING dimensions are never dimensioned on any official Cherry
+//     drawing. Taken as 13.9 mm square, bounded above by the CONFIRMED 14.00 mm
+//     plate cutout it must pass through. INFERRED.
+//   - The datasheet gives PCB HOLE diameters, not the plastic post/leg
+//     diameters. Post modelled at 3.85 and legs at 1.60, i.e. the confirmed
+//     holes less a nominal clearance. INFERRED.
+//   - CROSS STEM GEOMETRY IS NOT IN ANY CHERRY DRAWING. The widely circulated
+//     "4.1 x 1.17 mm" is the KEYCAP SLOT (female) spec from Cherry's keycap
+//     documentation, NOT the male stem. The stem here is modelled at
+//     3.95 x 1.05 mm, which matches community caliper measurements
+//     (~3.93-3.98 span, ~1.03-1.09 arms). Treat the stem cross-section as an
+//     ESTIMATE. Its HEIGHT (3.6 mm above the housing) is confirmed.
+//     If you are modelling a KEYCAP socket instead, use 4.1 x 1.17.
+
+const LOWER = 15.6; // CONFIRMED
+const UPPER_INFERRED = 13.9; // see note — bounded by the 14.00 plate cutout
+const SKIRT_H = 5.0; // CONFIRMED, lower housing below the plate
+const HOUSING_H = 11.6; // CONFIRMED, PCB -> top of upper housing
+const STEM_TOP = 15.2; // CONFIRMED, PCB -> stem top
+const STEM_H = STEM_TOP - HOUSING_H; // 3.6, CONFIRMED
+const PIN_BELOW = 3.3; // CONFIRMED
+
+const STEM_SPAN = 3.95; // ESTIMATE — not in any Cherry drawing
+const STEM_ARM = 1.05; // ESTIMATE
+
+const POST_DIA_INFERRED = 3.85; // from the CONFIRMED 3.99 hole, less clearance
+const LEG_DIA_INFERRED = 1.6; // from the CONFIRMED 1.70 hole, less clearance
+const CONTACT_DIA = 1.4; // mates the CONFIRMED 1.50 hole
+
+const HOUSING_BLACK = '#232329';
+const UPPER_GREY = '#43434c';
+const STEM_RED = '#c0392b';
+const PIN_METAL = '#c9a55a';
+const POST_WHITE = '#d8d8d2';
+
+// Origin = the central post, matching the datasheet's own grid origin.
+// z = 0 is the PCB surface.
+
+// --- Lower housing: 15.6 sq, PCB -> 5.0 ------------------------------------
+const lower = box(LOWER, LOWER, SKIRT_H).color(HOUSING_BLACK).translate(-LOWER / 2, -LOWER / 2, 0);
+
+// --- Upper housing: passes through the 14.00mm plate cutout, 5.0 -> 11.6 ---
+const upper = box(UPPER_INFERRED, UPPER_INFERRED, HOUSING_H - SKIRT_H)
+  .color(UPPER_GREY)
+  .translate(-UPPER_INFERRED / 2, -UPPER_INFERRED / 2, SKIRT_H);
+
+// --- Cross ("+") stem, 11.6 -> 15.2 ----------------------------------------
+// Two crossing bars rising directly off the upper housing's top face. There is
+// deliberately no pedestal: the real switch's stem emerges through a recess in
+// the upper housing, and a pedestal block would interpenetrate that housing.
+const stemBarX = box(STEM_SPAN, STEM_ARM, STEM_H)
+  .color(STEM_RED)
+  .translate(-STEM_SPAN / 2, -STEM_ARM / 2, HOUSING_H);
+const stemBarY = box(STEM_ARM, STEM_SPAN, STEM_H)
+  .color(STEM_RED)
+  .translate(-STEM_ARM / 2, -STEM_SPAN / 2, HOUSING_H);
+
+// --- Central plastic post (0,0), below the PCB ------------------------------
+const post = cylinder(PIN_BELOW, POST_DIA_INFERRED / 2, 32)
+  .color(POST_WHITE)
+  .translate(0, 0, -PIN_BELOW);
+
+// --- Two metal contact pins, at the CONFIRMED asymmetric positions ---------
+const contacts: Shape[] = [];
+const contactPositions: [number, number][] = [
+  [-3.81, 2.54],
+  [2.54, 5.08],
+];
+for (const [cx, cy] of contactPositions) {
+  contacts.push(
+    cylinder(PIN_BELOW + 1.0, CONTACT_DIA / 2, 16).color(PIN_METAL).translate(cx, cy, -PIN_BELOW),
+  );
+}
+
+// --- Two plastic fixation legs at (+/-5.08, 0) ------------------------------
+const legs: Shape[] = [];
+for (const lx of [-5.08, 5.08]) {
+  legs.push(
+    cylinder(PIN_BELOW, LEG_DIA_INFERRED / 2, 24).color(POST_WHITE).translate(lx, 0, -PIN_BELOW),
+  );
+}
+
+const asm = assembly('keyswitch-mx');
+asm.part('lower-housing', lower);
+asm.part('upper-housing', upper);
+asm.part('stem-cross-x', stemBarX);
+asm.part('stem-cross-y', stemBarY);
+asm.part('center-post', post);
+contacts.forEach((c, i) => asm.part(`contact-pin-${i}`, c));
+legs.forEach((l, i) => asm.part(`fixation-leg-${i}`, l));
+
+return asm.model();

--- a/scripts/parts/authored/oled-sh1106-13.kcad.ts
+++ b/scripts/parts/authored/oled-sh1106-13.kcad.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/oled-sh1106-13.kcad.ts
+//
+// 1.3" SH1106 128x64 I2C OLED module (4-pin: GND / VCC / SCL / SDA).
+//
+// DIMENSION SOURCES
+//   PCB outline 35.40 x 33.50 mm  — CONFIRMED, lcdwiki MC130VX ("Module PCB Size
+//     33.50x35.40") https://www.lcdwiki.com/1.3inch_IIC_OLED_Module_SKU:MC130VX
+//     independently corroborated by DisplayModule's 1.3" I2C product spec.
+//   Overall module thickness 2.7 mm (PCB + glass, excluding header pins)
+//     — CONFIRMED as a vendor spec (DisplayModule), no drawing behind it.
+//   Glass panel 34.5 x 23.0 x 1.4 mm (+/-0.2, t +/-0.1) — CONFIRMED from the
+//     outline drawing, Allvision 1.3" SH1106 datasheet section 1.4:
+//     https://cdn.sparkfun.com/assets/2/6/8/9/7/1.3inch-SH1106-OLED_Datasheet.pdf
+//   Metal cap (frame) 34.5 x 19.2 mm (+/-0.2)  — CONFIRMED, same drawing 1.4.
+//   Polarizer 33.5 x 18.2 mm (+/-0.2)          — CONFIRMED, same drawing 1.4.
+//   Viewing area 31.42 x 16.7 mm (+/-0.2)      — CONFIRMED, same drawing 1.4.
+//   Active area 29.42 x 14.7 mm                — CONFIRMED, same datasheet 1.2/1.3
+//     (= 0.23 mm pixel pitch x 128 - 0.02). Pixel pitch 0.23, pixel 0.21 mm.
+//
+// EXPLICITLY UNVERIFIED (modelled to a stated assumption, do not treat as spec):
+//   - PCB thickness alone. No source. Taken as 1.30 mm, inferred only as
+//     2.7 (overall) - 1.4 (glass) = 1.3. Marked PCB_T_ASSUMED below.
+//   - Where the glass sits on the carrier PCB, and which edge carries the
+//     header. No drawing of the carrier PCB could be found. The layout below
+//     (header along the -Y long edge, glass centred in X and pushed to +Y) is
+//     the common physical arrangement of this board but is NOT from a drawing.
+//   - Header pitch 2.54 mm is an INFERENCE from this board class, not a citation.
+//   - MOUNTING HOLES ARE DELIBERATELY NOT MODELLED. The 4-pin I2C variant's
+//     spec tables list none and no drawing was found; the 7-pin SPI variant is
+//     a different board. Inventing hole positions here would be worse than
+//     omitting them, since enclosures get designed against them.
+
+const PCB_L = 35.4; // X, CONFIRMED
+const PCB_W = 33.5; // Y, CONFIRMED
+const PCB_T_ASSUMED = 1.3; // see header note — inferred, not a spec
+
+const GLASS_L = 34.5; // CONFIRMED
+const GLASS_W = 23.0; // CONFIRMED
+const GLASS_T = 1.4; // CONFIRMED
+
+const CAP_L = 34.5; // metal frame, CONFIRMED
+const CAP_W = 19.2; // CONFIRMED
+const AA_L = 29.42; // active area, CONFIRMED
+const AA_W = 14.7; // CONFIRMED
+
+const PCB_BLUE = '#12325a';
+const GLASS_DARK = '#0a0f18';
+const FRAME_METAL = '#9aa0a8';
+const PIXEL_GLOW = '#2f6fd0';
+const HEADER_BLACK = '#1b1b22';
+const HEADER_GOLD = '#c8a040';
+const PASSIVE_TAN = '#8a7050';
+
+// --- PCB -------------------------------------------------------------------
+const pcb = box(PCB_L, PCB_W, PCB_T_ASSUMED).color(PCB_BLUE);
+
+// --- Glass panel: centred in X, pushed toward +Y to leave the header strip --
+const glassX = (PCB_L - GLASS_L) / 2; // 0.45
+const glassY = PCB_W - GLASS_W - 0.5; // ~10.0 -> leaves a 10mm header strip
+const glass = box(GLASS_L, GLASS_W, GLASS_T)
+  .color(GLASS_DARK)
+  .translate(glassX, glassY, PCB_T_ASSUMED);
+
+// --- Metal cap / frame bezel, sitting ON the glass as an open rim ----------
+// Built as four bars around the display window rather than a solid plate, so
+// the active area shows THROUGH it. A solid plate embedded in the glass would
+// both interpenetrate the glass and z-fight along the coincident side faces.
+const glassTop = PCB_T_ASSUMED + GLASS_T;
+const capX = glassX + (GLASS_L - CAP_L) / 2;
+const capY = glassY + (GLASS_W - CAP_W) / 2;
+const aaX = capX + (CAP_L - AA_L) / 2;
+const aaY = capY + (CAP_W - AA_W) / 2;
+const RIM_T = 0.35;
+
+const frameBars: Shape[] = [
+  // left / right bars, full bezel height
+  box(aaX - capX, CAP_W, RIM_T).color(FRAME_METAL).translate(capX, capY, glassTop),
+  box(capX + CAP_L - (aaX + AA_L), CAP_W, RIM_T)
+    .color(FRAME_METAL)
+    .translate(aaX + AA_L, capY, glassTop),
+  // bottom / top bars, spanning only the window width
+  box(AA_L, aaY - capY, RIM_T).color(FRAME_METAL).translate(aaX, capY, glassTop),
+  box(AA_L, capY + CAP_W - (aaY + AA_W), RIM_T)
+    .color(FRAME_METAL)
+    .translate(aaX, aaY + AA_W, glassTop),
+];
+
+// --- Active pixel area, filling the bezel window, slightly below the rim ----
+const activeArea = box(AA_L, AA_W, RIM_T - 0.1)
+  .color(PIXEL_GLOW)
+  .translate(aaX, aaY, glassTop);
+
+// --- 4-pin I2C header along the -Y long edge (2.54mm pitch, INFERRED) -------
+const PIN_COUNT = 4;
+const PIN_PITCH = 2.54;
+const headerW = (PIN_COUNT - 1) * PIN_PITCH + 2.54; // 10.16mm shroud
+const headerX = (PCB_L - headerW) / 2;
+const headerY = 1.2;
+const headerPins: Shape[] = [];
+const headerHoles: Shape[] = [];
+for (let i = 0; i < PIN_COUNT; i++) {
+  const px = headerX + 1.27 + i * PIN_PITCH - 0.32;
+  // 0.64mm square post, running from below the PCB up through the shroud
+  headerPins.push(
+    box(0.64, 0.64, 11.0)
+      .color(HEADER_GOLD)
+      .translate(px, headerY + 0.95, PCB_T_ASSUMED - 3.0),
+  );
+  // Clearance hole through the plastic shroud, so the pin passes THROUGH the
+  // body rather than interpenetrating it.
+  headerHoles.push(
+    box(0.9, 0.9, 4.0).translate(px - 0.13, headerY + 0.82, PCB_T_ASSUMED - 0.5),
+  );
+}
+
+const headerBody = box(headerW, 2.54, 2.54)
+  .translate(headerX, headerY, PCB_T_ASSUMED)
+  .subtract(...headerHoles)
+  .color(HEADER_BLACK);
+
+// --- SH1106 driver sits on the panel's FPC tail, at the glass edge ----------
+// The panel's FPC tail is 15 x 8 x 0.05mm, 30 pins @ 0.70mm pitch — CONFIRMED
+// (datasheet 1.4). On the assembled module the tail folds back UNDER the panel,
+// so only the run between the panel edge and the PCB is exposed. Only that
+// exposed run is modelled; drawing the full 8mm length here would drive the
+// tail into the glass solid.
+const FPC_EXPOSED = 6.8;
+const fpc = box(15.0, FPC_EXPOSED, 0.2)
+  .color('#3a2a10')
+  .translate((PCB_L - 15.0) / 2, glassY - FPC_EXPOSED - 0.2, PCB_T_ASSUMED);
+const driverIc = box(9.0, 1.6, 0.6)
+  .color('#181820')
+  .translate((PCB_L - 9.0) / 2, glassY - 5.2, PCB_T_ASSUMED + 0.2);
+
+// --- A few passives on the header strip -------------------------------------
+const passives: Shape[] = [];
+const passivePositions: [number, number][] = [
+  [5.0, 6.4],
+  [7.2, 6.4],
+  [26.5, 6.4],
+  [28.7, 6.4],
+];
+for (const [cx, cy] of passivePositions) {
+  passives.push(box(1.0, 0.5, 0.45).color(PASSIVE_TAN).translate(cx, cy, PCB_T_ASSUMED));
+}
+
+const asm = assembly('oled-sh1106-13');
+asm.part('pcb', pcb);
+asm.part('glass', glass);
+frameBars.forEach((b, i) => asm.part(`bezel-${i}`, b));
+asm.part('active-area', activeArea);
+asm.part('fpc-tail', fpc);
+asm.part('sh1106-driver', driverIc);
+asm.part('header-body', headerBody);
+headerPins.forEach((p, i) => asm.part(`header-pin-${i}`, p));
+passives.forEach((c, i) => asm.part(`passive-${i}`, c));
+
+return asm.model();

--- a/scripts/parts/authored/oled-ssd1327-15.kcad.ts
+++ b/scripts/parts/authored/oled-ssd1327-15.kcad.ts
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/oled-ssd1327-15.kcad.ts
+//
+// 1.5" SSD1327 128x128 16-grey OLED module (Waveshare "1.5inch OLED Module"
+// form factor, 8-pin SPI/I2C header).
+//
+// DIMENSION SOURCES
+//   PCB outline 44.5 x 37.0 mm — CONFIRMED, Waveshare 1.5inch OLED Module User
+//     Manual p.1, corroborated by the Waveshare product page and two resellers:
+//     https://files.waveshare.com/upload/8/80/1.5inch_OLED_Module_User_Manual_EN.pdf
+//   8-pin single-row header on the right edge (3.3V, GND, NC, DIN, CLK, CS,
+//     DC, RST) — CONFIRMED, same manual p.1 pin table + p.2 board photo.
+//   Bare panel outline 33.80 x 36.50 x 2.05 mm — CONFIRMED, Crystalfontz
+//     CFAL128128A0-015W (the underlying 1.5" 128x128 panel):
+//     https://www.crystalfontz.com/product/cfal128128a0015w-128x128-square-oled-display
+//   Active area  26.86 x 26.86 mm (square) — CONFIRMED, Crystalfontz,
+//     corroborated by DisplayModule. Consistent with 0.21 mm dot pitch x 128.
+//   Viewing area 28.86 x 28.86 mm — CONFIRMED, Crystalfontz.
+//   Dot pitch 0.21 mm, dot 0.19 x 0.19 mm — CONFIRMED, Crystalfontz.
+//
+//   NOTE: one search snippet circulates "26.855 x 25.864" (non-square) for the
+//   active area. That contradicts both the panel datasheet and the pixel
+//   geometry (0.21 x 128 ~= 26.9 on BOTH axes). 26.86 square is used here.
+//
+// EXPLICITLY UNVERIFIED (do not treat as spec):
+//   - PCB thickness and overall module thickness. Waveshare does not publish
+//     them; its wiki outline drawing is on a host that refuses automated
+//     fetches (403). PCB taken as 1.6 mm — a conventional assumption, NOT a
+//     citation. Marked PCB_T_ASSUMED below.
+//   - MOUNTING HOLES ARE DELIBERATELY NOT MODELLED. Four corner holes are
+//     clearly VISIBLE in the manual's board photo, so they certainly exist,
+//     but neither their diameter nor their positions are published anywhere
+//     reachable. Enclosures get designed against mounting holes, so guessing
+//     them would be worse than leaving them out. Confirm from the Waveshare
+//     wiki outline drawing in a real browser before adding them.
+//   - Header pitch 2.54 mm is an INFERENCE (Waveshare standard), not a citation.
+//   - The left-edge FPC/JST connector's pitch is unpublished; it is modelled
+//     as a plain block of the right footprint, not a detailed connector.
+//   - Exact panel placement on the carrier PCB is not published; the layout
+//     below (panel to the left, header strip on the right) matches the photo
+//     but is not from a drawing.
+
+const PCB_L = 44.5; // X, CONFIRMED
+const PCB_W = 37.0; // Y, CONFIRMED
+const PCB_T_ASSUMED = 1.6; // see header note — assumption, not a spec
+
+const PANEL_L = 33.8; // CONFIRMED (bare panel outline)
+const PANEL_W = 36.5; // CONFIRMED
+const PANEL_T = 2.05; // CONFIRMED
+
+const VA = 28.86; // viewing area, square, CONFIRMED
+const AA = 26.86; // active area, square, CONFIRMED
+
+const PCB_BLACK = '#141418';
+const PANEL_DARK = '#0a0c10';
+const BEZEL_METAL = '#8f959d';
+const PIXEL_GREY = '#c9cdd4';
+const HEADER_BLACK = '#1b1b22';
+const HEADER_GOLD = '#c8a040';
+const CONN_IVORY = '#c8c2b0';
+const PASSIVE_TAN = '#8a7050';
+
+// --- PCB -------------------------------------------------------------------
+const pcb = box(PCB_L, PCB_W, PCB_T_ASSUMED).color(PCB_BLACK);
+
+// --- OLED panel: left-hand side, centred in Y ------------------------------
+// Panel starts at x=3.0 to leave clear space for the left-edge FPC connector
+// (which occupies 0.3..2.5); at x=1.0 the two solids overlapped.
+const panelX = 3.0;
+const panelY = (PCB_W - PANEL_W) / 2; // 0.25
+const panel = box(PANEL_L, PANEL_W, PANEL_T)
+  .color(PANEL_DARK)
+  .translate(panelX, panelY, PCB_T_ASSUMED);
+
+// --- Viewing-area bezel, built as an open rim ON the panel ------------------
+// Four bars around the display window rather than a solid plate, so the active
+// area shows THROUGH it. A solid plate sunk into the panel would interpenetrate
+// the panel solid and z-fight along the coincident faces.
+const panelTop = PCB_T_ASSUMED + PANEL_T;
+const vaX = panelX + (PANEL_L - VA) / 2;
+const vaY = panelY + (PANEL_W - VA) / 2;
+const aaX = panelX + (PANEL_L - AA) / 2;
+const aaY = panelY + (PANEL_W - AA) / 2;
+const RIM_T = 0.4;
+
+const bezelBars: Shape[] = [
+  box(aaX - vaX, VA, RIM_T).color(BEZEL_METAL).translate(vaX, vaY, panelTop),
+  box(vaX + VA - (aaX + AA), VA, RIM_T).color(BEZEL_METAL).translate(aaX + AA, vaY, panelTop),
+  box(AA, aaY - vaY, RIM_T).color(BEZEL_METAL).translate(aaX, vaY, panelTop),
+  box(AA, vaY + VA - (aaY + AA), RIM_T).color(BEZEL_METAL).translate(aaX, aaY + AA, panelTop),
+];
+
+// --- Active pixel area (square, 128x128), filling the bezel window ----------
+const activeArea = box(AA, AA, RIM_T - 0.1).color(PIXEL_GREY).translate(aaX, aaY, panelTop);
+
+// --- 8-pin header along the right edge (2.54mm pitch, INFERRED) -------------
+const PIN_COUNT = 8;
+const PIN_PITCH = 2.54;
+const headerL = (PIN_COUNT - 1) * PIN_PITCH + 2.54; // 20.32mm shroud
+const headerX = PCB_L - 2.54 - 2.0;
+const headerY = (PCB_W - headerL) / 2;
+const headerPins: Shape[] = [];
+const headerHoles: Shape[] = [];
+for (let i = 0; i < PIN_COUNT; i++) {
+  const py = headerY + 1.27 + i * PIN_PITCH - 0.32;
+  headerPins.push(
+    box(0.64, 0.64, 11.0)
+      .color(HEADER_GOLD)
+      .translate(headerX + 0.95, py, PCB_T_ASSUMED - 3.0),
+  );
+  // Clearance hole through the plastic shroud, so the pin passes THROUGH the
+  // body rather than interpenetrating it.
+  headerHoles.push(
+    box(0.9, 0.9, 4.0).translate(headerX + 0.82, py - 0.13, PCB_T_ASSUMED - 0.5),
+  );
+}
+
+const headerBody = box(2.54, headerL, 2.54)
+  .translate(headerX, headerY, PCB_T_ASSUMED)
+  .subtract(...headerHoles)
+  .color(HEADER_BLACK);
+
+// --- SSD1327 sits on the panel's own FPC; carrier-side support parts --------
+// Left-edge FPC/JST-style connector (pitch unpublished — modelled as a block).
+const leftConn = box(2.2, 12.0, 1.4)
+  .color(CONN_IVORY)
+  .translate(0.3, (PCB_W - 12.0) / 2, PCB_T_ASSUMED);
+
+const passives: Shape[] = [];
+const passivePositions: [number, number][] = [
+  [36.5, 6.0],
+  [38.6, 6.0],
+  [36.5, 30.0],
+  [38.6, 30.0],
+];
+for (const [cx, cy] of passivePositions) {
+  passives.push(box(1.0, 0.5, 0.45).color(PASSIVE_TAN).translate(cx, cy, PCB_T_ASSUMED));
+}
+
+const asm = assembly('oled-ssd1327-15');
+asm.part('pcb', pcb);
+asm.part('panel', panel);
+bezelBars.forEach((b, i) => asm.part(`bezel-${i}`, b));
+asm.part('active-area', activeArea);
+asm.part('header-body', headerBody);
+headerPins.forEach((p, i) => asm.part(`header-pin-${i}`, p));
+asm.part('fpc-connector', leftConn);
+passives.forEach((c, i) => asm.part(`passive-${i}`, c));
+
+return asm.model();

--- a/scripts/parts/authored/rotary-encoder-ec11.kcad.ts
+++ b/scripts/parts/authored/rotary-encoder-ec11.kcad.ts
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/rotary-encoder-ec11.kcad.ts
+//
+// EC11-class 12 mm incremental rotary encoder with integral pushbutton switch,
+// knurled D-shaft, vertical PCB mount (shaft up, can flat on the board).
+// Modelled on Bourns PEC11R-4xxx with a 20 mm actuator (LB = 7 mm bushing),
+// cross-checked against ALPS EC11E. The two datasheets agree on every shared
+// number, so the "EC11 standard" this models is real and not a single vendor's.
+//
+// DIMENSION SOURCES
+//   Bourns PEC11R : https://www.bourns.com/docs/Product-Datasheets/PEC11R.pdf
+//   ALPS  EC11E   : https://file.elecfans.com/web1/M00/90/2D/o4YBAFzFBtCALQJ0AAlE9NU9dVE732.pdf
+//
+//   Can (body) front view    12.5 x 13.4 mm (Bourns)        CONFIRMED
+//                            11.7 x 12.0 mm (ALPS EC11E)    CONFIRMED
+//                            Bourns figures used here.
+//   Overall width incl. tabs 14.0 mm (.551)                 CONFIRMED (Bourns)
+//   Bushing thread           M7 x 0.75                      CONFIRMED (both)
+//   Bushing length LB        7.0 mm (for 20/25/30 mm shaft) CONFIRMED (Bourns)
+//   Shaft diameter           6.0 +/-0.1 mm                  CONFIRMED (both)
+//   Shaft length L           20 mm (option; 15/25/30 also)  CONFIRMED (Bourns)
+//   D-flat across-flat       4.5 +0/-0.05 mm                CONFIRMED (both)
+//   Flat length F            10 mm for L = 20               CONFIRMED (Bourns)
+//   Shaft-end chamfer        C 0.5 mm                       CONFIRMED (Bourns)
+//   Knurl                    18 teeth on the 6.0 dia shaft  CONFIRMED (Bourns p.3)
+//   Encoder pins A-C-B pitch 2.5 mm (5.0 mm A->B span)      CONFIRMED (both)
+//   Switch pins D-E pitch    5.0 mm                         CONFIRMED (ALPS)
+//   Row spacing enc <-> sw   7.0 mm                         CONFIRMED (ALPS)
+//   Pin hole diameter        1.0 +0.1/-0 mm, 5 places       CONFIRMED (both)
+//   Mounting pegs            RECTANGULAR 2.6 x 1.8 mm, 2x   CONFIRMED (Bourns
+//                            -4xxx). They are NOT round pegs.
+//   Mounting peg spacing     13.2 mm (Bourns -4xxx)         CONFIRMED
+//   Switch travel            0.5 +/-0.3 mm, ~610 gf         CONFIRMED (Bourns)
+//
+// EXPLICITLY UNVERIFIED (stated assumptions, not spec):
+//   - CAN DEPTH (the body thickness along the shaft axis) is taken as 7.5 mm.
+//     Bourns NEVER dimensions body depth; the 7.0/10 mm numbers in its side
+//     views are the pin side-facing offset (terminal codes 1 vs 2), not can
+//     thickness. 7.5 comes from ALPS's "7.5 max." front-view note, and closes
+//     ALPS's own arithmetic exactly (7.5 + 7 + 10 = 24.5 overall). Treated as
+//     INFERRED. Everything above the PCB therefore keys off CAN_DEPTH_INFERRED.
+//   - Shaft length above the bushing = L - LB = 20 - 7 = 13 mm is arithmetic
+//     from two confirmed numbers, not a dimensioned callout.
+//   - Bourns tabulates knurl-zone dimensions P and A (e.g. L=20 with switch:
+//     P=7, A=6) but the drawing is ambiguous about WHICH is knurl length and
+//     which is offset. The knurl is therefore modelled over the lower part of
+//     the exposed shaft at a plausible 7 mm; treat the knurl EXTENT as
+//     unverified. Tooth COUNT (18) and shaft diameter are confirmed.
+//   - The supplied nut (10.0 A/F x 2.0) and washer (12.0 OD) are NOT modelled;
+//     they ship loose, they are not part of the soldered footprint.
+
+const CAN_W = 12.5; // X, CONFIRMED (Bourns front view)
+const CAN_H = 13.4; // Y, CONFIRMED (Bourns front view)
+const CAN_DEPTH_INFERRED = 7.5; // Z above PCB — see note, INFERRED from ALPS
+const TAB_SPAN = 14.0; // overall width incl. side tabs, CONFIRMED
+
+const BUSHING_OD = 7.0; // M7 major dia, CONFIRMED thread spec
+const BUSHING_LEN = 7.0; // LB, CONFIRMED
+const SHAFT_DIA = 6.0; // CONFIRMED
+const SHAFT_ABOVE_BUSHING = 13.0; // L(20) - LB(7), arithmetic
+const FLAT_ACROSS = 4.5; // CONFIRMED
+const FLAT_LEN = 10.0; // F for L=20, CONFIRMED
+const KNURL_TEETH = 18; // CONFIRMED
+const KNURL_LEN = 7.0; // extent UNVERIFIED — see note
+
+const PIN_ENC_PITCH = 2.5; // CONFIRMED
+const PIN_SW_PITCH = 5.0; // CONFIRMED
+const ROW_SPACING = 7.0; // CONFIRMED
+const PIN_DIA = 1.0; // CONFIRMED
+const PEG_X = 2.6; // CONFIRMED (rectangular)
+const PEG_Y = 1.8; // CONFIRMED
+const PEG_SPACING = 13.2; // CONFIRMED
+
+const CAN_METAL = '#9fa4ab';
+const TAB_METAL = '#8b9098';
+const BUSHING_METAL = '#7d828a';
+const SHAFT_METAL = '#c2c6cc';
+const KNURL_METAL = '#a8acb2';
+const PIN_METAL = '#c9a55a';
+
+// Built about the shaft axis at (0,0); z = 0 is the PCB surface.
+const canTop = CAN_DEPTH_INFERRED;
+const bushingTop = canTop + BUSHING_LEN;
+const shaftTop = bushingTop + SHAFT_ABOVE_BUSHING; // 27.5 overall
+
+// --- Metal can -------------------------------------------------------------
+const can = box(CAN_W, CAN_H, CAN_DEPTH_INFERRED)
+  .color(CAN_METAL)
+  .translate(-CAN_W / 2, -CAN_H / 2, 0);
+
+// --- Side mounting tabs bringing overall width to 14.0 ---------------------
+const tabW = (TAB_SPAN - CAN_W) / 2; // 0.75 each side
+const tabs: Shape[] = [];
+for (const sx of [-1, 1]) {
+  tabs.push(
+    box(tabW, 4.5, 1.2)
+      .color(TAB_METAL)
+      .translate(sx > 0 ? CAN_W / 2 : -CAN_W / 2 - tabW, -2.25, 1.0),
+  );
+}
+
+// --- Threaded bushing (M7 x 0.75), plus a ring of thread crests ------------
+const bushing = cylinder(BUSHING_LEN, BUSHING_OD / 2, 48)
+  .color(BUSHING_METAL)
+  .translate(0, 0, canTop);
+
+// Thread crests: a stack of thin rings slightly proud of the bushing OD, at
+// the confirmed 0.75 mm pitch. Cosmetic, but makes the thread legible.
+const threads: Shape[] = [];
+const threadCount = Math.floor(BUSHING_LEN / 0.75) - 1;
+for (let i = 0; i < threadCount; i++) {
+  threads.push(
+    cylinder(0.36, BUSHING_OD / 2 + 0.12, 48)
+      .color(BUSHING_METAL)
+      .translate(0, 0, canTop + 0.4 + i * 0.75),
+  );
+}
+
+// --- Shaft: 6.0 dia, knurled over the lower zone, D-flat over the top 10mm --
+const shaftLen = shaftTop - bushingTop;
+let shaft = cylinder(shaftLen, SHAFT_DIA / 2, 48).color(SHAFT_METAL).translate(0, 0, bushingTop);
+
+// 18 axial knurl teeth around the circumference, on the lower knurl zone.
+const knurlRibs: Shape[] = [];
+for (let i = 0; i < KNURL_TEETH; i++) {
+  const ang = (i / KNURL_TEETH) * Math.PI * 2;
+  const r = SHAFT_DIA / 2 - 0.12;
+  knurlRibs.push(
+    box(0.55, 0.55, KNURL_LEN)
+      .color(KNURL_METAL)
+      .translate(-0.275, -0.275, 0)
+      .rotate([0, 0, 1], (ang * 180) / Math.PI)
+      .translate(r * Math.cos(ang), r * Math.sin(ang), bushingTop),
+  );
+}
+
+// D-flat: across-flat 4.5 means the flat plane sits 4.5 - 3.0 = 1.5 mm from the
+// axis. Cut it over the top FLAT_LEN of the shaft.
+const flatOffset = FLAT_ACROSS - SHAFT_DIA / 2; // 1.5
+const flatCutter = box(SHAFT_DIA, SHAFT_DIA, FLAT_LEN + 1.0).translate(
+  flatOffset,
+  -SHAFT_DIA / 2,
+  shaftTop - FLAT_LEN,
+);
+shaft = shaft.subtract(flatCutter).color(SHAFT_METAL);
+
+// --- Terminals -------------------------------------------------------------
+// Encoder row: A, C, B on 2.5mm pitch. Switch row: D, E on 5.0mm pitch,
+// 7.0mm away in Y. Pins exit the can and run down through the PCB.
+const pins: Shape[] = [];
+const encY = -ROW_SPACING / 2;
+const swY = ROW_SPACING / 2;
+for (const px of [-PIN_ENC_PITCH, 0, PIN_ENC_PITCH]) {
+  pins.push(cylinder(4.5, PIN_DIA / 2, 16).color(PIN_METAL).translate(px, encY, -3.2));
+}
+for (const px of [-PIN_SW_PITCH / 2, PIN_SW_PITCH / 2]) {
+  pins.push(cylinder(4.5, PIN_DIA / 2, 16).color(PIN_METAL).translate(px, swY, -3.2));
+}
+
+// --- Two RECTANGULAR mounting pegs at 13.2mm spacing -----------------------
+const pegs: Shape[] = [];
+for (const gx of [-PEG_SPACING / 2, PEG_SPACING / 2]) {
+  pegs.push(
+    box(PEG_X, PEG_Y, 3.0)
+      .color(CAN_METAL)
+      .translate(gx - PEG_X / 2, -PEG_Y / 2, -3.0),
+  );
+}
+
+const asm = assembly('rotary-encoder-ec11');
+asm.part('can', can);
+tabs.forEach((t, i) => asm.part(`mount-tab-${i}`, t));
+asm.part('bushing', bushing);
+threads.forEach((t, i) => asm.part(`thread-${i}`, t));
+asm.part('shaft', shaft);
+knurlRibs.forEach((k, i) => asm.part(`knurl-${i}`, k));
+pins.forEach((p, i) => asm.part(`pin-${i}`, p));
+pegs.forEach((p, i) => asm.part(`peg-${i}`, p));
+
+return asm.model();

--- a/scripts/parts/authored/tactile-12mm.kcad.ts
+++ b/scripts/parts/authored/tactile-12mm.kcad.ts
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/tactile-12mm.kcad.ts
+//
+// 12x12 mm THT tactile switch, projected-plunger type, with a round actuator cap.
+// Reference part: Omron B3F-4050 (12x12, projected plunger, 7.3 mm) fitted with
+// an Omron B32-16x0 9.5 mm round key top. The B3F-4050 IS the archetype that
+// the ubiquitous "12x12x7.3" maker clones copy.
+//
+// DIMENSION SOURCES — Omron B3F datasheet A070-E1 p.6 (footprint + outline):
+//   https://omronfs.omron.com/en_US/ecb/products/pdf/en-b3f.pdf
+// and Omron B32 key-top datasheet A077-E1 p.237 for the cap:
+//   https://datasheet.octopart.com/B32-1610-Omron-datasheet-10910218.pdf
+//
+//   Body footprint          12.0 +/-0.2 x 12.0 +/-0.2 mm   CONFIRMED (B3F p.6)
+//                           also corroborated by CamdenBoss CST12S series.
+//   Case (seating) height   3.5 mm                          CONFIRMED (B3F p.6)
+//   Total height, flat type 4.3 +/-0.2 mm                   CONFIRMED (B3F p.6)
+//   Total height, projected 7.3 +/-0.4 mm  (B3F-4050)       CONFIRMED (B3F p.6)
+//   Plunger                 SQUARE 3.8 +/-0.1 mm            CONFIRMED (B3F p.6)
+//                           -- NOT a round pin. This square is the mating
+//                              interface to the cap's square socket.
+//   Plunger protrusion      3.0 mm (= 7.3 - 4.3)            derived from two
+//                                                           CONFIRMED heights
+//   Circular boss, top face 7.1 mm dia (Omron)              CONFIRMED (B3F p.6)
+//                           (CamdenBoss's equivalent is 6.6 dia — differs by
+//                            manufacturer; the Omron value is used here.)
+//   PCB terminal pitch      12.5 +/-0.1 (X) x 5.0 +/-0.1 (Y) mm, 4 holes of
+//                           1.2 +/-0.05 mm dia              CONFIRMED (B3F p.6,
+//                           "PCB Processing Dimensions")
+//   Lead-tip span           12.5 +/-0.5 / 13.8 +/-0.5 mm    CONFIRMED (B3F p.6)
+//   Positioning bosses      2 x 1.6 mm dia                  CONFIRMED (B3F p.6)
+//   Operating force         1.27 N {130 gf}, pretravel 0.3 mm  CONFIRMED (p.3)
+//
+//   Cap (B32-16x0):  9.5 +/-0.2 mm ROUND, 7.0 mm tall, square 3.8 +/-0.1
+//                    socket, TOTAL HEIGHT FROM PCB 11.5 +/-0.4 mm,
+//                    panel cutout 9.7 +0.05/-0 dia.       ALL CONFIRMED (B32)
+//
+// NOTE ON PITCH: this part's terminal pitch is 12.5 x 5.0 mm. It is a common
+// error to carry over 10.16 x 4.5 — that is the 6x6 B3F footprint (6.5 x 4.5),
+// not the 12x12. CamdenBoss independently confirms 5.0 mm on 12x12.
+//
+// EXPLICITLY UNVERIFIED:
+//   - Positioning-boss SPACING is read as 9.0 +/-0.1 mm off the Omron drawing
+//     but is not stated in the text — INFERRED. The boss DIAMETER (1.6) and the
+//     mating PCB hole (1.8 +/-0.05) are both stated and CONFIRMED.
+//   - Cap colour is cosmetic (B32 trailing digit selects it); red is shown.
+
+const BODY = 12.0; // CONFIRMED
+const CASE_H = 3.5; // CONFIRMED, seating plane -> case top
+const BODY_TOP = 4.3; // CONFIRMED, total height of the flat body incl. boss
+const PLUNGER = 3.8; // CONFIRMED, SQUARE
+const PLUNGER_TOP = 7.3; // CONFIRMED, projected type total height
+const BOSS_DIA = 7.1; // CONFIRMED, circular boss on the top face
+
+// Cap fitted here is the B32-16x0 ROUND key top. The 12 mm square B32-13x0 is
+// equally valid but, being exactly as wide as the 12 mm body, it completely
+// hides the switch and makes the catalog model unreadable as a tactile switch.
+const CAP_DIA = 9.5; // CONFIRMED, B32-16x0 outline (9.5 +/-0.2 dia)
+const CAP_H = 7.0; // CONFIRMED, B32-16x0 cap height
+const CAP_TOP = 11.5; // CONFIRMED, B32-16x0 total height from PCB
+const CAP_BOTTOM = CAP_TOP - CAP_H; // 4.5
+const CAP_SOCKET = 3.9; // CONFIRMED socket is square 3.8 +/-0.1; 3.9 models it
+// with a nominal fit clearance over the 3.8 plunger.
+
+const PITCH_X = 12.5; // CONFIRMED
+const PITCH_Y = 5.0; // CONFIRMED
+const LEAD_DIA = 1.0; // lead body; mates the CONFIRMED 1.2mm PCB hole
+const BOSS_SPACING = 9.0; // INFERRED from the drawing — see note above
+const LOC_BOSS_DIA = 1.6; // CONFIRMED
+
+const BODY_BLACK = '#26262b';
+const BOSS_GREY = '#3d3d44';
+const PLUNGER_GREY = '#55555e';
+const CAP_RED = '#b8342c';
+const LEAD_METAL = '#b8b8b0';
+
+// Everything is built about the switch centre at (0,0); z=0 is the PCB surface.
+const half = BODY / 2;
+
+// --- Main case (12 x 12 x 3.5) ---------------------------------------------
+const caseBody = box(BODY, BODY, CASE_H).color(BODY_BLACK).translate(-half, -half, 0);
+
+// --- Circular boss on the top face, 7.1 dia, 3.5 -> 4.3 --------------------
+const boss = cylinder(BODY_TOP - CASE_H, BOSS_DIA / 2, 48).color(BOSS_GREY).translate(0, 0, CASE_H);
+
+// --- Square plunger, 3.8 sq, 4.3 -> 7.3 -------------------------------------
+const plunger = box(PLUNGER, PLUNGER, PLUNGER_TOP - BODY_TOP)
+  .color(PLUNGER_GREY)
+  .translate(-PLUNGER / 2, -PLUNGER / 2, BODY_TOP);
+
+// --- B32-16x0 round key top: 9.5 dia, 7.0 tall, sits at 4.5 -> 11.5 --------
+// The square socket is cut out so the cap SEATS on the plunger rather than
+// interpenetrating it — the socket is the real mating interface.
+const socketDepth = 3.0; // 4.5 -> 7.5, clearing the 7.3 plunger top
+const capSocket = box(CAP_SOCKET, CAP_SOCKET, socketDepth).translate(
+  -CAP_SOCKET / 2,
+  -CAP_SOCKET / 2,
+  CAP_BOTTOM,
+);
+const cap = cylinder(CAP_H, CAP_DIA / 2, 48)
+  .translate(0, 0, CAP_BOTTOM)
+  .subtract(capSocket)
+  .color(CAP_RED);
+
+// --- Four leads at 12.5 (X) x 5.0 (Y) pitch, running below the PCB ---------
+const leads: Shape[] = [];
+const leadPositions: [number, number][] = [
+  [-PITCH_X / 2, -PITCH_Y / 2],
+  [PITCH_X / 2, -PITCH_Y / 2],
+  [-PITCH_X / 2, PITCH_Y / 2],
+  [PITCH_X / 2, PITCH_Y / 2],
+];
+for (const [lx, ly] of leadPositions) {
+  // vertical through-hole pin
+  leads.push(cylinder(3.5, LEAD_DIA / 2, 16).color(LEAD_METAL).translate(lx, ly, -3.2));
+  // the flat strap that runs out of the case to the pin
+  leads.push(
+    box(Math.abs(lx) - half + 0.9, 1.4, 0.3)
+      .color(LEAD_METAL)
+      .translate(lx > 0 ? half - 0.6 : -Math.abs(lx) - 0.3, ly - 0.7, 0.15),
+  );
+}
+
+// --- Two locating bosses on the underside (1.6 dia) -------------------------
+const locBosses: Shape[] = [];
+for (const bx of [-BOSS_SPACING / 2, BOSS_SPACING / 2]) {
+  locBosses.push(cylinder(1.4, LOC_BOSS_DIA / 2, 24).color(BODY_BLACK).translate(bx, 0, -1.4));
+}
+
+const asm = assembly('tactile-12mm');
+asm.part('case', caseBody);
+asm.part('boss', boss);
+asm.part('plunger', plunger);
+asm.part('keycap', cap);
+leads.forEach((l, i) => asm.part(`lead-${i}`, l));
+locBosses.forEach((b, i) => asm.part(`locating-boss-${i}`, b));
+
+return asm.model();


### PR DESCRIPTION
Adds two real maker components to the electronics parts catalog (`scripts/electronics-parts.json`), fetched at ingest from allowlisted `raw.githubusercontent.com`:

- **cherry-mx-switch** — Cherry MX PCB-mount keyboard switch, MIT ([source](https://github.com/ConstantinoSchillebeeckx/cherry-mx-switch))
- **ec11-rotary-encoder** — Bourns PEC11R (EC11-class, push switch, Ø6 shaft) ([source](https://github.com/ubiqueIoT/rotary-encoder-PEC11R))

Both validated as real solids in kernelCAD before inclusion. Enables `lib.fetchPart` for panel/enclosure projects (the nodulo control-panel modules use both).

⚠️ The encoder source repo has **no LICENSE file** — marked `"license": "UNVERIFIED"`; confirm redistribution rights (or swap to a licensed encoder) before treating it as catalog-clean. Cherry-MX is clean MIT.

Deploy dispatched on this branch to push both live to kernelcad-parts.pages.dev.