### PR TITLE
fix(animate): provision the render surface, no dev server required

### DIFF
--- a/src/agent/cli/commands/animate.ts
+++ b/src/agent/cli/commands/animate.ts
@@ -32,8 +32,12 @@
 // under --json stdout carries exactly the envelope, so stderr is the only
 // safe progress channel. `--quiet` suppresses them.
 //
-// Requires a studio dev server reachable on VITE_PORT (or the default
-// render base URL); honors PW_CDP_URL to attach to an existing Chrome.
+// The render surface is provisioned automatically by resolveRenderBaseUrl()
+// (src/agent/render/playerServer.ts): the bundled static player
+// (dist/headless-player) is served from an ephemeral 127.0.0.1 port, so no
+// running studio dev server is required. `--base-url` remains an optional
+// override that bypasses provisioning entirely. Honors PW_CDP_URL to attach
+// to an existing Chrome.
 
 import { Command } from 'commander';
 import { captureAnimation, type CaptureAnimationResult } from '../../render/captureAnimation';
@@ -61,6 +65,9 @@ export interface AnimateCliInput {
   /** Hide matching objects by feature/part name (`--hide <names>`).
    *  Mutually exclusive with `focus`. */
   hide?: string[];
+  /** Optional render-surface override (`--base-url <url>`). When omitted,
+   *  the capture engine provisions the bundled static player. */
+  baseUrl?: string;
   /** Progress sink forwarded to the capture engine. The command wires a
    *  timestamped stderr writer here unless --quiet. */
   onProgress?: (msg: string) => void;
@@ -190,6 +197,10 @@ export async function runAnimate(input: AnimateCliInput): Promise<AnimateCliResu
     ...(input.skipVerify === true ? { skipVerify: true } : {}),
     ...(input.verifyEvery !== undefined ? { verifyEveryNthFrame: input.verifyEvery } : {}),
     ...(objectFilter !== undefined ? { objectFilter } : {}),
+    // Only forwarded when actually provided — an always-present value would
+    // take resolveRenderBaseUrl's 'explicit' lane and silently bypass
+    // static-player provisioning (exactly the defect #625 fixed for render).
+    ...(input.baseUrl !== undefined ? { baseUrl: input.baseUrl } : {}),
     ...(input.onProgress !== undefined ? { onProgress: input.onProgress } : {}),
   });
 
@@ -237,6 +248,10 @@ export function animateCommand(): Command {
     )
     .option('--focus <names>', 'show only comma-separated feature ids or assembly part names (mutually exclusive with --hide)')
     .option('--hide <names>', 'hide comma-separated feature ids or assembly part names (mutually exclusive with --focus)')
+    .option(
+      '--base-url <url>',
+      'optional render-surface override (e.g. a running studio dev server); default is the bundled static player',
+    )
     .option('--json', 'structured report to stdout (progress still goes to stderr)')
     .option('--quiet', 'suppress the stderr progress lines')
     .addHelpText(
@@ -250,8 +265,10 @@ Exit codes:
      record, an unsolvable pose, ffmpeg missing in MP4 mode, browser
      bootstrap failure, frame output write failure)
 
