### PR TITLE
fix(authoring): terminate the assembly part-chain; scope faceLabels per lineage

### DIFF
--- a/src/kernel/backends/occt/edgeSelection.ts
+++ b/src/kernel/backends/occt/edgeSelection.ts
@@ -27,7 +27,7 @@
 import type { Edge, Face } from 'replicad';
 import type { FeatureRecord, FaceLabelsMap } from '../../../shared/intent/featureRecord';
 import type { CompilerDiagnostic } from '../../../shared/diagnostics/diagnostic';
-import type { CanonicalFace, EdgeRef } from '../../../shared/intent/types';
+import type { CanonicalFace, EdgeRef, FeatureId, FeatureRef } from '../../../shared/intent/types';
 import { OcctBackend } from './occtBackend';
 import { resolveEdgeQuery, resolveFaceQuery, computeDihedralPublic } from './edgeQueries';
 import type { FaceQuery } from './edgeQueries';
@@ -830,21 +830,82 @@ interface MetadataLabelHit {
   resolved: CanonicalFace | FaceQuery;
 }
 
+/** Pull the referenced feature id out of a `FeatureRef`, if it has one.
+ *  `surface` refs point into the Surface table, not the feature-record
+ *  array, so they contribute no lineage edge here. */
+function featureRefTargetId(ref: FeatureRef): FeatureId | undefined {
+  switch (ref.kind) {
+    case 'feature': return ref.id;
+    case 'face':
+    case 'edge':
+    case 'vertex': return ref.featureId;
+    default: return undefined;
+  }
+}
+
 /**
- * Walk upstream records and look for any `metadata.faceLabels` entry that
- * declares `label`. Returns a three-way discriminated union:
- *   - `{ hit }` — exactly one upstream source found.
- *   - `{ collision }` — two or more upstream sources conflict (fatal).
- *   - `{ miss }` — no upstream source found (fall through to sketch path).
+ * Transitive closure of `consumer.inputs` — every record the consumer is
+ * actually built from (boolean operands `base`/`cutter_N`, pattern & mirror
+ * `base`, sketch `profile`, assembly part `shape`, face/edge ref owners),
+ * excluding the consumer itself.
+ *
+ * This is the scope a consumer legitimately "sees". Two independent shape
+ * subtrees produced by the same factory helper share no ancestors, so each
+ * may declare the same `faceLabels` name without colliding.
+ *
+ * Cycle-safe: the `ancestors` set doubles as the visited guard, so a
+ * malformed graph cannot hang the walk.
+ */
+function collectAncestorIds(
+  records: readonly FeatureRecord[],
+  consumer: FeatureRecord,
+): Set<FeatureId> {
+  const byId = new Map<FeatureId, FeatureRecord>();
+  for (const rec of records) byId.set(rec.id, rec);
+
+  const ancestors = new Set<FeatureId>();
+  const queue: FeatureId[] = [];
+  const pushInputs = (rec: FeatureRecord): void => {
+    for (const ref of Object.values(rec.inputs)) {
+      const id = featureRefTargetId(ref);
+      if (id !== undefined && id !== consumer.id && !ancestors.has(id)) {
+        ancestors.add(id);
+        queue.push(id);
+      }
+    }
+  };
+
+  pushInputs(consumer);
+  while (queue.length > 0) {
+    const next = byId.get(queue.pop() as FeatureId);
+    if (next) pushInputs(next);
+  }
+  return ancestors;
+}
+
+/**
+ * Walk the consumer's lineage (the transitive closure of its inputs) and look
+ * for any `metadata.faceLabels` entry that declares `label`. Returns a
+ * three-way discriminated union:
+ *   - `{ hit }` — exactly one ancestor declares it.
+ *   - `{ collision }` — two or more ancestors in the SAME lineage conflict (fatal).
+ *   - `{ miss }` — no ancestor declares it (fall through to sketch path).
+ *
+ * Scoping by lineage rather than by script order is what makes a reusable
+ * factory safe: `makeBase()` called three times stamps
+ * `faceLabels: { lid: 'top' }` on three unrelated records, and each consumer
+ * only ever sees the one in its own subtree.
  */
 function findFaceLabelInMetadata(
   records: readonly FeatureRecord[],
   consumer: FeatureRecord,
   label: string,
 ): { hit: MetadataLabelHit } | { collision: CompilerDiagnostic } | { miss: true } {
+  const ancestors = collectAncestorIds(records, consumer);
   const hits: MetadataLabelHit[] = [];
   for (const rec of records) {
     if (rec.id === consumer.id) break; // only upstream
+    if (!ancestors.has(rec.id)) continue; // ...and only within this lineage
     const fl = (rec.metadata as { faceLabels?: FaceLabelsMap } | undefined)?.faceLabels;
     if (fl && Object.prototype.hasOwnProperty.call(fl, label)) {
       const resolved = fl[label];

--- a/src/modeling/capture/assembly.ts
+++ b/src/modeling/capture/assembly.ts
@@ -142,6 +142,16 @@ export interface AssemblyPartRef {
    *  chaining: `assembly.part(a, ...).part(b, ...).part(c, ...)`. Identical to
    *  calling `assembly.part(...)` again on the assembly. */
   part(name: string, shape: Shape, opts?: AssemblyPartOpts): AssemblyPartRef;
+  /** Terminate the fluent chain: identical to calling `model()` on the owning
+   *  assembly. Lets `assembly.part(a, ...).part(b, ...).model()` work without
+   *  hoisting the assembly into a variable. */
+  model(): Scene;
+  /** Terminate the fluent chain with forward kinematics: identical to calling
+   *  `solve(poses)` on the owning assembly. */
+  solve(poses: Poses): SolvedKinematics;
+  /** Terminate the fluent chain with a solved scene: identical to calling
+   *  `solvedModel(...)` on the owning assembly. */
+  solvedModel(...args: Parameters<Assembly['solvedModel']>): Promise<Scene>;
 }
 
 function validateLimitRange(
@@ -777,6 +787,7 @@ export class Assembly {
       // Fluent chaining: `arm.part(a).part(b)` — the ref's `.part(...)` adds
       // another part to this same assembly (delegates straight to this method).
       (chainName, chainShape, chainOpts) => this.part(chainName, chainShape, chainOpts),
+      this,
     );
     const stored: AssemblyPartStored = {
       ...part,
@@ -3133,6 +3144,10 @@ function makePartRef(
   mateConnectors: Connector[],
   wrapGeoms: WrapGeomRecord[],
   addPart: (name: string, shape: Shape, opts?: AssemblyPartOpts) => AssemblyPartRef,
+  // Owning assembly — the ref's chain terminators (`model` / `solve` /
+  // `solvedModel`) delegate straight to it so there is exactly one
+  // implementation of each.
+  owner: Assembly,
 ): AssemblyPartRef {
   // Overload: `connector(name)` returns the v0.5 kinematic AssemblyConnectorRef;
   // `connector(name, opts)` registers a v0.6 mate-style Connector and returns
@@ -3262,6 +3277,9 @@ function makePartRef(
     connector: connector as AssemblyPartRef['connector'],
     wrapGeom,
     part: addPart,
+    model: () => owner.model(),
+    solve: (poses) => owner.solve(poses),
+    solvedModel: (...args) => owner.solvedModel(...args),
   };
   return ref;
 }

--- a/tests/integration/v0.2-faceLabels-resolution.test.ts
+++ b/tests/integration/v0.2-faceLabels-resolution.test.ts
@@ -111,4 +111,38 @@ describe('faceLabels resolution from upstream feature metadata (Task 4)', () => 
     const r = await run(code);
     expect(r.diagnostics.filter(d => d.severity === 'error')).toEqual([]);
   });
+
+  // ── H. Label scope is the consumer's lineage, not script order ─────────────
+  it('H: a factory called 3x stamping the same label does not collide', async () => {
+    // Each makeBase() call produces an independent subtree. `lid` is declared
+    // three times in the flat record array, but no consumer has more than one
+    // of them as an ancestor, so each must resolve cleanly.
+    const code = `
+      const makeBase = (s) => box(s, s, 5, false, { faceLabels: { lid: 'top' } });
+      const a = makeBase(10).fillet(1, { face: 'lid' });
+      const b = makeBase(12).fillet(1, { face: 'lid' }).translate(30, 0, 0);
+      const c = makeBase(14).fillet(1, { face: 'lid' }).translate(60, 0, 0);
+      return a.union(b).union(c);
+    `;
+    const r = await run(code);
+    expect(r.diagnostics.filter(d => d.severity === 'error')).toEqual([]);
+  });
+
+  // ── I. A genuine same-lineage duplicate still errors ──────────────────────
+  it('I: two labels declared in the SAME lineage still emit feature.label.collision', async () => {
+    // Both boxes are ancestors of the consumer (union operands), so this is a
+    // real ambiguity and must keep failing.
+    const code = `
+      const makeBase = (s) => box(s, s, 5, false, { faceLabels: { lid: 'top' } });
+      return makeBase(20).union(makeBase(10).translate(2, 2, 0))
+        .fillet(0.5, { face: 'lid' });
+    `;
+    const r = await run(code);
+    const errorCodes = r.diagnostics
+      .filter(d => d.severity === 'error')
+      .map(d => d.code);
+    expect(errorCodes).toContain('feature.label.collision');
+    const collision = r.diagnostics.find(d => d.code === 'feature.label.collision');
+    expect(collision?.message).toContain('is declared by multiple upstream features');
+  });
 });

--- a/tests/unit/assemblies/assemblyCapture.test.ts
+++ b/tests/unit/assemblies/assemblyCapture.test.ts
@@ -47,6 +47,29 @@ describe('assembly capture contract', () => {
     });
   });
 
