### PR TITLE
fix(hooks): make pre-commit work on macOS bash 3.2

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -34,7 +34,12 @@ if ! command -v node >/dev/null 2>&1; then
 fi
 
 # Staged added/copied/modified files (renames/deletes excluded by --diff-filter).
-mapfile -t staged < <(git diff --cached --name-only --diff-filter=ACM)
+# NB: not `mapfile` -- that is a bash 4 builtin and macOS ships bash 3.2, where
+# this hook would abort with "mapfile: command not found" and block every commit.
+staged=()
+while IFS= read -r staged_line; do
+  staged+=("$staged_line")
+done < <(git diff --cached --name-only --diff-filter=ACM)
 if [ "${#staged[@]}" -eq 0 ]; then
   exit 0
 fi


### PR DESCRIPTION
Cherry-pick of 50e138a (`-x`, original authorship preserved).

The fix was committed on `feat/import-stl-brep` and `feat/selector-algebra-and-mass-properties` but never reached `develop`, so on trunk the hook still calls `mapfile` — a bash 4 builtin — and exits 127 on macOS's bash 3.2, blocking every commit and silently taking the SPDX gate offline with it.

Verified on develop + this pick: `bash .githooks/pre-commit` exits 127 before, 0 after.