-Requires a studio dev server (run \`npm run dev\` first); honors VITE_PORT and
-PW_CDP_URL (attach to an existing Chrome over CDP).`,
+No studio dev server is required: the bundled static player
+(dist/headless-player) is served on an ephemeral port. Pass --base-url to
+render against a server you control instead. Honors VITE_PORT (dev-server
+fallback) and PW_CDP_URL (attach to an existing Chrome over CDP).`,
     )
     .action(async (file: string, out: string | undefined, opts: {
       frames?: string;
@@ -261,6 +278,7 @@ PW_CDP_URL (attach to an existing Chrome over CDP).`,
       verifyEvery?: number;
       focus?: string;
       hide?: string;
+      baseUrl?: string;
       json?: boolean;
       quiet?: boolean;
     }) => {
@@ -273,6 +291,10 @@ PW_CDP_URL (attach to an existing Chrome over CDP).`,
         ...(opts.verifyEvery !== undefined ? { verifyEvery: opts.verifyEvery } : {}),
         ...(opts.focus !== undefined ? { focus: [opts.focus] } : {}),
         ...(opts.hide !== undefined ? { hide: [opts.hide] } : {}),
+        // NOTE: --base-url deliberately has NO commander default. A
+        // materialized default would always take the 'explicit' lane and
+        // defeat static-player provisioning (#625).
+        ...(opts.baseUrl !== undefined ? { baseUrl: opts.baseUrl } : {}),
         // Progress always goes to stderr (even under --json — stdout must
         // stay pure JSON) unless --quiet.
         ...(opts.quiet ? {} : { onProgress: stderrProgressSink }),

--- a/src/agent/render/captureAnimation.ts
+++ b/src/agent/render/captureAnimation.ts
@@ -68,13 +68,13 @@ import type { AnimationViewMetadata } from '../../shared/intent/animationViewRec
 import { keyframeSampleSet, sampleTracks } from './animationSampler';
 import { verifyAnimation, type AnimationCollision } from './verifyAnimation';
 import {
-  DEFAULT_RENDER_BASE_URL,
   HEADLESS_VIEWPORT,
   loadFeatureMeshesIntoPage,
   openDemoPlayerPage,
   type DemoPlayerPageHandle,
   type HeadlessObjectFilter,
 } from './headlessRender';
+import { resolveRenderBaseUrl, type ResolvedRenderBase } from './playerServer';
 
 // `page.evaluate(...)` callbacks execute inside the browser. The CLI
 // tsconfig (lib: ES2022, no DOM) doesn't know that, so declare the narrow
@@ -129,6 +129,13 @@ export interface CaptureAnimationOpts {
    *  concern — it does NOT affect the animation-pose interference
    *  verification, which always runs against the FULL model. */
   objectFilter?: HeadlessObjectFilter;
+  /** Optional render-surface override (e.g. `http://localhost:5173` for a
+   *  running studio dev server). When omitted, resolveRenderBaseUrl()
+   *  provisions the bundled static player (dist/headless-player) on an
+   *  ephemeral 127.0.0.1 port, so a capture needs NO running dev server.
+   *  An explicit value takes resolveRenderBaseUrl's 'explicit' lane and
+   *  bypasses provisioning entirely. */
+  baseUrl?: string;
 }
 
 /** Which side is at fault when a capture refuses or aborts. Lets CLI/MCP
@@ -433,6 +440,10 @@ export async function captureAnimation(
   }
 
   let pageHandle: DemoPlayerPageHandle | undefined;
+  /** Provisioned render surface (bundled static player unless opts.baseUrl
+   *  overrides it). Torn down in the same `finally` as the page so a failed
+   *  capture never leaks a listening socket. */
+  let renderSurface: ResolvedRenderBase | undefined;
   let ffmpeg: FfmpegProcessLike | undefined;
   let written = 0;
 
@@ -487,11 +498,19 @@ export async function captureAnimation(
     // 6. Demo-player page via the shared bootstrap — CDP attach to an
     //    existing Chrome first (PW_CDP_URL ?? 127.0.0.1:9222), fresh
     //    chromium fallback.
-    // VITE_PORT keeps the same host as DEFAULT_RENDER_BASE_URL (localhost) —
-    // vite may bind ::1 only, where a 127.0.0.1 URL never connects.
-    const port = process.env.VITE_PORT;
+    //    The base URL is PROVISIONED, not assumed: resolveRenderBaseUrl
+    //    serves the bundled static player (dist/headless-player) on an
+    //    ephemeral 127.0.0.1 port, falling back to a live dev-server probe
+    //    (DEFAULT_RENDER_BASE_URL / VITE_PORT) and finally to a typed error
+    //    naming the fix. `opts.baseUrl` takes the 'explicit' lane and skips
+    //    provisioning. Mirrors `kernelcad render` (#625) — one source of
+    //    truth for how a render surface is obtained.
+    renderSurface = await resolveRenderBaseUrl(opts.baseUrl);
+    if (renderSurface.source !== 'explicit') {
+      onProgress(`render surface = ${renderSurface.source} (${renderSurface.baseUrl})`);
+    }
     pageHandle = await openPage({
-      baseUrl: port !== undefined ? `http://localhost:${port}` : DEFAULT_RENDER_BASE_URL,
+      baseUrl: renderSurface.baseUrl,
       // DemoPlayer's headless ViewerPane is fixed at 1920×1080; any other
       // viewport clips the canvas (headlessRender captures the full pane and
       // crops afterwards). Animation capture always emits 1920×1080 frames,
@@ -659,10 +678,14 @@ export async function captureAnimation(
       diagnostics: [...stashedWarns, diag(
         'cli.export-exception',
         `captureAnimation: ${errMsg(e)}`,
-        'Read the diagnostic message; common causes are a missing studio dev server (run `npm run dev`) or a missing playwright chromium.',
+        'Read the diagnostic message; common causes are a missing playwright chromium or an unavailable render surface (run `npm run build:player` once to bundle the static player, or start `npm run dev`).',
       )],
     };
   } finally {
     if (pageHandle) await pageHandle.close();
+    // Tear the ephemeral static-player server down on EVERY exit path
+    // (success, typed refusal, throw) — a no-op for the explicit/dev-server
+    // lanes.
+    if (renderSurface) await renderSurface.close();
   }
 }

--- a/tests/unit/render/captureAnimation.test.ts
+++ b/tests/unit/render/captureAnimation.test.ts
@@ -50,6 +50,30 @@ vi.mock('../../../src/modeling/buildModel', async (importOriginal) => {
   };
 });
 
