### PR TITLE
feat: selector algebra + mass properties (inertia tensor, principal axes, gyration)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -34,7 +34,12 @@ if ! command -v node >/dev/null 2>&1; then
 fi
 
 # Staged added/copied/modified files (renames/deletes excluded by --diff-filter).
-mapfile -t staged < <(git diff --cached --name-only --diff-filter=ACM)
+# NB: not `mapfile` -- that is a bash 4 builtin and macOS ships bash 3.2, where
+# this hook would abort with "mapfile: command not found" and block every commit.
+staged=()
+while IFS= read -r staged_line; do
+  staged+=("$staged_line")
+done < <(git diff --cached --name-only --diff-filter=ACM)
 if [ "${#staged[@]}" -eq 0 ]; then
   exit 0
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "react-dom": "^19.2.0",
         "react-markdown": "^10.1.0",
         "replicad": "^0.23.1",
-        "replicad-opencascadejs": "github:w1ne/replicad-opencascadejs#kcad-v0.24.0",
+        "replicad-opencascadejs": "github:w1ne/replicad-opencascadejs#kcad-v0.25.0",
         "sharp": "^0.33.5",
         "shiki": "^1.29.2",
         "three": "^0.184.0",
@@ -9193,8 +9193,8 @@
       }
     },
     "node_modules/replicad-opencascadejs": {
-      "version": "0.23.0",
-      "resolved": "git+ssh://git@github.com/w1ne/replicad-opencascadejs.git#0cf01a3e23edd6b06b0b67d6ac08fe3afe35ef1b",
+      "version": "0.25.0",
+      "resolved": "git+ssh://git@github.com/w1ne/replicad-opencascadejs.git#640dd37430a757a2ca4e73f54b67625ffeee9b3b",
       "license": "MIT"
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "react-dom": "^19.2.0",
     "react-markdown": "^10.1.0",
     "replicad": "^0.23.1",
-    "replicad-opencascadejs": "github:w1ne/replicad-opencascadejs#kcad-v0.24.0",
+    "replicad-opencascadejs": "github:w1ne/replicad-opencascadejs#kcad-v0.25.0",
     "sharp": "^0.33.5",
     "shiki": "^1.29.2",
     "three": "^0.184.0",
@@ -136,7 +136,7 @@
     "zod": "^4.3.6"
   },
   "overrides": {
-    "replicad-opencascadejs": "github:w1ne/replicad-opencascadejs#kcad-v0.24.0"
+    "replicad-opencascadejs": "github:w1ne/replicad-opencascadejs#kcad-v0.25.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260504.1",

--- a/scripts/parts/authored/arduino-uno-board.kcad.ts
+++ b/scripts/parts/authored/arduino-uno-board.kcad.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // scripts/parts/authored/arduino-uno-board.kcad.ts

--- a/scripts/parts/authored/blackpill-board.kcad.ts
+++ b/scripts/parts/authored/blackpill-board.kcad.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // scripts/parts/authored/blackpill-board.kcad.ts

--- a/scripts/parts/authored/esp32-c3-supermini-board.kcad.ts
+++ b/scripts/parts/authored/esp32-c3-supermini-board.kcad.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // scripts/parts/authored/esp32-c3-supermini-board.kcad.ts

--- a/scripts/parts/authored/esp32-devkit-board.kcad.ts
+++ b/scripts/parts/authored/esp32-devkit-board.kcad.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // scripts/parts/authored/esp32-devkit-board.kcad.ts

--- a/scripts/parts/authored/esp32-s3-zero-board.kcad.ts
+++ b/scripts/parts/authored/esp32-s3-zero-board.kcad.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // scripts/parts/authored/esp32-s3-zero-board.kcad.ts

--- a/scripts/parts/authored/h563zi-board.kcad.ts
+++ b/scripts/parts/authored/h563zi-board.kcad.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // scripts/parts/authored/h563zi-board.kcad.ts

--- a/scripts/parts/authored/kw41z-board.kcad.ts
+++ b/scripts/parts/authored/kw41z-board.kcad.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // scripts/parts/authored/kw41z-board.kcad.ts

--- a/scripts/parts/authored/nrf52840-dk-board.kcad.ts
+++ b/scripts/parts/authored/nrf52840-dk-board.kcad.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // scripts/parts/authored/nrf52840-dk-board.kcad.ts

--- a/scripts/parts/authored/nucleo64-board.kcad.ts
+++ b/scripts/parts/authored/nucleo64-board.kcad.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // scripts/parts/authored/nucleo64-board.kcad.ts

--- a/src/agent/mcp/registry/inspectionVerificationTools.ts
+++ b/src/agent/mcp/registry/inspectionVerificationTools.ts
@@ -15,7 +15,7 @@ const inspectToolEntry: ToolRegistryEntry = {
       "- 'robot' — URDF/SDFormat export preview (links, joints, planning groups, end-effectors, issues).\n" +
       "- 'step' — inspect an imported STEP file.\n" +
       "- 'shape' — volume / surfaceArea / bbox for one feature ({ feature_id? }).\n" +
-      "- 'mass' — mass, centre of mass, and centroidal inertia tensor ({ feature_id?, density? }); density in kg/m^3, defaults to 1000 (water).\n" +
+      "- 'mass' — mass, centre of mass, centroidal inertia tensor (inertia6 + 3x3 inertiaMatrix), principalMoments/principalAxes, symmetry flags, and optionally the radius of gyration about an arbitrary axis ({ feature_id?, density?, gyration_axis? }); density in kg/m^3, defaults to 1000 (water).\n" +
       "- 'features' — features captured by the script (kind, id, params, transforms, suppression).\n" +
       "- 'assemblies' — assembly intent (assemblies, parts, connectors, joints).\n" +
       "- 'topology' — canonical face names + edge count for a feature ({ feature_id? }).\n" +
@@ -44,6 +44,15 @@ const inspectToolEntry: ToolRegistryEntry = {
         assembly: { type: 'string', description: "of:'assembly'|'robot' — assembly name; defaults to the first captured assembly." },
         feature_id: { type: 'string', description: "of:'shape'|'mass'|'topology'|'edges'|'faces'|'face-edges'|'face-labels' — FeatureId; defaults to the last returned shape." },
         density: { type: 'number', description: "of:'mass' — material density in kg/m^3 (steel 7850, aluminium 2700, ABS 1050). Defaults to 1000 (water); the response echoes the value used and flags when it was defaulted." },
+        gyration_axis: {
+          type: 'object',
+          description: "of:'mass' — optional axis in shape-local mm to report the radius of gyration about. Omit for centroidal quantities only; the result is density-independent and returned in mm.",
+          properties: {
+            origin: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: 'A point on the axis, shape-local mm.' },
+            direction: { type: 'array', items: { type: 'number' }, minItems: 3, maxItems: 3, description: 'Axis direction; normalised internally, so it need not be a unit vector.' },
+          },
+          required: ['origin', 'direction'],
+        },
         face_name: { type: 'string', enum: ['top', 'bottom', 'left', 'right', 'front', 'back'], description: "of:'face-edges' — canonical face name (required for that subject)." },
         query: { type: 'object', description: "of:'edges'|'faces' — optional EdgeQuery/FaceQuery filter." },
         category: { type: 'string', description: "of:'part-families' — optional top-level category to filter families by." },

--- a/src/agent/mcp/toolOutputSchemas.ts
+++ b/src/agent/mcp/toolOutputSchemas.ts
@@ -213,6 +213,7 @@ export const TOOL_OUTPUT_SCHEMAS: Record<string, JSONSchemaObject> = {
       ok: { type: 'boolean' },
       globals: { type: 'array', items: { type: 'object', additionalProperties: true } },
       shapeMethods: { type: 'array', items: { type: 'object', additionalProperties: true } },
+      shapeListMethods: { type: 'array', items: { type: 'object', additionalProperties: true } },
       sketchMethods: { type: 'array', items: { type: 'object', additionalProperties: true } },
       pathBuilderMethods: { type: 'array', items: { type: 'object', additionalProperties: true } },
       paramRefMethods: { type: 'array', items: { type: 'object', additionalProperties: true } },

--- a/src/agent/mcp/tools/getMassProperties.test.ts
+++ b/src/agent/mcp/tools/getMassProperties.test.ts
@@ -81,4 +81,63 @@ describe('inspect({ of: "mass" })', () => {
     expect(r.ok).toBe(false);
     expect(r.errorCode).toBe('feature.invalid-args');
   });
+
+  it('surfaces the inertia matrix, principal moments/axes and symmetry flags', async () => {
+    const r = await getMassPropertiesTool({ code: 'return box(20, 10, 30);', density: 1000 });
+    expect(r.ok).toBe(true);
+    const mp = r.massProperties!;
+
+    // The matrix must agree with the 6-vector the tool already returned, so an
+    // agent reading either representation gets the same physics.
+    const [ixx, ixy, ixz, iyy, iyz, izz] = mp.inertia6;
+    expect(mp.inertiaMatrix).toEqual([
+      [ixx, ixy, ixz],
+      [ixy, iyy, iyz],
+      [ixz, iyz, izz],
+    ]);
+
+    expect(mp.principalMoments).toHaveLength(3);
+    expect(mp.principalAxes).toHaveLength(3);
+    for (const ax of mp.principalAxes) expect(Math.hypot(...ax)).toBeCloseTo(1, 9);
+    // Three distinct side lengths => no degenerate axis.
+    expect(mp.hasSymmetryAxis).toBe(false);
+    expect(mp.hasSymmetryPoint).toBe(false);
+  });
+
+  it('omits radiusOfGyration unless gyration_axis is supplied', async () => {
+    const r = await getMassPropertiesTool({ code: 'return box(20, 10, 30);' });
+    expect(r.massProperties!.radiusOfGyration).toBeUndefined();
+  });
+
+  it('returns the radius of gyration in mm about a requested axis', async () => {
+    const [a, b, c] = [20, 10, 30];
+    const r = await getMassPropertiesTool({
+      code: `return box(${a}, ${b}, ${c});`,
+      gyration_axis: { origin: [a / 2, b / 2, c / 2], direction: [0, 0, 1] },
+    });
+    expect(r.ok).toBe(true);
+    // k_z = sqrt((a^2 + b^2)/12) for a rectangular prism about its centroidal Z.
+    expect(r.massProperties!.radiusOfGyration).toBeCloseTo(
+      Math.sqrt((a * a + b * b) / 12),
+      6,
+    );
+  });
+
+  it('rejects a malformed or zero-length gyration axis', async () => {
+    const code = 'return box(10, 10, 10);';
+    const zero = await getMassPropertiesTool({
+      code,
+      gyration_axis: { origin: [0, 0, 0], direction: [0, 0, 0] },
+    });
+    expect(zero.ok).toBe(false);
+    expect(zero.errorCode).toBe('feature.invalid-args');
+
+    const malformed = await getMassPropertiesTool({
+      code,
+      // Two components instead of three — an easy agent mistake.
+      gyration_axis: { origin: [0, 0], direction: [0, 0, 1] } as never,
+    });
+    expect(malformed.ok).toBe(false);
+    expect(malformed.errorCode).toBe('feature.invalid-args');
+  });
 });

--- a/src/agent/mcp/tools/getMassProperties.ts
+++ b/src/agent/mcp/tools/getMassProperties.ts
@@ -14,6 +14,7 @@ import { RecomputeEngine } from '../../../modeling/compute/recomputeEngine';
 import { createOcctLowerer } from '../../../modeling/backends/occt/occtLowerer';
 import { resolveRootId } from '../../../modeling/buildModel';
 import { runMcpScript } from '../runMcpScript';
+import type { Vec3 } from '../../../shared/intent/types';
 
 /** Water. Same default as OcctBackend.massProperties and URDF's linkInertialBlock. */
 const DEFAULT_DENSITY = 1000;
@@ -24,6 +25,11 @@ export interface GetMassPropertiesInput {
   feature_id?: string;
   /** kg/m^3. Steel ~7850, aluminium ~2700, ABS ~1050. Defaults to water. */
   density?: number;
+  /**
+   * Optional arbitrary axis (shape-local mm) to additionally report the
+   * radius of gyration about. Omit to get only the centroidal quantities.
+   */
+  gyration_axis?: { origin: [number, number, number]; direction: [number, number, number] };
 }
 
 export interface MassPropertiesInfo {
@@ -38,6 +44,17 @@ export interface MassPropertiesInfo {
   com: [number, number, number];
   /** [ixx, ixy, ixz, iyy, iyz, izz] in kg*m^2, about the CoM. */
   inertia6: [number, number, number, number, number, number];
+  /** Full symmetric 3x3 centroidal inertia tensor, row-major, kg*m^2. */
+  inertiaMatrix: [Vec3, Vec3, Vec3];
+  /** Principal moments in kg*m^2; principalMoments[i] pairs with principalAxes[i]. Not sorted. */
+  principalMoments: [number, number, number];
+  /** Unit direction of each principal axis, shape-local. */
+  principalAxes: [Vec3, Vec3, Vec3];
+  /** True when the mass distribution is rotationally / spherically symmetric. */
+  hasSymmetryAxis: boolean;
+  hasSymmetryPoint: boolean;
+  /** mm, about the requested `gyration_axis`. Present only when that input was given. */
+  radiusOfGyration?: number;
   /** mm^3. Included because mass is only as good as the density guess; volume is not. */
   volume: number;
 }
@@ -60,6 +77,26 @@ export async function getMassPropertiesTool(
       error: `density must be a positive number (kg/m^3); got ${input.density}.`,
       errorCode: 'feature.invalid-args',
     };
+  }
+
+  const axis = input.gyration_axis;
+  if (axis !== undefined) {
+    const triple = (v: unknown): v is [number, number, number] =>
+      Array.isArray(v) && v.length === 3 && v.every(n => typeof n === 'number' && Number.isFinite(n));
+    if (!triple(axis.origin) || !triple(axis.direction)) {
+      return {
+        ok: false,
+        error: 'gyration_axis requires { origin: [x,y,z], direction: [x,y,z] } of finite numbers.',
+        errorCode: 'feature.invalid-args',
+      };
+    }
+    if (Math.hypot(...axis.direction) === 0) {
+      return {
+        ok: false,
+        error: 'gyration_axis.direction must be a non-zero vector; got [0, 0, 0].',
+        errorCode: 'feature.invalid-args',
+      };
+    }
   }
 
   const script = await runMcpScript(input);
@@ -93,7 +130,7 @@ export async function getMassPropertiesTool(
 
   const densityDefaulted = input.density === undefined;
   const density = input.density ?? DEFAULT_DENSITY;
-  const mp = shape.massProperties(density);
+  const mp = shape.massProperties(density, input.gyration_axis);
 
   return {
     ok: true,
@@ -104,6 +141,14 @@ export async function getMassPropertiesTool(
       densityDefaulted,
       com: mp.com,
       inertia6: mp.inertia6,
+      inertiaMatrix: mp.inertiaMatrix,
+      principalMoments: mp.principalMoments,
+      principalAxes: mp.principalAxes,
+      hasSymmetryAxis: mp.hasSymmetryAxis,
+      hasSymmetryPoint: mp.hasSymmetryPoint,
+      ...(mp.radiusOfGyration !== undefined
+        ? { radiusOfGyration: mp.radiusOfGyration }
+        : {}),
       volume: shape.volume(),
     },
     ...(densityDefaulted

--- a/src/agent/mcp/tools/listApi.ts
+++ b/src/agent/mcp/tools/listApi.ts
@@ -70,6 +70,8 @@ export interface ListApiOutput {
   ok: boolean;
   globals?: ApiEntry[];
   shapeMethods?: ApiEntry[];
+  /** Selector-algebra methods on the `ShapeList` returned by `selectEdges()` / `select()`. */
+  shapeListMethods?: ApiEntry[];
   sketchMethods?: ApiEntry[];
   pathBuilderMethods?: ApiEntry[];
   paramRefMethods?: ApiEntry[];
@@ -108,8 +110,9 @@ export const GLOBALS: ApiEntry[] = [
   { name: 'union', signature: '(...shapes) => Shape', description: 'Boolean union of two or more shapes.' },
   { name: 'assembly', signature: '(name?) => Assembly', description: 'Start an inspectable mechanical assembly. Use `.part(name, shape, { at?, connectors?, connect? })` to wrap modeled solids, `.connect(name, aConnector, bConnector)` for fixed connector metadata, joint primitives `.revolute/.prismatic/.fixed/.ball(name, parentPart, childPart, opts)` to declare DOF + joint origins (numeric Vec3 in parent local frame), `.solve(poses)` to run body-tree forward kinematics returning a SolvedKinematics handle (with `.transform(partName)`, `.value(jointName)`, `.bodies()`, `.toScene()`; `.toShape()` is deprecated — use `.toScene().toUnion()`), `.solvedModel(poses, opts?)` to return the posed `Scene` (opts: `{ validate: "warn" | "error" | "off" }` — default `warn`, attaches mate-aware validator diagnostics to `scene.warnings`), and `.model()` for the kinematic-zero `Scene`. v0.6 adds `partRef.connector(name, opts)` for mate-style connector frames and `.mate(name, aRef, bRef, type)` for typed mates. Physical mechanism intent can be declared with `.mechanicalJoint(name, { mate, actuator, shaft, supports, output, requiredSupport? })`; `requiredSupport` may name a hinge/bearing/bracket contract such as `{ kind: "hinge-bracket", around: "palm.left-hinge", supports: ["palm"], minBearingLengthMm: 8 }`. Drive transmission intent can be declared with `.transmission(name, { kind, sourceMate, drivenMates, actuator?, input?, output?, path, ratio?, notes?, springRateNPerMm?, freeLengthMm?, installedLengthMm?, preloadN?, momentArmMm?, requiredTorqueNmm?, anchorA?, anchorB? })`, where `kind` is `direct-horn`, `link-rod`, `four-bar`, `gear-pair`, `belt`, `tendon`, or `spring`; spring transmissions let `review_cad` reject decorative coils with no positive installed force, insufficient static torque budget, or anchors whose distance does not change across joint travel. `review_cad` requires every `coupleMates(...)` driven mate to have a matching physical transmission path, and consecutive `path` parts must stay near-contact adjacent across sampled mate travel. `design_loop` requires screenshot review by default so visually bad but structurally passing attempts are rejected; accepted visual reviews must include screenshotPath and non-empty findings from the vision-capable agent, and `requireVisualReview: false` is only for explicit non-visual batch checks. `review_cad` checks that declared actuators are mounted, shafts lie on revolute axes, support parts are fixed, outputs are connected by the mate, generic revolute connectors sit on modeled support material, declared support contracts reach their connector, and coupled mates are backed by adjacent transmission intent. Pose values accept `Editable<number>` — passing ParamRef poses to `.solvedModel` makes the rendered Scene reactive (param updates re-pose → fresh frozen Scene); `.solve` resolves ParamRefs at call time and returns a snapshot. The `Scene` return exposes `.parts`, `.bbox`, `.assemblyName`, `.warnings`, `.toCompound()` (lossless OCCT group, default for STEP), `.toUnion()` (lossy boolean fuse, antipattern), `.part(name)`, and iteration via `for (const p of scene)`.' },
   { name: 'helix', signature: '({ radius, pitch, turns, axis?, pointsPerTurn?, startAngle? }) => [number, number, number][]', description: 'Polyline helix rail for `Sketch.sweep`. Default axis Z, 32 points per turn.' },
-  { name: 'selectEdges', signature: '(shape, query?) => Promise<EdgeSegment[]>', description: 'Pre-select edges by EdgeQuery. Awaitable; lowers the shape lazily.' },
+  { name: 'selectEdges', signature: '(shape, query?) => Promise<ShapeList<EdgeSegment>>', description: 'Pre-select edges by EdgeQuery. Awaitable; lowers the shape lazily. Returns a `ShapeList` — an `EdgeSegment[]` (accepted anywhere fillet/chamfer take one) carrying the selector algebra on top: `.sortBy` / `.groupBy` / `.filterBy` / `.filterByPosition` / `.sortByDistance`, and the `.first` / `.last` / `.at(i)` / `.take(n)` accessors. Each `EdgeSegment` also carries `radius` when `curveType === "CIRCLE"`.' },
   { name: 'selectEdge', signature: '(shape, query) => Promise<EdgeSegment>', description: 'Like selectEdges but throws if zero or multiple edges match. Use for unambiguous single-edge selection.' },
+  { name: 'select', signature: '<T>(items: Iterable<T>) => ShapeList<T>', description: 'Wrap any array of topology query results in a `ShapeList` so the selector algebra applies — face summaries from `list_faces`, `ResolvedEntity[]` from `q.face(...).evaluate(scene)`, or a hand-assembled list. `selectEdges` already returns a ShapeList, so `select` is for every other result source. The algebra is pure TypeScript over already-resolved descriptors: it reorders and partitions the SAME objects, so `EdgeSegment.id` and the `@kc[...]` ref / OCCT handle on a `ResolvedEntity` survive a sort or a group untouched. Compose it with (do not replace) EdgeQuery/FaceQuery: let the declarative query filter inside OCCT first, then rank or bucket the resolved list here.' },
   { name: 'lib', signature: '{ fromSTEP(path: string): Promise<Shape> }', description: 'Parts library namespace. `lib.fromSTEP(path)` imports a STEP file as a Shape — path is resolved relative to the calling .kcad.ts script (absolute paths also accepted). Returned Shape composes with translate/rotate/color/arm.part(...) like any primitive. Use for vendor catalog parts (servos, bearings, fasteners) so geometric fidelity matches the real component instead of being hand-authored from box/cylinder.' },
   { name: 'nurbsSurface', signature: '({ controls, degree, weights?, knots?, periodic? }) => Surface', description: 'Build a NURBS surface from an explicit control net + degree. `controls` is a U-major V-minor rectangular Vec3 grid (mm). Returns a Surface (peer to Shape) — use `.thicken(t)` or `.toShape()` to enter the Shape pipeline. `weights` produces an exact rational surface (circles, cylinders, spheres, conics) as of v0.14.0.' },
   { name: 'surfaceFromCurves', signature: '(sections: Sketch[]) => Surface', description: 'Skin a NURBS surface through 2+ closed Sketch cross-sections in declaration order. Returns a Surface — chain `.thicken(t)` or `.toShape()`. Use for free-form panels and lofted shells.' },
@@ -168,6 +171,64 @@ export const SHAPE_METHODS: ApiEntry[] = [
   { name: 'recenter', signature: '(opts?: { x?: boolean; y?: boolean; z?: boolean }) => Promise<Shape>', description: 'Translate this Shape so its bounding-box center lands on the world origin, then return it for chaining. The key normalizer for a freshly-fetched catalog part: after `await part.recenter()`, a subsequent `.translate(x, y, z)` places the part\'s CENTER exactly at (x, y, z) instead of nudging it from the STEP file\'s arbitrary native offset. Async (lowers to read the bbox) and appends one translate, so it composes with prior transforms. Pass `{ z: false }` etc to recenter only the named axes.' },
   { name: 'seatOnFloor', signature: '(opts?: { center?: boolean }) => Promise<Shape>', description: 'Translate this Shape so it rests on the z = 0 floor (bbox min.z → 0), centered in x/y over the origin; returns it for chaining. Use for parts that must sit on a build plate / table / PCB plane in their upright pose. Pass `{ center: false }` to drop onto z = 0 without moving x/y. Async + appends one translate, same chaining contract as recenter().' },
   { name: 'lower', signature: '() => Promise<OcctBackend>', description: 'Eagerly lower this Shape for inspection. Used internally by selectEdges; agents rarely call directly.' },
+];
+
+/**
+ * Selector-algebra methods on the `ShapeList` returned by `selectEdges(...)`
+ * and `select(...)`. `ShapeList` extends `Array`, so every built-in array
+ * method is available too and is not re-advertised here.
+ *
+ * Drift-sentinel contract: adding a method to `ShapeList` REQUIRES updating
+ * this array — the test at
+ * `tests/integration/mcp/listApi.driftSentinel.test.ts` fails CI if they
+ * disagree.
+ */
+export const SHAPE_LIST_METHODS: ApiEntry[] = [
+  {
+    name: 'sortBy',
+    signature: "(criterion: 'X' | 'Y' | 'Z' | Vec3 | 'area' | 'length' | 'radius', opts?: { descending?: boolean; tolerance?: number }) => ShapeList<T>",
+    description: "Order the list by a criterion, ascending by default. An axis name or a Vec3 direction measures the projection of the entity's position onto that direction; 'area' / 'length' / 'radius' measure an intrinsic property ('radius' is populated on CIRCLE edges only). Comparison runs on the metric quantized to `tolerance` (default 1e-6) with the pre-sort position as tiebreak, so entities whose metrics differ only by kernel float noise keep their incoming relative order instead of swapping between runs. Returns a new list; entity identity is preserved.",
+  },
+  {
+    name: 'sortByDistance',
+    signature: '(point: Vec3, opts?: { descending?: boolean; tolerance?: number }) => ShapeList<T>',
+    description: 'Order by straight-line distance from each entity position to `point`, nearest first. Same quantization and stable-tiebreak contract as `sortBy`. Use to disambiguate "the hole nearest this mounting boss" without a `near` re-query.',
+  },
+  {
+    name: 'groupBy',
+    signature: "(criterion: 'X' | 'Y' | 'Z' | Vec3 | 'area' | 'length' | 'radius', opts?: { tolerance?: number; descending?: boolean }) => ShapeGroups<T>",
+    description: "Partition into groups sharing a quantized criterion value — one group per Z level, per hole diameter, per face area. Keys are rounded to 6 decimal digits by default, or snapped onto a `tolerance`-wide lattice, so near-coincident geometry lands in ONE bucket instead of two adjacent ones. Groups come back ordered by key and entities keep their incoming order within a group. The returned `ShapeGroups` exposes `.groups`, `.length`, `.keys`, `.at(i)` (negative indexes count from the end), `.byKey(v)` (quantizes the request the same way, so `byKey(5)` finds a bucket built from 4.999999999998), `.flat()`, and iteration yielding `{ key, items }`.",
+  },
+  {
+    name: 'filterBy',
+    signature: '(spec: ((item: T) => boolean) | Axis | string, opts?: { angleTolerance?: number }) => ShapeList<T>',
+    description: "Keep matching entities. Three forms picked by the argument's shape: a predicate for arbitrary logic; an axis ('X' | 'Y' | 'Z' | Vec3) to keep entities whose characteristic direction — an edge's tangent, a face's normal — is parallel to it within `angleTolerance` degrees (default 10); or any other string to match the geometry type case-insensitively ('CIRCLE' / 'LINE' for edges, 'PLANE' / 'CYLINDRE' for faces). Composes with EdgeQuery/FaceQuery rather than replacing them — query against the shape first so OCCT does the bulk filtering, then refine here.",
+  },
+  {
+    name: 'filterByPosition',
+    signature: "(axis: 'X' | 'Y' | 'Z' | Vec3, min: number, max: number, opts?: { inclusive?: boolean }) => ShapeList<T>",
+    description: 'Keep entities whose position projected onto `axis` falls within [min, max] (mm). Bounds are inclusive by default; pass `{ inclusive: false }` for a strict interval. `min` and `max` may be given in either order. Use for slab selections ("every edge in the top 2 mm") that `within` cannot express along an arbitrary direction.',
+  },
+  {
+    name: 'take',
+    signature: '(n: number) => ShapeList<T>',
+    description: 'First `n` entities, clamped to the list length. `n` must be a non-negative integer. Pair with `sortBy` for "the highest three faces": `faces.sortBy("Z", { descending: true }).take(3)`.',
+  },
+  {
+    name: 'first',
+    signature: 'T | undefined',
+    description: 'Getter — the first entity, or `undefined` when the list is empty. Empty is returned rather than thrown so a chain can be probed; use `selectEdge(...)` when a missing match should be a hard failure.',
+  },
+  {
+    name: 'last',
+    signature: 'T | undefined',
+    description: 'Getter — the last entity, or `undefined` when the list is empty. `list.sortBy("Z").last` is the topmost entity.',
+  },
+  {
+    name: 'at',
+    signature: '(i: number) => T | undefined',
+    description: 'Entity at index `i`; negative indexes count from the end. Inherited from `Array.prototype.at` — standard JS semantics, `undefined` when out of range.',
+  },
 ];
 
 export const SKETCH_METHODS: ApiEntry[] = [
@@ -377,6 +438,7 @@ export async function listApiTool(input: ListApiInput = {}): Promise<ListApiOutp
     ok: true,
     globals: p(GLOBALS),
     shapeMethods: p(SHAPE_METHODS),
+    shapeListMethods: p(SHAPE_LIST_METHODS),
     sketchMethods: p(SKETCH_METHODS),
     pathBuilderMethods: p(PATH_BUILDER_METHODS),
     paramRefMethods: p(PARAM_REF_METHODS),

--- a/src/agent/skills/kernelcad-authoring/SKILL.md
+++ b/src/agent/skills/kernelcad-authoring/SKILL.md
@@ -213,8 +213,15 @@ assembly(name?: string): Assembly;
 helix({ radius, pitch, turns, axis?, pointsPerTurn?, startAngle? }): [number, number, number][];
 
 // Edge selection — lowers the shape lazily (awaitable).
-selectEdges(shape: Shape, query?: EdgeQuery): Promise<EdgeSegment[]>;
+// selectEdges returns a ShapeList: still an EdgeSegment[] (fillet/chamfer accept
+// it directly), plus the selector algebra described under "Selector algebra" below.
+selectEdges(shape: Shape, query?: EdgeQuery): Promise<ShapeList<EdgeSegment>>;
 selectEdge(shape: Shape, query: EdgeQuery): Promise<EdgeSegment>;  // throws if zero or multiple match
+
+// Selector algebra — wrap ANY array of topology query results (face summaries,
+// q.face(...).evaluate(scene) results, a hand-built list) so the sort/group/filter
+// methods apply. selectEdges already returns one.
+select<T>(items: Iterable<T>): ShapeList<T>;
 
 // Parts library — STEP import for vendor catalog components.
 // Resolved relative to the calling .kcad.ts file; absolute paths also accepted.
@@ -336,6 +343,51 @@ dfmSpec(spec: {
   }>;
 }): DfmSpecHandle;
 ```
+
+### Selector algebra (ShapeList)
+
+`EdgeQuery` / `FaceQuery` are flat predicate bags: they answer *"which entities
+match these constraints?"*. They cannot answer *"the highest three faces"*,
+*"the largest bore"*, or *"one group per Z level"*. `ShapeList` is the other
+half — sort / group / filter over results the kernel has ALREADY resolved.
+
+Compose the two, don't substitute one for the other: let the declarative query
+filter inside OCCT first, then rank or bucket the resolved list in TypeScript.
+
+```typescript
+// selectEdges returns a ShapeList; select(...) wraps any other result array.
+const edges = await selectEdges(body, { convex: true });
+
+edges.sortBy('Z').last                       // topmost edge
+edges.sortBy('Z', { descending: true }).take(3)   // highest three
+edges.filterBy('CIRCLE').sortBy('radius').last    // largest circular edge
+edges.filterBy('Z')                          // edges running parallel to +Z
+edges.filterByPosition('Z', 8, 10)           // edges in the top 2 mm slab
+edges.sortByDistance([0, 0, 20]).first       // nearest to a point
+edges.filterBy((e) => e.length > 5)          // arbitrary predicate
+
+const levels = edges.groupBy('Z', { tolerance: 0.01 });  // one group per Z level
+levels.length; levels.keys;                  // 3, [0, 5, 10]
+levels.at(-1);                               // top level (ShapeList)
+levels.byKey(10);                            // same group, looked up by value
+```
+
+Contracts worth knowing:
+
+- **Immutable.** Every method returns a NEW list; nothing sorts in place.
+- **Identity survives.** The algebra reorders the SAME descriptor objects — it
+  never re-derives one — so `EdgeSegment.id` and the `@kc[...]` ref plus OCCT
+  handle on a `ResolvedEntity` are intact after any sort or group.
+- **Float-noise tolerant.** Both `sortBy` and `groupBy` compare on a quantized
+  metric (1e-6 by default, or an explicit `tolerance` in mm) with the incoming
+  position as tiebreak, so kernel noise cannot flip an order or split one Z
+  level into two groups. `byKey` quantizes the request identically.
+- **It is still an array.** `ShapeList` extends `Array`, so `.length`,
+  indexing, spread, `for..of` and `.map` / `.filter` all work, and a
+  `ShapeList<EdgeSegment>` passes straight into `fillet` / `chamfer`.
+- **`radius` is CIRCLE-only.** `sortBy('radius')` needs `EdgeSegment.radius`,
+  which is populated for `curveType === 'CIRCLE'` and deliberately absent
+  otherwise; asking for it elsewhere throws rather than approximating.
 
 ### Shape methods (chainable)
 

--- a/src/kernel/backends/backend.ts
+++ b/src/kernel/backends/backend.ts
@@ -4,7 +4,7 @@ import type { FeatureRecord } from '../../shared/intent/featureRecord';
 import type { FeatureKind, Vec3 } from '../../shared/intent/types';
 import type { CompilerDiagnostic } from '../../shared/diagnostics/diagnostic';
 import type { RuntimeMesh } from './runtimeMesh';
-import type { MassProperties } from '../../modeling/properties/massProperties';
+import type { MassProperties, GyrationAxis } from '../../modeling/properties/massProperties';
 
 // BackendTarget moved to shared/types/backendTarget so shared/diagnostics can
 // depend on it without breaking shared-stays-leaf. Re-exported here for
@@ -41,7 +41,10 @@ export interface ShapeBackend {
   /**
    * Mass, centre of mass, and the centroidal inertia tensor for a given
    * density (kg/m^3; default 1000 = water). Returns SI: mass in kg, CoM in
-   * shape-local mm, inertia6 in kg*m^2.
+   * shape-local mm, inertia6 / inertiaMatrix / principalMoments in kg*m^2.
+   *
+   * Pass `gyrationAxis` to additionally get the radius of gyration (mm)
+   * about that arbitrary axis.
    *
    * Backed by OCCT BRepGProp::VolumeProperties. Declared here rather than only
    * on OcctBackend so readers holding a ShapeBackend (the recompute engine
@@ -49,7 +52,7 @@ export interface ShapeBackend {
    * against the concrete class, which is why this stayed off the interface and
    * out of the agent's reach for so long.
    */
-  massProperties(density?: number): MassProperties;
+  massProperties(density?: number, gyrationAxis?: GyrationAxis): MassProperties;
   isEmpty(): boolean;
   /**
    * Split a BREP compound into its top-level physical solids. A correctly

--- a/src/kernel/backends/occt/edgeQueries.ts
+++ b/src/kernel/backends/occt/edgeQueries.ts
@@ -348,14 +348,55 @@ function signedAxisVec(axis: 'X' | '-X' | 'Y' | '-Y' | 'Z' | '-Z'): Vec3 {
  * Convert an Edge to an EdgeSegment (the agent-facing summary).
  * The `id` is a stable index within this lowering — derived from edge order.
  */
+/**
+ * Circumradius of a CIRCLE edge, in mm.
+ *
+ * Read off three points sampled at t = 0, 1/3, 2/3 of the edge's parametric
+ * domain and solved as a triangle circumradius: R = abc / 4A. Exact for
+ * circular geometry (any three distinct points on a circle determine it), and
+ * it needs no OCCT symbol beyond the `pointAt` replicad already exposes.
+ *
+ * Returns undefined for every non-CIRCLE curve type — an approximate radius
+ * for a spline or a line would be a lie the selector algebra would then sort
+ * on. Absent is honest; wrong is not.
+ */
+function circleRadius(edge: Edge): number | undefined {
+  if ((edge as unknown as { geomType?: string }).geomType !== 'CIRCLE') return undefined;
+  try {
+    const a = edge.pointAt(0);
+    const b = edge.pointAt(1 / 3);
+    const c = edge.pointAt(2 / 3);
+    const ab: Vec3 = [b.x - a.x, b.y - a.y, b.z - a.z];
+    const ac: Vec3 = [c.x - a.x, c.y - a.y, c.z - a.z];
+    const cross: Vec3 = [
+      ab[1] * ac[2] - ab[2] * ac[1],
+      ab[2] * ac[0] - ab[0] * ac[2],
+      ab[0] * ac[1] - ab[1] * ac[0],
+    ];
+    const twiceArea = Math.hypot(cross[0], cross[1], cross[2]);
+    if (twiceArea < 1e-12) return undefined; // collinear samples — degenerate
+    const lenAB = Math.hypot(ab[0], ab[1], ab[2]);
+    const lenAC = Math.hypot(ac[0], ac[1], ac[2]);
+    const lenBC = Math.hypot(c.x - b.x, c.y - b.y, c.z - b.z);
+    const r = (lenAB * lenAC * lenBC) / (2 * twiceArea);
+    return Number.isFinite(r) ? r : undefined;
+  } catch {
+    // Same defensive posture as computeDihedral: replicad/OCCT throws raw
+    // Standard_Failure pointers on degenerate curves.
+    return undefined;
+  }
+}
+
 export function toEdgeSegment(edge: Edge, index: number, shape: { faces: Face[] }): EdgeSegment {
   const dihedral = computeDihedral(shape, edge);
+  const radius = circleRadius(edge);
   return {
     id: `e${index}`,
     midpoint: edgeMidpoint(edge),
     direction: edgeDirection(edge),
     length: edge.length ?? 0,
     curveType: (edge as unknown as { geomType?: string }).geomType ?? 'UNKNOWN',
+    ...(radius !== undefined ? { radius } : {}),
     convex: dihedral?.convex ?? null,
     dihedralAngleDeg: dihedral?.angleDeg ?? null,
     normalA: dihedral?.normalA ?? null,

--- a/src/kernel/backends/occt/occtBackend.ts
+++ b/src/kernel/backends/occt/occtBackend.ts
@@ -15,7 +15,7 @@ import { verifyWatertight, stitchCracks, dropDegenerateTriangles, type Watertigh
 import { resolveColor } from '../../../shared/render/palette';
 import { type PBRMaterial } from '../../../shared/intent/material';
 import { sceneToWorldFrameParts } from './sceneToWorldFrame';
-import { computeMassProperties, type MassProperties } from '../../../modeling/properties/massProperties';
+import { computeMassProperties, type MassProperties, type GyrationAxis } from '../../../modeling/properties/massProperties';
 
 type ReplicadEdge = replicad.Edge;
 type ReplicadFace = replicad.Face;
@@ -1256,10 +1256,10 @@ export class OcctBackend implements ShapeBackend {
    * Backed by OCCT's `BRepGProp::VolumeProperties`. Mirrors the access
    * pattern in `curve3dEval.ts` for `LinearProperties`.
    */
-  massProperties(density: number = 1000): MassProperties {
+  massProperties(density: number = 1000, gyrationAxis?: GyrationAxis): MassProperties {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const wrapped = (this.shape as any).wrapped;
-    return computeMassProperties(wrapped, density);
+    return computeMassProperties(wrapped, density, gyrationAxis);
   }
 
   volume(): number {

--- a/src/modeling/api.ts
+++ b/src/modeling/api.ts
@@ -40,6 +40,7 @@ import {
   type FindPartResult,
 } from './parts/findPart';
 import { createStandardParts, type StandardParts } from './parts/standardParts';
+import { select, type ShapeList } from './selection/shapeList';
 import { sphere as sdfSphere, box as sdfBox, cylinder as sdfCylinder, torus as sdfTorus } from './sdf/primitives';
 import { smoothBlend as sdfSmoothBlend } from './sdf/smoothBlend';
 import { materialize as sdfMaterialize, type MaterializeOpts } from './sdf/materialize';
@@ -145,8 +146,20 @@ export interface KernelCadApi {
 
   path(): PathBuilder;
   helix(opts: HelixOptions): RailPoint[];
-  selectEdges(shape: Shape, query?: EdgeQuery): Promise<EdgeSegment[]>;
+  /**
+   * Pre-select edges by EdgeQuery. Returns a `ShapeList` — still an
+   * `EdgeSegment[]` everywhere one is expected, plus the selector algebra
+   * (`sortBy` / `groupBy` / `filterBy` / `filterByPosition` / `sortByDistance`
+   * and the `first` / `last` / `at` / `take` accessors).
+   */
+  selectEdges(shape: Shape, query?: EdgeQuery): Promise<ShapeList<EdgeSegment>>;
   selectEdge(shape: Shape, query: EdgeQuery): Promise<EdgeSegment>;
+  /**
+   * Wrap any array of topology query results in a `ShapeList` so the selector
+   * algebra applies — face summaries, `Query.evaluate(scene)` results, or a
+   * hand-assembled list. `selectEdges` already returns one.
+   */
+  select<T>(items: Iterable<T>): ShapeList<T>;
 
   /** Parts library — STEP-import + (future) parametric component wrappers. */
   lib: PartsLib;
@@ -860,8 +873,9 @@ export function createApi(ctx: ApiContext): KernelCadApi {
     helix,
     selectEdges: async (shape, query = {}) => {
       const lowered = await shape.lower();
-      return selectEdgesBackend(lowered, query);
+      return select(selectEdgesBackend(lowered, query));
     },
+    select,
     selectEdge: async (shape, query) => {
       const lowered = await shape.lower();
       return selectEdgeBackend(lowered, query);

--- a/src/modeling/properties/massProperties.ts
+++ b/src/modeling/properties/massProperties.ts
@@ -12,20 +12,33 @@
 //   - returned CoM is in shape-local mm
 //   - returned inertia6 is [ixx, ixy, ixz, iyy, iyz, izz] in kg*m^2
 //
+//   - returned principal moments are kg*m^2, principal axes are unit vectors
+//   - returned radiusOfGyration is in shape-local mm (density-cancelling)
+//
 // The mm -> m conversion happens here once; callers always see SI.
 //
-// Implementation note: this build of opencascade.js does NOT bind
-// `gp_Mat` or `GProp_PrincipalProps`, so `MatrixOfInertia()` is
-// unavailable. We reconstruct the 6 unique components of the symmetric
-// inertia tensor via six `MomentOfInertia(gp_Ax1)` calls — three about
-// the X/Y/Z axes through the CoM (the diagonal components Ixx, Iyy, Izz)
-// and three about diagonal axes ((X+Y)/√2 etc.) from which the products
-// of inertia Ixy, Ixz, Iyz follow from the identity
-//   M(n) = n^T · I · n
-// applied to a unit vector at 45° between two principal axes.
+// Implementation note: `GProp_GProps::MatrixOfInertia()` returns a `gp_Mat`,
+// which is NOT registered with embind — calling it from JS throws
+// `BindingError: unbound types` at RUNTIME (it type-checks fine, so the
+// failure only shows up under execution). The kcad OCCT build therefore ships
+// a static `oc.GPropWrapper` that reads the matrix and the principal
+// properties out component-by-component as plain numbers. Always go through
+// the wrapper; never call `MatrixOfInertia()` or `PrincipalProperties()`
+// directly.
+//
+// OCCT reports both the inertia matrix and the principal properties about the
+// CENTRE OF MASS, not about the shape origin, so no parallel-axis correction
+// is applied here. Verified numerically against the closed form for a
+// 20x10x30 box: diag = V*(b^2+c^2)/12 etc. exactly.
 
 import { getOC } from 'replicad';
 import type { Vec3 } from '../../shared/intent/types';
+
+/** An axis in shape-local mm: a point on the axis plus a direction (need not be unit). */
+export interface GyrationAxis {
+  origin: Vec3;
+  direction: Vec3;
+}
 
 export interface MassProperties {
   /** Mass in kg, assuming the declared density. */
@@ -34,6 +47,32 @@ export interface MassProperties {
   com: Vec3;
   /** Symmetric 6-vector [ixx, ixy, ixz, iyy, iyz, izz] in kg*m^2 about the CoM. */
   inertia6: [number, number, number, number, number, number];
+  /**
+   * Full symmetric 3x3 centroidal inertia tensor in kg*m^2, row-major.
+   * Same data as `inertia6`, in the shape most physics/robotics code wants.
+   */
+  inertiaMatrix: [Vec3, Vec3, Vec3];
+  /**
+   * The three principal moments of inertia in kg*m^2, about the CoM.
+   * `principalMoments[i]` corresponds to `principalAxes[i]`. Ordering is
+   * OCCT's own — it is NOT sorted.
+   */
+  principalMoments: [number, number, number];
+  /** Unit direction of each principal axis, in shape-local coordinates. */
+  principalAxes: [Vec3, Vec3, Vec3];
+  /**
+   * True when the shape's principal moments are degenerate about an axis /
+   * a point respectively — i.e. OCCT detected rotational / spherical
+   * symmetry of the mass distribution. A generic box reports false for both.
+   */
+  hasSymmetryAxis: boolean;
+  hasSymmetryPoint: boolean;
+  /**
+   * Radius of gyration in mm about the caller-supplied axis. Present only
+   * when `gyrationAxis` was passed. Independent of density (both the moment
+   * and the mass scale with it), which is why it stays in mm rather than SI.
+   */
+  radiusOfGyration?: number;
 }
 
 const MM3_TO_M3 = 1e-9;
@@ -51,6 +90,7 @@ const INERTIA_SCALE_PER_DENSITY = 1e-15;
 export function computeMassProperties(
   occtShape: unknown,
   density: number = 1000,
+  gyrationAxis?: GyrationAxis,
 ): MassProperties {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const oc = getOC() as any;
@@ -68,46 +108,80 @@ export function computeMassProperties(
   const c = props.CentreOfMass();
   const com: Vec3 = [c.X(), c.Y(), c.Z()];
 
-  // Per-axis moments at unit density (mm^5). The six axes pass through the
-  // CoM so the values are already centroidal moments — no parallel-axis
-  // correction needed. Scaling to SI happens via INERTIA_SCALE_PER_DENSITY.
-  const Mx = momentOfInertiaAlong(oc, props, c, [1, 0, 0]);
-  const My = momentOfInertiaAlong(oc, props, c, [0, 1, 0]);
-  const Mz = momentOfInertiaAlong(oc, props, c, [0, 0, 1]);
-  const INV_SQRT2 = 1 / Math.SQRT2;
-  const Mxy = momentOfInertiaAlong(oc, props, c, [INV_SQRT2, INV_SQRT2, 0]);
-  const Mxz = momentOfInertiaAlong(oc, props, c, [INV_SQRT2, 0, INV_SQRT2]);
-  const Myz = momentOfInertiaAlong(oc, props, c, [0, INV_SQRT2, INV_SQRT2]);
-
-  // M(n) = n^T I n. For diagonal unit vector (1/√2, 1/√2, 0):
-  //   Mxy = (Ixx + Iyy)/2 + Ixy  ⇒  Ixy = Mxy - (Ixx + Iyy)/2.
-  // Same shape for Ixz and Iyz.
-  const Ixx = Mx;
-  const Iyy = My;
-  const Izz = Mz;
-  const Ixy = Mxy - (Ixx + Iyy) / 2;
-  const Ixz = Mxz - (Ixx + Izz) / 2;
-  const Iyz = Myz - (Iyy + Izz) / 2;
-
+  // Centroidal inertia tensor at unit density (mm^5), read out of the
+  // unbound gp_Mat one component at a time. GPropWrapper indices are
+  // 1-BASED (OCCT convention), unlike the 0-based principal-props indices
+  // right below — the asymmetry is OCCT's, not ours.
   const k = density * INERTIA_SCALE_PER_DENSITY;
-  return {
+  const m = (i: number, j: number): number =>
+    oc.GPropWrapper.MatrixOfInertiaValue(props, i, j) * k;
+
+  // Symmetrise explicitly: OCCT's integration leaves the two halves of the
+  // tensor differing in the last bits, and callers (URDF/MJCF) require an
+  // exactly symmetric matrix.
+  const Ixx = m(1, 1);
+  const Iyy = m(2, 2);
+  const Izz = m(3, 3);
+  const Ixy = (m(1, 2) + m(2, 1)) / 2;
+  const Ixz = (m(1, 3) + m(3, 1)) / 2;
+  const Iyz = (m(2, 3) + m(3, 2)) / 2;
+
+  const principalMoments = [0, 1, 2].map(
+    i => oc.GPropWrapper.PrincipalMoment(props, i) * k,
+  ) as [number, number, number];
+  const principalAxes = [0, 1, 2].map(
+    axis =>
+      [0, 1, 2].map(comp =>
+        oc.GPropWrapper.PrincipalAxisComponent(props, axis, comp),
+      ) as Vec3,
+  ) as [Vec3, Vec3, Vec3];
+
+  const result: MassProperties = {
     mass: massKg,
     com,
-    inertia6: [Ixx * k, Ixy * k, Ixz * k, Iyy * k, Iyz * k, Izz * k],
+    inertia6: [Ixx, Ixy, Ixz, Iyy, Iyz, Izz],
+    inertiaMatrix: [
+      [Ixx, Ixy, Ixz],
+      [Ixy, Iyy, Iyz],
+      [Ixz, Iyz, Izz],
+    ],
+    principalMoments,
+    principalAxes,
+    hasSymmetryAxis: Boolean(oc.GPropWrapper.HasSymmetryAxis(props)),
+    hasSymmetryPoint: Boolean(oc.GPropWrapper.HasSymmetryPoint(props)),
   };
+
+  if (gyrationAxis) {
+    result.radiusOfGyration = radiusOfGyrationAbout(oc, props, gyrationAxis);
+  }
+  return result;
 }
 
-/** Moment of inertia about an axis through `centre` aligned with `dir`. */
-function momentOfInertiaAlong(
+/**
+ * Radius of gyration (mm) about an arbitrary axis, via
+ * `GProp_GProps::RadiusOfGyration` — which, unlike `MatrixOfInertia`, IS
+ * bound directly because `gp_Ax1` is a registered type.
+ *
+ * Unlike the tensor above this is about the caller's axis wherever it sits,
+ * NOT about the centroid; OCCT applies the parallel-axis shift internally.
+ */
+function radiusOfGyrationAbout(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   oc: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   props: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  centre: any,
-  dir: Vec3,
+  { origin, direction }: GyrationAxis,
 ): number {
-  const d = new oc.gp_Dir_4(dir[0], dir[1], dir[2]);
-  const axis = new oc.gp_Ax1_2(centre, d);
-  return props.MomentOfInertia(axis);
+  const len = Math.hypot(direction[0], direction[1], direction[2]);
+  if (!(len > 0)) {
+    throw new Error(
+      'radiusOfGyration axis direction must be a non-zero vector; got [0, 0, 0].',
+    );
+  }
+  const p = new oc.gp_Pnt_3(origin[0], origin[1], origin[2]);
+  // gp_Dir normalises, but a zero-length input would abort inside wasm rather
+  // than throw a catchable JS error, hence the guard above.
+  const d = new oc.gp_Dir_4(direction[0], direction[1], direction[2]);
+  const axis = new oc.gp_Ax1_2(p, d);
+  return props.RadiusOfGyration(axis);
 }

--- a/src/modeling/selection/shapeList.test.ts
+++ b/src/modeling/selection/shapeList.test.ts
@@ -1,0 +1,640 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/modeling/selection/shapeList.test.ts
+//
+// Selector-algebra unit tests. Pure TS over descriptor fixtures — no OCCT, no
+// lowering — because that is exactly the boundary the module lives on.
+
+import { describe, it, expect } from 'vitest';
+import { ShapeList, ShapeGroups, select, quantizeMetric, metricOf, positionOf } from './shapeList';
+import type { EdgeSegment } from '../../shared/intent/queryTypes';
+import { KernelError } from '../../shared/intent/kernelError';
+import type { Vec3 } from '../../shared/intent/types';
+import { q } from '../../kernel/naming/queryConstructors';
+import type { QueryScene } from '../../kernel/naming/query';
+import type { HistoryMap, FaceLineage } from '../../kernel/naming/evolutionRecord';
+// Importing the evaluator installs its delegates onto the Query chainables —
+// `.evaluate()` reads that table at call time (see query.ts cycle-breaker).
+import '../../kernel/naming/queryEvaluator';
+
+// ---------------------------------------------------------------------------
+// Fixtures. Three descriptor shapes, matching the three real result sources.
+// ---------------------------------------------------------------------------
+
+function edge(id: string, midpoint: Vec3, over: Partial<EdgeSegment> = {}): EdgeSegment {
+  return {
+    id,
+    midpoint,
+    direction: [1, 0, 0],
+    length: 10,
+    curveType: 'LINE',
+    convex: true,
+    dihedralAngleDeg: 90,
+    normalA: [0, 0, 1],
+    normalB: [1, 0, 0],
+    boundary: false,
+    ...over,
+  };
+}
+
+/** Mirrors the `FaceSummary` shape produced by the `list_faces` MCP tool. */
+interface FaceLike {
+  ref: string;
+  centroid: Vec3;
+  normal: Vec3;
+  surfaceType: string;
+  area: number;
+}
+
+function face(ref: string, centroid: Vec3, area: number, over: Partial<FaceLike> = {}): FaceLike {
+  return { ref, centroid, normal: [0, 0, 1], surfaceType: 'PLANE', area, ...over };
+}
+
+/** Mirrors `ResolvedEntity` from the naming-DSL evaluator. */
+interface EntityLike {
+  kind: string;
+  ref: string;
+  handle: string;
+  snapshot: { centroid: Vec3; normal: Vec3; area: number };
+}
+
+function entity(name: string, centroid: Vec3, area: number): EntityLike {
+  return {
+    kind: 'face',
+    ref: `@kc[body/face/${name}]`,
+    handle: `F${name}`,
+    snapshot: { centroid, normal: [0, 0, 1], area },
+  };
+}
+
+// ---------------------------------------------------------------------------
+
+describe('select / ShapeList construction', () => {
+  it('is a real Array, so existing EdgeSegment[] consumers keep working', () => {
+    const list = select([edge('e0', [0, 0, 0]), edge('e1', [0, 0, 5])]);
+    expect(Array.isArray(list)).toBe(true);
+    expect(list).toBeInstanceOf(ShapeList);
+    expect(list.length).toBe(2);
+    expect([...list].map((e) => e.id)).toEqual(['e0', 'e1']);
+    // Assignable to EdgeSegment[] — the whole point of extending Array.
+    const asPlain: EdgeSegment[] = list;
+    expect(asPlain[1].id).toBe('e1');
+  });
+
+  it('inherited array methods still return a ShapeList (species allocation path)', () => {
+    const list = select([edge('e0', [0, 0, 0]), edge('e1', [0, 0, 5])]);
+    const mapped = list.map((e) => e.id);
+    const filtered = list.filter((e) => e.id === 'e1');
+    expect(mapped).toBeInstanceOf(ShapeList);
+    expect([...mapped]).toEqual(['e0', 'e1']);
+    expect(filtered).toBeInstanceOf(ShapeList);
+    expect(filtered.length).toBe(1);
+  });
+
+  it('rejects a non-iterable input with a named kernel error', () => {
+    expect(() => select(42 as unknown as Iterable<unknown>)).toThrow(KernelError);
+    expect(() => select(42 as unknown as Iterable<unknown>)).toThrow(/expected an iterable/);
+  });
+});
+
+describe('empty and single-element lists', () => {
+  const empty = select<EdgeSegment>([]);
+
+  it('every algebra method is total on an empty list', () => {
+    expect(empty.length).toBe(0);
+    expect(empty.first).toBeUndefined();
+    expect(empty.last).toBeUndefined();
+    expect(empty.at(0)).toBeUndefined();
+    expect(empty.take(3).length).toBe(0);
+    expect(empty.sortBy('Z').length).toBe(0);
+    expect(empty.sortByDistance([0, 0, 0]).length).toBe(0);
+    expect(empty.filterBy('CIRCLE').length).toBe(0);
+    expect(empty.filterBy(() => true).length).toBe(0);
+    expect(empty.filterByPosition('Z', 0, 10).length).toBe(0);
+  });
+
+  it('groupBy on an empty list yields zero groups, not one empty group', () => {
+    const groups = empty.groupBy('Z');
+    expect(groups).toBeInstanceOf(ShapeGroups);
+    expect(groups.length).toBe(0);
+    expect(groups.keys).toEqual([]);
+    expect(groups.at(0)).toBeUndefined();
+    expect(groups.byKey(0)).toBeUndefined();
+    expect([...groups]).toEqual([]);
+  });
+
+  it('a single-element list is its own first, last, and only group', () => {
+    const one = select([edge('e0', [1, 2, 3])]);
+    expect(one.first?.id).toBe('e0');
+    expect(one.last?.id).toBe('e0');
+    expect(one.sortBy('Z').first?.id).toBe('e0');
+    expect(one.take(99).length).toBe(1);
+
+    const groups = one.groupBy('Z');
+    expect(groups.length).toBe(1);
+    expect(groups.keys).toEqual([3]);
+    expect(groups.at(0)?.length).toBe(1);
+    expect(groups.byKey(3)?.first?.id).toBe('e0');
+  });
+});
+
+describe('sortBy', () => {
+  it('orders by principal axis, ascending by default', () => {
+    const list = select([
+      edge('mid', [0, 0, 5]),
+      edge('top', [0, 0, 10]),
+      edge('bottom', [0, 0, 0]),
+    ]);
+    expect([...list.sortBy('Z')].map((e) => e.id)).toEqual(['bottom', 'mid', 'top']);
+    expect([...list.sortBy('Z', { descending: true })].map((e) => e.id)).toEqual(['top', 'mid', 'bottom']);
+  });
+
+  it('orders by an arbitrary direction vector (normalized internally)', () => {
+    const list = select([
+      edge('a', [3, 0, 0]),
+      edge('b', [0, 3, 0]),
+      edge('c', [-3, 0, 0]),
+    ]);
+    // Projection onto the +XY diagonal: c = -2.12, b = +2.12, a = +2.12 — a and
+    // b tie, so incoming order breaks the tie.
+    expect([...list.sortBy([1, 1, 0])].map((e) => e.id)).toEqual(['c', 'a', 'b']);
+  });
+
+  it('orders by intrinsic scalars: length, area, radius', () => {
+    const byLength = select([edge('l3', [0, 0, 0], { length: 3 }), edge('l1', [0, 0, 0], { length: 1 })]);
+    expect([...byLength.sortBy('length')].map((e) => e.id)).toEqual(['l1', 'l3']);
+
+    const byArea = select([face('big', [0, 0, 0], 100), face('small', [0, 0, 0], 4)]);
+    expect([...byArea.sortBy('area')].map((f) => f.ref)).toEqual(['small', 'big']);
+
+    const byRadius = select([
+      edge('r5', [0, 0, 0], { curveType: 'CIRCLE', radius: 5 }),
+      edge('r2', [0, 0, 0], { curveType: 'CIRCLE', radius: 2 }),
+    ]);
+    expect([...byRadius.sortBy('radius', { descending: true })].map((e) => e.id)).toEqual(['r5', 'r2']);
+  });
+
+  it('reads position off a ResolvedEntity snapshot as readily as off an edge midpoint', () => {
+    const list = select([entity('top', [0, 0, 10], 1), entity('bottom', [0, 0, 0], 1)]);
+    expect([...list.sortBy('Z')].map((e) => e.ref)).toEqual([
+      '@kc[body/face/bottom]',
+      '@kc[body/face/top]',
+    ]);
+  });
+
+  it('is IMMUTABLE — the source list keeps its original order', () => {
+    const list = select([edge('b', [0, 0, 9]), edge('a', [0, 0, 1])]);
+    const sorted = list.sortBy('Z');
+    expect([...list].map((e) => e.id)).toEqual(['b', 'a']);
+    expect([...sorted].map((e) => e.id)).toEqual(['a', 'b']);
+    expect(sorted).not.toBe(list);
+  });
+
+  it('is stable under float noise: sub-tolerance jitter cannot flip the order', () => {
+    // Three edges nominally at the same Z, jittered by ~1e-12 in the direction
+    // that would REVERSE a naive numeric sort. Quantization collapses them to
+    // one key, and the index tiebreak preserves the incoming order.
+    const noisy = select([
+      edge('first', [0, 0, 5 + 3e-12]),
+      edge('second', [0, 0, 5 - 1e-12]),
+      edge('third', [0, 0, 5 + 1e-12]),
+    ]);
+    expect([...noisy.sortBy('Z')].map((e) => e.id)).toEqual(['first', 'second', 'third']);
+    // Descending must not reverse a tie group either — the tiebreak is the
+    // incoming position, not the comparison direction.
+    expect([...noisy.sortBy('Z', { descending: true })].map((e) => e.id)).toEqual([
+      'first',
+      'second',
+      'third',
+    ]);
+  });
+
+  it('an explicit tolerance widens what counts as "the same position"', () => {
+    const list = select([
+      edge('a', [0, 0, 5.004]),
+      edge('b', [0, 0, 4.998]),
+      edge('c', [0, 0, 9.0]),
+    ]);
+    // Untoleranced, b sorts before a. At 0.01 mm buckets they tie and keep
+    // incoming order.
+    expect([...list.sortBy('Z')].map((e) => e.id)).toEqual(['b', 'a', 'c']);
+    expect([...list.sortBy('Z', { tolerance: 0.01 })].map((e) => e.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('throws a named error when the descriptor cannot supply the metric', () => {
+    const list = select([edge('e0', [0, 0, 0])]); // LINE — no radius
+    expect(() => list.sortBy('radius')).toThrow(KernelError);
+    expect(() => list.sortBy('radius')).toThrow(/carries no radius/);
+    expect(() => select([{ id: 'x' }]).sortBy('Z')).toThrow(/carries no position/);
+  });
+
+  it('rejects a degenerate or malformed axis', () => {
+    const list = select([edge('e0', [0, 0, 0])]);
+    expect(() => list.sortBy([0, 0, 0])).toThrow(/zero length/);
+    expect(() => list.sortBy('W' as unknown as 'X')).toThrow(/axis must be/);
+  });
+});
+
+describe('sortByDistance', () => {
+  it('orders nearest-first from an arbitrary point', () => {
+    const list = select([
+      edge('far', [0, 0, 100]),
+      edge('near', [0, 0, 1]),
+      edge('mid', [0, 0, 20]),
+    ]);
+    expect([...list.sortByDistance([0, 0, 0])].map((e) => e.id)).toEqual(['near', 'mid', 'far']);
+    expect(list.sortByDistance([0, 0, 0], { descending: true }).first?.id).toBe('far');
+  });
+
+  it('breaks equidistant ties by incoming order, not by coordinate', () => {
+    const list = select([
+      edge('plusX', [5, 0, 0]),
+      edge('minusX', [-5, 0, 0]),
+      edge('plusY', [0, 5, 0]),
+    ]);
+    expect([...list.sortByDistance([0, 0, 0])].map((e) => e.id)).toEqual(['plusX', 'minusX', 'plusY']);
+  });
+
+  it('rejects a malformed point', () => {
+    const list = select([edge('e0', [0, 0, 0])]);
+    expect(() => list.sortByDistance([0, 0] as unknown as Vec3)).toThrow(/point must be a finite/);
+    expect(() => list.sortByDistance([0, NaN, 0])).toThrow(/point must be a finite/);
+  });
+});
+
+describe('groupBy', () => {
+  const levels = select([
+    edge('a0', [0, 0, 0]),
+    edge('b10', [0, 0, 10]),
+    edge('a0b', [1, 0, 0]),
+    edge('c5', [0, 0, 5]),
+    edge('b10b', [1, 0, 10]),
+  ]);
+
+  it('buckets by criterion, orders groups by key, preserves incoming order inside', () => {
+    const g = levels.groupBy('Z');
+    expect(g.length).toBe(3);
+    expect(g.keys).toEqual([0, 5, 10]);
+    expect([...g.at(0)!].map((e) => e.id)).toEqual(['a0', 'a0b']);
+    expect([...g.at(2)!].map((e) => e.id)).toEqual(['b10', 'b10b']);
+  });
+
+  it('is indexable by group position AND by key', () => {
+    const g = levels.groupBy('Z');
+    expect(g.at(0)).toBe(g.byKey(0));
+    expect(g.at(-1)).toBe(g.byKey(10));
+    expect(g.at(99)).toBeUndefined();
+    expect(g.byKey(7)).toBeUndefined();
+  });
+
+  it('descending flips group order without disturbing within-group order', () => {
+    const g = levels.groupBy('Z', { descending: true });
+    expect(g.keys).toEqual([10, 5, 0]);
+    expect([...g.at(0)!].map((e) => e.id)).toEqual(['b10', 'b10b']);
+  });
+
+  it('folds float noise into ONE group and rounds the key to the nominal value', () => {
+    const noisy = select([
+      edge('a', [0, 0, 5.000000000002]),
+      edge('b', [0, 0, 4.999999999998]),
+      edge('c', [0, 0, 5]),
+    ]);
+    const g = noisy.groupBy('Z');
+    expect(g.length).toBe(1);
+    expect(g.keys).toEqual([5]);
+    expect(g.at(0)!.length).toBe(3);
+    // The nominal value finds the bucket — an agent never has to know the noise.
+    expect(g.byKey(5)?.length).toBe(3);
+  });
+
+  it('an explicit tolerance folds genuinely-distinct-but-coincident geometry', () => {
+    const list = select([
+      edge('a', [0, 0, 5.004]),
+      edge('b', [0, 0, 4.998]),
+      edge('c', [0, 0, 9.0]),
+    ]);
+    expect(list.groupBy('Z').length).toBe(3); // 1e-6 default keeps them apart
+    const coarse = list.groupBy('Z', { tolerance: 0.01 });
+    expect(coarse.length).toBe(2);
+    expect(coarse.keys).toEqual([5, 9]);
+    // byKey must quantize the REQUEST with the same tolerance, or lookup by the
+    // nominal value would miss the bucket it just built.
+    expect(coarse.byKey(5)?.length).toBe(2);
+    expect(coarse.byKey(4.999)?.length).toBe(2);
+  });
+
+  it('never emits a -0 key (it would compare unequal to the 0 an agent writes)', () => {
+    const g = select([edge('a', [0, 0, -1e-15])]).groupBy('Z');
+    expect(Object.is(g.keys[0], -0)).toBe(false);
+    expect(g.byKey(0)?.length).toBe(1);
+  });
+
+  it('groups by radius — the "one bucket per hole size" case', () => {
+    const bores = select([
+      edge('h1', [0, 0, 0], { curveType: 'CIRCLE', radius: 1.5 }),
+      edge('h2', [5, 0, 0], { curveType: 'CIRCLE', radius: 3.0 }),
+      edge('h3', [10, 0, 0], { curveType: 'CIRCLE', radius: 1.5000000001 }),
+    ]);
+    const g = bores.groupBy('radius');
+    expect(g.keys).toEqual([1.5, 3]);
+    expect(g.byKey(1.5)?.length).toBe(2);
+  });
+
+  it('flat() reassembles every entity in group order', () => {
+    const g = levels.groupBy('Z');
+    expect([...g.flat()].map((e) => e.id)).toEqual(['a0', 'a0b', 'c5', 'b10', 'b10b']);
+    expect(g.flat()).toBeInstanceOf(ShapeList);
+  });
+
+  it('iterating yields { key, items } records', () => {
+    const seen = [...levels.groupBy('Z')].map((grp) => [grp.key, grp.items.length]);
+    expect(seen).toEqual([[0, 2], [5, 1], [10, 2]]);
+  });
+
+  it('rejects a non-positive tolerance instead of silently dividing by zero', () => {
+    expect(() => levels.groupBy('Z', { tolerance: 0 })).toThrow(/tolerance must be a positive/);
+    expect(() => levels.groupBy('Z', { tolerance: -1 })).toThrow(/tolerance must be a positive/);
+  });
+});
+
+describe('filterBy', () => {
+  it('filters by predicate', () => {
+    const list = select([edge('short', [0, 0, 0], { length: 1 }), edge('long', [0, 0, 0], { length: 50 })]);
+    expect([...list.filterBy((e) => e.length > 10)].map((e) => e.id)).toEqual(['long']);
+  });
+
+  it('filters by geometry type, case-insensitively, across descriptor shapes', () => {
+    const edges = select([
+      edge('line', [0, 0, 0], { curveType: 'LINE' }),
+      edge('circle', [0, 0, 0], { curveType: 'CIRCLE' }),
+    ]);
+    expect([...edges.filterBy('CIRCLE')].map((e) => e.id)).toEqual(['circle']);
+    expect([...edges.filterBy('circle')].map((e) => e.id)).toEqual(['circle']);
+
+    const faces = select([face('plane', [0, 0, 0], 1), face('cyl', [0, 0, 0], 1, { surfaceType: 'CYLINDRE' })]);
+    expect([...faces.filterBy('CYLINDRE')].map((f) => f.ref)).toEqual(['cyl']);
+  });
+
+  it('filters by axis alignment — edge tangent parallel to the axis', () => {
+    const list = select([
+      edge('alongX', [0, 0, 0], { direction: [1, 0, 0] }),
+      edge('alongZ', [0, 0, 0], { direction: [0, 0, 1] }),
+      edge('antiZ', [0, 0, 0], { direction: [0, 0, -1] }),
+    ]);
+    // Parallel is orientation-independent: -Z counts as aligned with Z.
+    expect([...list.filterBy('Z')].map((e) => e.id)).toEqual(['alongZ', 'antiZ']);
+    expect([...list.filterBy([1, 0, 0])].map((e) => e.id)).toEqual(['alongX']);
+  });
+
+  it('honors angleTolerance on axis filtering', () => {
+    const tilt = Math.sin((8 * Math.PI) / 180);
+    const list = select([edge('tilted8deg', [0, 0, 0], { direction: [tilt, 0, Math.cos((8 * Math.PI) / 180)] })]);
+    expect(list.filterBy('Z').length).toBe(1); // default 10 deg
+    expect(list.filterBy('Z', { angleTolerance: 5 }).length).toBe(0);
+  });
+
+  it('falls back to a face normal when there is no direction field', () => {
+    const faces = select([
+      face('up', [0, 0, 0], 1, { normal: [0, 0, 1] }),
+      face('side', [0, 0, 0], 1, { normal: [1, 0, 0] }),
+    ]);
+    expect([...faces.filterBy('Z')].map((f) => f.ref)).toEqual(['up']);
+  });
+
+  it('rejects a malformed spec', () => {
+    const list = select([edge('e0', [0, 0, 0])]);
+    expect(() => list.filterBy(7 as unknown as string)).toThrow(/expected a predicate/);
+  });
+});
+
+describe('filterByPosition', () => {
+  const list = select([
+    edge('low', [0, 0, 0]),
+    edge('mid', [0, 0, 5]),
+    edge('high', [0, 0, 10]),
+  ]);
+
+  it('keeps entities inside the interval, bounds inclusive by default', () => {
+    expect([...list.filterByPosition('Z', 0, 5)].map((e) => e.id)).toEqual(['low', 'mid']);
+  });
+
+  it('excludes the bounds when inclusive is false', () => {
+    expect([...list.filterByPosition('Z', 0, 5, { inclusive: false })].map((e) => e.id)).toEqual([]);
+    expect([...list.filterByPosition('Z', -1, 6, { inclusive: false })].map((e) => e.id)).toEqual(['low', 'mid']);
+  });
+
+  it('accepts the bounds in either order', () => {
+    expect([...list.filterByPosition('Z', 5, 0)].map((e) => e.id)).toEqual(['low', 'mid']);
+  });
+
+  it('projects onto an arbitrary direction', () => {
+    const diag = select([edge('a', [1, 1, 0]), edge('b', [-1, -1, 0])]);
+    expect([...diag.filterByPosition([1, 1, 0], 0, 10)].map((e) => e.id)).toEqual(['a']);
+  });
+
+  it('rejects non-finite bounds', () => {
+    expect(() => list.filterByPosition('Z', NaN, 5)).toThrow(/must be finite/);
+  });
+});
+
+describe('terminal accessors', () => {
+  const list = select([edge('a', [0, 0, 0]), edge('b', [0, 0, 5]), edge('c', [0, 0, 10])]);
+
+  it('first / last / at / take', () => {
+    expect(list.first?.id).toBe('a');
+    expect(list.last?.id).toBe('c');
+    expect(list.at(1)?.id).toBe('b');
+    expect(list.at(-1)?.id).toBe('c');
+    expect(list.at(9)).toBeUndefined();
+    expect([...list.take(2)].map((e) => e.id)).toEqual(['a', 'b']);
+    expect(list.take(0).length).toBe(0);
+    expect(list.take(99).length).toBe(3);
+  });
+
+  it('take rejects a negative or fractional count', () => {
+    expect(() => list.take(-1)).toThrow(/non-negative integer/);
+    expect(() => list.take(1.5)).toThrow(/non-negative integer/);
+  });
+});
+
+describe('composition with existing EdgeQuery / FaceQuery results', () => {
+  // The declarative query is the kernel's job; these fixtures stand in for
+  // what `selectEdges(shape, { convex: true, atZ: ... })` would hand back. The
+  // point under test is that the algebra layers cleanly ON TOP of that result
+  // without needing to re-enter OCCT.
+  const queryResult = select([
+    edge('rim-a', [0, 0, 10], { curveType: 'CIRCLE', radius: 8, convex: true }),
+    edge('rim-b', [0, 0, 10], { curveType: 'CIRCLE', radius: 3, convex: true }),
+    edge('side', [5, 0, 5], { curveType: 'LINE', direction: [0, 0, 1], convex: true }),
+    edge('floor', [0, 0, 0], { curveType: 'CIRCLE', radius: 8, convex: false }),
+  ]);
+
+  it('chains filter -> sort -> terminal to answer "the largest top circle"', () => {
+    const largestTopCircle = queryResult
+      .filterByPosition('Z', 9, 11)
+      .filterBy('CIRCLE')
+      .sortBy('radius')
+      .last;
+    expect(largestTopCircle?.id).toBe('rim-a');
+  });
+
+  it('chains predicate + group to answer "bores per level, convex only"', () => {
+    const g = queryResult
+      .filterBy((e) => e.convex === true)
+      .filterBy('CIRCLE')
+      .groupBy('Z');
+    expect(g.keys).toEqual([10]);
+    expect(g.byKey(10)?.length).toBe(2);
+  });
+
+  it('every intermediate stage is a ShapeList, so the chain never dead-ends', () => {
+    const stage = queryResult.filterBy('CIRCLE').sortBy('radius').take(2);
+    expect(stage).toBeInstanceOf(ShapeList);
+    expect(stage.groupBy('radius')).toBeInstanceOf(ShapeGroups);
+  });
+});
+
+describe('lineage preservation', () => {
+  // The load-bearing guarantee: the algebra reorders references, it never
+  // rebuilds descriptors. If it ever started cloning, `@kc[...]` refs and OCCT
+  // handles could drift out from under a downstream fillet.
+  const entities = [entity('top', [0, 0, 10], 50), entity('bottom', [0, 0, 0], 50), entity('side', [5, 0, 5], 20)];
+
+  it('sortBy returns the SAME object references, not copies', () => {
+    const sorted = select(entities).sortBy('Z');
+    expect(sorted.first).toBe(entities[1]); // bottom
+    expect(sorted.last).toBe(entities[0]); // top
+    for (const e of sorted) expect(entities).toContain(e);
+  });
+
+  it('@kc[...] refs and OCCT handles survive sort, group, and filter', () => {
+    const list = select(entities);
+    const refsBefore = entities.map((e) => e.ref).sort();
+    const handlesBefore = entities.map((e) => e.handle).sort();
+
+    const roundTripped = list.sortBy('Z', { descending: true }).groupBy('area').flat().filterBy(() => true);
+
+    expect([...roundTripped].map((e) => e.ref).sort()).toEqual(refsBefore);
+    expect([...roundTripped].map((e) => e.handle).sort()).toEqual(handlesBefore);
+    for (const e of roundTripped) {
+      expect(e.ref).toMatch(/^@kc\[body\/face\/.+\]$/);
+    }
+  });
+
+  it('EdgeSegment ids survive and stay bound to their own geometry', () => {
+    const edges = [edge('e7', [0, 0, 9]), edge('e2', [0, 0, 1]), edge('e5', [0, 0, 5])];
+    const sorted = select(edges).sortBy('Z');
+    expect([...sorted].map((e) => e.id)).toEqual(['e2', 'e5', 'e7']);
+    // Ids stayed attached to the right midpoints — not renumbered by position.
+    expect(sorted.map((e) => `${e.id}@${e.midpoint[2]}`).join(',')).toBe('e2@1,e5@5,e7@9');
+  });
+
+  it('the source array is never mutated by any algebra call', () => {
+    const source = [entity('a', [0, 0, 9], 1), entity('b', [0, 0, 1], 2)];
+    const snapshot = [...source];
+    const list = select(source);
+    list.sortBy('Z');
+    list.sortByDistance([0, 0, 0]);
+    list.groupBy('area');
+    list.filterBy(() => false);
+    list.filterByPosition('Z', 0, 1);
+    expect(source).toEqual(snapshot);
+    expect(source[0].ref).toBe('@kc[body/face/a]');
+  });
+});
+
+describe('exported helpers', () => {
+  it('quantizeMetric snaps onto the lattice and kills -0', () => {
+    expect(quantizeMetric(5.0000000001)).toBe(5);
+    expect(quantizeMetric(5.004, 0.01)).toBe(5);
+    expect(quantizeMetric(4.998, 0.01)).toBe(5);
+    expect(Object.is(quantizeMetric(-1e-15), 0)).toBe(true);
+    expect(() => quantizeMetric(NaN)).toThrow(/non-finite metric/);
+  });
+
+  it('metricOf / positionOf resolve fields across all three descriptor shapes', () => {
+    expect(positionOf(edge('e', [1, 2, 3]))).toEqual([1, 2, 3]);
+    expect(positionOf(face('f', [4, 5, 6], 1))).toEqual([4, 5, 6]);
+    expect(positionOf(entity('g', [7, 8, 9], 1))).toEqual([7, 8, 9]);
+    expect(metricOf(entity('g', [7, 8, 9], 42), 'area')).toBe(42);
+    expect(metricOf(face('f', [4, 5, 6], 11), 'area')).toBe(11);
+    expect(metricOf(edge('e', [1, 2, 3], { length: 12 }), 'length')).toBe(12);
+    expect(metricOf(edge('e', [1, 2, 3]), 'Y')).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration with the naming-DSL evaluator.
+//
+// The fixtures above stand in for a `ResolvedEntity`; this block uses the REAL
+// `q.face(...).evaluate(scene)` path so the "stable naming survives the
+// algebra" claim is checked against the actual producer rather than a
+// look-alike. A stub HistoryMap is the same surface the evaluator consumes at
+// lowering time (see queryEvaluator.test.ts for the rationale).
+// ---------------------------------------------------------------------------
+
+describe('naming-DSL integration: @kc[...] refs survive the algebra', () => {
+  function sceneWithSnapshottedFaces(): QueryScene {
+    const map: HistoryMap = new Map();
+    const spec: Array<[string, string, Vec3, number]> = [
+      ['h-top', 'top', [0, 0, 10], 100],
+      ['h-bottom', 'bottom', [0, 0, 0], 100],
+      ['h-front', 'front', [0, -5, 5], 50],
+      ['h-back', 'back', [0, 5, 5], 50],
+    ];
+    for (const [hash, canonicalName, centroid, area] of spec) {
+      map.set(hash, {
+        rootHash: hash,
+        canonicalName,
+        rootFeatureId: 'box-1',
+        featureId: 'box-1',
+        featureName: 'plate',
+        featureKind: 'box',
+        surfaceType: 'PLANE',
+        snapshot: { centroid, normal: [0, 0, 1], area },
+      } as FaceLineage);
+    }
+    return {
+      backend: { historyMap: map, kind: undefined } as unknown as QueryScene['backend'],
+      featureId: 'box-1',
+      records: [{ id: 'box-1' } as never],
+    };
+  }
+
+  it('sorts real evaluator output by Z and keeps every ref resolvable', () => {
+    const resolved = q.face().evaluate(sceneWithSnapshottedFaces());
+    expect(resolved.length).toBe(4);
+
+    const sorted = select(resolved).sortBy('Z');
+    // front and back share z = 5. They tie, so the evaluator's own canonical
+    // (sort-by-ref) order decides — the algebra's stable tiebreak defers to
+    // upstream ordering rather than imposing one of its own.
+    expect([...sorted].map((e) => e.ref)).toEqual([
+      '@kc[plate/face/bottom]',
+      '@kc[plate/face/back]',
+      '@kc[plate/face/front]',
+      '@kc[plate/face/top]',
+    ]);
+    // Same objects the evaluator produced — no descriptor was rebuilt.
+    for (const e of sorted) expect(resolved).toContain(e);
+  });
+
+  it('groups real evaluator output by area and preserves handles', () => {
+    const resolved = q.face().evaluate(sceneWithSnapshottedFaces());
+    const groups = select(resolved).groupBy('area');
+    expect(groups.keys).toEqual([50, 100]);
+    expect([...groups.byKey(100)!].map((e) => e.handle).sort()).toEqual(['h-bottom', 'h-top']);
+    expect([...groups.byKey(50)!].map((e) => e.handle).sort()).toEqual(['h-back', 'h-front']);
+  });
+
+  it('the topmost face by algebra is the entity the query DSL resolves independently', () => {
+    // Cross-check against a path that never touches the algebra: `closestTo`
+    // is resolved inside the evaluator. Both must name the same face.
+    const scene = sceneWithSnapshottedFaces();
+    const topByAlgebra = select(q.face().evaluate(scene)).sortBy('Z').last;
+    const topByQuery = q.face().and(q.closestTo([0, 0, 100])).evaluateUnique(scene);
+    expect(topByAlgebra?.ref).toBe('@kc[plate/face/top]');
+    expect(topByAlgebra?.ref).toBe(topByQuery.ref);
+    expect(topByAlgebra?.handle).toBe(topByQuery.handle);
+  });
+});

--- a/src/modeling/selection/shapeList.ts
+++ b/src/modeling/selection/shapeList.ts
@@ -1,0 +1,544 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/modeling/selection/shapeList.ts
+//
+// Selector algebra — sort / group / filter over topology query results.
+//
+// The flat predicate bags (`EdgeQuery` / `FaceQuery`) answer "which entities
+// match these constraints?". They cannot answer "the highest three faces",
+// "the largest hole", or "one group per Z level". This module supplies the
+// missing half: an immutable, chainable list over ALREADY-RESOLVED query
+// results.
+//
+// Division of labour (deliberate, keep it this way):
+//   - The kernel resolves. `selectEdges(shape, query)` / `q.face(...).evaluate(scene)`
+//     touch OCCT and produce descriptors.
+//   - This module is PURE TypeScript over those descriptors. It never lowers a
+//     Shape, never calls OCCT, and never allocates a new descriptor — every
+//     operation reorders or partitions the SAME object references. That is what
+//     keeps `EdgeSegment.id` and the `@kc[...]` ref on a `ResolvedEntity` intact
+//     across a sort or a group: there is nothing to re-derive, so there is
+//     nothing to drift.
+//
+// Structural, not nominal. A ShapeList works on anything carrying the usual
+// geometry fields, so one implementation covers all three descriptor shapes we
+// ship today (`EdgeSegment`, the `FaceSummary` from `list_faces`, and
+// `ResolvedEntity` from the naming-DSL evaluator) plus anything a later slice
+// adds. See `SelectableGeometry` for the fields that are read.
+//
+// Float discipline. CAD metrics arrive with kernel noise: two edges nominally
+// at z = 5 can read 4.999999999998 and 5.000000000002. Both `sortBy` and
+// `groupBy` compare on a QUANTIZED metric (6 decimal digits by default, or an
+// explicit `tolerance` in mm), with the source position as the tiebreak. Sorts
+// are therefore stable under noise instead of merely deterministic, and group
+// keys land in one bucket instead of two adjacent ones.
+
+import { KernelError } from '../../shared/intent/kernelError';
+import type { Vec3 } from '../../shared/intent/types';
+
+/** Digits kept when quantizing a metric. 1e-6 mm is a nanometre at the mm
+ *  scale kernelCAD works in — far below any real geometric distinction, and
+ *  far above OCCT's accumulated float noise. */
+const DEFAULT_METRIC_DIGITS = 6;
+
+/** Default half-angle (degrees) for "is this direction parallel to that axis".
+ *  Matches the `angleTolerance` default on `EdgeQuery`. */
+const DEFAULT_ANGLE_TOLERANCE_DEG = 10;
+
+/** A principal axis name or an explicit direction vector. */
+export type SelectionAxis = 'X' | 'Y' | 'Z' | Vec3;
+
+/** What to sort or group by.
+ *
+ *  An axis (`'X' | 'Y' | 'Z'` or a `Vec3` direction) measures the projection of
+ *  the entity's position onto that direction. The scalar names measure an
+ *  intrinsic property instead. */
+export type SelectionCriterion = SelectionAxis | 'area' | 'length' | 'radius';
+
+/**
+ * The fields a ShapeList reads. Every field is optional — a descriptor only
+ * needs to carry the ones the criteria in play actually use, and asking for a
+ * metric a descriptor cannot supply throws a named error rather than silently
+ * sorting by NaN.
+ *
+ * Position resolves in order: `centroid`, `midpoint`, `position`,
+ * `snapshot.centroid`. Direction resolves: `direction`, `normal`,
+ * `snapshot.normal`. Area resolves: `area`, `snapshot.area`.
+ */
+export interface SelectableGeometry {
+  /** Face centre (FaceSummary). */
+  readonly centroid?: Vec3;
+  /** Edge midpoint (EdgeSegment). */
+  readonly midpoint?: Vec3;
+  /** Generic position, for descriptors that use neither name. */
+  readonly position?: Vec3;
+  /** Edge direction (EdgeSegment). */
+  readonly direction?: Vec3;
+  /** Face normal (FaceSummary). */
+  readonly normal?: Vec3 | null;
+  readonly length?: number;
+  readonly area?: number;
+  /** Present on circular edges only — see `toEdgeSegment`. */
+  readonly radius?: number;
+  /** EdgeSegment. */
+  readonly curveType?: string;
+  /** FaceSummary. */
+  readonly surfaceType?: string;
+  /** replicad-style descriptors. */
+  readonly geomType?: string;
+  /** ResolvedEntity from the naming DSL. */
+  readonly snapshot?: {
+    readonly centroid?: Vec3;
+    readonly normal?: Vec3;
+    readonly area?: number;
+  };
+}
+
+export interface SortOptions {
+  /** Sort high-to-low instead of low-to-high. */
+  descending?: boolean;
+  /** Bucket width (mm, mm², or mm depending on criterion) used to quantize the
+   *  sort metric so kernel noise cannot flip the order. Defaults to 1e-6. */
+  tolerance?: number;
+}
+
+export interface GroupOptions {
+  /** Bucket width for the group key. Defaults to 1e-6 (six decimal digits).
+   *  Raise it to fold near-coincident geometry into one group — e.g.
+   *  `{ tolerance: 0.01 }` groups faces within 10 µm onto the same level. */
+  tolerance?: number;
+  /** Group high-to-low instead of low-to-high. */
+  descending?: boolean;
+}
+
+export interface FilterByPositionOptions {
+  /** Keep entities exactly on the bounds. Default true. */
+  inclusive?: boolean;
+}
+
+export interface FilterByAxisOptions {
+  /** Half-angle (degrees) within which a direction counts as parallel to the
+   *  axis. Default 10, matching `EdgeQuery.angleTolerance`. */
+  angleTolerance?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Numeric helpers.
+// ---------------------------------------------------------------------------
+
+function roundToDigits(value: number, digits: number): number {
+  const factor = 10 ** digits;
+  const rounded = Math.round(value * factor) / factor;
+  // `Object.is(-0, 0)` is false and `-0` stringifies as "0", which would make a
+  // group key that compares unequal to the key an agent would naturally write.
+  return rounded === 0 ? 0 : rounded;
+}
+
+/** Snap `value` onto a tolerance-wide lattice, then trim residual float dust.
+ *  This is the single quantizer behind both sort ordering and group keys, so a
+ *  sort and a group over the same criterion always agree about which entities
+ *  are "at the same place". */
+export function quantizeMetric(value: number, tolerance?: number): number {
+  if (!Number.isFinite(value)) {
+    throw new KernelError(
+      'feature.invalid-args',
+      `ShapeList: cannot order or group by a non-finite metric (got ${String(value)}).`,
+      undefined,
+      'invalid-args.shape-list.non-finite-metric — the descriptor produced NaN or Infinity for this criterion. Check that the query results carry the field the criterion reads.',
+    );
+  }
+  if (tolerance === undefined) return roundToDigits(value, DEFAULT_METRIC_DIGITS);
+  if (!Number.isFinite(tolerance) || tolerance <= 0) {
+    throw new KernelError(
+      'feature.invalid-args',
+      `ShapeList: tolerance must be a positive finite number; got ${String(tolerance)}.`,
+      undefined,
+      'invalid-args.shape-list.bad-tolerance — pass a positive bucket width in mm, or omit tolerance for the 1e-6 default.',
+    );
+  }
+  return roundToDigits(Math.round(value / tolerance) * tolerance, DEFAULT_METRIC_DIGITS);
+}
+
+function axisVector(axis: SelectionAxis): Vec3 {
+  if (axis === 'X') return [1, 0, 0];
+  if (axis === 'Y') return [0, 1, 0];
+  if (axis === 'Z') return [0, 0, 1];
+  if (!Array.isArray(axis) || axis.length !== 3 || !axis.every((n) => Number.isFinite(n))) {
+    throw new KernelError(
+      'feature.invalid-args',
+      `ShapeList: axis must be 'X' | 'Y' | 'Z' or a finite [x, y, z] direction; got ${JSON.stringify(axis)}.`,
+      undefined,
+      "invalid-args.shape-list.bad-axis — use 'X' / 'Y' / 'Z' for principal axes, or a Vec3 for an arbitrary direction.",
+    );
+  }
+  const len = Math.hypot(axis[0], axis[1], axis[2]);
+  if (len < 1e-12) {
+    throw new KernelError(
+      'feature.invalid-args',
+      'ShapeList: axis direction has zero length.',
+      undefined,
+      'invalid-args.shape-list.bad-axis — a direction axis must be non-degenerate.',
+    );
+  }
+  return [axis[0] / len, axis[1] / len, axis[2] / len];
+}
+
+function isAxisName(v: unknown): v is 'X' | 'Y' | 'Z' {
+  return v === 'X' || v === 'Y' || v === 'Z';
+}
+
+function dot(a: Vec3, b: Vec3): number {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+// ---------------------------------------------------------------------------
+// Descriptor field readers.
+// ---------------------------------------------------------------------------
+
+function missingField(item: unknown, what: string, fields: string): KernelError {
+  return new KernelError(
+    'feature.invalid-args',
+    `ShapeList: entity carries no ${what}. Looked for ${fields}. Entity: ${JSON.stringify(item)?.slice(0, 200)}`,
+    undefined,
+    `invalid-args.shape-list.missing-metric — this criterion needs ${fields} on the query result. Edge descriptors carry midpoint/direction/length (and radius on circles); face descriptors carry centroid/normal/area.`,
+  );
+}
+
+/** World position of the entity. */
+export function positionOf(item: SelectableGeometry): Vec3 {
+  const p = item.centroid ?? item.midpoint ?? item.position ?? item.snapshot?.centroid;
+  if (!p) throw missingField(item, 'position', 'centroid / midpoint / position / snapshot.centroid');
+  return p;
+}
+
+/** Characteristic direction: an edge's tangent, or a face's normal. */
+export function directionOf(item: SelectableGeometry): Vec3 {
+  const d = item.direction ?? item.normal ?? item.snapshot?.normal;
+  if (!d) throw missingField(item, 'direction', 'direction / normal / snapshot.normal');
+  return d;
+}
+
+/** Geometry-type token, whatever the descriptor calls it. */
+export function geomTypeOf(item: SelectableGeometry): string | undefined {
+  return item.curveType ?? item.surfaceType ?? item.geomType;
+}
+
+/** Scalar value of `criterion` for one entity. */
+export function metricOf(item: SelectableGeometry, criterion: SelectionCriterion): number {
+  if (criterion === 'area') {
+    const a = item.area ?? item.snapshot?.area;
+    if (a === undefined) throw missingField(item, 'area', 'area / snapshot.area');
+    return a;
+  }
+  if (criterion === 'length') {
+    if (item.length === undefined) throw missingField(item, 'length', 'length');
+    return item.length;
+  }
+  if (criterion === 'radius') {
+    if (item.radius === undefined) {
+      throw missingField(item, 'radius', 'radius (populated on CIRCLE edges only)');
+    }
+    return item.radius;
+  }
+  return dot(positionOf(item), axisVector(criterion));
+}
+
+// ---------------------------------------------------------------------------
+// ShapeList.
+// ---------------------------------------------------------------------------
+
+/**
+ * An immutable, chainable list of topology query results.
+ *
+ * `ShapeList` extends `Array`, so it IS the array a caller already expects —
+ * `.length`, indexing, spread, `for..of`, and every built-in array method keep
+ * working, and a `ShapeList<EdgeSegment>` still satisfies `EdgeSegment[]`
+ * wherever `fillet` / `chamfer` accept one. The selector algebra is additive.
+ *
+ * Every algebra method returns a NEW list; nothing mutates in place and no
+ * descriptor is copied, so the ordering changes while entity identity —
+ * `EdgeSegment.id`, the `@kc[...]` ref and OCCT handle on a `ResolvedEntity` —
+ * is carried through untouched.
+ *
+ * ```ts
+ * const edges = await selectEdges(body, { convex: true });
+ * const topRim = edges.filterBy('CIRCLE').sortBy('Z').last;
+ * const levels = edges.groupBy('Z', { tolerance: 0.01 });
+ * const biggest = levels.at(levels.length - 1)?.sortBy('radius').last;
+ * ```
+ */
+export class ShapeList<T> extends Array<T> {
+  /**
+   * Prefer the `select(items)` factory. The constructor also
+   * accepts a bare length because the built-in array methods this class
+   * inherits (`map`, `filter`, `slice`, …) allocate the result via
+   * `new ShapeList(length)`; honoring that keeps those methods returning a
+   * ShapeList instead of blowing up or degrading to a plain Array.
+   */
+  constructor(items?: readonly T[] | number) {
+    super();
+    if (typeof items === 'number') {
+      this.length = items;
+      return;
+    }
+    if (items) for (const item of items) this.push(item);
+  }
+
+  // -- terminal accessors ---------------------------------------------------
+
+  /** First entity, or `undefined` when the list is empty. */
+  get first(): T | undefined {
+    return this[0];
+  }
+
+  /** Last entity, or `undefined` when the list is empty. */
+  get last(): T | undefined {
+    return this[this.length - 1];
+  }
+
+  /** First `n` entities (clamped to the list length). `n` must be >= 0. */
+  take(n: number): ShapeList<T> {
+    if (!Number.isInteger(n) || n < 0) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `ShapeList.take: n must be a non-negative integer; got ${String(n)}.`,
+        undefined,
+        'invalid-args.shape-list.bad-take — pass a count >= 0.',
+      );
+    }
+    return new ShapeList<T>(this.slice(0, n));
+  }
+
+  // -- algebra --------------------------------------------------------------
+
+  /**
+   * Order by `criterion`, ascending by default.
+   *
+   * Comparison runs on the metric quantized to `opts.tolerance` (default
+   * 1e-6), with the pre-sort position as the tiebreak. Entities whose metrics
+   * differ only by kernel noise therefore keep their incoming relative order
+   * instead of swapping between runs.
+   */
+  sortBy(criterion: SelectionCriterion, opts: SortOptions = {}): ShapeList<T> {
+    const keyed = this.map((item, index) => ({
+      item,
+      index,
+      key: quantizeMetric(metricOf(item as unknown as SelectableGeometry, criterion), opts.tolerance),
+    }));
+    const dir = opts.descending ? -1 : 1;
+    keyed.sort((a, b) => (a.key === b.key ? a.index - b.index : (a.key < b.key ? -1 : 1) * dir));
+    return new ShapeList<T>(keyed.map((k) => k.item));
+  }
+
+  /**
+   * Order by distance to `point`, nearest first.
+   *
+   * Same quantization + stable-tiebreak contract as `sortBy`.
+   */
+  sortByDistance(point: Vec3, opts: SortOptions = {}): ShapeList<T> {
+    if (!Array.isArray(point) || point.length !== 3 || !point.every((n) => Number.isFinite(n))) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `ShapeList.sortByDistance: point must be a finite [x, y, z]; got ${JSON.stringify(point)}.`,
+        undefined,
+        'invalid-args.shape-list.bad-point — pass a Vec3 in the current world frame.',
+      );
+    }
+    const keyed = this.map((item, index) => {
+      const p = positionOf(item as unknown as SelectableGeometry);
+      return {
+        item,
+        index,
+        key: quantizeMetric(Math.hypot(p[0] - point[0], p[1] - point[1], p[2] - point[2]), opts.tolerance),
+      };
+    });
+    const dir = opts.descending ? -1 : 1;
+    keyed.sort((a, b) => (a.key === b.key ? a.index - b.index : (a.key < b.key ? -1 : 1) * dir));
+    return new ShapeList<T>(keyed.map((k) => k.item));
+  }
+
+  /**
+   * Partition into groups sharing a quantized `criterion` value.
+   *
+   * Groups come back ordered by key (ascending unless `opts.descending`), and
+   * entities keep their incoming order within a group. Look a group up by
+   * ordinal with `.at(i)` or by value with `.byKey(v)` — `byKey` quantizes the
+   * request the same way, so `byKey(5)` finds the bucket built from
+   * 4.999999999998.
+   */
+  groupBy(criterion: SelectionCriterion, opts: GroupOptions = {}): ShapeGroups<T> {
+    const buckets = new Map<number, T[]>();
+    for (const item of this) {
+      const key = quantizeMetric(metricOf(item as unknown as SelectableGeometry, criterion), opts.tolerance);
+      const bucket = buckets.get(key);
+      if (bucket) bucket.push(item);
+      else buckets.set(key, [item]);
+    }
+    const dir = opts.descending ? -1 : 1;
+    const groups = [...buckets.entries()]
+      .sort((a, b) => (a[0] - b[0]) * dir)
+      .map((entry) => ({ key: entry[0], items: new ShapeList<T>(entry[1]) }));
+    return new ShapeGroups<T>(groups, opts.tolerance);
+  }
+
+  /**
+   * Keep entities matching `spec`.
+   *
+   * Three forms, picked by the argument's shape:
+   *  - a predicate `(item) => boolean` — arbitrary user logic;
+   *  - `'X' | 'Y' | 'Z'` or a `Vec3` — keep entities whose characteristic
+   *    direction is parallel to that axis (an edge's tangent, a face's
+   *    normal), within `opts.angleTolerance` degrees;
+   *  - any other string — keep entities whose geometry type matches, e.g.
+   *    `'CIRCLE'` / `'LINE'` for edges, `'PLANE'` / `'CYLINDRE'` for faces
+   *    (case-insensitive).
+   *
+   * This composes with, rather than replaces, `EdgeQuery` / `FaceQuery`: run
+   * the declarative query against the shape first (the kernel does that
+   * filtering inside OCCT), then refine the resolved list here.
+   */
+  filterBy(
+    spec: ((item: T) => boolean) | SelectionAxis | string,
+    opts: FilterByAxisOptions = {},
+  ): ShapeList<T> {
+    if (typeof spec === 'function') {
+      return new ShapeList<T>(this.filter((item) => spec(item)));
+    }
+    if (isAxisName(spec) || Array.isArray(spec)) {
+      const axis = axisVector(spec as SelectionAxis);
+      const tolDeg = opts.angleTolerance ?? DEFAULT_ANGLE_TOLERANCE_DEG;
+      const minCos = Math.cos((tolDeg * Math.PI) / 180);
+      return new ShapeList<T>(
+        this.filter((item) => {
+          const d = directionOf(item as unknown as SelectableGeometry);
+          const len = Math.hypot(d[0], d[1], d[2]);
+          if (len < 1e-12) return false;
+          return Math.abs(dot(d, axis)) / len >= minCos;
+        }),
+      );
+    }
+    if (typeof spec === 'string') {
+      const wanted = spec.toUpperCase();
+      return new ShapeList<T>(
+        this.filter((item) => geomTypeOf(item as unknown as SelectableGeometry)?.toUpperCase() === wanted),
+      );
+    }
+    throw new KernelError(
+      'feature.invalid-args',
+      `ShapeList.filterBy: expected a predicate, an axis, or a geometry-type string; got ${JSON.stringify(spec)}.`,
+      undefined,
+      "invalid-args.shape-list.bad-filter — pass (item) => boolean, 'X' | 'Y' | 'Z' | Vec3, or a type token such as 'CIRCLE'.",
+    );
+  }
+
+  /**
+   * Keep entities whose position projected onto `axis` falls in `[min, max]`.
+   *
+   * Bounds are inclusive by default; pass `{ inclusive: false }` for a strict
+   * interval. `min` and `max` may be supplied in either order.
+   */
+  filterByPosition(
+    axis: SelectionAxis,
+    min: number,
+    max: number,
+    opts: FilterByPositionOptions = {},
+  ): ShapeList<T> {
+    if (!Number.isFinite(min) || !Number.isFinite(max)) {
+      throw new KernelError(
+        'feature.invalid-args',
+        `ShapeList.filterByPosition: min and max must be finite; got ${String(min)}, ${String(max)}.`,
+        undefined,
+        'invalid-args.shape-list.bad-bounds — pass finite numeric bounds in mm.',
+      );
+    }
+    const lo = Math.min(min, max);
+    const hi = Math.max(min, max);
+    const dirVec = axisVector(axis);
+    const inclusive = opts.inclusive ?? true;
+    return new ShapeList<T>(
+      this.filter((item) => {
+        const v = dot(positionOf(item as unknown as SelectableGeometry), dirVec);
+        return inclusive ? v >= lo && v <= hi : v > lo && v < hi;
+      }),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ShapeGroups.
+// ---------------------------------------------------------------------------
+
+/** One group produced by `ShapeList.groupBy`. */
+export interface ShapeGroup<T> {
+  /** The quantized criterion value shared by every entity in the group. */
+  readonly key: number;
+  readonly items: ShapeList<T>;
+}
+
+/**
+ * The result of `ShapeList.groupBy` — key-ordered groups, reachable by ordinal
+ * (`at`) or by value (`byKey`). Iterable, so `for (const g of groups)` yields
+ * `{ key, items }` records.
+ */
+export class ShapeGroups<T> implements Iterable<ShapeGroup<T>> {
+  readonly groups: ReadonlyArray<ShapeGroup<T>>;
+  private readonly tolerance: number | undefined;
+  private readonly index: Map<number, ShapeList<T>>;
+
+  constructor(groups: ReadonlyArray<ShapeGroup<T>>, tolerance?: number) {
+    this.groups = groups;
+    this.tolerance = tolerance;
+    this.index = new Map(groups.map((g) => [g.key, g.items]));
+  }
+
+  /** Number of groups. */
+  get length(): number {
+    return this.groups.length;
+  }
+
+  /** Group keys in group order. */
+  get keys(): readonly number[] {
+    return this.groups.map((g) => g.key);
+  }
+
+  /** Group at ordinal `i` (negative indexes count from the end), or
+   *  `undefined` when out of range. */
+  at(i: number): ShapeList<T> | undefined {
+    const n = i < 0 ? this.groups.length + i : i;
+    return this.groups[n]?.items;
+  }
+
+  /** Group whose key equals `key` after the same quantization `groupBy` used,
+   *  or `undefined` when no such group exists. Ask for the nominal value
+   *  (`byKey(5)`); the noise is handled for you. */
+  byKey(key: number): ShapeList<T> | undefined {
+    return this.index.get(quantizeMetric(key, this.tolerance));
+  }
+
+  /** All entities, flattened back into one list in group order. */
+  flat(): ShapeList<T> {
+    return new ShapeList<T>(this.groups.flatMap((g) => [...g.items]));
+  }
+
+  [Symbol.iterator](): Iterator<ShapeGroup<T>> {
+    return this.groups[Symbol.iterator]();
+  }
+}
+
+/**
+ * Wrap any array of topology query results in a `ShapeList` so the selector
+ * algebra applies. `selectEdges` already returns one; use `select` for face
+ * summaries, for `Query.evaluate(scene)` results, or for a list an agent has
+ * assembled by hand.
+ */
+export function select<T>(items: Iterable<T>): ShapeList<T> {
+  if (items === null || items === undefined || typeof (items as Iterable<T>)[Symbol.iterator] !== 'function') {
+    throw new KernelError(
+      'feature.invalid-args',
+      `select: expected an iterable of query results; got ${JSON.stringify(items)}.`,
+      undefined,
+      'invalid-args.shape-list.not-iterable — pass the array returned by selectEdges / list_faces / Query.evaluate.',
+    );
+  }
+  return new ShapeList<T>([...items]);
+}

--- a/src/shared/intent/queryTypes.ts
+++ b/src/shared/intent/queryTypes.ts
@@ -58,6 +58,15 @@ export type EdgeSegment = {
   direction: Vec3;
   length: number;
   curveType: string;
+  /**
+   * Circumradius in mm, present ONLY when `curveType === 'CIRCLE'` (full
+   * circles and arcs alike). Derived from three points sampled on the edge,
+   * so it is exact for circular geometry and deliberately absent for every
+   * other curve type rather than approximated. Consumed by the selector
+   * algebra (`ShapeList.sortBy('radius')` / `groupBy('radius')`) to rank
+   * bore lips, fillet rims, and hole mouths by size.
+   */
+  radius?: number;
   convex: boolean | null;
   dihedralAngleDeg: number | null;
   normalA: Vec3 | null;

--- a/tests/fixtures/mcp/toolRegistry.publicContract.json
+++ b/tests/fixtures/mcp/toolRegistry.publicContract.json
@@ -189,7 +189,7 @@
   },
   {
     "name": "inspect",
-    "description": "Use this when you need to read facts about a model. One reader, selected by `of`:\n- 'assembly' — physical assembly inventory (parts, bboxes, connectors, mates, disconnected solids).\n- 'robot' — URDF/SDFormat export preview (links, joints, planning groups, end-effectors, issues).\n- 'step' — inspect an imported STEP file.\n- 'shape' — volume / surfaceArea / bbox for one feature ({ feature_id? }).\n- 'mass' — mass, centre of mass, and centroidal inertia tensor ({ feature_id?, density? }); density in kg/m^3, defaults to 1000 (water).\n- 'features' — features captured by the script (kind, id, params, transforms, suppression).\n- 'assemblies' — assembly intent (assemblies, parts, connectors, joints).\n- 'topology' — canonical face names + edge count for a feature ({ feature_id? }).\n- 'edges' — edges of a shape with optional EdgeQuery ({ feature_id?, query? }); returns @kc[...] refs.\n- 'face-edges' — boundary edges of a named canonical face ({ feature_id?, face_name }).\n- 'faces' — faces of a shape with optional FaceQuery ({ feature_id?, query? }); returns @kc[...] refs.\n- 'face-labels' — user-applied labels visible in the script.\n- 'mates' — mates captured by the script.\n- 'constraints' — sketch constraints captured by the script.\n- 'part-stats' — bundled parts-catalog statistics.\n- 'bend-table' — sheet-metal bend table for a flattened pattern.\n- 'params' — declared model parameters.\n- 'part-categories' — top-level part-catalog categories available in the bundled (and configured remote) catalog.\n- 'part-families' — part families within a category ({ category? }); count + exemplar ids per family.\nAll params except `of` are subject-specific and forwarded verbatim. Most subjects accept { file | code }.",
+    "description": "Use this when you need to read facts about a model. One reader, selected by `of`:\n- 'assembly' — physical assembly inventory (parts, bboxes, connectors, mates, disconnected solids).\n- 'robot' — URDF/SDFormat export preview (links, joints, planning groups, end-effectors, issues).\n- 'step' — inspect an imported STEP file.\n- 'shape' — volume / surfaceArea / bbox for one feature ({ feature_id? }).\n- 'mass' — mass, centre of mass, centroidal inertia tensor (inertia6 + 3x3 inertiaMatrix), principalMoments/principalAxes, symmetry flags, and optionally the radius of gyration about an arbitrary axis ({ feature_id?, density?, gyration_axis? }); density in kg/m^3, defaults to 1000 (water).\n- 'features' — features captured by the script (kind, id, params, transforms, suppression).\n- 'assemblies' — assembly intent (assemblies, parts, connectors, joints).\n- 'topology' — canonical face names + edge count for a feature ({ feature_id? }).\n- 'edges' — edges of a shape with optional EdgeQuery ({ feature_id?, query? }); returns @kc[...] refs.\n- 'face-edges' — boundary edges of a named canonical face ({ feature_id?, face_name }).\n- 'faces' — faces of a shape with optional FaceQuery ({ feature_id?, query? }); returns @kc[...] refs.\n- 'face-labels' — user-applied labels visible in the script.\n- 'mates' — mates captured by the script.\n- 'constraints' — sketch constraints captured by the script.\n- 'part-stats' — bundled parts-catalog statistics.\n- 'bend-table' — sheet-metal bend table for a flattened pattern.\n- 'params' — declared model parameters.\n- 'part-categories' — top-level part-catalog categories available in the bundled (and configured remote) catalog.\n- 'part-families' — part families within a category ({ category? }); count + exemplar ids per family.\nAll params except `of` are subject-specific and forwarded verbatim. Most subjects accept { file | code }.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -237,6 +237,34 @@
         "density": {
           "type": "number",
           "description": "of:'mass' — material density in kg/m^3 (steel 7850, aluminium 2700, ABS 1050). Defaults to 1000 (water); the response echoes the value used and flags when it was defaulted."
+        },
+        "gyration_axis": {
+          "type": "object",
+          "description": "of:'mass' — optional axis in shape-local mm to report the radius of gyration about. Omit for centroidal quantities only; the result is density-independent and returned in mm.",
+          "properties": {
+            "origin": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 3,
+              "maxItems": 3,
+              "description": "A point on the axis, shape-local mm."
+            },
+            "direction": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 3,
+              "maxItems": 3,
+              "description": "Axis direction; normalised internally, so it need not be a unit vector."
+            }
+          },
+          "required": [
+            "origin",
+            "direction"
+          ]
         },
         "face_name": {
           "type": "string",
@@ -2241,6 +2269,13 @@
           }
         },
         "shapeMethods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "shapeListMethods": {
           "type": "array",
           "items": {
             "type": "object",

--- a/tests/integration/mcp/listApi.driftSentinel.test.ts
+++ b/tests/integration/mcp/listApi.driftSentinel.test.ts
@@ -16,6 +16,7 @@ import { Scene } from '../../../src/modeling/validation/scene';
 import { SurfaceProxy } from '../../../src/modeling/capture/surfaceProxy';
 import { Curve3DProxy } from '../../../src/modeling/capture/curveProxy';
 import { Curve3DAnalyticsImpl } from '../../../src/modeling/capture/curveAnalyticsProxy';
+import { ShapeList } from '../../../src/modeling/selection/shapeList';
 
 describe('list_api drift sentinels', () => {
   it('GLOBALS matches the keys returned by createApi(ctx)', async () => {
@@ -39,6 +40,30 @@ describe('list_api drift sentinels', () => {
 
     for (const name of shapeMethodNames) {
       expect(advertised.has(name)).toBe(true);
+    }
+  });
+
+  it('SHAPE_LIST_METHODS lists every public ShapeList selector-algebra member', async () => {
+    const r = await listApiTool({});
+    const advertised = new Set(r.shapeListMethods!.map((m) => m.name));
+
+    // ShapeList extends Array; only its OWN prototype members are the selector
+    // algebra. Inherited array methods are standard JS and not re-advertised,
+    // except `at`, which is documented because it is a named terminal accessor.
+    const proto = ShapeList.prototype as unknown as Record<string, unknown>;
+    const own = Object.getOwnPropertyNames(proto).filter((n) => n !== 'constructor' && !n.startsWith('_'));
+
+    for (const name of own) {
+      expect(
+        advertised.has(name),
+        `SHAPE_LIST_METHODS missing entry for ShapeList.prototype.${name}`,
+      ).toBe(true);
+    }
+    // And nothing advertised may be absent from the runtime surface.
+    for (const name of advertised) {
+      const onOwn = own.includes(name);
+      const inherited = name in ([] as unknown as Record<string, unknown>);
+      expect(onOwn || inherited, `SHAPE_LIST_METHODS advertises ${name}, which ShapeList does not expose`).toBe(true);
     }
   });
 

--- a/tests/unit/backends/occt/edgeQueries.test.ts
+++ b/tests/unit/backends/occt/edgeQueries.test.ts
@@ -260,3 +260,45 @@ describe('resolveFaceQuery — v0.2-finish polish keys', () => {
     expect(faces).toHaveLength(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// EdgeSegment.radius — the metric backing `ShapeList.sortBy('radius')`.
+// Verified against real OCCT geometry, not a fixture, because the whole point
+// is that the three-point circumradius solve agrees with the kernel.
+// ---------------------------------------------------------------------------
+describe('EdgeSegment.radius', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('reports the exact radius on the circular edges of a cylinder', () => {
+    const cyl = OcctBackend.cylinder(10, 4);
+    const circles = selectEdges(cyl, {}).filter(e => e.curveType === 'CIRCLE');
+    expect(circles.length).toBeGreaterThan(0);
+    for (const c of circles) {
+      expect(c.radius).toBeCloseTo(4, 6);
+    }
+  });
+
+  it('distinguishes two different bore sizes on one solid', () => {
+    const plate = OcctBackend.box(40, 20, 5);
+    const smallBore = OcctBackend.cylinder(20, 2).translate(10, 10, -5);
+    const bigBore = OcctBackend.cylinder(20, 5).translate(30, 10, -5);
+    const drilled = plate.subtract(smallBore).subtract(bigBore);
+
+    const radii = selectEdges(drilled, {})
+      .filter(e => e.curveType === 'CIRCLE')
+      .map(e => e.radius)
+      .filter((r): r is number => r !== undefined)
+      .map(r => Math.round(r * 1e6) / 1e6);
+
+    expect(radii).toContain(2);
+    expect(radii).toContain(5);
+  });
+
+  it('is absent (not approximated) on non-circular edges', () => {
+    const box = OcctBackend.box(10, 10, 5);
+    for (const e of selectEdges(box, {})) {
+      expect(e.curveType).toBe('LINE');
+      expect(e.radius).toBeUndefined();
+    }
+  });
+});

--- a/tests/unit/modeling/properties/massProperties.test.ts
+++ b/tests/unit/modeling/properties/massProperties.test.ts
@@ -53,3 +53,164 @@ describe('OcctBackend.massProperties', () => {
     expect(defaulted.mass).toBeCloseTo(explicit.mass, 9);
   });
 });
+
+// Every check below is against a textbook closed form, not against a
+// previously-recorded output. A binding that type-checks can still return
+// garbage (or throw `BindingError: unbound types`) at runtime, so the numbers
+// are the only real evidence that GPropWrapper is wired correctly.
+describe('OcctBackend.massProperties — inertia tensor vs closed form', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  const DENSITY = 1000;
+  /** Relative closeness, since these values span many orders of magnitude. */
+  const expectRel = (actual: number, expected: number, rel = 1e-6) => {
+    expect(Math.abs(actual - expected)).toBeLessThanOrEqual(Math.abs(expected) * rel);
+  };
+
+  it('matches I = m(b^2+c^2)/12 for an asymmetric solid box', () => {
+    // Deliberately three DIFFERENT side lengths: a cube cannot distinguish a
+    // correct tensor from a transposed / axis-swapped one.
+    const [a, b, c] = [20, 10, 30]; // mm
+    const mp = OcctBackend.box(a, b, c).massProperties(DENSITY);
+
+    const m = DENSITY * (a * b * c) * 1e-9; // kg
+    expect(m).toBeCloseTo(6e-3, 12);
+    const [A, B, C] = [a * 1e-3, b * 1e-3, c * 1e-3]; // m
+
+    const [ixx, ixy, ixz, iyy, iyz, izz] = mp.inertia6;
+    expectRel(ixx, (m * (B * B + C * C)) / 12);
+    expectRel(iyy, (m * (A * A + C * C)) / 12);
+    expectRel(izz, (m * (A * A + B * B)) / 12);
+    // Axis-aligned box about its centroid => products of inertia vanish.
+    for (const p of [ixy, ixz, iyz]) expect(Math.abs(p)).toBeLessThan(1e-18);
+  });
+
+  it('returns a matrix that is exactly symmetric and agrees with inertia6', () => {
+    const mp = OcctBackend.box(20, 10, 30).massProperties(DENSITY);
+    const M = mp.inertiaMatrix;
+    expect(M).toHaveLength(3);
+    for (const row of M) expect(row).toHaveLength(3);
+    // Exact equality, not toBeCloseTo: the implementation symmetrises, and
+    // URDF/MJCF consumers rely on that being exact.
+    expect(M[0][1]).toBe(M[1][0]);
+    expect(M[0][2]).toBe(M[2][0]);
+    expect(M[1][2]).toBe(M[2][1]);
+
+    const [ixx, ixy, ixz, iyy, iyz, izz] = mp.inertia6;
+    expect([M[0][0], M[0][1], M[0][2]]).toEqual([ixx, ixy, ixz]);
+    expect([M[1][1], M[1][2], M[2][2]]).toEqual([iyy, iyz, izz]);
+  });
+
+  it('matches I = 2mr^2/5 about every centroidal axis of a solid sphere', () => {
+    const r = 15; // mm
+    const mp = OcctBackend.sphere(r).massProperties(DENSITY);
+
+    const R = r * 1e-3;
+    const m = DENSITY * (4 / 3) * Math.PI * R ** 3;
+    // A sphere is meshed exactly by OCCT's analytic surface, but tolerate a
+    // loose band anyway — this asserts the physics, not the tessellator.
+    expectRel(mp.mass, m, 1e-4);
+
+    const expected = (2 / 5) * mp.mass * R * R;
+    const [ixx, ixy, ixz, iyy, iyz, izz] = mp.inertia6;
+    for (const d of [ixx, iyy, izz]) expectRel(d, expected, 1e-4);
+    for (const p of [ixy, ixz, iyz]) expect(Math.abs(p)).toBeLessThan(expected * 1e-6);
+    // Degenerate in all three directions => OCCT should flag a symmetry point.
+    expect(mp.hasSymmetryPoint).toBe(true);
+  });
+
+  it('matches mr^2/2 axial and m(3r^2+h^2)/12 transverse for a solid cylinder', () => {
+    const [r, h] = [8, 40]; // mm; OcctBackend.cylinder extrudes along +Z
+    // NOTE: the factory is cylinder(height, radius) — height first.
+    const mp = OcctBackend.cylinder(h, r).massProperties(DENSITY);
+
+    const [R, H] = [r * 1e-3, h * 1e-3];
+    expectRel(mp.mass, DENSITY * Math.PI * R * R * H, 1e-4);
+
+    const axial = (mp.mass * R * R) / 2;
+    const transverse = (mp.mass * (3 * R * R + H * H)) / 12;
+    const [ixx, , , iyy, , izz] = mp.inertia6;
+    expectRel(izz, axial, 1e-4);
+    expectRel(ixx, transverse, 1e-4);
+    expectRel(iyy, transverse, 1e-4);
+    // Rotationally symmetric about Z, but not spherically symmetric.
+    expect(mp.hasSymmetryAxis).toBe(true);
+    expect(mp.hasSymmetryPoint).toBe(false);
+  });
+
+  it('reports principal moments equal to the diagonal for an axis-aligned box', () => {
+    const mp = OcctBackend.box(20, 10, 30).massProperties(DENSITY);
+    const [ixx, , , iyy, , izz] = mp.inertia6;
+
+    // The box's principal frame IS the global frame, so the principal moments
+    // are a permutation of the diagonal. OCCT does not sort them, so compare
+    // as multisets rather than element-wise.
+    const sortNum = (v: readonly number[]) => [...v].sort((x, y) => x - y);
+    const got = sortNum(mp.principalMoments);
+    const want = sortNum([ixx, iyy, izz]);
+    for (let i = 0; i < 3; i++) expectRel(got[i], want[i]);
+
+    // Each principal axis must be a unit vector aligned with a global axis,
+    // and must pair with the matching diagonal entry at the SAME index.
+    const diag = [ixx, iyy, izz];
+    for (let i = 0; i < 3; i++) {
+      const ax = mp.principalAxes[i];
+      expect(Math.hypot(...ax)).toBeCloseTo(1, 9);
+      const dominant = ax.findIndex(component => Math.abs(component) > 0.5);
+      expect(dominant).toBeGreaterThanOrEqual(0);
+      expectRel(mp.principalMoments[i], diag[dominant]);
+    }
+
+    // Principal axes must form an orthonormal frame.
+    const dot = (u: readonly number[], v: readonly number[]) =>
+      u[0] * v[0] + u[1] * v[1] + u[2] * v[2];
+    expect(Math.abs(dot(mp.principalAxes[0], mp.principalAxes[1]))).toBeLessThan(1e-9);
+    expect(Math.abs(dot(mp.principalAxes[0], mp.principalAxes[2]))).toBeLessThan(1e-9);
+    expect(Math.abs(dot(mp.principalAxes[1], mp.principalAxes[2]))).toBeLessThan(1e-9);
+  });
+
+  it('omits radiusOfGyration unless an axis is requested', () => {
+    expect(OcctBackend.box(20, 10, 30).massProperties(DENSITY).radiusOfGyration)
+      .toBeUndefined();
+  });
+
+  it('computes radius of gyration about an arbitrary axis as sqrt(I/m)', () => {
+    const [a, b, c] = [20, 10, 30];
+    const box = OcctBackend.box(a, b, c);
+    const com: [number, number, number] = [a / 2, b / 2, c / 2];
+
+    // Centroidal Z axis: k_z = sqrt(Izz/m) = sqrt((a^2+b^2)/12), in mm.
+    const kz = box.massProperties(DENSITY, { origin: com, direction: [0, 0, 1] })
+      .radiusOfGyration!;
+    expectRel(kz, Math.sqrt((a * a + b * b) / 12), 1e-9);
+
+    // Radius of gyration is density-independent — both I and m scale with it.
+    const kzSteel = box.massProperties(7850, { origin: com, direction: [0, 0, 1] })
+      .radiusOfGyration!;
+    expectRel(kzSteel, kz, 1e-12);
+
+    // A non-unit direction must be normalised internally, not taken literally.
+    const kzScaled = box.massProperties(DENSITY, { origin: com, direction: [0, 0, 7] })
+      .radiusOfGyration!;
+    expectRel(kzScaled, kz, 1e-12);
+
+    // Parallel-axis check: shifting the axis off the centroid by d in X must
+    // give sqrt(k_z^2 + d^2). This proves OCCT applies the shift and that we
+    // are not silently ignoring `origin`.
+    const d = 25;
+    const kOff = box.massProperties(DENSITY, {
+      origin: [com[0] + d, com[1], com[2]],
+      direction: [0, 0, 1],
+    }).radiusOfGyration!;
+    expectRel(kOff, Math.sqrt(kz * kz + d * d), 1e-9);
+  });
+
+  it('rejects a zero-length gyration axis instead of trapping inside wasm', () => {
+    expect(() =>
+      OcctBackend.box(10, 10, 10).massProperties(1000, {
+        origin: [0, 0, 0],
+        direction: [0, 0, 0],
+      }),
+    ).toThrow(/non-zero vector/);
+  });
+});


### PR DESCRIPTION
Closes two gaps against build123d: selector algebra over query results, and the inertia/gyration half of mass properties.

## Commits
| | |
|---|---|
| `fix(hooks)` | pre-commit used `mapfile` (bash 4); macOS ships bash 3.2, so the hook exited non-zero and **blocked every commit locally** |
| `build(deps)` | bump `replicad-opencascadejs` to `kcad-v0.25.0` (fork PR w1ne/replicad-opencascadejs#1) |
| `feat(selection)` | `ShapeList` — `sortBy` / `groupBy` / `filterBy` / `filterByPosition` / `sortByDistance` / `take`, plus a `select` global |
| `feat(properties)` | centroidal inertia tensor, principal moments/axes, radius of gyration about an arbitrary axis |

## Notes

**`ShapeList extends Array`**, so it *is* the `EdgeSegment[]` that `fillet`/`chamfer` already accept — the `selectEdges` change is additive, not breaking. One criterion type (`'X'|'Y'|'Z'|Vec3|'area'|'length'|'radius'`) instead of parallel `sortByArea`/`groupByRadius` methods.

`sortBy`/`groupBy` quantize the metric to 1e-6 with position as tiebreak, so ordering is stable **under float noise**, not merely deterministic. build123d quantizes only for grouping.

**`inertia6` now reads the real matrix** instead of reconstructing it from six `MomentOfInertia` calls via the `M(n)=nᵀIn` identity — that was a workaround for the unbound `gp_Mat`, obsolete now that `GPropWrapper` ships. One integration instead of six, no reconstruction error.

⚠️ This feeds URDF/SDF/MJCF export. Those tests assert mass and origin but **never inertia** (`mjcfExport.test.ts` only exercises `regularizeInertia6` against hand-written arrays), so these numbers were previously unverified by any test. They are now checked against closed form.

## Verification
Closed-form, exact to ~1e-15 relative — not type-checks, since the failure mode here is a binding that type-checks and throws at runtime:

- box 20×10×30 → `m(b²+c²)/12` etc., products of inertia < 1e-18
- sphere r=15 → `2mr²/5` on all three diagonals
- cylinder r=8 h=40 → `mr²/2` axial, `m(3r²+h²)/12` transverse
- gyration → `√((a²+b²)/12)`, density-independent, parallel-axis holds

Suite: **9 failed / 5396 passed** — the 9 are pre-existing macOS `/private/var` vs `/var` symlink assertions that reproduce on pristine `develop`. Zero regressions. The new `listApi` drift sentinel was verified non-vacuous by breaking it.