+  it('terminates the fluent part-chain: part(a).part(b).model() equals assembly.model()', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+
+    const lamp = kcad.assembly('desk lamp');
+    const chained = lamp
+      .part('base', kcad.box(40, 40, 6), { at: [0, 0, 0] })
+      .part('arm', kcad.box(80, 8, 8), { at: [35, 16, 20] })
+      .model();
+
+    expect(chained.assemblyName).toBe('desk lamp');
+    expect(chained.parts.map(p => p.name)).toEqual(['base', 'arm']);
+    // Same Scene as calling model() on the owning assembly — the ref
+    // delegates, it does not reimplement. `_sourceFeatureId` is the only
+    // legitimate difference: each model() call mints its own
+    // `assemblyModel` FeatureRecord.
+    const direct = lamp.model();
+    expect(chained.assemblyName).toBe(direct.assemblyName);
+    expect(chained.mates).toEqual(direct.mates);
+    expect(chained.parts.map(p => [p.name, p.id])).toEqual(direct.parts.map(p => [p.name, p.id]));
+    expect(chained.parts.map(p => p.at)).toEqual(direct.parts.map(p => p.at));
+  });
+
   it('captures posed mate metadata on assembly.model() for Studio joint controls', () => {
     const session = new CaptureSession();
     const kcad = createApi({ session });


### PR DESCRIPTION
Two authoring papercuts reported from real enclosure work.

## 1. `assembly().part(a).part(b).model()` threw `asm.model is not a function`
`.part()` returns an `AssemblyPartRef` exposing only `connector`/`wrapGeom`/`part` — so the fluent chain the interface doc comment explicitly advertises could not terminate. `.model()` lives only on `Assembly`.

`AssemblyPartRef` now also exposes `model`/`solve`/`solvedModel` as **pure delegations** to the owning assembly — one implementation of each, no divergent logic. `.part()`'s return type is unchanged, so no existing caller breaks.

## 2. Reusing a shape factory broke with a label collision
Calling a helper that stamps `faceLabels: { lid: 'top' }` three times produced `Label 'lid' is declared by multiple upstream features`. The scope was merely *earlier in the flat, script-order record array* — no lineage walk at all — so independent instances collided with each other.

`findFaceLabelInMetadata` now restricts the search to the transitive closure of the consumer's `inputs` (cycle-safe BFS). Independent subtrees can each use `lid`. **A genuine same-lineage duplicate still errors**, with the original message and hint — the check was scoped, not deleted.

## Verification
Vacuous-green check done explicitly: with `edgeSelection.ts` reverted and the new tests kept, the factory-×3 test **fails** with exactly the reported error, then passes with the fix.

typecheck clean · `proof:assembly-contract` green (18 passed) · label/face-selection suites 61 passed · `src/kernel` + capture/backends 1048 passed.