+// Render-surface provisioning is mocked at the MODULE seam rather than
+// side-stepped per test by passing an explicit `baseUrl`. Two reasons:
+//   1. one 6-line stub covers all ~22 existing call sites, instead of an
+//      unrelated `baseUrl:` argument bolted onto every one of them;
+//   2. the default (no-override) path is what production takes, so mocking
+//      keeps the tests exercising the real branch — passing an explicit URL
+//      everywhere would pin every test to the 'explicit' lane and no test
+//      would cover provisioning at all.
+// Either way NO real HTTP server is started: the stub never touches
+// dist/headless-player. `renderBase.close` doubles as the leak assertion.
+const renderBase = vi.hoisted(() => ({
+  resolve: vi.fn(),
+  close: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../src/agent/render/playerServer', () => ({
+  resolveRenderBaseUrl: vi.fn(async (explicit?: string) => {
+    renderBase.resolve(explicit);
+    return explicit !== undefined && explicit !== ''
+      ? { baseUrl: explicit, source: 'explicit', close: renderBase.close }
+      : { baseUrl: 'http://127.0.0.1:45999', source: 'static-player', close: renderBase.close };
+  }),
+}));
+
 // Import after mock registration. buildModelFromFile comes through the mock
 // (which spreads the actual module), so it is the REAL implementation.
 import { captureAnimation } from '../../../src/agent/render/captureAnimation';
