### PR TITLE
fix(export): resolve GLB colour by lineage, not just the tail record

### DIFF
--- a/src/agent/script-runtime/export.ts
+++ b/src/agent/script-runtime/export.ts
@@ -3,7 +3,8 @@
 import { runScript } from '../../modeling/runtime/runScript';
 import { RecomputeEngine } from '../../modeling/compute/recomputeEngine';
 import { createOcctLowerer } from '../../modeling/backends/occt/occtLowerer';
-import { exportSceneToSTEPAsync, pbrFromMetadata, meshShapeForExport, type OcctBackend } from '../../kernel/backends/occt/occtBackend';
+import { exportSceneToSTEPAsync, meshShapeForExport, type OcctBackend } from '../../kernel/backends/occt/occtBackend';
+import { lookupColorFromLineage, lookupMaterialFromLineage } from '../../kernel/backends/occt/lookupSourceColor';
 import { encodeBinaryStl } from '../../kernel/backends/occt/exportStlBinary';
 import { verifyWatertight, type WatertightReport } from '../../kernel/backends/occt/meshHeal';
 import { exportDxf, type DxfWriterOptions } from '../../kernel/backends/occt/exportDxf';
@@ -476,15 +477,28 @@ export async function runAndExport(input: ExportInput): Promise<ExportResult> {
     }
     case 'glb': {
       // Single-shape GLB: wrap in a one-part `WorldFramePart[]` so the
-      // writer can mesh + emit identically to the Scene path. Pull
-      // material / color attribution from the target FeatureRecord's
-      // metadata so a script that ends with `.material({...})` exports the
-      // expected PBR fields without going through an assembly.
+      // writer can mesh + emit identically to the Scene path.
+      //
+      // Colour/material attribution is resolved by walking the target
+      // record's *lineage*, not just the target record itself. `.color()`
+      // mutates the metadata of the record that was current when it was
+      // called, so `box(...).color('#f00').fillet(1)` attributes the colour
+      // to the box while the export target is the fillet — reading only the
+      // tail silently dropped the colour.
+      //
+      // Precedence (identical to `lookupSourceColor`, used by the assembly
+      // fan-out — one convention, not two): the tail's own attribution wins,
+      // otherwise follow the primary upstream pointer (shape > base >
+      // target). A boolean therefore inherits from its base but NEVER from
+      // its cutters; recolour the boolean result to override.
       const optsGlb = (input.options as ExportGlbOptions | undefined) ?? { format: 'glb' };
       const tailRecord = run.records.find((rec) => rec.id === targetId);
-      const meta = tailRecord?.metadata as Record<string, unknown> | undefined;
-      const partColor = typeof meta?.color === 'string' ? meta.color : undefined;
-      const partMaterial = pbrFromMetadata(meta);
+      const partColor = tailRecord
+        ? lookupColorFromLineage(tailRecord, run.records)
+        : undefined;
+      const partMaterial = tailRecord
+        ? lookupMaterialFromLineage(tailRecord, run.records)
+        : undefined;
       const part: WorldFramePart = {
         name: 'part',
         shape,

--- a/src/kernel/backends/occt/exportGlb.ts
+++ b/src/kernel/backends/occt/exportGlb.ts
@@ -43,6 +43,7 @@ import type { PBRMaterial } from '../../../shared/intent/material';
 import {
   meshShapeForExport,
 } from './occtBackend';
+import { resolveColor } from '../../../shared/render/palette';
 import type { MeshData } from './exportStlBinary';
 import type { WorldFramePart } from './sceneToWorldFrame';
 
@@ -252,7 +253,13 @@ function buildMaterial(
   color: string | undefined,
 ): THREE.MeshPhysicalMaterial {
   const mat = new THREE.MeshPhysicalMaterial();
-  const baseColor = pbr?.baseColor ?? color ?? '#cccccc';
+  const authored = pbr?.baseColor ?? color;
+  // Role tokens ('plate', 'servo', …) are authoring intent, not CSS colour
+  // names — resolve them through the shared ROLE_PALETTE first. Handing a
+  // token straight to THREE.Color logs "Unknown color plate" and silently
+  // leaves the material white, which the exporter then omits entirely
+  // (baseColorFactor [1,1,1,1] is the glTF default).
+  const baseColor = resolveColor(authored) ?? authored ?? '#cccccc';
   try {
     mat.color = new THREE.Color(baseColor);
   } catch {

--- a/src/kernel/backends/occt/lookupSourceColor.ts
+++ b/src/kernel/backends/occt/lookupSourceColor.ts
@@ -21,6 +21,12 @@
 //     coloured leaf hidden behind a fillet/hole is reachable but a leaf
 //     hidden behind a boolean's cutter chain is intentionally NOT reachable
 //     unless the user explicitly recolours the boolean result.
+//
+// The same walk is exported as `lookupColorFromLineage` /
+// `lookupMaterialFromLineage` (inclusive of the start record, any record
+// kind) for the single-shape GLB export path, whose "part" is the script's
+// tail FeatureRecord rather than an `assemblyPart`. Both callers share one
+// precedence rule on purpose — see runAndExport's `case 'glb'`.
 
 import type { FeatureRecord } from '../../../shared/intent/featureRecord';
 import type { FeatureId, FeatureRef } from '../../../shared/intent/types';
@@ -54,26 +60,87 @@ export function lookupSourceColor(
   allRecords: readonly FeatureRecord[],
 ): string | undefined {
   if (partRecord.kind !== 'assemblyPart') return undefined;
+  // Start at the *source shape*, not the assemblyPart node itself — the part
+  // node's own metadata is not a colour attribution site.
+  const source = sourceShapeRecord(partRecord, allRecords);
+  return source && lookupColorFromLineage(source, allRecords);
+}
 
+/** Resolve an `assemblyPart`'s `inputs.shape` to its FeatureRecord. */
+function sourceShapeRecord(
+  partRecord: FeatureRecord,
+  allRecords: readonly FeatureRecord[],
+): FeatureRecord | undefined {
+  const shapeInput = partRecord.inputs.shape as FeatureRef | undefined;
+  if (!shapeInput || shapeInput.kind !== 'feature') return undefined;
+  return allRecords.find((r) => r.id === shapeInput.id);
+}
+
+/**
+ * Walk a record's own metadata, then its upstream chain, for the nearest
+ * `metadata.color`. Unlike `lookupSourceColor` this starts *at* `record`
+ * (inclusive) and accepts any record kind, so a returned Shape's own colour
+ * always wins over anything inherited from its ancestors.
+ *
+ * Used by the single-shape GLB export path, where the "part" is the tail
+ * FeatureRecord of the script rather than an `assemblyPart` node. Sharing the
+ * walker keeps ONE colour-precedence convention across assembly fan-out and
+ * single-shape export: follow only the primary upstream pointer
+ * (shape > base > target), so a colour hidden behind a fillet/hole/transform
+ * is reachable but a colour on a boolean's *cutter* is intentionally not.
+ */
+export function lookupColorFromLineage(
+  record: FeatureRecord,
+  allRecords: readonly FeatureRecord[],
+): string | undefined {
+  return walkLineage(record, allRecords, (r) => {
+    const color = (r.metadata as { color?: unknown } | undefined)?.color;
+    return typeof color === 'string' ? color : undefined;
+  });
+}
+
+/**
+ * `lookupColorFromLineage`'s counterpart for `metadata.material` — same
+ * inclusive start, same primary-pointer rule.
+ */
+export function lookupMaterialFromLineage(
+  record: FeatureRecord,
+  allRecords: readonly FeatureRecord[],
+): PBRMaterial | undefined {
+  return walkLineage(record, allRecords, (r) => {
+    const material = (r.metadata as { material?: unknown } | undefined)?.material;
+    return isPBRMaterial(material) ? material : undefined;
+  });
+}
+
+/**
+ * Shared lineage walker: apply `pick` to `start`, then to each record along
+ * the primary upstream pointer, returning the first defined result.
+ *
+ * Cycle-safe via a `seen` set (records are captured in dependency order by
+ * construction, but the guard keeps the walk terminating against future
+ * record-graph rewrites).
+ */
+function walkLineage<T>(
+  start: FeatureRecord,
+  allRecords: readonly FeatureRecord[],
+  pick: (record: FeatureRecord) => T | undefined,
+): T | undefined {
   const recordById = new Map<FeatureId, FeatureRecord>(
     allRecords.map((r) => [r.id, r]),
   );
 
-  const shapeInput = partRecord.inputs.shape as FeatureRef | undefined;
-  if (!shapeInput || shapeInput.kind !== 'feature') return undefined;
-
   const seen = new Set<FeatureId>();
-  let cursor: FeatureId | undefined = shapeInput.id;
+  let record: FeatureRecord | undefined = start;
 
-  while (cursor !== undefined && !seen.has(cursor)) {
-    seen.add(cursor);
-    const record = recordById.get(cursor);
-    if (record === undefined) return undefined;
+  while (record !== undefined && !seen.has(record.id)) {
+    seen.add(record.id);
 
-    const color = (record.metadata as { color?: unknown } | undefined)?.color;
-    if (typeof color === 'string') return color;
+    const found = pick(record);
+    if (found !== undefined) return found;
 
-    cursor = nextUpstreamId(record);
+    const next = nextUpstreamId(record);
+    record = next === undefined ? undefined : recordById.get(next);
   }
 
   return undefined;
@@ -101,29 +168,8 @@ export function lookupSourceMaterial(
   allRecords: readonly FeatureRecord[],
 ): PBRMaterial | undefined {
   if (partRecord.kind !== 'assemblyPart') return undefined;
-
-  const recordById = new Map<FeatureId, FeatureRecord>(
-    allRecords.map((r) => [r.id, r]),
-  );
-
-  const shapeInput = partRecord.inputs.shape as FeatureRef | undefined;
-  if (!shapeInput || shapeInput.kind !== 'feature') return undefined;
-
-  const seen = new Set<FeatureId>();
-  let cursor: FeatureId | undefined = shapeInput.id;
-
-  while (cursor !== undefined && !seen.has(cursor)) {
-    seen.add(cursor);
-    const record = recordById.get(cursor);
-    if (record === undefined) return undefined;
-
-    const material = (record.metadata as { material?: unknown } | undefined)?.material;
-    if (isPBRMaterial(material)) return material;
-
-    cursor = nextUpstreamId(record);
-  }
-
-  return undefined;
+  const source = sourceShapeRecord(partRecord, allRecords);
+  return source && lookupMaterialFromLineage(source, allRecords);
 }
 
 /**

--- a/tests/unit/script-runtime/glbColorLineage.test.ts
+++ b/tests/unit/script-runtime/glbColorLineage.test.ts
@@ -1,0 +1,126 @@
+// tests/unit/script-runtime/glbColorLineage.test.ts
+//
+// Behaviour gate for single-shape GLB colour attribution. `.color()` mutates
+// the metadata of the record that is current when it is called, so any
+// subsequent modelling op (fillet, boolean, hole, …) leaves the export target
+// pointing at a record with no colour of its own. The exporter therefore walks
+// the target's lineage for the nearest attribution.
+//
+// These tests assert on the *decoded GLB* (`baseColorFactor`), never on source
+// code — the whole class of bug this pins is "the code looks right but the
+// bytes are grey".
+//
+// baseColorFactor is linear-light; sRGB #ff0000 -> [1,0,0,1] and the writer's
+// no-colour default #cccccc -> 0.60382…
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { NodeIO } from '@gltf-transform/core';
+import { runAndExport } from '../../../src/agent/script-runtime/export';
+import { initOcct } from '../../../src/kernel/backends/occt/occtBackend';
+
+/** sRGB->linear value the writer emits for its uncoloured #cccccc default. */
+const DEFAULT_GREY = 0.6038273388475408;
+/** ROLE_PALETTE.plate (#a89a7c) in linear light. */
+const PLATE_LINEAR = [0.3915724777393922, 0.3231432091022285, 0.20155625378383743];
+
+async function baseColorFactor(code: string): Promise<number[]> {
+  const r = await runAndExport({ code, fileName: 'demo.kcad.ts', format: 'glb' });
+  expect(r.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0);
+  const doc = await new NodeIO().readBinary(r.bytes);
+  const mat = doc.getRoot().listMaterials()[0];
+  expect(mat, 'GLB carried no material').toBeDefined();
+  return Array.from(mat.getBaseColorFactor() as number[]);
+}
+
+function expectClose(actual: number[], expected: number[]): void {
+  expect(actual).toHaveLength(expected.length);
+  actual.forEach((v, i) => expect(v).toBeCloseTo(expected[i], 6));
+}
+
+describe('single-shape GLB colour lineage', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('uses the writer default when no colour is authored', async () => {
+    expectClose(
+      await baseColorFactor('return box(10,10,10);'),
+      [DEFAULT_GREY, DEFAULT_GREY, DEFAULT_GREY, 1],
+    );
+  });
+
+  it('honours a colour on the tail record (no regression)', async () => {
+    expectClose(
+      await baseColorFactor("return box(10,10,10).color('#ff0000');"),
+      [1, 0, 0, 1],
+    );
+  });
+
+  it('inherits a colour through a fillet', async () => {
+    // The bug: this exported byte-identical grey to the no-colour baseline.
+    expectClose(
+      await baseColorFactor("return box(10,10,10).color('#ff0000').fillet(1);"),
+      [1, 0, 0, 1],
+    );
+  });
+
+  it('inherits a colour through a hole', async () => {
+    expectClose(
+      await baseColorFactor(
+        "return box(20,20,20).color('#00ff00')"
+          + ".holes('top', { positions: [{ u: 5, v: 5 }], diameter: 3, depth: 'through' });",
+      ),
+      [0, 1, 0, 1],
+    );
+  });
+
+  it("inherits a boolean's base colour", async () => {
+    expectClose(
+      await baseColorFactor(
+        "return box(20,20,20).color('#ff0000').subtract(cylinder(30,3));",
+      ),
+      [1, 0, 0, 1],
+    );
+  });
+
+  it('does NOT inherit colour from a boolean cutter', async () => {
+    // Documented precedence, shared with `lookupSourceColor`: the walk follows
+    // only the primary upstream pointer (shape > base > target), so colour
+    // identity dies at the cutter branch. An uncoloured base keeps the default.
+    expectClose(
+      await baseColorFactor(
+        "return box(20,20,20).subtract(cylinder(30,3).color('#ff0000'));",
+      ),
+      [DEFAULT_GREY, DEFAULT_GREY, DEFAULT_GREY, 1],
+    );
+  });
+
+  it("the tail's own colour wins over an ancestor's", async () => {
+    expectClose(
+      await baseColorFactor(
+        "return box(10,10,10).color('#ff0000').fillet(1).color('#0000ff');",
+      ),
+      [0, 0, 1, 1],
+    );
+  });
+
+  it('resolves a role token through the shared ROLE_PALETTE', async () => {
+    // Previously handed straight to THREE.Color -> "Unknown color plate" and a
+    // white material, which the exporter omits as the glTF default.
+    expectClose(await baseColorFactor("return box(10,10,10).color('plate');"), [...PLATE_LINEAR, 1]);
+  });
+
+  it('resolves a role token inherited through a fillet', async () => {
+    expectClose(
+      await baseColorFactor("return box(10,10,10).color('plate').fillet(1);"),
+      [...PLATE_LINEAR, 1],
+    );
+  });
+
+  it('inherits a PBR material through a fillet', async () => {
+    expectClose(
+      await baseColorFactor(
+        "return box(10,10,10).material({ baseColor: '#ff0000', metalness: 1 }).fillet(1);",
+      ),
+      [1, 0, 0, 1],
+    );
+  });
+});


### PR DESCRIPTION
## The bug

Single-shape GLB export read colour/material from the target `FeatureRecord`'s metadata **only** (`src/agent/script-runtime/export.ts`). `.color()` mutates the metadata of the record that is current when it is called rather than allocating a new node, so any subsequent modelling op left the export target with no colour of its own — and the colour was silently dropped.

This is **not** boolean-specific. It hit every non-tail attribution: fillet, hole, boolean, shell, pattern.

## Before / after — actual `baseColorFactor` read back from the emitted GLB

Decoded with `@gltf-transform/core`, not asserted from source code. `[0.6038, 0.6038, 0.6038, 1]` is the writer's uncoloured `#cccccc` default in linear light — i.e. byte-identical to a script with no `.color()` at all.

| script | before | after |
|---|---|---|
| `box(10,10,10)` (baseline) | `[0.6038, 0.6038, 0.6038, 1]` | `[0.6038, 0.6038, 0.6038, 1]` |
| `.color('#ff0000')` (tail) | `[1, 0, 0, 1]` | `[1, 0, 0, 1]` |
| `.color('#ff0000').fillet(1)` | **`[0.6038, 0.6038, 0.6038, 1]`** | **`[1, 0, 0, 1]`** |
| `.color('#00ff00').holes(...)` | **grey** | **`[0, 1, 0, 1]`** |
| `.color('#ff0000').subtract(cyl)` | **grey** | **`[1, 0, 0, 1]`** |
| `subtract(cyl.color('#ff0000'))` (cutter only) | `[0.6038, …]` | `[0.6038, …]` (unchanged by design) |
| `.color('#ff0000').fillet(1).color('#0000ff')` | `[0, 0, 1, 1]` | `[0, 0, 1, 1]` |
| `.color('plate')` (role token) | **`[1, 1, 1, 1]`** (white) | **`[0.3916, 0.3231, 0.2016, 1]`** |
| `.color('plate').fillet(1)` | **grey** | **`[0.3916, 0.3231, 0.2016, 1]`** |
| `.material({baseColor:'#ff0000'}).fillet(1)` | **grey** | **`[1, 0, 0, 1]`** |

## Precedence decision

Export now walks the target's lineage for the nearest attribution, **reusing the walker that already backs the assembly fan-out** (`lookupSourceColor`) rather than introducing a second convention:

1. **The tail's own colour/material always wins** — no regression on `.color()` as the last call, and an explicit recolour overrides anything inherited.
2. Otherwise follow the **primary upstream pointer only**: `shape > base > target`.
3. **A boolean inherits from its base but never from its cutters.** This matches `lookupSourceColor`'s documented rule ("colour identity dies at boolean operations" — the cutter chain is deliberately unreachable). Deviating would have meant two competing rules for the same question depending on whether the shape went through an assembly, and would make the colour of `a.subtract(b)` depend on cutter authoring order. Pinned by the `does NOT inherit colour from a boolean cutter` test.

`lookupSourceColor` / `lookupSourceMaterial` keep their **exact** previous behaviour — they still start at `inputs.shape`, not at the `assemblyPart` node, so the part node's own metadata is still not consulted — and now delegate to the shared `walkLineage` helper instead of duplicating it (the two functions were byte-for-byte the same walk over a different metadata key).

Per-feature meshing and scene lowering are untouched.

## Second defect found: role tokens were dropped by the GLB writer

Reported separately in the task and confirmed. `buildMaterial` in `exportGlb.ts` handed the colour string straight to `THREE.Color`, so a semantic token like `'plate'` logged `THREE.Color: Unknown color plate` and left the material **white** — which `GLTFExporter` then omits entirely, since `[1,1,1,1]` is the glTF default. The palette (`src/shared/render/palette.ts`, `ROLE_PALETTE` / `resolveColor`) was wired into the Studio path but never into the export writer.

Fixed here as a one-line reuse of the canonical `resolveColor` helper. It is in scope because it is the same "colour never reaches the bytes" failure and because the lineage fix would otherwise deliver *more* tokens to a writer that cannot resolve them (`.color('plate').fillet(1)` would have gone from grey to white — still wrong). Note this also corrects token-coloured **assembly** GLB exports, which were white for the same reason.

## Verification

- `npm run typecheck` — exit 0.
- `npm run proof:foundation` — exit 0.
- Export / capture / meshing / assembly suites (`tests/unit/script-runtime`, `tests/unit/kernel/backends/occt`, `tests/unit/capture`, `tests/unit/assemblies`, `tests/unit/backends/occt`, `src/modeling/capture`, `tests/integration/mcp/exportModel.test.ts`) — 1007 passed. 8 pre-existing failures in `safeOutputPath.test.ts` and `exportModel.test.ts` reproduce **identically on pristine `develop`** (macOS `/tmp` symlink + sandboxed-path environment issues, unrelated to colour).
- **Vacuous-green check:** the 10 new tests were run against unfixed `src/` — **6 fail**, 4 pass (those 4 are the intended no-regression guards: baseline, coloured tail, tail-wins, cutter-not-inherited). All 10 pass with the fix.

