### PR TITLE
fix(render): headless render without a studio dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "preview": "vite preview",
     "release": "npx tsx scripts/release.ts",
     "prepack": "npm run build:cli && npm run build:studio && npm run build:player",
-    "prepare": "git config core.hooksPath .githooks || true; npm run build:studio",
+    "prepare": "git config core.hooksPath .githooks || true; npm run build:studio && npm run build:player",
     "generate:parts": "npx tsx scripts/generateSeedCatalog.ts assets/parts",
     "prepublishOnly": "npm run generate:parts",
     "pretest": "npm run generate:parts",

--- a/src/agent/cli/commands/render.ts
+++ b/src/agent/cli/commands/render.ts
@@ -7,9 +7,11 @@
 // Default: 2×2 composite PNG (front, right, top, iso) saved next to the
 // script. Use `--separate` to emit four individual files.
 //
-// Requires a studio dev server reachable at the configured base URL
-// (see --base-url; default DEFAULT_RENDER_BASE_URL). For development run `npm run dev` first;
-// a bundled-static-dist mode is on the v2 list.
+// The render surface is provisioned automatically by resolveRenderBaseUrl()
+// (src/agent/render/playerServer.ts): the bundled static player
+// (dist/headless-player) is served from an ephemeral 127.0.0.1 port, so no
+// running studio dev server is required. `--base-url` remains an optional
+// override that bypasses provisioning entirely.
 
 import { Command } from 'commander';
 import { mkdir, writeFile } from 'node:fs/promises';
@@ -19,10 +21,10 @@ import {
   headlessRender,
   composite2x2,
   ALL_VIEWS,
-  DEFAULT_RENDER_BASE_URL,
   type HeadlessObjectFilter,
   type HeadlessInspectionChannel,
 } from '../../render/headlessRender';
+import { resolveRenderBaseUrl } from '../../render/playerServer';
 import { buildModelFromFile } from '../../../modeling/buildModel';
 import type { Assembly } from '../../../modeling/capture/assembly';
 import { probeAssemblies } from '../../../modeling/runtime/mechanismProbe';
