### PR TITLE
fix(diagnostics): stop three failure modes surfacing as silence or noise

### DIFF
--- a/src/agent/cli/commands/evaluate.ts
+++ b/src/agent/cli/commands/evaluate.ts
@@ -7,6 +7,9 @@ import { Command } from 'commander';
 import { formatHuman } from '../../../shared/diagnostics/formatter';
 import type { CompilerDiagnostic } from '../../../shared/diagnostics/diagnostic';
 import { withNextActions } from '../../../shared/diagnostics/diagnostic';
+import {
+  FILE_READ_CODE, FILE_READ_HINT, fileReadErrorMessage,
+} from '../../../shared/diagnostics/fileReadError';
 import { kernelErrorToDiagnostic } from '../../script-runtime/kernelErrorToDiagnostic';
 import { buildModel, buildModelFromFile, type BuiltModel } from '../../../modeling/buildModel';
 import { initOcct } from '../../../kernel/backends/occt/occtBackend';
@@ -249,13 +252,12 @@ function invalidArgsEvaluation(): EvaluateResult {
 }
 
 function fileReadEvaluation(e: unknown): EvaluateResult {
-  const msg = e instanceof Error ? e.message : String(e);
   return {
     exitCode: 2, featureCount: 0, featureHealth: [],
     diagnostics: withNextActions([{
-      target: 'export-occt', code: 'cli.file-read', severity: 'error',
-      message: `Cannot read file: ${msg}`,
-      hint: 'Check that the file path exists and is readable.',
+      target: 'export-occt', code: FILE_READ_CODE, severity: 'error',
+      message: fileReadErrorMessage(e),
+      hint: FILE_READ_HINT,
     }]),
   };
 }

--- a/src/agent/cli/lib/readScript.ts
+++ b/src/agent/cli/lib/readScript.ts
@@ -11,6 +11,9 @@ import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import type { CompilerDiagnostic } from '../../../shared/diagnostics/diagnostic';
 import { withNextActions } from '../../../shared/diagnostics/diagnostic';
+import {
+  FILE_READ_CODE, FILE_READ_HINT, fileReadErrorMessage,
+} from '../../../shared/diagnostics/fileReadError';
 
 export type ReadScriptResult =
   | { ok: true; filePath: string; code: string }
@@ -26,9 +29,9 @@ export async function readScriptOrDiagnostic(file: string): Promise<ReadScriptRe
     return {
       ok: false,
       diagnostics: withNextActions([{
-        target: 'export-occt', code: 'cli.file-read', severity: 'error',
-        message: e instanceof Error ? e.message : String(e),
-        hint: 'Check that the file path exists and is readable.',
+        target: 'export-occt', code: FILE_READ_CODE, severity: 'error',
+        message: fileReadErrorMessage(e),
+        hint: FILE_READ_HINT,
       }]),
     };
   }

--- a/src/agent/mcp/runMcpScript.ts
+++ b/src/agent/mcp/runMcpScript.ts
@@ -5,6 +5,7 @@ import { dirname, resolve } from 'node:path';
 import { initOcct } from '../../kernel/backends/occt/occtBackend';
 import { kernelErrorToDiagnostic } from '../script-runtime/kernelErrorToDiagnostic';
 import { runScript, type RunScriptResult } from '../../modeling/runtime/runScript';
+import { FILE_READ_CODE, fileReadErrorMessage } from '../../shared/diagnostics/fileReadError';
 
 export interface McpScriptInput {
   file?: string;
@@ -46,7 +47,7 @@ export async function runMcpScript(input: McpScriptInput): Promise<RunMcpScriptR
 
 export type LoadMcpScriptSourceResult =
   | { ok: true; code: string; fileName: string }
-  | { ok: false; error: string };
+  | { ok: false; error: string; errorCode?: string };
 
 export async function loadMcpScriptSource(input: McpScriptInput): Promise<LoadMcpScriptSourceResult> {
   if (input.code !== undefined) {
@@ -71,7 +72,8 @@ export async function loadMcpScriptSource(input: McpScriptInput): Promise<LoadMc
   } catch (e) {
     return {
       ok: false,
-      error: `Cannot read file: ${e instanceof Error ? e.message : String(e)}`,
+      error: fileReadErrorMessage(e),
+      errorCode: FILE_READ_CODE,
     };
   }
 }

--- a/src/agent/mcp/tools/designLoop.ts
+++ b/src/agent/mcp/tools/designLoop.ts
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, relative, resolve } from 'node:path';
+import { fileReadErrorMessage } from '../../../shared/diagnostics/fileReadError';
 import type { GripperApertureRequest } from '../../../modeling/mates/gripperAperture';
 import type { MechanismFitnessResult } from '../../../modeling/mates/mechanismFitness';
 import type { ContactGraphResult } from '../../../modeling/runtime/contactGraph';
@@ -172,7 +173,14 @@ export async function designLoopTool(input: DesignLoopInput): Promise<DesignLoop
 
     const id = attempt.id ?? String(index + 1).padStart(2, '0');
     const title = attempt.title ?? `Attempt ${id}`;
-    const source = attempt.code ?? (attempt.file !== undefined ? await readFile(attempt.file, 'utf-8') : '');
+    // design_loop signals misuse by throwing (see the guards above), so a
+    // failed read re-throws with the shared message rather than a raw ENOENT.
+    let source: string;
+    try {
+      source = attempt.code ?? (attempt.file !== undefined ? await readFile(attempt.file, 'utf-8') : '');
+    } catch (e) {
+      throw new Error(`design_loop attempt ${index + 1}: ${fileReadErrorMessage(e)}`);
+    }
     const requirePhysicalAcceptance =
       input.requirePhysicalAcceptance === true ||
       containsPhysicalUseCaseDeclaration(source);

--- a/src/agent/mcp/tools/flattenPattern.ts
+++ b/src/agent/mcp/tools/flattenPattern.ts
@@ -13,6 +13,9 @@ import { flattenPattern } from '../../../kernel/backends/occt/flattenPattern';
 import type { CompilerDiagnostic } from '../../../shared/diagnostics/diagnostic';
 import type { Vec3 } from '../../../shared/intent/types';
 import type { Vec2 } from '../../../shared/intent/region';
