### PR TITLE
fix(security): stop the output-path deny-list failing open on macOS

### DIFF
--- a/src/agent/script-runtime/safeOutputPath.ts
+++ b/src/agent/script-runtime/safeOutputPath.ts
@@ -17,7 +17,7 @@
 // 6. Symlink resolution: canonicalize via parent-chain realpath before
 //    deny-list checks, so symlinks pointing at dangerous targets are caught.
 
-import { resolve as resolvePath, isAbsolute, dirname } from 'node:path';
+import { resolve as resolvePath, isAbsolute, dirname, basename } from 'node:path';
 import { homedir } from 'node:os';
 import { realpathSync, existsSync } from 'node:fs';
 
@@ -91,7 +91,7 @@ export function validateOutputPath(rawPath: string): ValidateOutputPathResult {
   // Symlink resolution: walk the parent chain to find the deepest existing
   // ancestor, realpath it, then append the remaining suffix. This catches
   // the case where ~/safe-link symlinks to /etc/passwd.
-  const resolved = canonicalize(resolvedAbsolute);
+  const resolved = stripPrivatePrefix(canonicalize(resolvedAbsolute));
 
   // Check resolved path against deny-list patterns.
   for (const prefix of DANGEROUS_SYSTEM_PREFIXES) {
@@ -117,6 +117,31 @@ export function validateOutputPath(rawPath: string): ValidateOutputPathResult {
 }
 
 /**
+ * Undo macOS's `/private` indirection.
+ *
+ * On darwin, /etc, /tmp and /var are symlinks into /private. canonicalize()
+ * therefore turns `/etc/passwd` into `/private/etc/passwd`, which matches
+ * NONE of the DANGEROUS_SYSTEM_PREFIXES — so the deny-list silently failed
+ * OPEN on every macOS host, and the symlink resolution added as defense in
+ * depth was the very thing defeating it. Linux CI has no such symlinks, so
+ * the whole class was invisible there.
+ *
+ * Mapping back to the canonical spelling is safe because the two paths name
+ * the same inode: /private/etc/passwd IS /etc/passwd. Doing it here (rather
+ * than widening the deny-list with /private/... twins) keeps ONE spelling
+ * flowing into both the deny-list checks and the returned `resolved`.
+ */
+function stripPrivatePrefix(absolutePath: string): string {
+  if (process.platform !== 'darwin') return absolutePath;
+  for (const dir of ['etc', 'tmp', 'var']) {
+    if (absolutePath === `/private/${dir}` || absolutePath.startsWith(`/private/${dir}/`)) {
+      return absolutePath.slice('/private'.length);
+    }
+  }
+  return absolutePath;
+}
+
+/**
  * Walk the parent chain to the deepest existing ancestor; realpath it;
  * append the remaining (not-yet-existing) suffix. Handles the legitimate
  * case where the agent specifies a path inside a tree that hasn't been
@@ -132,12 +157,21 @@ function canonicalize(absolutePath: string): string {
   while (current !== '/' && current !== '.' && !existsSync(current)) {
     const parent = dirname(current);
     if (parent === current) break; // reached root
-    trailingParts.unshift(current.slice(parent.length + 1)); // segment after parent's slash
+    // basename(), NOT slice(parent.length + 1): when the parent IS root the
+    // arithmetic is off by one ('/proc'.slice(2) === 'roc'), which mangled
+    // every path whose top-level dir does not exist — so '/proc/self/environ'
+    // canonicalized to '//roc/self/environ' and matched no deny-list prefix.
+    // Invisible on Linux, where /proc, /sys and /root all exist.
+    trailingParts.unshift(basename(current));
     current = parent;
   }
   if (existsSync(current)) {
     const realParent = realpathSync(current);
-    return trailingParts.length > 0 ? `${realParent}/${trailingParts.join('/')}` : realParent;
+    // resolvePath(), NOT template interpolation: when the deepest existing
+    // ancestor IS root, `${'/'}/${parts}` yields a DOUBLE leading slash
+    // ('//proc/self/environ'), which startsWith('/proc/') rejects — the second
+    // way this walk could hand the deny-list a path it could not recognise.
+    return trailingParts.length > 0 ? resolvePath(realParent, ...trailingParts) : realParent;
   }
   // No existing ancestor found; fallback to the input (should not happen on a real FS).
   return absolutePath;

--- a/tests/unit/script-runtime/safeOutputPath.test.ts
+++ b/tests/unit/script-runtime/safeOutputPath.test.ts
@@ -220,3 +220,31 @@ describe('validateOutputPath — credential-dir patterns', () => {
     expect(r.ok).toBe(false);
   });
 });
+
+// The three canonicalize() defects fixed alongside these tests were all
+// macOS-only in their SYMPTOM (/etc, /tmp, /var are symlinks there; /proc,
+// /sys, /root do not exist), so the deny-list failed open on darwin while
+// Linux CI stayed green. These cases exercise the same code paths using a
+// top-level directory that exists on NO platform, so they fail on Linux too
+// if the path-walk regresses — a green CI run means something here.
+describe('validateOutputPath — canonicalize path-walk (platform independent)', () => {
+  it('does not mangle a path whose top-level directory does not exist', () => {
+    const r = validateOutputPath('/kcad-no-such-top-dir/sub/model.stl');
+    // Pre-fix this produced '//cad-no-such-top-dir/sub/model.stl': the first
+    // character eaten by slice(parent.length + 1) against a root parent, and
+    // a doubled leading slash from string interpolation onto '/'.
+    expect(r.resolved).toBe('/kcad-no-such-top-dir/sub/model.stl');
+  });
+
+  it('never returns a path with a doubled leading slash', () => {
+    for (const p of ['/kcad-no-such-top-dir/a.stl', '/kcad-missing/deep/nest/b.stl']) {
+      expect(validateOutputPath(p).resolved?.startsWith('//')).toBe(false);
+    }
+  });
+
+  it('still rejects a dangerous prefix when the directory does not exist', () => {
+    // The deny-list must not depend on the target existing on this host.
+    expect(validateOutputPath('/proc/self/environ').ok).toBe(false);
+    expect(validateOutputPath('/root/foo.stl').ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

`validateOutputPath()` — the guard on every MCP file-writing tool — returns `ok: true` for `/etc/passwd` on macOS. The deny-list is defeated by the symlink canonicalization added to strengthen it.

## Why it happens

macOS makes `/etc`, `/tmp` and `/var` symlinks into `/private`. `canonicalize()` resolves `/etc/passwd` to `/private/etc/passwd`, which matches no entry in `DANGEROUS_SYSTEM_PREFIXES`. The check falls through to `return { ok: true }`.

Two further defects in the same walk, both requiring the target *not* to exist — which on Linux is never true for `/proc`, `/sys` or `/root`:

- `slice(parent.length + 1)` is off by one when the parent is root: `'/proc'.slice(2) === 'roc'`.
- `` `${realParent}/${parts}` `` doubles the leading slash at root: `//proc/self/environ`.

All three are invisible on Linux CI, which is why this shipped.

## Verification

The 7 long-standing local failures in `safeOutputPath.test.ts` were this bug reporting itself accurately, not test rot.

Since every symptom is macOS-only, a fix here would be unverifiable by CI — so this adds 3 platform-independent cases that drive the same walk through a top-level directory existing on no platform. **10 fail without the source fix, 35 pass with it.** Confirmed by reverting the source and re-running tests alone.

Full suite: 2239 passed, 1 failed — `partsAutoConnectors.test.ts > boltSHCS`, confirmed pre-existing on pristine `develop` and unrelated.