@@ -34,7 +36,9 @@ export interface RenderInput {
   separate: boolean;
   width: number;
   height: number;
-  baseUrl: string;
+  /** Optional render-surface override. When omitted, resolveRenderBaseUrl()
+   *  provisions the bundled static player (or falls back to a dev server). */
+  baseUrl?: string;
   hideReferenceImages: boolean;
   /** Additional `--pose <az,el>` captures, repeatable on the CLI. */
   poses?: string[];
@@ -66,7 +70,8 @@ export interface RenderInspectInput {
   outDir: string;
   width: number;
   height: number;
-  baseUrl: string;
+  /** Optional render-surface override; see RenderInput.baseUrl. */
+  baseUrl?: string;
   hideReferenceImages: boolean;
   environment?: string;
   noWatermark?: boolean;
@@ -249,6 +254,26 @@ function normalizeInspectChannels(values: readonly string[] | undefined): Headle
   return [...new Set(requested)] as HeadlessInspectionChannel[];
 }
 
+/**
+ * Provision a render surface, run `fn` against it, and ALWAYS tear the
+ * ephemeral static-player server down — including when the render throws, so
+ * a failed capture never leaks a listening socket.
+ */
+async function withRenderBase<T>(
+  explicit: string | undefined,
+  fn: (baseUrl: string) => Promise<T>,
+): Promise<T> {
+  const surface = await resolveRenderBaseUrl(explicit);
+  if (surface.source !== 'explicit') {
+    console.error(`kernelcad render: render surface = ${surface.source} (${surface.baseUrl})`);
+  }
+  try {
+    return await fn(surface.baseUrl);
+  } finally {
+    await surface.close();
+  }
+}
+
 export async function renderScript(input: RenderInput): Promise<RenderCliResult> {
   const filePath = resolve(input.file);
   let objectFilter: HeadlessObjectFilter | undefined;
@@ -273,19 +298,21 @@ export async function renderScript(input: RenderInput): Promise<RenderCliResult>
 
   let result;
   try {
-    result = await headlessRender({
-      scriptPath: filePath,
-      viewportWidth: input.width,
-      viewportHeight: input.height,
-      views: ALL_VIEWS,
-      poses: input.poses,
-      baseUrl: input.baseUrl,
-      hideReferenceImages: input.hideReferenceImages,
-      environment: input.environment,
-      noWatermark: input.noWatermark,
-      objectFilter,
-      section,
-    });
+    result = await withRenderBase(input.baseUrl, (baseUrl) =>
+      headlessRender({
+        scriptPath: filePath,
+        viewportWidth: input.width,
+        viewportHeight: input.height,
+        views: ALL_VIEWS,
+        poses: input.poses,
+        baseUrl,
+        hideReferenceImages: input.hideReferenceImages,
+        environment: input.environment,
+        noWatermark: input.noWatermark,
+        objectFilter,
+        section,
+      }),
+    );
   } catch (e) {
     console.error(e instanceof Error ? e.message : String(e));
     return { exitCode: 1, outputPaths: [] };
@@ -374,18 +401,20 @@ export async function renderInspectBundle(input: RenderInspectInput): Promise<Re
 
   let result;
   try {
-    result = await headlessRender({
-      scriptPath: filePath,
-      viewportWidth: input.width,
-      viewportHeight: input.height,
-      views: ALL_VIEWS,
-      baseUrl: input.baseUrl,
-      hideReferenceImages: input.hideReferenceImages,
-      environment: input.environment,
-      noWatermark: input.noWatermark,
-      objectFilter,
-      inspectionChannels: requestedChannels,
-    });
+    result = await withRenderBase(input.baseUrl, (baseUrl) =>
+      headlessRender({
+        scriptPath: filePath,
+        viewportWidth: input.width,
+        viewportHeight: input.height,
+        views: ALL_VIEWS,
+        baseUrl,
+        hideReferenceImages: input.hideReferenceImages,
+        environment: input.environment,
+        noWatermark: input.noWatermark,
+        objectFilter,
+        inspectionChannels: requestedChannels,
+      }),
+    );
   } catch (e) {
     console.error(e instanceof Error ? e.message : String(e));
     return { exitCode: 1, outputPaths: [] };
@@ -531,8 +560,7 @@ export function renderCommand(): Command {
     .option('--height <n>', 'per-tile height in pixels', (v) => parseInt(v, 10), 1024)
     .option(
       '--base-url <url>',
-      'studio dev server URL (run `npm run dev` first)',
-      DEFAULT_RENDER_BASE_URL,
+      'optional render-surface override (e.g. a running studio dev server); default is the bundled static player',
     )
     .option('--hide-reference-images', 'hide referenceImage() overlays in rendered output (default false)', false)
     .option(
@@ -550,7 +578,7 @@ export function renderCommand(): Command {
     .action(async (file: string, outDir: string, opts: {
       width: number;
       height: number;
-      baseUrl: string;
+      baseUrl?: string;
       hideReferenceImages: boolean;
       environment?: string;
       watermark: boolean;
@@ -583,8 +611,7 @@ export function renderCommand(): Command {
     .option('--height <n>', 'per-tile height in pixels', (v) => parseInt(v, 10), 1024)
     .option(
       '--base-url <url>',
-      'studio dev server URL (run `npm run dev` first)',
-      DEFAULT_RENDER_BASE_URL,
+      'optional render-surface override (e.g. a running studio dev server); default is the bundled static player',
     )
     .option('--hide-reference-images', 'hide referenceImage() overlays in rendered output (default false)', false)
     .option(
@@ -614,7 +641,7 @@ export function renderCommand(): Command {
       separate: boolean;
       width: number;
       height: number;
-      baseUrl: string;
+      baseUrl?: string;
       hideReferenceImages: boolean;
       pose: string[];
       environment?: string;

--- a/tests/unit/cli/renderBaseUrlDefault.test.ts
+++ b/tests/unit/cli/renderBaseUrlDefault.test.ts
@@ -1,16 +1,30 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { renderCommand } from '../../../src/agent/cli/commands/render';
-import { DEFAULT_RENDER_BASE_URL } from '../../../src/agent/render/headlessRender';
 
-describe('render base-url single source of truth', () => {
-  it('render and render inspect both default --base-url to the shared constant', () => {
+describe('render base-url provisioning contract', () => {
+  // `--base-url` must NOT carry a default: commander would materialize it on
+  // every invocation, which sends resolveRenderBaseUrl() down the `explicit`
+  // lane and permanently bypasses the bundled static player. Leaving it
+  // undefined is what makes headless rendering work without `npm run dev`.
+  it('render and render inspect both leave --base-url undefined by default', () => {
     const cmd = renderCommand();
     const baseOpt = cmd.options.find(o => o.long === '--base-url');
-    expect(baseOpt?.defaultValue).toBe(DEFAULT_RENDER_BASE_URL);
+    expect(baseOpt).toBeDefined();
+    expect(baseOpt?.defaultValue).toBeUndefined();
     const inspect = cmd.commands.find(c => c.name() === 'inspect');
     const inspectOpt = inspect?.options.find(o => o.long === '--base-url');
-    expect(inspectOpt?.defaultValue).toBe(DEFAULT_RENDER_BASE_URL);
+    expect(inspectOpt).toBeDefined();
+    expect(inspectOpt?.defaultValue).toBeUndefined();
+  });
+
+  it('both render paths provision their base URL through resolveRenderBaseUrl', () => {
+    const renderSrc = readFileSync('src/agent/cli/commands/render.ts', 'utf8');
+    expect(renderSrc).toContain('resolveRenderBaseUrl');
+    // renderScript + renderInspectBundle each wrap headlessRender.
+    expect(renderSrc.match(/withRenderBase\(input\.baseUrl/g) ?? []).toHaveLength(2);
+    // The ephemeral static-player server must be torn down on every exit path.
+    expect(renderSrc).toContain('await surface.close()');
   });
 
   it('no port literal outside the constant definition', () => {


### PR DESCRIPTION
Reported from real use: `render`/`render_preview` hard-depend on the vite dev server at localhost:5173, and there is no `dist/headless-player`.

The static player was **not** missing — `vite.player.config.ts` exists precisely to close this (#440), and `resolveRenderBaseUrl()` already implements the right lane order (bundled player → dev-server probe → an error naming the fix). Two gaps kept it unreachable:

1. `prepare` ran only `build:studio`, so a clone never built the player. Only `prepack` (npm publish) did — docs were correct for the published package, wrong for a source checkout.
2. **`kernelcad render` never called `resolveRenderBaseUrl` at all** — only MCP `render_preview` did. And commander always materialized the `--base-url` default, so the CLI could not take the static-player lane even once wired. `tests/unit/cli/renderBaseUrlDefault.test.ts` actively pinned that broken default.

## Verification
With nothing listening on 5173:
```
kernelcad render: render surface = static-player (http://127.0.0.1:55137)
Wrote /tmp/acc-out.png   # 51645 bytes, PNG 1024x1024, non-uniform channel means
```
Ephemeral port closed, no leak. `render inspect` likewise. typecheck clean; cli+render suites 206 passed; `proof:foundation` green.

## Follow-up (not in this PR)
`kernelcad animate` has the same defect — `captureAnimation.ts` hardcodes the dev-server URL. Not a drop-in fix: needs a `baseUrl` param + `--base-url` flag, and its 22 tests mock `openPage` so they would spin up real servers.