@@ -178,6 +202,8 @@ let buildErrorScript: string;
 beforeEach(() => {
   paramCtl.failAtCall = -1;
   paramCtl.calls = [];
+  renderBase.resolve.mockClear();
+  renderBase.close.mockClear();
   tmp = mkdtempSync(join(tmpdir(), 'captureAnimation-'));
   animScript = join(tmp, 'anim-box.kcad.ts');
   noAnimScript = join(tmp, 'no-anim.kcad.ts');
@@ -278,6 +304,39 @@ describe('captureAnimation', () => {
     const result = await captureAnimation({ scriptPath: animScript }, deps);
     expect(result.ok).toBe(true);
     expect(result.outPath).toBe(join(tmp, 'anim-box-animation.mp4'));
+  });
+
+  it('no baseUrl → the render surface is PROVISIONED (no dev server assumed) and its URL drives the page', async () => {
+    const { deps, openPage } = makeDeps();
+    const framesDir = join(tmp, 'frames-provision');
+    const result = await captureAnimation({ scriptPath: animScript, framesDir, skipVerify: true }, deps);
+    expect(result.ok).toBe(true);
+    // Provisioning was asked for with no override → static-player lane.
+    expect(renderBase.resolve).toHaveBeenCalledWith(undefined);
+    expect(openPage.mock.calls[0][0].baseUrl).toBe('http://127.0.0.1:45999');
+    // ...and the ephemeral server is always torn down.
+    expect(renderBase.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('explicit baseUrl overrides provisioning and is forwarded verbatim', async () => {
+    const { deps, openPage } = makeDeps();
+    const framesDir = join(tmp, 'frames-explicit');
+    const result = await captureAnimation(
+      { scriptPath: animScript, framesDir, skipVerify: true, baseUrl: 'http://localhost:5173' },
+      deps,
+    );
+    expect(result.ok).toBe(true);
+    expect(renderBase.resolve).toHaveBeenCalledWith('http://localhost:5173');
+    expect(openPage.mock.calls[0][0].baseUrl).toBe('http://localhost:5173');
+  });
+
+  it('render surface is closed even when the capture throws mid-frame', async () => {
+    paramCtl.failAtCall = 2;
+    const framesDir = join(tmp, 'frames-leak');
+    const { deps } = makeDeps();
+    const result = await captureAnimation({ scriptPath: animScript, framesDir, skipVerify: true }, deps);
+    expect(result.ok).toBe(false);
+    expect(renderBase.close).toHaveBeenCalledTimes(1);
   });
 
   it('mid-frame solve failure → abort: ffmpeg killed, partial mp4 deleted, ok:false names tMs', async () => {


### PR DESCRIPTION
Completes the work started in #625.

#625 fixed `kernelcad render` so it no longer requires a running vite dev server, provisioning the bundled static player via `resolveRenderBaseUrl()`. `kernelcad animate` had the same defect and was deliberately left out, because it was not a drop-in fix:

- `captureAnimation` hardcoded `process.env.VITE_PORT ?? DEFAULT_RENDER_BASE_URL` into `openPage()` and had no `baseUrl` parameter; `animate.ts` had no `--base-url` escape hatch.
- The 22 engine tests mock `openPage`; naively adding provisioning would have made every one of them start a real HTTP server against `dist/headless-player`.

## Changes

- `CaptureAnimationOpts.baseUrl?: string` — optional render-surface override.
- The engine routes through `resolveRenderBaseUrl(opts.baseUrl)` — the same single source of truth `render` uses — so the bundled static player (`dist/headless-player`) is served on an ephemeral `127.0.0.1` port, with the dev-server probe and the typed "here is how to fix it" error behind it.
- The returned `close()` runs in the **existing** page-teardown `finally`, so the ephemeral server is released on success, typed refusal, and throw alike.
- `animate --base-url <url>` escape hatch, with **no commander default** — a materialized default always takes the `explicit` lane and silently defeats provisioning, which is precisely what broke render.
- Help text / header comments no longer claim a dev server is required.

## Tests

Provisioning is mocked at the **module seam** (`vi.mock('.../playerServer')`) rather than side-stepped by passing an explicit `baseUrl` at each call site. Two reasons:

1. one 6-line stub covers all ~22 existing call sites instead of bolting an unrelated `baseUrl:` argument onto every one of them;
2. the no-override path is what production takes — pinning every test to the `explicit` lane would mean no test covers provisioning at all.

Either way no real HTTP server starts. Three new cases pin the static-player lane, the explicit override, and that the surface is closed even when a capture aborts mid-frame.

## Verification

- `npm run typecheck` — clean.
- `npx vitest run tests/unit/render/captureAnimation.test.ts` — 25 passed (22 existing + 3 new), no real servers.
- `npm run proof:foundation` — 52 passed / 11 files.
- **Acceptance test**, nothing listening on 5173 (`lsof -iTCP:5173 -sTCP:LISTEN` empty), built CLI:

  ```
  node dist/cli/index.js animate examples/gallery/gearfinity-planetary-stage.kcad.ts \
    /tmp/.../gearfinity.mp4 --fps 2 --no-verify

  [..] render surface = static-player (http://127.0.0.1:57322)
  [..] page ready (6614ms)
  [..] frame 8/8 (tMs=4000) +21591ms
  Wrote /tmp/.../gearfinity.mp4 — 8 frames, 4000 ms @ 2 fps; verify skipped
  ```

  `ffprobe`: h264, 1920x1080, 8 frames, 4.0 s, **120425 bytes**. Port 57322 released after exit (no leaked listener).

## Note on the shared helper

#625 adds a private `withRenderBase(explicit, fn)` wrapper inside `render.ts`. That wrapper is try/finally sugar shaped for a CLI command body; `captureAnimation` already owns a long `try/finally` that tears down the page and aborts ffmpeg, so it calls the shared primitive `resolveRenderBaseUrl` directly and closes in that same `finally`. Both surfaces go through one source of truth for *how a render surface is obtained* — `resolveRenderBaseUrl` in `playerServer.ts`. No second provisioning convention is introduced.