### PR TITLE
docs(cheat-sheet): plainer wording in the group blurbs

### DIFF
--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -2,28 +2,29 @@
 
 # kernelCAD cheat sheet
 
-The script API grouped by what you are trying to DO. Every row is generated from
-`src/agent/mcp/tools/listApi.ts`; call `lookup_api(query)` for the full description of any entry.
+The script API, grouped by the job you are doing rather than by the object you
+call it on. Rows come from `src/agent/mcp/tools/listApi.ts`; for the full
+description of any entry, call `lookup_api(query)`.
 
 | Task | What it covers |
 |---|---|
-| [Start a shape](#start-a-shape) | The first call of any model: a solid primitive, or a 2D profile you will extrude. |
-| [Add material](#add-material) | Turn a profile into a solid, or grow an existing one along a path. |
-| [Remove material](#remove-material) | Cut into a solid: bolt holes, pockets, slots, and arbitrary subtractions. |
+| [Start a shape](#start-a-shape) | The first call in any model: a solid primitive, or a 2D profile to extrude. |
+| [Add material](#add-material) | Turn a profile into a solid, or grow one along a path. |
+| [Remove material](#remove-material) | Cut into a solid: bolt holes, pockets, slots, plain subtraction. |
 | [Combine shapes](#combine-shapes) | Merge or intersect solids, or group them without paying for a boolean. |
-| [Finish edges](#finish-edges) | Manufacturing-facing finishing: break edges, add draft, hollow out, fold sheet. |
-| [Select geometry](#select-geometry) | Name the edges or faces a feature should act on — query inside OCCT first, then rank or bucket the resolved list. |
-| [Place & transform](#place--transform) | Move a finished body into position, mirror it, or repeat it. |
-| [Assemble](#assemble) | Compose parts into a mechanism with connectors, mates, joints, and posed Scenes. |
-| [Curves & surfaces](#curves--surfaces) | Free-form work: NURBS curves and surfaces, and the evaluators that let you reason about them before they become solids. |
-| [Measure & verify](#measure--verify) | Ask the kernel what you actually built, and gate the answer before shipping it. |
+| [Finish edges](#finish-edges) | Break edges, add draft, hollow out a wall, fold sheet metal. |
+| [Select geometry](#select-geometry) | Pick the edges or faces a feature acts on. Query inside OCCT first, then sort or group what comes back. |
+| [Place & transform](#place--transform) | Move a body into position, mirror it, or repeat it. |
+| [Assemble](#assemble) | Build a mechanism from parts: connectors, mates, joints, posed Scenes. |
+| [Curves & surfaces](#curves--surfaces) | NURBS curves and surfaces, plus the evaluators for measuring them before they become solids. |
+| [Measure & verify](#measure--verify) | Ask the kernel what you actually built, and check it before shipping. |
 | [Parametrize](#parametrize) | Declare editable dimensions and do arithmetic on them (JS operators throw on a ParamRef). |
-| [Import & export](#import--export) | Bring in vendor geometry, and hand a model to the outside world. |
-| [Annotate & present](#annotate--present) | Everything that changes how the model reads rather than what it is: text, color, lighting, camera, motion. |
+| [Import & export](#import--export) | Bring in vendor geometry, and write models back out. |
+| [Annotate & present](#annotate--present) | Change how a model reads without changing what it is: text, color, lighting, camera, motion. |
 
 ## Start a shape
 
-The first call of any model: a solid primitive, or a 2D profile you will extrude.
+The first call in any model: a solid primitive, or a 2D profile to extrude.
 
 | Call | What it does |
 |---|---|
@@ -57,7 +58,7 @@ The first call of any model: a solid primitive, or a 2D profile you will extrude
 
 ## Add material
 
-Turn a profile into a solid, or grow an existing one along a path.
+Turn a profile into a solid, or grow one along a path.
 
 | Call | What it does |
 |---|---|
@@ -70,7 +71,7 @@ Turn a profile into a solid, or grow an existing one along a path.
 
 ## Remove material
 
-Cut into a solid: bolt holes, pockets, slots, and arbitrary subtractions.
+Cut into a solid: bolt holes, pockets, slots, plain subtraction.
 
 | Call | What it does |
 |---|---|
@@ -95,7 +96,7 @@ Merge or intersect solids, or group them without paying for a boolean.
 
 ## Finish edges
 
-Manufacturing-facing finishing: break edges, add draft, hollow out, fold sheet.
+Break edges, add draft, hollow out a wall, fold sheet metal.
 
 | Call | What it does |
 |---|---|
@@ -108,7 +109,7 @@ Manufacturing-facing finishing: break edges, add draft, hollow out, fold sheet.
 
 ## Select geometry
 
-Name the edges or faces a feature should act on — query inside OCCT first, then rank or bucket the resolved list.
+Pick the edges or faces a feature acts on. Query inside OCCT first, then sort or group what comes back.
 
 | Call | What it does |
 |---|---|
@@ -128,7 +129,7 @@ Name the edges or faces a feature should act on — query inside OCCT first, the
 
 ## Place & transform
 
-Move a finished body into position, mirror it, or repeat it.
+Move a body into position, mirror it, or repeat it.
 
 | Call | What it does |
 |---|---|
@@ -151,7 +152,7 @@ Move a finished body into position, mirror it, or repeat it.
 
 ## Assemble
 
-Compose parts into a mechanism with connectors, mates, joints, and posed Scenes.
+Build a mechanism from parts: connectors, mates, joints, posed Scenes.
 
 | Call | What it does |
 |---|---|
@@ -163,7 +164,7 @@ Compose parts into a mechanism with connectors, mates, joints, and posed Scenes.
 
 ## Curves & surfaces
 
-Free-form work: NURBS curves and surfaces, and the evaluators that let you reason about them before they become solids.
+NURBS curves and surfaces, plus the evaluators for measuring them before they become solids.
 
 | Call | What it does |
 |---|---|
@@ -195,7 +196,7 @@ Free-form work: NURBS curves and surfaces, and the evaluators that let you reaso
 
 ## Measure & verify
 
-Ask the kernel what you actually built, and gate the answer before shipping it.
+Ask the kernel what you actually built, and check it before shipping.
 
 | Call | What it does |
 |---|---|
@@ -223,7 +224,7 @@ Declare editable dimensions and do arithmetic on them (JS operators throw on a P
 
 ## Import & export
 
-Bring in vendor geometry, and hand a model to the outside world.
+Bring in vendor geometry, and write models back out.
 
 | Call | What it does |
 |---|---|
@@ -232,7 +233,7 @@ Bring in vendor geometry, and hand a model to the outside world.
 
 ## Annotate & present
 
-Everything that changes how the model reads rather than what it is: text, color, lighting, camera, motion.
+Change how a model reads without changing what it is: text, color, lighting, camera, motion.
 
 | Call | What it does |
 |---|---|

--- a/scripts/buildCheatSheet.ts
+++ b/scripts/buildCheatSheet.ts
@@ -21,8 +21,9 @@ const HEADER = [
   '',
   '# kernelCAD cheat sheet',
   '',
-  'The script API grouped by what you are trying to DO. Every row is generated from',
-  '`src/agent/mcp/tools/listApi.ts`; call `lookup_api(query)` for the full description of any entry.',
+  'The script API, grouped by the job you are doing rather than by the object you',
+  'call it on. Rows come from `src/agent/mcp/tools/listApi.ts`; for the full',
+  'description of any entry, call `lookup_api(query)`.',
   '',
 ];
 

--- a/src/agent/mcp/tools/cheatSheetTaxonomy.ts
+++ b/src/agent/mcp/tools/cheatSheetTaxonomy.ts
@@ -83,7 +83,7 @@ export interface CheatSheetGroup {
 export const CHEAT_SHEET_TAXONOMY: readonly CheatSheetGroup[] = [
   {
     task: 'Start a shape',
-    blurb: 'The first call of any model: a solid primitive, or a 2D profile you will extrude.',
+    blurb: 'The first call in any model: a solid primitive, or a 2D profile to extrude.',
     names: [
       'box', 'cylinder', 'sphere', 'torus', 'spring',
       'extrudeRect', 'extrudeCircle', 'extrudePolygon', 'extrudeRoundedRect',
@@ -95,12 +95,12 @@ export const CHEAT_SHEET_TAXONOMY: readonly CheatSheetGroup[] = [
   },
   {
     task: 'Add material',
-    blurb: 'Turn a profile into a solid, or grow an existing one along a path.',
+    blurb: 'Turn a profile into a solid, or grow one along a path.',
     names: ['extrude', 'revolve', 'sweep', 'loft', 'variableSweep', 'helix'],
   },
   {
     task: 'Remove material',
-    blurb: 'Cut into a solid: bolt holes, pockets, slots, and arbitrary subtractions.',
+    blurb: 'Cut into a solid: bolt holes, pockets, slots, plain subtraction.',
     names: ['subtract', 'hole', 'holes', 'cutout'],
   },
   {
@@ -110,13 +110,13 @@ export const CHEAT_SHEET_TAXONOMY: readonly CheatSheetGroup[] = [
   },
   {
     task: 'Finish edges',
-    blurb: 'Manufacturing-facing finishing: break edges, add draft, hollow out, fold sheet.',
+    blurb: 'Break edges, add draft, hollow out a wall, fold sheet metal.',
     names: ['fillet', 'chamfer', 'draft', 'shell', 'bend', 'flattenPattern'],
   },
   {
     task: 'Select geometry',
     blurb:
-      'Name the edges or faces a feature should act on — query inside OCCT first, then rank or bucket the resolved list.',
+      'Pick the edges or faces a feature acts on. Query inside OCCT first, then sort or group what comes back.',
     names: [
       'selectEdges', 'selectEdge', 'select', 'q',
       'sortBy', 'sortByDistance', 'groupBy', 'filterBy', 'filterByPosition',
@@ -125,7 +125,7 @@ export const CHEAT_SHEET_TAXONOMY: readonly CheatSheetGroup[] = [
   },
   {
     task: 'Place & transform',
-    blurb: 'Move a finished body into position, mirror it, or repeat it.',
+    blurb: 'Move a body into position, mirror it, or repeat it.',
     names: [
       'translate', 'rotate', 'rotateX', 'rotateY', 'rotateZ', 'transform',
       'alongAxis', 'scale', 'reflect', 'mirror',
@@ -135,13 +135,13 @@ export const CHEAT_SHEET_TAXONOMY: readonly CheatSheetGroup[] = [
   },
   {
     task: 'Assemble',
-    blurb: 'Compose parts into a mechanism with connectors, mates, joints, and posed Scenes.',
+    blurb: 'Build a mechanism from parts: connectors, mates, joints, posed Scenes.',
     names: ['assembly', 'joint', 'part', 'parts', 'assemblyName'],
   },
   {
     task: 'Curves & surfaces',
     blurb:
-      'Free-form work: NURBS curves and surfaces, and the evaluators that let you reason about them before they become solids.',
+      'NURBS curves and surfaces, plus the evaluators for measuring them before they become solids.',
     names: [
       'nurbsCurve', 'spline3d', 'hermiteG2', 'nurbsSurface', 'surfaceFromCurves',
       'surfaceFromBoundary', 'sew', 'thicken', 'toShape', 'trimTo', 'split',
@@ -153,7 +153,7 @@ export const CHEAT_SHEET_TAXONOMY: readonly CheatSheetGroup[] = [
   },
   {
     task: 'Measure & verify',
-    blurb: 'Ask the kernel what you actually built, and gate the answer before shipping it.',
+    blurb: 'Ask the kernel what you actually built, and check it before shipping.',
     names: ['boundingBox', 'bbox', 'length', 'lower', 'kinematic', 'dfmSpec'],
   },
   {
@@ -163,12 +163,12 @@ export const CHEAT_SHEET_TAXONOMY: readonly CheatSheetGroup[] = [
   },
   {
     task: 'Import & export',
-    blurb: 'Bring in vendor geometry, and hand a model to the outside world.',
+    blurb: 'Bring in vendor geometry, and write models back out.',
     names: ['lib', 'toCompound'],
   },
   {
     task: 'Annotate & present',
-    blurb: 'Everything that changes how the model reads rather than what it is: text, color, lighting, camera, motion.',
+    blurb: 'Change how a model reads without changing what it is: text, color, lighting, camera, motion.',
     names: [
       'sketch', 'fontPath', 'embossText', 'color', 'material',
       'referenceImage', 'setRenderEnvironment', 'setCameraTarget', 'setCameraDistance',


### PR DESCRIPTION
Rewrites the 13 task-group blurbs and the page header.

The originals read like copy nobody writes by hand:

| before | after |
|---|---|
| the evaluators that **let you reason about** them before they become solids | the evaluators **for measuring** them before they become solids |
| **Manufacturing-facing finishing:** break edges, add draft, hollow out, fold sheet | Break edges, add draft, hollow out a wall, fold sheet metal |
| **Everything that changes how** the model reads rather than what it is | Change how a model reads without changing what it is |
| Name the edges a feature should act on — **then rank or bucket the resolved list** | Pick the edges a feature acts on. **Then sort or group what comes back** |

Same facts, fewer words. No name, signature, or grouping changed; drift gates pass (44 tests).