+import {
+  FILE_READ_CODE, FILE_READ_HINT, fileReadErrorMessage,
+} from '../../../shared/diagnostics/fileReadError';
 
 export interface FlattenPatternInput {
   /** Path to a .kcad.ts script. Either `file` or `code` is required. */
@@ -41,7 +44,21 @@ export interface FlattenPatternOutput {
 }
 
 export async function flattenPatternTool(input: FlattenPatternInput): Promise<FlattenPatternOutput> {
-  const code = input.code ?? (input.file ? readFileSync(input.file, 'utf-8') : undefined);
+  let code: string | undefined;
+  try {
+    code = input.code ?? (input.file ? readFileSync(input.file, 'utf-8') : undefined);
+  } catch (e) {
+    return {
+      ok: false,
+      diagnostics: [{
+        target: 'export-occt',
+        code: FILE_READ_CODE,
+        severity: 'error',
+        message: fileReadErrorMessage(e),
+        hint: FILE_READ_HINT,
+      }],
+    };
+  }
   if (!code) {
     return {
       ok: false,

--- a/src/agent/mcp/tools/getBendTable.ts
+++ b/src/agent/mcp/tools/getBendTable.ts
@@ -13,6 +13,9 @@ import { OcctLowerer } from '../../../modeling/backends/occt/occtLowerer';
 import { computeBendAllowance } from '../../../modeling/sheetMetal';
 import type { CompilerDiagnostic } from '../../../shared/diagnostics/diagnostic';
 import type { Vec3 } from '../../../shared/intent/types';
+import {
+  FILE_READ_CODE, FILE_READ_HINT, fileReadErrorMessage,
+} from '../../../shared/diagnostics/fileReadError';
 
 export interface GetBendTableInput {
   file?: string;
@@ -35,7 +38,21 @@ export interface GetBendTableOutput {
 }
 
 export async function getBendTableTool(input: GetBendTableInput): Promise<GetBendTableOutput> {
-  const code = input.code ?? (input.file ? readFileSync(input.file, 'utf-8') : undefined);
+  let code: string | undefined;
+  try {
+    code = input.code ?? (input.file ? readFileSync(input.file, 'utf-8') : undefined);
+  } catch (e) {
+    return {
+      ok: false, bends: [],
+      diagnostics: [{
+        target: 'export-occt',
+        code: FILE_READ_CODE,
+        severity: 'error',
+        message: fileReadErrorMessage(e),
+        hint: FILE_READ_HINT,
+      }],
+    };
+  }
   if (!code) {
     return {
       ok: false, bends: [],

--- a/src/modeling/capture/featureMeshing.test.ts
+++ b/src/modeling/capture/featureMeshing.test.ts
@@ -224,6 +224,105 @@ describe('meshFeaturesPerFeature', () => {
     });
   });
 
+  describe('color shadowing diagnostic', () => {
+    // THE FALSE-POSITIVE GUARD. The reported complaint was "`.color()` on a
+    // post-boolean root is a silent no-op". On THIS path that claim is false:
+    // colorByFeatureId is built from every record's metadata, booleans
+    // included, so the boolean root's color reaches the fused mesh. Warning
+    // here would be noise on working code, which is worse than silence.
+    it('does NOT warn for .color() on a boolean root when no leaf is colored', async () => {
+      const code = `
+        const body = box(20, 20, 10);
+        const boss = box(10, 10, 2).translate(5, 5, 8);
+        return body.union(boss).color('#808080');
+      `;
+      const { records } = await runScript({ code, fileName: 'root-color.kcad.ts' });
+      const { features, colorShadowingWarnings } = await meshFeaturesPerFeature(records);
+
+      expect(colorShadowingWarnings).toEqual([]);
+      // And prove the color is genuinely honored — i.e. the silence is correct,
+      // not merely a detector that never fires.
+      const fused = features.find((f) => f.featureKind === 'boolean');
+      expect(fused?.color).toBe('#808080');
+    });
+
+    it('does NOT warn when only the leaf is colored and the head is not', async () => {
+      const code = `
+        const body = box(20, 20, 10);
+        const insert = box(10, 10, 2).translate(5, 5, 8).color('#3050a0');
+        return body.union(insert);
+      `;
+      const { records } = await runScript({ code, fileName: 'leaf-color.kcad.ts' });
+      const { colorShadowingWarnings } = await meshFeaturesPerFeature(records);
+      expect(colorShadowingWarnings).toEqual([]);
+    });
+
+    it('does NOT warn when a subtract cutter is colored', async () => {
+      const code = `
+        const plate = box(20, 20, 5);
+        const hole = cylinder(8, 3).translate(10, 10, -1).color('#ff0000');
+        return plate.subtract(hole).color('#00ff00');
+      `;
+      const { records } = await runScript({ code, fileName: 'cutter-color.kcad.ts' });
+      const { colorShadowingWarnings } = await meshFeaturesPerFeature(records);
+      expect(colorShadowingWarnings).toEqual([]);
+    });
+
+    it('warns when a colored leaf is unioned into a colored head', async () => {
+      const code = `
+        const body = box(20, 20, 10).color('#101010');
+        const lensInsert = box(10, 10, 2).translate(5, 5, 8).color('#3050a0');
+        return body.union(lensInsert).color('#808080');
+      `;
+      const { records } = await runScript({ code, fileName: 'color-shadow.kcad.ts' });
+      const { colorShadowingWarnings } = await meshFeaturesPerFeature(records);
+
+      expect(colorShadowingWarnings.length).toBeGreaterThan(0);
+      const w = colorShadowingWarnings.find(
+        (x) => x.leafFeatureKind === 'box' && x.shadowingFeatureKind === 'boolean',
+      );
+      expect(w).toBeDefined();
+      expect(w!.attribute).toBe('color');
+      expect(w!.message).toMatch(/build animation/);
+      expect(w!.message).toMatch(/color/);
+    });
+
+    it('keeps color and material shadowing independent', async () => {
+      // Material only — the color detector must stay quiet, proving the two
+      // channels are not cross-wired by the shared detector.
+      const code = `
+        const body = box(20, 20, 10).material({ baseColor: '#101010' });
+        const insert = box(10, 10, 2).translate(5, 5, 8).material({ baseColor: '#3050a0' });
+        return body.union(insert).material({ baseColor: '#808080' });
+      `;
+      const { records } = await runScript({ code, fileName: 'mat-only.kcad.ts' });
+      const { materialShadowingWarnings, colorShadowingWarnings } =
+        await meshFeaturesPerFeature(records);
+
+      expect(materialShadowingWarnings.length).toBeGreaterThan(0);
+      expect(materialShadowingWarnings.every((w) => w.attribute === 'material')).toBe(true);
+      expect(colorShadowingWarnings).toEqual([]);
+    });
+
+    it('reports a pure-.color() script as color shadowing ONLY, not material', async () => {
+      // `pbrFromMetadata` promotes `metadata.color` into `{ baseColor }`, so a
+      // naive material detector fires on colour-only scripts and tells the
+      // author to fix a `.material()` call they never wrote. Shadowing must key
+      // off EXPLICIT `.material()` metadata.
+      const code = `
+        const body = box(20, 20, 10).color('#101010');
+        const insert = box(10, 10, 2).translate(5, 5, 8).color('#3050a0');
+        return body.union(insert).color('#808080');
+      `;
+      const { records } = await runScript({ code, fileName: 'color-only.kcad.ts' });
+      const { materialShadowingWarnings, colorShadowingWarnings } =
+        await meshFeaturesPerFeature(records);
+
+      expect(materialShadowingWarnings).toEqual([]);
+      expect(colorShadowingWarnings.length).toBeGreaterThan(0);
+    });
+  });
+
   it('does not fail valid renderless sketch profiles used by cutouts', async () => {
     const code = `
       const profile = path()

--- a/src/modeling/capture/featureMeshing.ts
+++ b/src/modeling/capture/featureMeshing.ts
@@ -104,30 +104,41 @@ export interface PerFaceMaterialWarning {
   detail: string;
 }
 
-/** Diagnostic emitted when a leaf record with its own explicit material is
- *  consumed by a downstream boolean.fuse (union/intersect) whose head record
- *  also has its own material. The kernel's boolean operation produces a single
- *  post-fuse mesh whose faces inherit the head record's material — the leaf's
- *  material is therefore invisible on the static silhouette (post-fuse render
+/** Which display attribute a shadowing warning is about. `.material()` and
+ *  `.color()` are attributed by the SAME record-metadata mechanism and are
+ *  therefore shadowed by the same DAG rule — one detector serves both. */
+export type ShadowedAttribute = 'material' | 'color';
+
+/** Diagnostic emitted when a leaf record with its own explicit material/color
+ *  is consumed by a downstream boolean.fuse (union/intersect) whose head record
+ *  also has its own material/color. The kernel's boolean operation produces a
+ *  single post-fuse mesh whose faces inherit the head record's attribution —
+ *  the leaf's is therefore invisible on the static silhouette (post-fuse render
  *  in `kernelcad render` and after the build animation settles in
- *  `npm run capture-demo`). The leaf material IS visible during the staged
+ *  `npm run capture-demo`). The leaf attribution IS visible during the staged
  *  build animation while predecessor groups are still fading.
  *
- *  Authors who want a multi-material static render today must either:
- *    (a) split the construction so the material-bearing leaf is not unioned
- *        into a parent that also has its own material, OR
+ *  Authors who want a multi-material/multi-color static render today must
+ *  either:
+ *    (a) split the construction so the attributed leaf is not unioned
+ *        into a parent that also carries its own attribution, OR
  *    (b) author the leaf as a separate `assemblyPart` (assembly fan-out path
- *        preserves per-part materials in the static render).
+ *        preserves per-part attribution in the static render).
  *
  *  Tracked as a follow-up code fix in
  *  `docs/specs/per-leaf-material-survives-static-render.md`. */
-export interface MaterialShadowingWarning {
+export interface AttributeShadowingWarning {
+  /** Which attribute was shadowed. Lets a single consumer render both. */
+  attribute: ShadowedAttribute;
   leafFeatureId: FeatureId;
   leafFeatureKind: FeatureKind;
   shadowingFeatureId: FeatureId;
   shadowingFeatureKind: FeatureKind;
   message: string;
 }
+
+/** Back-compat alias: the material flavour of `AttributeShadowingWarning`. */
+export type MaterialShadowingWarning = AttributeShadowingWarning;
 
 export interface MeshFeaturesResult {
   features: FeatureMesh[];
@@ -136,8 +147,13 @@ export interface MeshFeaturesResult {
   /** Soft warnings collected during per-face material label resolution.
    *  Optional — absent when no labels were referenced. */
   perFaceMaterialWarnings?: PerFaceMaterialWarning[];
-  /** Multi-material diagnostic. See `MaterialShadowingWarning` for context. */
-  materialShadowingWarnings: MaterialShadowingWarning[];
+  /** Multi-material diagnostic. See `AttributeShadowingWarning` for context. */
+  materialShadowingWarnings: AttributeShadowingWarning[];
+  /** Multi-color diagnostic — same DAG rule as `materialShadowingWarnings`,
+   *  applied to `metadata.color`. This is the answer to "`.color()` after a
+   *  boolean is silent": it is NOT a no-op on the per-feature meshing path,
+   *  but a leaf color IS discarded when the fuse head recolors the result. */
+  colorShadowingWarnings: AttributeShadowingWarning[];
 }
 
 /**
@@ -733,6 +749,12 @@ export async function meshFeaturesPerFeature(
   const colorByFeatureId = new Map<FeatureId, string>();
   // Lookup table for full PBR material derived from record metadata.
   const materialByFeatureId = new Map<FeatureId, PBRMaterial>();
+  // Materials the author wrote EXPLICITLY via `.material({...})`. Distinct
+  // from `materialByFeatureId`, which also contains materials *promoted* from
+  // `metadata.color` by `pbrFromMetadata`. Shadowing diagnostics must use this
+  // map: otherwise a pure-`.color()` script is reported as "material
+  // shadowing" and told to fix a `.material()` call it never made.
+  const explicitMaterialByFeatureId = new Map<FeatureId, PBRMaterial>();
   // Lookup table for per-face PBR overrides (label → PBR). Resolution into
   // face-index keys happens at feature.compiled time when we hold the OCCT
   // shape.
@@ -749,6 +771,10 @@ export async function meshFeaturesPerFeature(
     if (typeof color === 'string') colorByFeatureId.set(r.id, color);
     const pbr = pbrFromMetadata(r.metadata as Record<string, unknown> | undefined);
     if (pbr !== undefined) materialByFeatureId.set(r.id, pbr);
+    const explicitMaterial = (r.metadata as { material?: unknown } | undefined)?.material;
+    if (explicitMaterial !== undefined && typeof explicitMaterial === 'object') {
+      explicitMaterialByFeatureId.set(r.id, explicitMaterial as PBRMaterial);
+    }
     const perFace = (r.metadata as { materialByLabel?: Record<string, PBRMaterial> } | undefined)
       ?.materialByLabel;
     if (perFace !== undefined && Object.keys(perFace).length > 0) {
@@ -1129,12 +1155,25 @@ export async function meshFeaturesPerFeature(
     max: features.length > 0 ? [maxX, maxY, maxZ] : [0, 0, 0],
   };
 
-  const materialShadowingWarnings = detectMaterialShadowing(
+  const materialShadowingWarnings = detectAttributeShadowing(
     features,
-    materialByFeatureId,
+    explicitMaterialByFeatureId,
+    'material',
   );
   for (const w of materialShadowingWarnings) {
     console.warn(`meshFeaturesPerFeature: material shadowing — ${w.message}`);
+  }
+
+  // Same detector, same DAG rule, applied to `.color()`. Color is attributed
+  // by the identical metadata mechanism, so forking a parallel detector here
+  // would be two sources of truth for one rule.
+  const colorShadowingWarnings = detectAttributeShadowing(
+    features,
+    colorByFeatureId,
+    'color',
+  );
+  for (const w of colorShadowingWarnings) {
+    console.warn(`meshFeaturesPerFeature: color shadowing — ${w.message}`);
   }
 
   return {
@@ -1142,32 +1181,41 @@ export async function meshFeaturesPerFeature(
     bounds,
     failedFeatureIds,
     materialShadowingWarnings,
+    colorShadowingWarnings,
     ...(warnings.length > 0 ? { perFaceMaterialWarnings: warnings } : {}),
   };
 }
 
 /**
- * Walk the post-mesh DAG forward from each material-bearing leaf. Emit a
- * warning for every (leaf, shadowing-boolean) pair where the leaf is reachable
- * via a chain of union/intersect predecessors from a downstream record that
- * also carries its own material. The leaf's material survives only on the
- * intermediate group during the build animation; the post-fuse silhouette
- * carries the head record's material.
+ * Walk the post-mesh DAG forward from each attributed leaf. Emit a warning for
+ * every (leaf, shadowing-boolean) pair where the leaf is reachable via a chain
+ * of union/intersect predecessors from a downstream record that ALSO carries
+ * its own attribution of the same kind. The leaf's attribution survives only on
+ * the intermediate group during the build animation; the post-fuse silhouette
+ * carries the head record's.
+ *
+ * Generic over the attribute (`material` | `color`) because both are attributed
+ * by the same `FeatureRecord.metadata` mechanism and therefore obey the same
+ * shadowing rule. One detector, one source of truth.
  *
  * Walk semantics:
- *   - Visit each leaf with a material exactly once.
+ *   - Visit each attributed leaf exactly once.
  *   - Reverse-adjacency lookup is built from `feature.predecessors`.
  *   - We follow boolean fuse-style edges only (op === 'union' | 'intersect').
  *     subtract edges represent cutters that DON'T enter the post-fuse mesh,
  *     so a leaf consumed only as a `subtract` cutter never produces a
  *     shadowing warning.
- *   - The first material-bearing descendant on each forward path is the
- *     "shadowing" record reported.
+ *   - The first attributed descendant on each forward path is the "shadowing"
+ *     record reported.
+ *   - A head with NO attribution of its own is NOT a shadower: nothing
+ *     competes for the silhouette, so warning there would be a false positive
+ *     on the common single-color-on-leaf pattern.
  */
-function detectMaterialShadowing(
+function detectAttributeShadowing(
   features: readonly FeatureMesh[],
-  materialByFeatureId: ReadonlyMap<FeatureId, PBRMaterial>,
-): MaterialShadowingWarning[] {
+  attributeByFeatureId: ReadonlyMap<FeatureId, PBRMaterial | string>,
+  attribute: ShadowedAttribute,
+): AttributeShadowingWarning[] {
   const featureById = new Map<FeatureId, FeatureMesh>();
   for (const f of features) featureById.set(f.featureId, f);
 
@@ -1190,15 +1238,15 @@ function detectMaterialShadowing(
     }
   }
 
-  const out: MaterialShadowingWarning[] = [];
+  const out: AttributeShadowingWarning[] = [];
   for (const leaf of features) {
     if (leaf.virtual) continue;
-    if (!materialByFeatureId.has(leaf.featureId)) continue;
+    if (!attributeByFeatureId.has(leaf.featureId)) continue;
 
-    // BFS forward; stop at the first material-bearing descendant on each
+    // BFS forward; stop at the first attributed descendant on each
     // branch. We only need one shadower per leaf for the diagnostic; if
     // there's a chain (.union().union().union()), the FIRST one with its
-    // own material is the load-bearing one.
+    // own attribution is the load-bearing one.
     const visited = new Set<FeatureId>([leaf.featureId]);
     const queue: FeatureId[] = [];
     const seedDescendants = descendantsByPredecessor.get(leaf.featureId);
@@ -1209,7 +1257,7 @@ function detectMaterialShadowing(
       const id = queue.shift()!;
       if (visited.has(id)) continue;
       visited.add(id);
-      if (materialByFeatureId.has(id)) {
+      if (attributeByFeatureId.has(id)) {
         shadower = featureById.get(id);
         break;
       }
@@ -1219,17 +1267,18 @@ function detectMaterialShadowing(
 
     if (shadower) {
       out.push({
+        attribute,
         leafFeatureId: leaf.featureId,
         leafFeatureKind: leaf.featureKind,
         shadowingFeatureId: shadower.featureId,
         shadowingFeatureKind: shadower.featureKind,
         message:
-          `leaf '${leaf.featureId}' (${leaf.featureKind}) has its own material but is unioned into ` +
-          `'${shadower.featureId}' (${shadower.featureKind}) which also has its own material. ` +
-          `The leaf material is visible during the build animation only; the static render ` +
-          `(kernelcad render, post-rotate capture-demo) shows the head material on the fused silhouette. ` +
-          `To preserve per-leaf material in the static render, split the construction so the leaf is not ` +
-          `unioned into a material-bearing parent, or author the leaf as a separate assemblyPart.`,
+          `leaf '${leaf.featureId}' (${leaf.featureKind}) has its own ${attribute} but is unioned into ` +
+          `'${shadower.featureId}' (${shadower.featureKind}) which also has its own ${attribute}. ` +
+          `The leaf ${attribute} is visible during the build animation only; the static render ` +
+          `(kernelcad render, post-rotate capture-demo) shows the head ${attribute} on the fused silhouette. ` +
+          `To preserve per-leaf ${attribute} in the static render, split the construction so the leaf is not ` +
+          `unioned into a ${attribute}-bearing parent, or author the leaf as a separate assemblyPart.`,
       });
     }
   }

--- a/src/modeling/parts/fetchPart.test.ts
+++ b/src/modeling/parts/fetchPart.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { CaptureSession } from '../capture/captureSession';
 import { fetchPartHost } from './fetchPart';
 
@@ -32,6 +32,84 @@ describe('fetchPart orchestrator', () => {
       throw new Error('expected fetchPartHost to throw');
     } catch (e) {
       expect((e as { code?: string }).code).toBe('parts.fetch.remote-disabled');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GLB-only catalog records (authored `*-board` entries).
+//
+// scripts/buildBoardGlbs.ts deliberately swaps these boards from STEP to GLB —
+// their STEP is 4–27 MB and nucleo-h563zi-board's exceeds Cloudflare Pages'
+// 25 MiB per-file limit. The record therefore carries `glbUrl` and NO
+// `stepUrl`. fetchPart used to report a bare `parts.fetch.api-error: Remote
+// record X has no stepUrl`, which reads like a broken catalog. It must instead
+// say the part is GLB-only and name a route that works.
+//
+// The fixture below is the verbatim live response for nucleo-h563zi-board
+// (fetched July 2026), so no network is touched here.
+// ---------------------------------------------------------------------------
+const GLB_ONLY_RESPONSE = {
+  id: 'nucleo-h563zi-board',
+  name: 'ST Nucleo-144 H563ZI',
+  category: 'Electronics',
+  family: 'STM32',
+  tags: ['nucleo', 'stm32', 'h563', 'dev-board'],
+  attributes: { bboxXmm: 147, bboxYmm: 70, bboxZmm: 1.6 },
+  sha256: '29b087a46fc778ebd727c6de57ba053638eae9dfecb1c14180e43ee45322842e',
+  license: 'CC-BY-SA-4.0',
+  glbUrl: 'https://kernelcad-parts.pages.dev/glb/nucleo-h563zi-board.glb',
+};
+
+describe('fetchPart — GLB-only authored board records', () => {
+  let prevEnv: string | undefined;
+  beforeEach(() => {
+    prevEnv = process.env.KERNELCAD_PARTS_BASE_URL;
+    process.env.KERNELCAD_PARTS_BASE_URL = 'https://parts.example';
+  });
+  afterEach(() => {
+    if (prevEnv === undefined) delete process.env.KERNELCAD_PARTS_BASE_URL;
+    else process.env.KERNELCAD_PARTS_BASE_URL = prevEnv;
+    vi.restoreAllMocks();
+  });
+
+  function mockCatalog(body: unknown): void {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(body), { status: 200 }),
+    );
+  }
+
+  it('fails with parts.fetch.geometry-not-brep, naming glbUrl and a working route', async () => {
+    mockCatalog(GLB_ONLY_RESPONSE);
+    const session = new CaptureSession();
+    try {
+      await fetchPartHost({ session }, 'nucleo-h563zi-board', {});
+      throw new Error('expected fetchPartHost to throw');
+    } catch (e) {
+      const err = e as { code?: string; message?: string; hint?: string };
+      expect(err.code).toBe('parts.fetch.geometry-not-brep');
+      // The message must name the field and the actual GLB url, not just
+      // "has no stepUrl".
+      expect(err.message).toContain('glbUrl');
+      expect(err.message).toContain(GLB_ONLY_RESPONSE.glbUrl);
+      expect(err.message).not.toMatch(/^Remote record .* has no stepUrl\.$/);
+      // …and the hint must point at a route that exists.
+      expect(err.hint).toContain('lib.fromSTEP');
+      expect(err.hint).toContain('.kcad.ts');
+    }
+  });
+
+  it('still reports the generic api-error when a record has neither stepUrl nor glbUrl', async () => {
+    const { glbUrl: _drop, ...noGeometry } = GLB_ONLY_RESPONSE;
+    mockCatalog(noGeometry);
+    const session = new CaptureSession();
+    try {
+      await fetchPartHost({ session }, 'nucleo-h563zi-board', {});
+      throw new Error('expected fetchPartHost to throw');
+    } catch (e) {
+      const err = e as { code?: string; message?: string };
+      expect(err.code).toBe('parts.fetch.api-error');
+      expect(err.message).toContain('has no stepUrl');
     }
   });
 });

--- a/src/modeling/parts/fetchPart.ts
+++ b/src/modeling/parts/fetchPart.ts
@@ -342,6 +342,28 @@ export async function fetchPartHost(
         : {}),
     });
     if (!meta.stepUrl) {
+      // GLB-only record. The authored dev-board catalog entries (`*-board`) ship
+      // `glbUrl` and NO `stepUrl` by design (scripts/buildBoardGlbs.ts drops the
+      // 4–27 MB STEP so the catalog stays under Cloudflare Pages' 25 MiB
+      // per-file limit). Fail with a code that says *that*, not a generic
+      // "no stepUrl" API error, so the agent stops re-fetching a record that
+      // will never carry BREP.
+      //
+      // We deliberately do NOT route these into the `importedMesh` escape hatch:
+      // `importedMesh` has no lowerer (occtLowerer's switch falls through to
+      // `default:` → "Feature kind 'importedMesh' is not supported"), and the
+      // boards are multi-component meshes that OCCT cannot sew into a solid
+      // anyway (nucleo-h563zi-board = 10 disjoint meshes → sewing yields a
+      // COMPOUND, and fromTriangleMesh rejects it). A mesh Shape here would fail
+      // later, further from the cause.
+      if (meta.glbUrl) {
+        throw new KernelError(
+          'parts.fetch.geometry-not-brep',
+          `Catalog record ${idOrQuery} is GLB-only: it has glbUrl (${meta.glbUrl}) but no stepUrl, so there is no BREP geometry to import.`,
+          undefined,
+          'parts.fetch.geometry-not-brep — the authored dev-board records are served as display meshes (GLB) because their STEP exceeds the catalog file-size limit. kernelCAD has no mesh-import lowerer, so fetch_part cannot build a Shape from a GLB. Use the authored source instead: compile scripts/parts/authored/<board>.kcad.ts to STEP and load it with lib.fromSTEP(path), or pick a catalog part that exposes stepUrl.',
+        );
+      }
       throw new KernelError(
         'parts.fetch.api-error',
         `Remote record ${idOrQuery} has no stepUrl.`,

--- a/src/modeling/parts/stepPartsAdapter.test.ts
+++ b/src/modeling/parts/stepPartsAdapter.test.ts
@@ -27,6 +27,21 @@ const REAL: StepPartsRecord = {
   pageUrl: 'https://www.step.parts/parts/din913_set_screw_m3x3',
 };
 
+/** A GLB-only authored dev-board record, verbatim from kernelCAD's own catalog
+ *  (https://kernelcad-parts.pages.dev/v1/parts/nucleo-h563zi-board, July 2026).
+ *  buildBoardGlbs.ts deliberately strips `stepUrl` from these and serves
+ *  `glbUrl` instead — the mapper must not drop it. */
+const GLB_ONLY_BOARD: StepPartsRecord = {
+  id: 'nucleo-h563zi-board',
+  name: 'ST Nucleo-144 H563ZI',
+  category: 'Electronics',
+  family: 'STM32',
+  tags: ['nucleo', 'stm32', 'h563', 'dev-board'],
+  attributes: { bboxXmm: 147, bboxYmm: 70, bboxZmm: 1.6 },
+  sha256: '29b087a46fc778ebd727c6de57ba053638eae9dfecb1c14180e43ee45322842e',
+  glbUrl: 'https://kernelcad-parts.pages.dev/glb/nucleo-h563zi-board.glb',
+};
+
 describe('mapStepPartsRecord', () => {
   it('produces a valid PartRecord from a real step.parts detail record', () => {
     const r = mapStepPartsRecord(REAL);
@@ -71,5 +86,20 @@ describe('mapStepPartsRecord', () => {
     expect(r.standard).toBe('ISO 4762');
     expect(r.sha256).toBe('');
     expect(r.attributes).toEqual({});
+  });
+
+  // Regression: the mapper used to copy only `stepUrl`, silently dropping
+  // `glbUrl`. fetchPartHost then saw a record with neither and reported a bare
+  // "Remote record X has no stepUrl", hiding the real (by-design) reason.
+  it('preserves glbUrl on a GLB-only authored board record', () => {
+    const r = mapStepPartsRecord(GLB_ONLY_BOARD);
+    expect(r.glbUrl).toBe(GLB_ONLY_BOARD.glbUrl);
+    expect(r.stepUrl).toBeUndefined();
+    expect(isPartRecord(r)).toBe(true);
+  });
+
+  it('leaves glbUrl undefined for a STEP-backed record', () => {
+    expect(mapStepPartsRecord(REAL).glbUrl).toBeUndefined();
+    expect(mapStepPartsRecord(REAL).stepUrl).toBe(REAL.stepUrl);
   });
 });

--- a/src/modeling/parts/stepPartsAdapter.ts
+++ b/src/modeling/parts/stepPartsAdapter.ts
@@ -42,6 +42,11 @@ export interface StepPartsRecord {
   standard?: { body?: string; number?: string; designation?: string } | string | null;
   attributes?: Record<string, unknown>;
   stepUrl?: string;
+  /** Display-mesh URL. kernelCAD's own catalog serves the authored `*-board`
+   *  records as GLB-only (no `stepUrl`) — see PartRecord.glbUrl. Must survive
+   *  the mapping so fetchPartHost can explain *why* there is no BREP instead of
+   *  reporting a bare "no stepUrl". */
+  glbUrl?: string;
   pngUrl?: string;
   byteSize?: number;
   sha256?: string;
@@ -99,5 +104,6 @@ export function mapStepPartsRecord(raw: StepPartsRecord): PartRecord {
   if (standard !== undefined) record.standard = standard;
   if (raw.pageUrl) record.attribution = raw.pageUrl;
   if (raw.stepUrl) record.stepUrl = raw.stepUrl;
+  if (raw.glbUrl) record.glbUrl = raw.glbUrl;
   return record;
 }

--- a/src/shared/diagnostics/fileReadError.ts
+++ b/src/shared/diagnostics/fileReadError.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/shared/diagnostics/fileReadError.ts
+//
+// One source of truth for the "could not read the script file" message.
+//
+// Why this exists: the `file` parameter on the script-taking tools only works
+// when the kernelCAD server runs on the SAME machine as the caller (local
+// stdio MCP / the CLI). Against a hosted server the tool executes in a remote
+// process that cannot see the caller's filesystem, so ANY `file` path fails
+// with a raw ENOENT — a message that reads like a typo and sends agents into
+// a path-fixing loop that can never succeed.
+//
+// There is no reliable hosted-vs-local signal available inside the tool
+// implementations (the `--cloud` flag in src/agent/mcp/server.ts lives in the
+// *client* bridge process, which merely proxies arguments to the gateway and
+// never runs this code). So the wording names BOTH possibilities explicitly
+// and always points at the escape hatch that works everywhere: pass `code`.
+
+/** Diagnostic code every file-read failure reports. Already registered in
+ *  `src/shared/diagnostics/registry.ts` with a hint + nextAction. */
+export const FILE_READ_CODE = 'cli.file-read';
+
+/** Hint attached to every file-read diagnostic. */
+export const FILE_READ_HINT =
+  'Either the path does not exist locally, or this kernelCAD server is hosted/remote and cannot see your filesystem. Pass the script inline via `code` instead of `file` — that works on both.';
+
+/** Full user-facing message for a failed read of `file`. */
+export function fileReadErrorMessage(e: unknown): string {
+  const msg = e instanceof Error ? e.message : String(e);
+  return `Cannot read file: ${msg}. ${FILE_READ_HINT}`;
+}

--- a/src/shared/diagnostics/registry.ts
+++ b/src/shared/diagnostics/registry.ts
@@ -339,11 +339,12 @@ export const DIAGNOSTIC_REGISTRY = {
     description: 'The user script raised an uncaught JavaScript exception during execution.',
   },
   'cli.file-read': {
-    hintTemplate: 'kernelCAD could not read the script file. Check the path exists and is readable.',
+    hintTemplate:
+      'kernelCAD could not read the script file. Either the path does not exist locally, or this server is hosted/remote and cannot see your filesystem — pass the script inline via `code` instead of `file`.',
     nextAction: { kind: 'check-file-path' },
     defaultSeverity: 'error',
     group: 'cli',
-    description: 'kernelCAD could not read the script file at the given path.',
+    description: 'kernelCAD could not read the script file at the given path (missing locally, or the server is remote and has no access to the caller\'s filesystem).',
   },
   'cli.file-write': {
     hintTemplate:
@@ -1667,6 +1668,15 @@ export const DIAGNOSTIC_REGISTRY = {
     defaultSeverity: 'error',
     group: 'parts',
     description: 'A tool call required a remote round-trip but partsBaseUrl was unset, so the remote tier was dormant.',
+  },
+  'parts.fetch.geometry-not-brep': {
+    hintTemplate:
+      'This catalog record exposes only a display mesh (glbUrl) and no stepUrl, so there is no BREP body to import. The authored dev-board records are GLB-only because their STEP exceeds the catalog per-file size limit. Compile the authored scripts/parts/authored/<board>.kcad.ts to STEP and load it with lib.fromSTEP(path), or choose a catalog part that exposes stepUrl.',
+    nextAction: { kind: 'call-tool', tool: 'find_part', args: { source: 'local' } },
+    defaultSeverity: 'error',
+    group: 'parts',
+    description:
+      'fetch_part resolved a remote record whose only geometry is a GLB display mesh; kernelCAD has no mesh-import lowerer, so no Shape can be built.',
   },
   // DFM preflight (23) — Slice E
   'dfm.input.vendor-required': {

--- a/src/shared/parts/types.ts
+++ b/src/shared/parts/types.ts
@@ -41,6 +41,20 @@ export interface PartRecord {
   attribution?: string;
   connectors: string[];
   stepUrl?: string;
+  /**
+   * Display-mesh URL (GLB), when the catalog serves this part as a mesh instead
+   * of BREP. The authored dev-board records (`*-board`, built by
+   * scripts/buildBoardGlbs.ts) are GLB-only *by design*: their STEP is 4–27 MB
+   * and the biggest exceeds Cloudflare Pages' 25 MiB per-file limit, so the
+   * catalog drops `stepUrl` and serves `glbUrl`.
+   *
+   * A GLB is a triangle mesh, NOT a BREP body — kernelCAD's OCCT kernel has no
+   * mesh-import lowerer, so a record with only `glbUrl` cannot be turned into a
+   * Shape. `fetchPartHost` detects that case and fails with
+   * `parts.fetch.geometry-not-brep` naming this field, rather than reporting a
+   * generic "no stepUrl" API error.
+   */
+  glbUrl?: string;
   /** License class governing redistribution. Optional for back-compat with the
    *  pre-ingestion bundled catalog (those records are implicitly 'permissive'). */
   licenseClass?: LicenseClass;

--- a/tests/unit/diagnostics/codes.test.ts
+++ b/tests/unit/diagnostics/codes.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { DIAGNOSTIC_CODES, HINT_TEMPLATES } from '../../../src/shared/diagnostics/registry';
 
 describe('diagnostic catalogue invariants', () => {
-  it('emits exactly 242 codes', () => {
+  it('emits exactly 243 codes', () => {
     // 204 from develop (NURBS analytics, Query DSL, K1-K9 kinematic, assembly/mechanism gates)
     // + 6 parts catalog codes (parts.* — Slice C bundled parts catalog)
     // + 1 feature.emboss-text.boolean-noop (#393 silent no-op guard)
@@ -41,8 +41,11 @@ describe('diagnostic catalogue invariants', () => {
     // + 2 articulated pose-envelope DFM clearance diagnostics:
     //   assembly.pose-envelope.clearance-violated,
     //   assembly.pose-envelope.clearance-unresolved. = 242.
-    expect(DIAGNOSTIC_CODES).toHaveLength(242);
-    expect(new Set(DIAGNOSTIC_CODES).size).toBe(242);
+    // + 1 parts.fetch.geometry-not-brep (fetch_part hit a catalog record whose
+    //   only geometry is a GLB display mesh — the authored `*-board` entries,
+    //   which drop stepUrl by design). = 243.
+    expect(DIAGNOSTIC_CODES).toHaveLength(243);
+    expect(new Set(DIAGNOSTIC_CODES).size).toBe(243);
   });
 
   it('every code has a non-empty hint template', () => {

--- a/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
+++ b/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
@@ -75,7 +75,7 @@ describe('every diagnostic code emitted in src/ is in the catalogue', () => {
     ).toEqual([]);
   });
 
-  it('catalogue has exactly 242 codes', () => {
+  it('catalogue has exactly 243 codes', () => {
     // 47 baseline (milestone-C diagnostic-vocab spec)
     //  + 23 NURBS Slice B/C/D (Curve3D / variableSweep / surface / G2 / 2D path NURBS)
     //  + 31 Assembly fold (validator / pose-envelope / mechanical-plausibility / transmission / visual / connector)
@@ -168,7 +168,9 @@ describe('every diagnostic code emitted in src/ is in the catalogue', () => {
     //  +  2 articulated pose-envelope DFM clearance diagnostics:
     //       assembly.pose-envelope.clearance-violated,
     //       assembly.pose-envelope.clearance-unresolved = 242.
-    expect(catalogue.size).toBe(242);
+    //  +  1 parts.fetch.geometry-not-brep (GLB-only authored `*-board` catalog
+    //       records: glbUrl present, stepUrl absent by design) = 243.
+    expect(catalogue.size).toBe(243);
   });
 
   it('no emit site uses a code outside the catalogue', () => {

--- a/tests/unit/diagnostics/partsCodes.test.ts
+++ b/tests/unit/diagnostics/partsCodes.test.ts
@@ -11,6 +11,7 @@ describe('parts.* diagnostic codes (Slice C)', () => {
     'parts.fetch.checksum-drift',
     'parts.fetch.api-error',
     'parts.fetch.remote-disabled',
+    'parts.fetch.geometry-not-brep',
   ] as const;
 
   for (const code of PARTS_CODES) {

--- a/tests/unit/mcp/fileReadHostedHint.test.ts
+++ b/tests/unit/mcp/fileReadHostedHint.test.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// Regression: a `file` path that cannot be read must explain BOTH causes —
+// the path is missing locally, OR the server is hosted/remote and cannot see
+// the caller's filesystem — and point at the `code` param, which works
+// everywhere. Raw ENOENT sent agents into an unwinnable path-fixing loop.
+//
+// There are two independent file-read seams and both are covered here:
+//   seam 1: loadMcpScriptSource/runMcpScript (export, query, topology, …)
+//   seam 2: evaluate_script → cli/commands/evaluate
+
+import { describe, expect, it } from 'vitest';
+import { runMcpScript, loadMcpScriptSource } from '../../../src/agent/mcp/runMcpScript';
+import { evaluateScriptTool } from '../../../src/agent/mcp/tools/evaluateScript';
+import { getBendTableTool } from '../../../src/agent/mcp/tools/getBendTable';
+import { flattenPatternTool } from '../../../src/agent/mcp/tools/flattenPattern';
+import { readScriptOrDiagnostic } from '../../../src/agent/cli/lib/readScript';
+import { FILE_READ_HINT } from '../../../src/shared/diagnostics/fileReadError';
+
+const MISSING = '/tmp/kernelcad-definitely-missing-hosted-hint.kcad.ts';
+
+/** Both causes named, plus the inline escape hatch. */
+function expectHostedAwareText(text: string): void {
+  expect(text).toContain('does not exist locally');
+  expect(text).toMatch(/hosted\/remote/);
+  expect(text).toContain('`code`');
+}
+
+describe('file-read failures name the hosted-server cause', () => {
+  it('the shared hint states both possibilities', () => {
+    expectHostedAwareText(FILE_READ_HINT);
+  });
+
+  it('seam 1: loadMcpScriptSource', async () => {
+    const r = await loadMcpScriptSource({ file: MISSING });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected failure');
+    expect(r.error).toMatch(/^Cannot read file:/);
+    expect(r.errorCode).toBe('cli.file-read');
+    expectHostedAwareText(r.error);
+  });
+
+  it('seam 1: runMcpScript', async () => {
+    const r = await runMcpScript({ file: MISSING });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected failure');
+    expect(r.errorCode).toBe('cli.file-read');
+    expectHostedAwareText(r.error);
+  });
+
+  it('seam 2: evaluate_script', async () => {
+    const r = await evaluateScriptTool({ file: MISSING });
+    const d = r.diagnostics.find(x => x.code === 'cli.file-read');
+    expect(d, `no cli.file-read in [${r.diagnostics.map(x => x.code).join(', ')}]`).toBeDefined();
+    expectHostedAwareText(d!.message);
+    expectHostedAwareText(d!.hint);
+  });
+
+  it('seam 2: evaluate_script dry run', async () => {
+    const r = await evaluateScriptTool({ file: MISSING, dryRun: true });
+    const d = r.diagnostics.find(x => x.code === 'cli.file-read');
+    expect(d).toBeDefined();
+    expectHostedAwareText(d!.message);
+  });
+
+  it('previously unguarded: get_bend_table returns a diagnostic, not a raw throw', async () => {
+    const r = await getBendTableTool({ file: MISSING });
+    expect(r.ok).toBe(false);
+    const d = r.diagnostics.find(x => x.code === 'cli.file-read');
+    expect(d).toBeDefined();
+    expectHostedAwareText(d!.message);
+  });
+
+  it('previously unguarded: flatten_pattern returns a diagnostic, not a raw throw', async () => {
+    const r = await flattenPatternTool({ file: MISSING });
+    expect(r.ok).toBe(false);
+    const d = r.diagnostics.find(x => x.code === 'cli.file-read');
+    expect(d).toBeDefined();
+    expectHostedAwareText(d!.message);
+  });
+
+  it('CLI readScriptOrDiagnostic carries the same wording', async () => {
+    const r = await readScriptOrDiagnostic(MISSING);
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected failure');
+    expectHostedAwareText(r.diagnostics[0]!.message);
+  });
+});


### PR DESCRIPTION
Three reported papercuts that share a theme: the tool knew what was wrong and didn't say.

## 1. Hosted MCP can't read local file paths
`evaluate_script{file}` / `export{file}` failed with raw `ENOENT`, and evaluate's hint said *'check that the file path exists'* — actively misleading on a hosted server where the path can **never** exist. All three read seams now share one message naming both causes and the `code` escape hatch. `getBendTable`/`flattenPattern`/`designLoop` no longer throw raw ENOENT.

No hosted-mode signal exists in the codebase (the `cloud` flag lives only in the local client bridge, which proxies args to a remote process), so the wording is unconditional rather than inventing detection infrastructure. `cli.file-read` already existed in the registry — no gate was weakened.

## 2. `fetchPart` rejected GLB-only catalog records
Authored `*-board` parts are served as GLB by design (their STEP exceeds Cloudflare's 25 MiB per-file limit). But `glbUrl` was silently dropped by `mapStepPartsRecord` and never reached `PartRecord` — so the part arrived with neither URL and threw *'no stepUrl'*.

`glbUrl` is now threaded through, and the failure is a precise `parts.fetch.geometry-not-brep` naming the working route.

**The mesh-import route was ruled out empirically, not assumed.** `importedMesh` has no lowerer, and the real 420 KB board GLB is 10 disjoint component meshes:
```
fromTriangleMesh FAILED: sewing produced shape type 0 (expected SHELL=3)
```
It sews to a COMPOUND, so it would not import even with a lowerer. Shipping that path would have failed later and further from the cause.

## 3. Colour shadowing unreported; material shadowing false-positiving
`detectMaterialShadowing` is generalized to `detectAttributeShadowing` over `material|color` — one detector, not a fork.

**Deliberately NOT a blanket warning on `.color()` after a boolean.** That case *is* honored by per-feature meshing and by scene lowering, so warning there would fire on working code. Also fixes an existing false positive: `pbrFromMetadata` promoted `metadata.color` into `baseColor`, making the material detector flag `.material()` calls the author never wrote.

## Verification
typecheck clean · 143 passed across parts/diagnostics/mcp/meshing · `proof:foundation` green · both diagnostics gates pass unmodified.

## Follow-up (not in this PR)
`.color()` is dropped on single-shape GLB export for **any** non-tail record — verified: `box().color('#ff0000').fillet(1)` exports byte-identical to no-colour. That is a behaviour change needing its own precedence decision.