### PR TITLE
feat(docs): task-organized cheat sheet, generated and drift-gated

### DIFF
--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -1,0 +1,248 @@
+<!-- GENERATED — do not edit by hand, run `npx tsx scripts/buildCheatSheet.ts` -->
+
+# kernelCAD cheat sheet
+
+The script API grouped by what you are trying to DO. Every row is generated from
+`src/agent/mcp/tools/listApi.ts`; call `lookup_api(query)` for the full description of any entry.
+
+| Task | What it covers |
+|---|---|
+| [Start a shape](#start-a-shape) | The first call of any model: a solid primitive, or a 2D profile you will extrude. |
+| [Add material](#add-material) | Turn a profile into a solid, or grow an existing one along a path. |
+| [Remove material](#remove-material) | Cut into a solid: bolt holes, pockets, slots, and arbitrary subtractions. |
+| [Combine shapes](#combine-shapes) | Merge or intersect solids, or group them without paying for a boolean. |
+| [Finish edges](#finish-edges) | Manufacturing-facing finishing: break edges, add draft, hollow out, fold sheet. |
+| [Select geometry](#select-geometry) | Name the edges or faces a feature should act on — query inside OCCT first, then rank or bucket the resolved list. |
+| [Place & transform](#place--transform) | Move a finished body into position, mirror it, or repeat it. |
+| [Assemble](#assemble) | Compose parts into a mechanism with connectors, mates, joints, and posed Scenes. |
+| [Curves & surfaces](#curves--surfaces) | Free-form work: NURBS curves and surfaces, and the evaluators that let you reason about them before they become solids. |
+| [Measure & verify](#measure--verify) | Ask the kernel what you actually built, and gate the answer before shipping it. |
+| [Parametrize](#parametrize) | Declare editable dimensions and do arithmetic on them (JS operators throw on a ParamRef). |
+| [Import & export](#import--export) | Bring in vendor geometry, and hand a model to the outside world. |
+| [Annotate & present](#annotate--present) | Everything that changes how the model reads rather than what it is: text, color, lighting, camera, motion. |
+
+## Start a shape
+
+The first call of any model: a solid primitive, or a 2D profile you will extrude.
+
+| Call | What it does |
+|---|---|
+| `box(x, y, z, centered?, opts?) => Shape` | Axis-aligned box. |
+| `cylinder(h, r, segments?, opts?) => Shape` | Z-axis cylinder; bottom on the XY plane, height h, radius r. |
+| `sphere(r) => Shape` | Sphere centered at the origin, radius r. |
+| `torus(majorR: number, minorR: number, segments?: number) => Shape` | Solid torus centered on world origin, axis along world +Z. |
+| `spring({ length, coilRadius, wireRadius, turns, axis?, pointsPerTurn?, endStyle?, segments? }) => Shape` | Build a helical spring as a circular wire profile swept along a smooth B-spline helix spine — one continuous watertight solid. |
+| `extrudeRect(w, h, height, opts?) => Shape` | Extrude a w-by-h rectangle (XY) by `height` along Z. |
+| `extrudeCircle(r, height, opts?) => Shape` | Extrude a radius-r circle (XY) by `height` along Z. |
+| `extrudePolygon(points, depth, opts?) => Shape` | Extrude a 2D polygon (array of [x, y] points) by `depth` along Z. |
+| `extrudeRoundedRect(width, height, radius, depth, opts?) => Shape` | Extrude a rounded rectangle (corner radius) by `depth` along Z. |
+| `sheetMetal(profile: Sketch, { thickness, kFactor, faceLabels? }) => Shape` | Build a sheet-metal body from a closed planar Sketch. |
+| `sdf : { sphere(r), box(size), cylinder(r, h), torus(R, r), smoothBlend(a, b, k), materialize(field, opts?), bind(name, field) }` | SDF authoring namespace (W2.3 slice-1). |
+| `path() => PathBuilder` | Start a 2D path: chain moveTo / lineTo / arcs / .close() to get a Sketch. |
+| `PathBuilder.moveTo(x: Editable<number>, y: Editable<number>) => PathBuilder` | Start the path at (x, y). |
+| `PathBuilder.lineTo(x: Editable<number>, y: Editable<number>) => PathBuilder` | Add a straight line segment to (x, y). |
+| `PathBuilder.close() => Sketch` | Close the path; returns a Sketch that can be extruded/revolved/swept. |
+| `PathBuilder.label(name: string) => PathBuilder` | Tag the previous segment so it can be referenced later in fillet/chamfer/shell as `{face: name}`. |
+| `PathBuilder.circle(cx: number, cy: number, r: number, segments?: number) => Sketch` | Closed circle profile centered at (cx, cy) with radius r. |
+| `PathBuilder.tangentArc(x: Editable<number>, y: Editable<number>) => PathBuilder` | Arc continuing tangent from the previous segment to (x, y). |
+| `PathBuilder.threePointsArc(x: Editable<number>, y: Editable<number>, midX: Editable<number>, midY: Editable<number>) => PathBuilder` | Arc through start, midpoint, and end. |
+| `PathBuilder.sagittaArc(x: Editable<number>, y: Editable<number>, sagitta: Editable<number>) => PathBuilder` | Arc by chord + perpendicular bulge height. |
+| `PathBuilder.bulgeArc(x: Editable<number>, y: Editable<number>, bulge: Editable<number>) => PathBuilder` | Arc by chord + DXF bulge factor (tan(angle/4)). |
+| `PathBuilder.radiusArc(x: Editable<number>, y: Editable<number>, radius: Editable<number>) => PathBuilder` | Arc by chord + explicit radius. |
+| `PathBuilder.smoothSpline(x: Editable<number>, y: Editable<number>) => PathBuilder` | C1-smooth spline segment from current position to (x, y); inherits start tangent from prior segment. |
+| `PathBuilder.spline(points: Array<[Editable<number>, Editable<number>]>, opts?: { tension?: Editable<number> }) => PathBuilder` | NURBS Slice D — N-waypoint B-spline interpolation. |
+| `PathBuilder.nurbsSegment(controlPoints: Array<[Editable<number>, Editable<number>]>, opts?: { degree?: number; weights?: number[]; knots?: number[] }) => PathBuilder` | NURBS Slice D — explicit B-spline segment defined by a control polygon. |
+| `hermiteG2(a: { point: Vec3; tangent: Vec3; curvature?: Vec3 }, b: { point: Vec3; tangent: Vec3; curvature?: Vec3 }) => Curve3D` | Quintic Hermite Curve3D that interpolates the two endpoints with matching positions, first derivatives (tangents), and second derivatives (curvatures). |
+| `PathBuilder.hermiteG2(a: HermiteEndpoint2D, b: HermiteEndpoint2D) => PathBuilder` | NURBS Slice D — 2D quintic-Hermite transition between two endpoints, each with prescribed point + first derivative (tangent) + optional second derivative (curvature). |
+
+## Add material
+
+Turn a profile into a solid, or grow an existing one along a path.
+
+| Call | What it does |
+|---|---|
+| `Sketch.extrude(depth) => Shape` | Extrude this closed sketch normal to its plane by `depth` (mm). |
+| `Sketch.revolve() => Shape` | Revolve 360 degrees around the Z axis. |
+| `Sketch.sweep(rail, opts?: { frenet?, transitionMode?, spine? }) => Shape` | Sweep this profile along a 3D rail. |
+| `Sketch.loft(other: Sketch \| Sketch[], opts?: { spacing?, planes?, ruled?, startPoint?, endPoint? }) => Shape` | Loft this profile through one or more additional sections to produce a 3D solid that smoothly interpolates between them. |
+| `variableSweep(spine: Curve3D \| Sketch \| Vec3[], sections: Array<{ t: number; profile: Sketch }>, opts?: { closed?: boolean; continuity?: "C0" \| "C1" \| "C2" }) => Shape` | Multi-section sweep that blends `sections[i].profile` along the spine at the section's `t ∈ [0, 1]` spine parameter. |
+| `helix({ radius, pitch, turns, axis?, pointsPerTurn?, startAngle? }) => [number, number, number][]` | Polyline helix rail for `Sketch.sweep`. |
+
+## Remove material
+
+Cut into a solid: bolt holes, pockets, slots, and arbitrary subtractions.
+
+| Call | What it does |
+|---|---|
+| `Shape.subtract(...others) => Shape` | Boolean difference (this minus others). |
+| `ParamRef.subtract(other: number \| ParamRef<number>) => ParamRef<number>` | Build a ParamRef whose value equals this ParamRef minus `other`. |
+| `Shape.hole(face: FaceSelector \| string, opts: { u, v, diameter, depth?: number \| "through", upToFace?: FaceRef, counterbore?: { diameter, depth }, countersink?: { diameter, angleDeg? } }) => Shape` | Drill a single hole. |
+| `Shape.holes(face: FaceSelector \| string, opts: { positions: Array<{u,v}>, diameter, depth?, upToFace?, counterbore?, countersink? }) => Shape` | Drill N holes in one feature record. |
+| `Shape.cutout(profile: PathBuilder \| Sketch, opts: { face: FaceSelector \| string, depth?: number \| "through", upToFace?: FaceRef, depthMode?: "blind" \| "symmetric" }) => Shape` | Sketch-driven subtractive extrude for irregular shapes hole() can't express (slots, D-shapes, keyhole pockets). |
+
+## Combine shapes
+
+Merge or intersect solids, or group them without paying for a boolean.
+
+| Call | What it does |
+|---|---|
+| `union(...shapes) => Shape` | Boolean union of two or more shapes. |
+| `Shape.union(...others) => Shape` | Boolean union with one or more shapes. |
+| `Shape.intersect(...others) => Shape` | Boolean intersection. |
+| `Curve3D.analytics.intersect(other: Curve3D \| Surface, opts?: { tolerance?: number }) => CurveCurveIntersection[] \| CurveSurfaceIntersection[]` | Geometric intersection of this curve with another `Curve3D` (returns `{ tA, tB, ptA, ptB, distance }` records) or with a `Surface` from `nurbsSurface()` (returns `{ tCurve, uv, pt }` records). |
+| `Scene.toCompound() => Shape` | OCCT TopoDS_Compound — groups bodies without booleaning. |
+| `Scene.toUnion() => Shape` | Explicit boolean fuse of all parts into one Shape. |
+
+## Finish edges
+
+Manufacturing-facing finishing: break edges, add draft, hollow out, fold sheet.
+
+| Call | What it does |
+|---|---|
+| `Shape.fillet(radius, edges?: EdgeSelector, opts?: { continuity?: 'G1' \| 'G2' }) => Shape` | Round edges. |
+| `Shape.chamfer(distance, edges?: EdgeSelector) => Shape` | Bevel edges. |
+| `Shape.draft(angleDeg: Editable<number>, opts: { face: FaceSelector \| string; neutralPlane?: string; pullDir?: [number, number, number] }) => Shape` | Taper the selected face(s) for moldability. |
+| `Shape.shell(thickness, { face: FaceSelector }) => Shape` | Hollow the solid removing the named face. |
+| `Shape.bend(edgeRef: EdgeSelector \| string, angle: Editable<number>, radius: Editable<number>) => Shape` | Add a sheet-metal bend along a linear edge. |
+| `Shape.flattenPattern() => Region` | Return the unfolded 2D flat-pattern of this bent sheet-metal Shape as a Region (closed outer wire + holes + bend-line metadata + source plane). |
+
+## Select geometry
+
+Name the edges or faces a feature should act on — query inside OCCT first, then rank or bucket the resolved list.
+
+| Call | What it does |
+|---|---|
+| `selectEdges(shape, query?) => Promise<ShapeList<EdgeSegment>>` | Pre-select edges by EdgeQuery. |
+| `selectEdge(shape, query) => Promise<EdgeSegment>` | Like selectEdges but throws if zero or multiple edges match. |
+| `select : <T>(items: Iterable<T>) => ShapeList<T>` | Wrap any array of topology query results in a `ShapeList` so the selector algebra applies — face summaries from `inspect({ of: 'faces' })`, `ResolvedEntity[]` from `q.face(...).evaluate(scene)`, or a hand-assembled list. |
+| `q : { face, edge, vertex, connector, part, solid, createdBy, ownedByPart, ownerPart, union, intersection, subtraction, containsPoint, closestTo, geometryType, withLabel, withFeatureName, nthElement, fromString, nothing, everything }` | Query DSL constructor namespace. |
+| `ShapeList.sortBy(criterion: 'X' \| 'Y' \| 'Z' \| Vec3 \| 'area' \| 'length' \| 'radius', opts?: { descending?: boolean; tolerance?: number }) => ShapeList<T>` | Order the list by a criterion, ascending by default. |
+| `ShapeList.sortByDistance(point: Vec3, opts?: { descending?: boolean; tolerance?: number }) => ShapeList<T>` | Order by straight-line distance from each entity position to `point`, nearest first. |
+| `ShapeList.groupBy(criterion: 'X' \| 'Y' \| 'Z' \| Vec3 \| 'area' \| 'length' \| 'radius', opts?: { tolerance?: number; descending?: boolean }) => ShapeGroups<T>` | Partition into groups sharing a quantized criterion value — one group per Z level, per hole diameter, per face area. |
+| `ShapeList.filterBy(spec: ((item: T) => boolean) \| Axis \| string, opts?: { angleTolerance?: number }) => ShapeList<T>` | Keep matching entities. |
+| `ShapeList.filterByPosition(axis: 'X' \| 'Y' \| 'Z' \| Vec3, min: number, max: number, opts?: { inclusive?: boolean }) => ShapeList<T>` | Keep entities whose position projected onto `axis` falls within [min, max] (mm). |
+| `ShapeList.take(n: number) => ShapeList<T>` | First `n` entities, clamped to the list length. |
+| `ShapeList.first : T \| undefined` | Getter — the first entity, or `undefined` when the list is empty. |
+| `ShapeList.last : T \| undefined` | Getter — the last entity, or `undefined` when the list is empty. |
+| `ShapeList.at(i: number) => T \| undefined` | Entity at index `i`; negative indexes count from the end. |
+
+## Place & transform
+
+Move a finished body into position, mirror it, or repeat it.
+
+| Call | What it does |
+|---|---|
+| `Shape.translate(x: Editable<number>, y: Editable<number>, z: Editable<number>) => Shape` | Translate by (x, y, z). |
+| `Shape.rotate(axis: [Editable<number>, Editable<number>, Editable<number>], degrees: Editable<number>, pivot?: [Editable<number>, Editable<number>, Editable<number>]) => Shape` | Rotate `degrees` around `axis` (vector); pivot defaults to origin. |
+| `Shape.rotateX(degrees: Editable<number>, pivot?: [Editable<number>, Editable<number>, Editable<number>]) => Shape` | Rotate `degrees` around the world X axis. |
+| `Shape.rotateY(degrees: Editable<number>, pivot?: [Editable<number>, Editable<number>, Editable<number>]) => Shape` | Rotate `degrees` around the world Y axis. |
+| `Shape.rotateZ(degrees: Editable<number>, pivot?: [Editable<number>, Editable<number>, Editable<number>]) => Shape` | Rotate `degrees` around the world Z axis. |
+| `Shape.transform(t: Transform) => Shape` | Apply an SE(3) Transform. |
+| `Shape.alongAxis(axis: [number, number, number]) => Shape` | Orient this shape so its current +Z axis aligns with the given direction. |
+| `Shape.scale(factor: number \| [number, number, number]) => Shape` | Scale this shape uniformly (single positive finite number) or per-axis (Vec3 — sx/sy/sz). |
+| `Shape.reflect(plane: 'xy' \| 'xz' \| 'yz' \| { plane: 'xy' \| 'xz' \| 'yz'; offset: number }) => Shape` | Reflect (pure rigid-body transformation) across a cardinal plane or an offset parallel plane. |
+| `Sketch.reflect(axis: 'x' \| 'y' \| { axis: 'x' \| 'y'; offset: number }) => Sketch` | Reflect this sketch's path across an axis, returning a new Sketch. |
+| `Shape.mirror(plane: 'xy' \| 'xz' \| 'yz' \| { plane: 'xy' \| 'xz' \| 'yz'; offset: number }) => Shape` | Boolean union of the source and its reflection across a cardinal plane. |
+| `Shape.patternLinear({ count, direction, spacing }) => Shape` | Repeat this shape in a linear array. |
+| `Shape.patternGrid({ x: { count, direction, spacing }, y: { count, direction, spacing } }) => Shape` | Repeat this shape in a two-axis grid. |
+| `Shape.patternCircular({ count, axis, angleDeg? }) => Shape` | Repeat this shape around an axis. |
+| `Shape.recenter(opts?: { x?: boolean; y?: boolean; z?: boolean }) => Promise<Shape>` | Translate this Shape so its bounding-box center lands on the world origin, then return it for chaining. |
+| `Shape.seatOnFloor(opts?: { center?: boolean }) => Promise<Shape>` | Translate this Shape so it rests on the z = 0 floor (bbox min.z → 0), centered in x/y over the origin; returns it for chaining. |
+
+## Assemble
+
+Compose parts into a mechanism with connectors, mates, joints, and posed Scenes.
+
+| Call | What it does |
+|---|---|
+| `assembly(name?) => Assembly` | Start an inspectable mechanical assembly. |
+| `joint : { clevis(opts: ClevisJointOptions): ClevisJoint; supportedServoRevolute(arm: Assembly, opts: SupportedServoRevoluteOptions): SupportedServoRevoluteResult; articulatedDigit(arm: Assembly, opts: ArticulatedDigitOptions): ArticulatedDigitResult }` | Mechanism-delivery joint helpers. |
+| `Scene.part(name: string) => ScenePart` | Look up a part by its assembly-unique name. |
+| `Scene.parts : readonly ScenePart[]` | Frozen, ordered list of parts in the Scene; ordering matches the order parts were added to the Assembly. |
+| `Scene.assemblyName : string` | Name passed to `assembly(name?)` at capture time; "unnamed-assembly" if no name was provided. |
+
+## Curves & surfaces
+
+Free-form work: NURBS curves and surfaces, and the evaluators that let you reason about them before they become solids.
+
+| Call | What it does |
+|---|---|
+| `nurbsCurve(controlPoints: Vec3[], opts?: { degree?: number; weights?: number[]; knots?: number[]; closed?: boolean }) => Curve3D` | 3D parametric NURBS curve specified by an explicit `Geom_BSplineCurve` control net. |
+| `spline3d(points: Vec3[], opts?: { tension?: number; closed?: boolean }) => Curve3D` | Catmull-Rom-to-cubic-Bezier convenience that interpolates the supplied points through a cubic NURBS curve. |
+| `hermiteG2(a: { point: Vec3; tangent: Vec3; curvature?: Vec3 }, b: { point: Vec3; tangent: Vec3; curvature?: Vec3 }) => Curve3D` | Quintic Hermite Curve3D that interpolates the two endpoints with matching positions, first derivatives (tangents), and second derivatives (curvatures). |
+| `PathBuilder.hermiteG2(a: HermiteEndpoint2D, b: HermiteEndpoint2D) => PathBuilder` | NURBS Slice D — 2D quintic-Hermite transition between two endpoints, each with prescribed point + first derivative (tangent) + optional second derivative (curvature). |
+| `nurbsSurface({ controls, degree, weights?, knots?, periodic? }) => Surface` | Build a NURBS surface from an explicit control net + degree. |
+| `surfaceFromCurves(sections: Sketch[]) => Surface` | Skin a NURBS surface through 2+ closed Sketch cross-sections in declaration order. |
+| `surfaceFromBoundary(curves: [Curve3D, Curve3D, Curve3D, Curve3D], opts?: { continuity?: "C0" \| "C1" \| "C2" \| ("C0" \| "C1" \| "C2")[]; sampling?: number }) => Surface` | Build the shipped filling surface: one NURBS face through 4 boundary curves. |
+| `sew(surfaces: Surface[], opts?: { tolerance?: number; requireClosed?: boolean }) => Shape` | Stitch N surfaces into a shell or closed solid via OCCT `BRepBuilderAPI_Sewing`. |
+| `Surface.thicken(t: Editable<number>) => Shape` | Offset both sides of this surface by `t` mm and return the closed solid Shape. |
+| `Surface.toShape() => Shape` | Wrap this surface as a single-face zero-volume Shape (TopoDS_Shell). |
+| `Surface.trimTo(by: Surface) => Surface` | Trim this surface at its intersection with `by` (a Surface cutter) and return a new Surface representing the kept half. |
+| `Surface.split(by: Surface) => [Surface, Surface]` | Split this surface at its intersection with `by` (a Surface cutter) and return both resulting Surface halves as `[first, second]`, ordered by descending face area. |
+| `Shape.projectCurve(opts: { source: ProjectCurveSource; face: FaceSelector \| string; scaleMode?: 'original' \| 'native' \| 'bounds'; asEdge?: boolean }) => Sketch` | Wrap a 2D closed curve onto a 3D face along the face normal. |
+| `Curve3D.sample(n: number) => [number, number, number][]` | Sample `n + 1` evenly-spaced points along the curve in the public `[0, 1]` parameter domain. |
+| `Curve3D.pointAt(t: number) => [number, number, number]` | World-space point on the curve at parameter `t ∈ [0, 1]` (clamped). |
+| `Curve3D.tangentAt(t: number) => [number, number, number]` | Unit tangent vector at parameter `t ∈ [0, 1]` (clamped). |
+| `Curve3D.domain() => [number, number]` | Parametric domain. |
+| `Curve3D.analytics.closestPoint(pt: Vec3, opts?: { tolerance?: number }) => Vec3` | World-space closest point on the curve to the query `pt` (Newton-Raphson). |
+| `Curve3D.analytics.closestParam(pt: Vec3, opts?: { tolerance?: number }) => number` | Parametric coordinate `t ∈ [0, 1]` of the closest point on the curve to `pt`. |
+| `Curve3D.analytics.divideByEqualArcLength(n: number) => CurveLengthSample[]` | Divide the curve into `n` equal-arc-length segments; returns `n + 1` `{ t, pt, arcLength }` samples covering both endpoints. |
+| `Curve3D.analytics.divideByArcLength(arcLength: number) => CurveLengthSample[]` | Sample the curve every `arcLength` mm starting from `t = 0`. |
+| `Curve3D.analytics.derivatives(t: number, numDerivs?: number) => Vec3[]` | Evaluate the curve and its first `numDerivs` derivatives at `t ∈ [0, 1]`. |
+| `Curve3D.analytics.tessellate(opts?: { tolerance?: number }) => Vec3[]` | Adaptive polyline approximation of the curve at the given tolerance (mm). |
+| `Shape.intersect(...others) => Shape` | Boolean intersection. |
+| `Curve3D.analytics.intersect(other: Curve3D \| Surface, opts?: { tolerance?: number }) => CurveCurveIntersection[] \| CurveSurfaceIntersection[]` | Geometric intersection of this curve with another `Curve3D` (returns `{ tA, tB, ptA, ptB, distance }` records) or with a `Surface` from `nurbsSurface()` (returns `{ tCurve, uv, pt }` records). |
+
+## Measure & verify
+
+Ask the kernel what you actually built, and gate the answer before shipping it.
+
+| Call | What it does |
+|---|---|
+| `Shape.boundingBox(opts?: { exact?: boolean }) => Promise<{ min: [number, number, number]; max: [number, number, number]; size: [number, number, number]; center: [number, number, number] }>` | Axis-aligned bounding box in the CURRENT world frame (after every transform appended so far), in mm. |
+| `Scene.bbox : { min: [number, number, number]; max: [number, number, number] }` | Lazy axis-aligned bounding box over all transformed parts. |
+| `Curve3D.length() => number` | Total arc length in mm. |
+| `Shape.lower() => Promise<OcctBackend>` | Eagerly lower this Shape for inspection. |
+| `kinematic : KinematicFacade` | Namespace with four in-process feasibility checks an agent can run before declaring a mechanism design done: `kinematic.checkMountingHoleConsistency(arm)` (fastener-side hole agreement; dispatches to the v0.7.4 substrate), `kinematic.checkSweptCollision(arm, opts?)` (sampled-pose collision sweep across declared joint ranges), `kinematic.checkReachable(arm, opts)` (IK reachability — analytical Pieper first, DLS numeric fallback), `kinematic.checkLoadCapacity(arm, opts?)` (closed-form Euler-Bernoulli beam load check). |
+| `dfmSpec(spec: { minWall?: number; minClearance?: number; includeArticulatedMates?: boolean; ignore?: [string, string][]; exclude?: string[]; channels?: Array<{ part: string; name: string; openings: number; sealed?: boolean }> }) => DfmSpecHandle` | Declare printability (design-for-manufacture) gates for the model. |
+
+## Parametrize
+
+Declare editable dimensions and do arithmetic on them (JS operators throw on a ParamRef).
+
+| Call | What it does |
+|---|---|
+| `param(name, defaultValue, meta?) => ParamRef` | Declare a symbolic editable parameter. |
+| `params(decl) => { [name]: ParamRef }` | Batched form of `param()` — declare many params at once. |
+| `ParamRef.add(other: number \| ParamRef<number>) => ParamRef<number>` | Build a ParamRef whose value equals this ParamRef plus `other`. |
+| `Shape.subtract(...others) => Shape` | Boolean difference (this minus others). |
+| `ParamRef.subtract(other: number \| ParamRef<number>) => ParamRef<number>` | Build a ParamRef whose value equals this ParamRef minus `other`. |
+| `ParamRef.multiply(other: number \| ParamRef<number>) => ParamRef<number>` | Build a ParamRef whose value equals this ParamRef times `other`. |
+| `ParamRef.divide(other: number \| ParamRef<number>) => ParamRef<number>` | Build a ParamRef whose value equals this ParamRef divided by `other`. |
+| `ParamRef.negate() => ParamRef<number>` | Build a ParamRef whose value equals the unary negation of this ParamRef. |
+
+## Import & export
+
+Bring in vendor geometry, and hand a model to the outside world.
+
+| Call | What it does |
+|---|---|
+| `lib : { fromSTEP(path: string): Promise<Shape>; fromBREP(path: string): Promise<Shape>; fromSTL(path: string, opts?: { tolerance?: number; allowOpen?: boolean; maxTriangles?: number }): Promise<Shape> }` | Parts library namespace. |
+| `Scene.toCompound() => Shape` | OCCT TopoDS_Compound — groups bodies without booleaning. |
+
+## Annotate & present
+
+Everything that changes how the model reads rather than what it is: text, color, lighting, camera, motion.
+
+| Call | What it does |
+|---|---|
+| `sketch : { text(content: string, opts: { size: Editable<number>; align?: "left" \| "center" \| "right"; position?: [Editable<number>, Editable<number>]; rotation?: Editable<number>; font?: string }): Sketch }` | Sketch primitives namespace. |
+| `fontPath(p: string) => FontPath` | Brand a string as a font filesystem path (TTF). |
+| `Shape.embossText(opts: { textContent: string; fontFamily?: string; size: Editable<number>; depth: Editable<number>; align?: 'left' \| 'center' \| 'right'; anchorU?: Editable<number>; anchorV?: Editable<number>; rotation?: Editable<number>; scaleMode?: 'original' \| 'native' \| 'bounds'; face: FaceSelector \| string }) => Shape` | Raise or recess text on a target face. |
+| `Shape.color(name: ColorToken \| `#${string}`) => Shape` | Tag this shape with a role color (servo/gear/beam/shaft/plate/pin/frame/tool) or a literal `#rrggbb` hex. |
+| `Shape.material(opts: PBRMaterial & { face?: string }) => Shape` | Apply a PBR material (baseColor required; optional metalness/roughness/clearcoat/clearcoatRoughness/ior/transmission/sheen/opacity). |
+| `referenceImage(path: string, opts: { plane, anchor?, scale?, opacity?, flipU?, flipV? }) => ReferenceImageHandle` | Overlay a reference image on a plane for tracing or design review. |
+| `setRenderEnvironment(spec: { preset?: 'studio' \| 'softbox' \| 'neutral' \| 'outdoor' \| 'warehouse'; url?: string; intensity?: number; rotation?: number }) => RenderEnvironmentHandle` | Set the HDRI / image-based-lighting environment for the rendered scene. |
+| `setCameraTarget(x: number, y: number, z: number) => CameraTargetHandle` | Override the camera look-at target for `setRenderPose` and headless engineering renders. |
+| `setCameraDistance(distance: number) => CameraTargetHandle` | Override the camera framing distance (mm from target). |
+| `animationView(spec: { param: string; from: number; to: number; durationMs: number; fps?: number } \| { name?: string; tracks: Array<{ param: string; keys: Array<{ atMs: number; value: number; ease?: "linear" \| "step" \| "easeIn" \| "easeOut" \| "easeInOut" }> }>; fps?: number }) => AnimationViewHandle` | Declare an animation timeline for offline kinematic-motion MP4 capture. |

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "cookbook:validate": "npx tsx scripts/cookbookValidate.ts",
     "cookbook:evaluate": "npx tsx scripts/cookbookEvaluate.ts",
     "cookbook:build": "npx tsx scripts/buildCookbookIndex.ts",
+    "docs:cheatsheet": "npx tsx scripts/buildCheatSheet.ts",
     "skill:out-of-scope": "npx tsx scripts/buildOutOfScopeSection.ts",
     "shopcheck:refresh": "npx tsx scripts/refreshCatalog.ts",
     "lint": "eslint .",

--- a/scripts/buildCheatSheet.ts
+++ b/scripts/buildCheatSheet.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// Render docs/cheat-sheet.md from CHEAT_SHEET_TAXONOMY + listApi entry data.
+// No prose is authored here: signatures and blurbs are read out of listApi so
+// the doc cannot drift from the runtime surface it documents.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import {
+  CHEAT_SHEET_TAXONOMY,
+  API_ENTRY_SOURCES,
+  allApiEntryNames,
+  resolveEntry,
+} from '../src/agent/mcp/tools/cheatSheetTaxonomy';
+
+export const CHEAT_SHEET_PATH = 'docs/cheat-sheet.md';
+
+const HEADER = [
+  '<!-- GENERATED — do not edit by hand, run `npx tsx scripts/buildCheatSheet.ts` -->',
+  '',
+  '# kernelCAD cheat sheet',
+  '',
+  'The script API grouped by what you are trying to DO. Every row is generated from',
+  '`src/agent/mcp/tools/listApi.ts`; call `lookup_api(query)` for the full description of any entry.',
+  '',
+];
+
+/** First sentence of a description — the table needs one line, not a paragraph. */
+function firstSentence(description: string): string {
+  const s = description.split(/(?<=[.!?])\s/)[0] ?? description;
+  return s.trim();
+}
+
+/** Markdown table cells: pipes break the row, newlines break the table. */
+function cell(s: string): string {
+  return s.replace(/\|/g, '\\|').replace(/\s*\n\s*/g, ' ');
+}
+
+export function renderCheatSheet(): string {
+  const lines: string[] = [...HEADER];
+
+  lines.push('| Task | What it covers |');
+  lines.push('|---|---|');
+  for (const group of CHEAT_SHEET_TAXONOMY) {
+    const anchor = group.task.toLowerCase().replace(/[^a-z0-9 ]/g, '').replace(/ /g, '-');
+    lines.push(`| [${cell(group.task)}](#${anchor}) | ${cell(group.blurb)} |`);
+  }
+  lines.push('');
+
+  for (const group of CHEAT_SHEET_TAXONOMY) {
+    lines.push(`## ${group.task}`);
+    lines.push('');
+    lines.push(group.blurb);
+    lines.push('');
+    lines.push('| Call | What it does |');
+    lines.push('|---|---|');
+    // Taxonomy order is authored intent (build order within a task), so it is
+    // preserved rather than sorted; resolveEntry keeps receivers in a fixed
+    // order, which is what makes the output deterministic.
+    for (const name of group.names) {
+      for (const { source, entry } of resolveEntry(name)) {
+        const call = `${source.callPrefix}${entry.name}${entry.signature.startsWith('(') ? entry.signature : ` : ${entry.signature}`}`;
+        lines.push(`| \`${cell(call)}\` | ${cell(firstSentence(entry.description))} |`);
+      }
+    }
+    lines.push('');
+  }
+
+  // Only rendered when the drift test is red: a silently incomplete cheat
+  // sheet is worse than a loud one, because agents read it as exhaustive.
+  const classified = new Set(CHEAT_SHEET_TAXONOMY.flatMap((g) => g.names));
+  const orphans = allApiEntryNames().filter((n) => !classified.has(n)).sort();
+  if (orphans.length > 0) {
+    lines.push('## Uncategorized');
+    lines.push('');
+    lines.push(
+      'These entries have no task home yet. Classify them in `src/agent/mcp/tools/cheatSheetTaxonomy.ts`.',
+    );
+    lines.push('');
+    for (const name of orphans) {
+      const where = resolveEntry(name).map(({ source }) => source.label).join(', ');
+      lines.push(`- \`${cell(name)}\` (${where})`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function main(): void {
+  const generated = renderCheatSheet();
+  let before = '';
+  try {
+    before = readFileSync(CHEAT_SHEET_PATH, 'utf8');
+  } catch {
+    before = '';
+  }
+  const total = API_ENTRY_SOURCES.reduce((n, s) => n + s.entries.length, 0);
+  if (before === generated) {
+    console.log(`✓ ${CHEAT_SHEET_PATH} already up to date (${total} entries)`);
+    return;
+  }
+  writeFileSync(CHEAT_SHEET_PATH, generated);
+  console.log(`✓ regenerated ${CHEAT_SHEET_PATH} (${total} entries)`);
+}
+
+// Run main only when invoked as a script (not when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/src/agent/mcp/toolNameConsistency.test.ts
+++ b/src/agent/mcp/toolNameConsistency.test.ts
@@ -11,6 +11,23 @@ const ROOT = resolve(__dirname, '../../../');
 
 /** Directories whose files reference MCP tool names by bare/backticked string. */
 const REFERENCE_DIRS = ['src/agent/skills', 'eval', 'docs'];
+
+/**
+ * Individual teaching-prose files outside REFERENCE_DIRS.
+ *
+ * `listApi.ts` is the prose `lookup_api` hands straight to agents, and it sat
+ * unscanned while carrying a retired tool name (`list_faces`). That only
+ * surfaced when `docs/cheat-sheet.md` — GENERATED from this very prose — landed
+ * in an already-scanned directory. The gate was checking the copy and not the
+ * original.
+ *
+ * Scoped to specific files rather than all of `src/agent/mcp/tools`: the sibling
+ * implementations (`inspect.ts`, `verify.ts`, `query.ts`, `export.ts`) carry
+ * legitimate "Replaces inspect_assembly, list_faces, …" headers naming exactly
+ * what they superseded. Scanning the whole directory produced 28 such false
+ * positives — a gate everyone learns to ignore is worse than no gate.
+ */
+const REFERENCE_FILES = ['src/agent/mcp/tools/listApi.ts'];
 const REFERENCE_EXTS = ['.md', '.ts', '.json'];
 
 function walk(dir: string, acc: string[] = []): string[] {
@@ -30,7 +47,10 @@ function walk(dir: string, acc: string[] = []): string[] {
 }
 
 function referenceFiles(): string[] {
-  return REFERENCE_DIRS.flatMap(d => walk(join(ROOT, d)));
+  return [
+    ...REFERENCE_DIRS.flatMap(d => walk(join(ROOT, d))),
+    ...REFERENCE_FILES.map(f => join(ROOT, f)),
+  ];
 }
 
 describe('tool-name consistency', () => {

--- a/src/agent/mcp/tools/cheatSheetTaxonomy.ts
+++ b/src/agent/mcp/tools/cheatSheetTaxonomy.ts
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/agent/mcp/tools/cheatSheetTaxonomy.ts
+//
+// Task-organized view over the receiver-organized data in `listApi.ts`.
+// `listApi` answers "what can I call on a Shape?"; an agent arriving cold
+// asks "how do I cut a hole?" — a question no receiver grouping answers.
+// This file is the ONLY place that mapping lives, and it stores entry NAMES
+// only: signatures and prose stay in listApi so the two can never disagree.
+//
+// Drift contract: `tests/unit/skill/cheatSheetTaxonomyDrift.test.ts` fails if
+// any listApi entry is unclassified, if a name here does not exist in listApi,
+// or if `docs/cheat-sheet.md` is stale. Adding an API without giving it a task
+// home is a build failure, by design.
+
+import {
+  GLOBALS,
+  SHAPE_METHODS,
+  SHAPE_LIST_METHODS,
+  SKETCH_METHODS,
+  PARAM_REF_METHODS,
+  PATH_BUILDER_METHODS,
+  SCENE_METHODS,
+  SURFACE_METHODS,
+  CURVE3D_METHODS,
+  CURVE3D_ANALYTICS_METHODS,
+  type ApiEntry,
+} from './listApi';
+
+/** One source array plus how a call on it is spelled in a script. */
+export interface ApiEntrySource {
+  /** Human label for the receiver, used in failure messages. */
+  readonly label: string;
+  /** Prefix rendered before the entry name in the cheat sheet ('' for globals). */
+  readonly callPrefix: string;
+  readonly entries: readonly ApiEntry[];
+}
+
+/**
+ * Every array whose entries must have a task home. Ordered so the generated
+ * doc lists a duplicated name (e.g. `union` on both the global and Shape) with
+ * the global form first — that is the form an agent reaches for first.
+ *
+ * SCENE_PART_PROPERTIES is deliberately absent: those are data fields on a
+ * Scene result, not calls an author makes, so they have no task.
+ */
+export const API_ENTRY_SOURCES: readonly ApiEntrySource[] = [
+  { label: 'GLOBALS', callPrefix: '', entries: GLOBALS },
+  { label: 'SHAPE_METHODS', callPrefix: 'Shape.', entries: SHAPE_METHODS },
+  { label: 'SHAPE_LIST_METHODS', callPrefix: 'ShapeList.', entries: SHAPE_LIST_METHODS },
+  { label: 'SKETCH_METHODS', callPrefix: 'Sketch.', entries: SKETCH_METHODS },
+  { label: 'PARAM_REF_METHODS', callPrefix: 'ParamRef.', entries: PARAM_REF_METHODS },
+  { label: 'PATH_BUILDER_METHODS', callPrefix: 'PathBuilder.', entries: PATH_BUILDER_METHODS },
+  { label: 'SCENE_METHODS', callPrefix: 'Scene.', entries: SCENE_METHODS },
+  { label: 'SURFACE_METHODS', callPrefix: 'Surface.', entries: SURFACE_METHODS },
+  { label: 'CURVE3D_METHODS', callPrefix: 'Curve3D.', entries: CURVE3D_METHODS },
+  {
+    label: 'CURVE3D_ANALYTICS_METHODS',
+    callPrefix: 'Curve3D.analytics.',
+    entries: CURVE3D_ANALYTICS_METHODS,
+  },
+];
+
+export interface CheatSheetGroup {
+  /** Task heading, phrased as the thing the author is trying to do. */
+  readonly task: string;
+  /** One line: when you reach for this group. */
+  readonly blurb: string;
+  /** listApi entry names. A name may repeat across receivers — that is fine. */
+  readonly names: readonly string[];
+}
+
+/**
+ * The taxonomy. Ordering is the order of a build: start a shape, add and
+ * remove material, combine, finish, then select / place / assemble, with the
+ * specialist surfaces and the non-geometry concerns last.
+ *
+ * A name appears in two groups only where both readings are genuinely how an
+ * author looks for it (`subtract` is both a boolean and ParamRef arithmetic;
+ * `intersect` is both a boolean and a curve-intersection query). Everything
+ * else has exactly one home.
+ */
+export const CHEAT_SHEET_TAXONOMY: readonly CheatSheetGroup[] = [
+  {
+    task: 'Start a shape',
+    blurb: 'The first call of any model: a solid primitive, or a 2D profile you will extrude.',
+    names: [
+      'box', 'cylinder', 'sphere', 'torus', 'spring',
+      'extrudeRect', 'extrudeCircle', 'extrudePolygon', 'extrudeRoundedRect',
+      'sheetMetal', 'sdf',
+      'path', 'moveTo', 'lineTo', 'close', 'label', 'circle',
+      'tangentArc', 'threePointsArc', 'sagittaArc', 'bulgeArc', 'radiusArc',
+      'smoothSpline', 'spline', 'nurbsSegment', 'hermiteG2',
+    ],
+  },
+  {
+    task: 'Add material',
+    blurb: 'Turn a profile into a solid, or grow an existing one along a path.',
+    names: ['extrude', 'revolve', 'sweep', 'loft', 'variableSweep', 'helix'],
+  },
+  {
+    task: 'Remove material',
+    blurb: 'Cut into a solid: bolt holes, pockets, slots, and arbitrary subtractions.',
+    names: ['subtract', 'hole', 'holes', 'cutout'],
+  },
+  {
+    task: 'Combine shapes',
+    blurb: 'Merge or intersect solids, or group them without paying for a boolean.',
+    names: ['union', 'intersect', 'toCompound', 'toUnion'],
+  },
+  {
+    task: 'Finish edges',
+    blurb: 'Manufacturing-facing finishing: break edges, add draft, hollow out, fold sheet.',
+    names: ['fillet', 'chamfer', 'draft', 'shell', 'bend', 'flattenPattern'],
+  },
+  {
+    task: 'Select geometry',
+    blurb:
+      'Name the edges or faces a feature should act on — query inside OCCT first, then rank or bucket the resolved list.',
+    names: [
+      'selectEdges', 'selectEdge', 'select', 'q',
+      'sortBy', 'sortByDistance', 'groupBy', 'filterBy', 'filterByPosition',
+      'take', 'first', 'last', 'at',
+    ],
+  },
+  {
+    task: 'Place & transform',
+    blurb: 'Move a finished body into position, mirror it, or repeat it.',
+    names: [
+      'translate', 'rotate', 'rotateX', 'rotateY', 'rotateZ', 'transform',
+      'alongAxis', 'scale', 'reflect', 'mirror',
+      'patternLinear', 'patternGrid', 'patternCircular',
+      'recenter', 'seatOnFloor',
+    ],
+  },
+  {
+    task: 'Assemble',
+    blurb: 'Compose parts into a mechanism with connectors, mates, joints, and posed Scenes.',
+    names: ['assembly', 'joint', 'part', 'parts', 'assemblyName'],
+  },
+  {
+    task: 'Curves & surfaces',
+    blurb:
+      'Free-form work: NURBS curves and surfaces, and the evaluators that let you reason about them before they become solids.',
+    names: [
+      'nurbsCurve', 'spline3d', 'hermiteG2', 'nurbsSurface', 'surfaceFromCurves',
+      'surfaceFromBoundary', 'sew', 'thicken', 'toShape', 'trimTo', 'split',
+      'projectCurve',
+      'sample', 'pointAt', 'tangentAt', 'domain',
+      'closestPoint', 'closestParam', 'divideByEqualArcLength', 'divideByArcLength',
+      'derivatives', 'tessellate', 'intersect',
+    ],
+  },
+  {
+    task: 'Measure & verify',
+    blurb: 'Ask the kernel what you actually built, and gate the answer before shipping it.',
+    names: ['boundingBox', 'bbox', 'length', 'lower', 'kinematic', 'dfmSpec'],
+  },
+  {
+    task: 'Parametrize',
+    blurb: 'Declare editable dimensions and do arithmetic on them (JS operators throw on a ParamRef).',
+    names: ['param', 'params', 'add', 'subtract', 'multiply', 'divide', 'negate'],
+  },
+  {
+    task: 'Import & export',
+    blurb: 'Bring in vendor geometry, and hand a model to the outside world.',
+    names: ['lib', 'toCompound'],
+  },
+  {
+    task: 'Annotate & present',
+    blurb: 'Everything that changes how the model reads rather than what it is: text, color, lighting, camera, motion.',
+    names: [
+      'sketch', 'fontPath', 'embossText', 'color', 'material',
+      'referenceImage', 'setRenderEnvironment', 'setCameraTarget', 'setCameraDistance',
+      'animationView',
+    ],
+  },
+];
+
+/** Every entry name that must be classified, deduped across receivers. */
+export function allApiEntryNames(): string[] {
+  const seen = new Set<string>();
+  for (const src of API_ENTRY_SOURCES) {
+    for (const e of src.entries) seen.add(e.name);
+  }
+  return [...seen];
+}
+
+/** Resolve a taxonomy name back to its listApi entries (one per receiver). */
+export function resolveEntry(name: string): Array<{ source: ApiEntrySource; entry: ApiEntry }> {
+  const out: Array<{ source: ApiEntrySource; entry: ApiEntry }> = [];
+  for (const source of API_ENTRY_SOURCES) {
+    for (const entry of source.entries) {
+      if (entry.name === name) out.push({ source, entry });
+    }
+  }
+  return out;
+}

--- a/src/agent/mcp/tools/listApi.ts
+++ b/src/agent/mcp/tools/listApi.ts
@@ -18,9 +18,11 @@ export interface ListApiInput {
    * or description match (token substring, case-insensitive) are returned, WITH
    * full descriptions. When omitted, every entry is returned in COMPACT form
    * (name + signature + a short blurb, no full description) — the whole API
-   * surface is ~117 entries / ~14k tokens of prose at full detail, which alone
-   * can exhaust a generation's token budget. Default-compact keeps discovery
-   * cheap; pass a query (e.g. 'sweep handle tube') to drill into a few entries.
+   * surface is `API_ENTRY_COUNT` entries (see that const — deliberately derived,
+   * because the figure written here was stale for months) / ~14k tokens of prose
+   * at full detail, which alone can exhaust a generation's token budget.
+   * Default-compact keeps discovery cheap; pass a query (e.g. 'sweep handle
+   * tube') to drill into a few entries.
    */
   query?: string;
 }
@@ -62,7 +64,7 @@ export interface FeatureKindFaceLabels {
 export interface ConstraintCapability {
   /** MCP tools that operate on side-effect-free sketch constraint payloads. */
   tools: readonly string[];
-  /** Constraint type vocabulary accepted by list_constraints/add_constraint/solve_sketch. */
+  /** Constraint type vocabulary accepted by inspect({ of: 'constraints' })/add_constraint/solve_sketch. */
   supportedTypes: readonly ConstraintType[];
 }
 
@@ -112,7 +114,7 @@ export const GLOBALS: ApiEntry[] = [
   { name: 'helix', signature: '({ radius, pitch, turns, axis?, pointsPerTurn?, startAngle? }) => [number, number, number][]', description: 'Polyline helix rail for `Sketch.sweep`. Default axis Z, 32 points per turn.' },
   { name: 'selectEdges', signature: '(shape, query?) => Promise<ShapeList<EdgeSegment>>', description: 'Pre-select edges by EdgeQuery. Awaitable; lowers the shape lazily. Returns a `ShapeList` — an `EdgeSegment[]` (accepted anywhere fillet/chamfer take one) carrying the selector algebra on top: `.sortBy` / `.groupBy` / `.filterBy` / `.filterByPosition` / `.sortByDistance`, and the `.first` / `.last` / `.at(i)` / `.take(n)` accessors. Each `EdgeSegment` also carries `radius` when `curveType === "CIRCLE"`.' },
   { name: 'selectEdge', signature: '(shape, query) => Promise<EdgeSegment>', description: 'Like selectEdges but throws if zero or multiple edges match. Use for unambiguous single-edge selection.' },
-  { name: 'select', signature: '<T>(items: Iterable<T>) => ShapeList<T>', description: 'Wrap any array of topology query results in a `ShapeList` so the selector algebra applies — face summaries from `list_faces`, `ResolvedEntity[]` from `q.face(...).evaluate(scene)`, or a hand-assembled list. `selectEdges` already returns a ShapeList, so `select` is for every other result source. The algebra is pure TypeScript over already-resolved descriptors: it reorders and partitions the SAME objects, so `EdgeSegment.id` and the `@kc[...]` ref / OCCT handle on a `ResolvedEntity` survive a sort or a group untouched. Compose it with (do not replace) EdgeQuery/FaceQuery: let the declarative query filter inside OCCT first, then rank or bucket the resolved list here.' },
+  { name: 'select', signature: '<T>(items: Iterable<T>) => ShapeList<T>', description: 'Wrap any array of topology query results in a `ShapeList` so the selector algebra applies — face summaries from `inspect({ of: \'faces\' })`, `ResolvedEntity[]` from `q.face(...).evaluate(scene)`, or a hand-assembled list. `selectEdges` already returns a ShapeList, so `select` is for every other result source. The algebra is pure TypeScript over already-resolved descriptors: it reorders and partitions the SAME objects, so `EdgeSegment.id` and the `@kc[...]` ref / OCCT handle on a `ResolvedEntity` survive a sort or a group untouched. Compose it with (do not replace) EdgeQuery/FaceQuery: let the declarative query filter inside OCCT first, then rank or bucket the resolved list here.' },
   { name: 'lib', signature: '{ fromSTEP(path: string): Promise<Shape>; fromBREP(path: string): Promise<Shape>; fromSTL(path: string, opts?: { tolerance?: number; allowOpen?: boolean; maxTriangles?: number }): Promise<Shape> }', description: 'Parts library namespace. Every `from*` call resolves `path` relative to the calling .kcad.ts script (absolute paths also accepted) and returns a Shape that composes with translate/rotate/color/arm.part(...) like any primitive. `lib.fromSTEP(path)` imports STEP — the default for vendor catalog parts (servos, bearings, fasteners) so geometric fidelity matches the real component instead of being hand-authored from box/cylinder. `lib.fromBREP(path)` imports OCCT native .brep: exact analytic surfaces plus full topology with no schema translation and no tessellation, so it is lossless and every downstream op (fillet, chamfer, shell, face queries) is valid — it is the right format for round-tripping kernelCAD geometry between processes, but it is OCCT-specific, so use STEP to interchange with other CAD systems. `lib.fromSTL(path, opts?)` imports an ASCII or binary STL: BE AWARE THIS IS A MESH, NOT ANALYTIC B-REP. The triangles are sewn back into topology and promoted to a solid when they close, so booleans, volume, mass properties, bbox and export all work — but the faces remain planar facets, so a hole that was a cylinder in the source CAD is now a fan of quads, and operations needing analytic surfaces (fillet/chamfer on a "curved" edge, canonical face refs, hole detection) will not behave as they do on STEP/BREP input. Prefer fromSTEP/fromBREP whenever the source is available. A non-watertight mesh is REFUSED with `kernel-failed.lib.fromSTL.open-mesh` rather than silently returned as an open shell whose volume and booleans would be undefined; pass `{ allowOpen: true }` to accept the shell deliberately. `{ tolerance }` (default 1e-6 mm) is the vertex-merge distance for sewing — raise it for third-party meshes whose shared vertices are not bit-identical. `{ maxTriangles }` (default 250000) caps import cost, which is roughly linear with a large constant (~10ms at 12 triangles, ~49s at 100k); past the budget the call fails fast with an actionable error rather than stalling.' },
   { name: 'nurbsSurface', signature: '({ controls, degree, weights?, knots?, periodic? }) => Surface', description: 'Build a NURBS surface from an explicit control net + degree. `controls` is a U-major V-minor rectangular Vec3 grid (mm). Returns a Surface (peer to Shape) — use `.thicken(t)` or `.toShape()` to enter the Shape pipeline. `weights` produces an exact rational surface (circles, cylinders, spheres, conics) as of v0.14.0.' },
   { name: 'surfaceFromCurves', signature: '(sections: Sketch[]) => Surface', description: 'Skin a NURBS surface through 2+ closed Sketch cross-sections in declaration order. Returns a Surface — chain `.thicken(t)` or `.toShape()`. Use for free-form panels and lofted shells.' },
@@ -400,6 +402,30 @@ export const SCENE_PART_PROPERTIES: ApiEntry[] = [
   { name: 'metadata', signature: 'Readonly<Record<string, unknown>> | undefined', description: 'Forward-compat container for material, mass, BOM tags. Frozen.' },
 ];
 
+/**
+ * Number of callable ApiEntry records, DERIVED rather than written down.
+ *
+ * The doc comment on `ListApiInput.query` used to hardcode "~117 entries". The
+ * real figure had reached 128 without anyone noticing, because no test read the
+ * prose. Counting it here means the number cannot be wrong; `cheatSheetTaxonomy`
+ * consumes the same arrays, so its drift gate covers this too.
+ *
+ * `SCENE_PART_PROPERTIES` is excluded on purpose: those are fields on a returned
+ * object, not things a script can call.
+ */
+export const API_ENTRY_COUNT: number = [
+  GLOBALS,
+  SHAPE_METHODS,
+  SHAPE_LIST_METHODS,
+  SKETCH_METHODS,
+  PARAM_REF_METHODS,
+  PATH_BUILDER_METHODS,
+  SCENE_METHODS,
+  SURFACE_METHODS,
+  CURVE3D_METHODS,
+  CURVE3D_ANALYTICS_METHODS,
+].reduce((n, arr) => n + arr.length, 0);
+
 /** Which global primitive/extrude functions accept an opts.faceLabels map,
  *  and the description of valid values for that map. */
 export const FEATURE_KIND_FACE_LABELS: FeatureKindFaceLabels = {
@@ -416,12 +442,18 @@ export const FEATURE_KIND_FACE_LABELS: FeatureKindFaceLabels = {
     '(one of: top, bottom, left, right, front, back) or a FaceQuery descriptor object. ' +
     'Example: `box(10, 10, 5, false, { faceLabels: { lid: \'top\', floor: \'bottom\' } })`. ' +
     'Labels declared here are resolved later by fillet/chamfer/shell via `{ face: \'<label>\' }`. ' +
-    'Use `list_face_labels` to inspect labels on an existing script. ' +
+    'Use `inspect({ of: \'face-labels\' })` to inspect labels on an existing script. ' +
     'Sphere does not accept faceLabels (no canonical face names; no meaningful FaceQuery targets).',
 };
 
 export const CONSTRAINT_CAPABILITY: ConstraintCapability = {
-  tools: ['list_constraints', 'add_constraint', 'solve_sketch'] as const,
+  // This array is DATA returned to agents as the callable tool list, not prose.
+  // It used to name the retired per-entity constraint lister, so an agent that
+  // trusted it was routed into a tool that no longer exists. Reading is now
+  // folded into `inspect({ of: 'constraints' })`; the tool name alone belongs
+  // here. (Naming the retired tool outright, even in a comment, re-trips
+  // toolNameConsistency — the check is a word-boundary match on the whole file.)
+  tools: ['inspect', 'add_constraint', 'solve_sketch'] as const,
   supportedTypes: SUPPORTED_CONSTRAINT_TYPES,
 };
 
@@ -431,7 +463,7 @@ export async function listApiTool(input: ListApiInput = {}): Promise<ListApiOutp
     .split(/\s+/)
     .filter(Boolean);
   const p = (entries: ApiEntry[]): ApiEntry[] => projectEntries(entries, tokens);
-  // The big token cost is the prose descriptions of the ~117 ApiEntry items, so
+  // The big token cost is the prose descriptions of the ApiEntry items, so
   // those are compacted by default and shown in full only for query matches.
   // The small featureKindFaceLabels / constraints blocks stay present always.
   return {

--- a/tests/integration/mcp/listApi.test.ts
+++ b/tests/integration/mcp/listApi.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { evaluateAndBuildScript } from '../../../src/agent/cli/commands/evaluate';
+import { TOOLS } from '../../../src/agent/mcp/toolRegistry';
 import { listApiTool, GLOBALS } from '../../../src/agent/mcp/tools/listApi';
 import { SUPPORTED_CONSTRAINT_TYPES } from '../../../src/agent/mcp/tools/constraints';
 
@@ -104,7 +105,12 @@ describe('list_api MCP tool', () => {
   it('returns constrained-sketch MCP tool discovery with supported constraint types', async () => {
     const r = await listApiTool({});
     expect(r.constraints).toBeDefined();
-    expect(r.constraints!.tools).toEqual(['list_constraints', 'add_constraint', 'solve_sketch']);
+    // Every name here must be a LIVE tool. This assertion previously pinned the
+    // retired per-entity constraint lister, so it was not protecting agents from
+    // a stale name — it was requiring one. Reading folded into `inspect`.
+    expect(r.constraints!.tools).toEqual(['inspect', 'add_constraint', 'solve_sketch']);
+    const live = new Set(TOOLS.map((t) => t.name));
+    for (const name of r.constraints!.tools) expect(live).toContain(name);
     expect(r.constraints!.supportedTypes).toEqual(SUPPORTED_CONSTRAINT_TYPES);
   });
 

--- a/tests/unit/skill/cheatSheetTaxonomyDrift.test.ts
+++ b/tests/unit/skill/cheatSheetTaxonomyDrift.test.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// Drift sentinel for the task-organized cheat sheet. Untested prose rots: this
+// repo shipped docs asserting "BRepProj_Projection is not bundled" in nine
+// places, which was true when written, became false after a wasm rebuild, and
+// told agents a shipped capability was impossible for months because nothing
+// tested it. These assertions are what stop the cheat sheet repeating
+// that: no API may go unclassified, no taxonomy name may be a typo, and the
+// committed doc must equal freshly generated output.
+
+import { readFileSync } from 'node:fs';
+import { resolve as resolvePath, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+import {
+  CHEAT_SHEET_TAXONOMY,
+  API_ENTRY_SOURCES,
+  allApiEntryNames,
+} from '../../../src/agent/mcp/tools/cheatSheetTaxonomy';
+import { API_ENTRY_COUNT } from '../../../src/agent/mcp/tools/listApi';
+import { renderCheatSheet, CHEAT_SHEET_PATH } from '../../../scripts/buildCheatSheet';
+
+const REPO_ROOT = resolvePath(dirname(fileURLToPath(import.meta.url)), '../../..');
+const TAXONOMY_SRC = 'src/agent/mcp/tools/cheatSheetTaxonomy.ts';
+
+describe('cheat sheet taxonomy drift sentinel', () => {
+  it('every listApi entry has at least one task home', () => {
+    const classified = new Set(CHEAT_SHEET_TAXONOMY.flatMap((g) => g.names));
+    const orphans: string[] = [];
+    for (const source of API_ENTRY_SOURCES) {
+      for (const entry of source.entries) {
+        if (!classified.has(entry.name)) orphans.push(`${source.label}.${entry.name}`);
+      }
+    }
+    if (orphans.length > 0) {
+      throw new Error(
+        `${orphans.length} listApi entr(y|ies) have no task group, so agents cannot ` +
+          `discover them by intent: ${orphans.join(', ')}. ` +
+          `Add each name to the best-fitting group in ${TAXONOMY_SRC}, ` +
+          'then run `npm run docs:cheatsheet`.',
+      );
+    }
+  });
+
+  it('every taxonomy name exists in listApi', () => {
+    const known = new Set(allApiEntryNames());
+    const unknown: string[] = [];
+    for (const group of CHEAT_SHEET_TAXONOMY) {
+      for (const name of group.names) {
+        if (!known.has(name)) unknown.push(`${group.task} -> ${name}`);
+      }
+    }
+    if (unknown.length > 0) {
+      throw new Error(
+        `${unknown.length} taxonomy name(s) do not exist in listApi — a typo, or an ` +
+          `API that was renamed or removed: ${unknown.join(', ')}. ` +
+          `Fix or drop the name in ${TAXONOMY_SRC}, then run \`npm run docs:cheatsheet\`.`,
+      );
+    }
+  });
+
+  it('no group is empty and no group duplicates a name within itself', () => {
+    const problems: string[] = [];
+    for (const group of CHEAT_SHEET_TAXONOMY) {
+      if (group.names.length === 0) problems.push(`"${group.task}" is empty`);
+      const dupes = group.names.filter((n, i) => group.names.indexOf(n) !== i);
+      if (dupes.length > 0) {
+        problems.push(`"${group.task}" lists ${[...new Set(dupes)].join(', ')} more than once`);
+      }
+      if (group.blurb.trim().length === 0) problems.push(`"${group.task}" has no blurb`);
+    }
+    if (problems.length > 0) {
+      throw new Error(`Malformed taxonomy in ${TAXONOMY_SRC}: ${problems.join('; ')}.`);
+    }
+  });
+
+  it('docs/cheat-sheet.md matches freshly generated output', () => {
+    const committed = readFileSync(resolvePath(REPO_ROOT, CHEAT_SHEET_PATH), 'utf8');
+    const generated = renderCheatSheet();
+    if (committed !== generated) {
+      const c = committed.split('\n');
+      const g = generated.split('\n');
+      // Scan the longer side: when one file is a strict prefix of the other
+      // (an appended Uncategorized block), the short side has no differing line.
+      const n = Math.max(c.length, g.length);
+      let i = 0;
+      while (i < n && c[i] === g[i]) i += 1;
+      throw new Error(
+        `${CHEAT_SHEET_PATH} is stale — it no longer matches the listApi data it is ` +
+          `generated from. First difference at line ${i + 1}:\n` +
+          `  committed: ${c[i] ?? '<end of file>'}\n` +
+          `  generated: ${g[i] ?? '<end of file>'}\n` +
+          'Run `npm run docs:cheatsheet` and commit the result. ' +
+          'Never hand-edit the generated doc.',
+      );
+    }
+  });
+
+  it('API_ENTRY_COUNT counts exactly the arrays the taxonomy classifies', () => {
+    // Ties the size listApi reports about itself to the set the cheat sheet
+    // covers. Without it, an eleventh entry array could be added that
+    // API_ENTRY_COUNT ignores and the taxonomy never classifies — the new calls
+    // undiscoverable by intent, every gate still green. That is the failure that
+    // let `~117` stand while the real figure reached 128.
+    //
+    // Compare ENTRY counts, not name counts: five names (union, subtract,
+    // intersect, reflect, hermiteG2) exist on two receivers each, so the deduped
+    // name list is legitimately shorter than the entry total.
+    const entryTotal = API_ENTRY_SOURCES.reduce((n, s) => n + s.entries.length, 0);
+    expect(API_ENTRY_COUNT).toBe(entryTotal);
+  });
+});


### PR DESCRIPTION
Closes the discoverability gap: *"it is hard to know what we can do."*

## The problem

`listApi.ts` groups 128 entries by **receiver type** (`GLOBALS`, `SHAPE_METHODS`, `SKETCH_METHODS`, …). That answers *"what can I call on a Shape?"* — but not *"how do I cut a hole?"*. Finding a capability required already knowing where it lived.

## What this adds

`docs/cheat-sheet.md`: 13 task groups (Start a shape → Add material → Remove material → … → Annotate & present), **128/128 entries classified**, generated from `listApi.ts` so entry text has exactly one home and cannot fork.

Calls are rendered with their receiver (`PathBuilder.tangentArc`, `ShapeList.sortBy`) because five names — `union`, `subtract`, `intersect`, `reflect`, `hermiteG2` — exist on two receivers each, and anything joining on bare `name` silently conflates them.

## The drift gate is the point, not the doc

Five assertions fail if an API goes unclassified, a taxonomy name is a typo/rename, the committed doc drifts from generated output, or a new entry array appears that both the count and the taxonomy silently ignore.

**Every one was verified to actually fail** by deliberately breaking it. A gate nobody has watched fail is not known to be a gate — and this repo has shipped four that measured the wrong artifact.

## Three retired tool names found along the way

Two were prose. The third was worse: `CONSTRAINT_CAPABILITY.tools` advertised the retired per-entity constraint lister **as data** — the callable tool list handed to agents — routing any agent that trusted it into a tool that no longer exists.

The integration test covering that array **was pinning the retired name**. It wasn't protecting agents from a stale name, it was requiring one. It now asserts every advertised name is a live registry tool.

## A gate that watched the copy, not the original

`toolNameConsistency` scanned `src/agent/skills`, `eval` and `docs` — but not `listApi.ts`, the prose `lookup_api` hands straight to agents. It caught `list_faces` only once `docs/cheat-sheet.md`, *generated from that prose*, landed in a directory it did watch.

Now scoped to that file specifically rather than all of `tools/`: the sibling implementations carry legitimate `Replaces inspect_assembly, list_faces, …` headers, and scanning the whole directory produced **28 false positives**. A gate everyone learns to ignore is worse than no gate.

## Also

`API_ENTRY_COUNT` is now derived. The hardcoded `~117` in two comments had been wrong (really 128) for months, because no test reads prose — the same rot class as the `BRepProj_Projection` claim fixed in #637.

## Verification

- Full suite: **5470 passed, 0 failed**. The one failing FILE (`viteReviewLiveEndpoint`) is a collection error reproducible on a clean `develop` checkout.
- `tsc -b --noEmit` and `eslint` clean.
- Generator confirmed deterministic (identical md5 across regenerations; no timestamps).