### PR TITLE
fix(site): gate GLB colour loss on the colour SET, not material count

### DIFF
--- a/scripts/lib/optimizeGlb.test.ts
+++ b/scripts/lib/optimizeGlb.test.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/lib/optimizeGlb.test.ts
+//
+// Guards the colour gate against the false positive that broke the marketing
+// deploy: `dedup` legitimately collapses duplicate material OBJECTS (93 -> 10 on
+// royal-pop-pocket-watch) while every distinct COLOUR survives. Gating on object
+// count rejected a perfectly good build; gating on the colour set does not.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Document, NodeIO } from '@gltf-transform/core';
+import { countDistinctColors, countMaterials } from './optimizeGlb';
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'kc-glb-mat-')); });
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+/** Write a GLB carrying `colors`, each repeated `dupes` times as separate
+ *  material objects — the shape OCCT exports produce. */
+async function writeGlb(name: string, colors: number[][], dupes: number): Promise<string> {
+  const doc = new Document();
+  const buf = doc.createBuffer();
+  for (const c of colors) {
+    for (let i = 0; i < dupes; i++) {
+      doc.createMaterial().setBaseColorFactor(c as [number, number, number, number]);
+    }
+  }
+  // a GLB needs at least one scene to round-trip
+  doc.createScene();
+  void buf;
+  const path = join(dir, name);
+  await new NodeIO().write(path, doc);
+  return path;
+}
+
+const RED: number[] = [1, 0, 0, 1];
+const GREEN: number[] = [0, 1, 0, 1];
+const BLUE: number[] = [0, 0, 1, 1];
+
+describe('countDistinctColors', () => {
+  it('counts COLOURS, not material objects — 9 objects sharing 3 colours reads as 3', async () => {
+    const p = await writeGlb('dupes.glb', [RED, GREEN, BLUE], 3);
+    expect(await countMaterials(p)).toBe(9);
+    expect(await countDistinctColors(p)).toBe(3);
+  });
+
+  it('treats every material as one colour when they are all identical', async () => {
+    const p = await writeGlb('same.glb', [RED], 12);
+    expect(await countMaterials(p)).toBe(12);
+    expect(await countDistinctColors(p)).toBe(1);
+  });
+
+  it('is unchanged by dedup: the real-world 93 -> 10 case preserves the colour count', async () => {
+    // before: 10 colours x 9 duplicate objects; after dedup: 10 objects, 10 colours
+    const before = await writeGlb('before.glb',
+      Array.from({ length: 10 }, (_, i) => [i / 10, 0, 0, 1]), 9);
+    const after = await writeGlb('after.glb',
+      Array.from({ length: 10 }, (_, i) => [i / 10, 0, 0, 1]), 1);
+    expect(await countMaterials(before)).toBe(90);
+    expect(await countMaterials(after)).toBe(10);
+    // the object count collapses, the colour set does not — so preserveMaterials holds
+    expect(await countDistinctColors(after)).toBe(await countDistinctColors(before));
+  });
+
+  it('DOES detect real palette flattening — distinct colours actually lost', async () => {
+    const before = await writeGlb('rich.glb', [RED, GREEN, BLUE], 1);
+    const flattened = await writeGlb('flat.glb', [RED], 3);
+    expect(await countDistinctColors(flattened)).toBeLessThan(
+      await countDistinctColors(before),
+    );
+  });
+});

--- a/scripts/lib/optimizeGlb.ts
+++ b/scripts/lib/optimizeGlb.ts
@@ -55,9 +55,32 @@ export function gltfTransformBin(repoRoot: string): string {
   return bin;
 }
 
-/** Read a GLB and count its distinct materials — the proxy for "colors kept".
- *  Optimization preserves one material per component (palette merging is
- *  disabled), so a multi-component model keeps multiple materials. */
+/** Count DISTINCT BASE COLOURS in a GLB — the real proxy for "colours kept".
+ *
+ *  Counting material OBJECTS is the wrong measure and produced a false failure
+ *  that blocked the marketing deploy: royal-pop-pocket-watch carries 93 material
+ *  instances that share only 10 distinct colours, so `optimize`'s (lossless)
+ *  `dedup` pass collapses 93 -> 10 with the rendered result byte-identical in
+ *  appearance. Measured:
+ *
+ *      BEFORE materials=93 uniqueColors=10
+ *      AFTER  materials=10 uniqueColors=10
+ *
+ *  What we actually care about is that no distinct colour disappears — that is
+ *  what palette merging would destroy. Deduplicating identical materials is a
+ *  win, not a regression, so gate on the colour set instead. */
+export async function countDistinctColors(glbPath: string): Promise<number> {
+  const io = new NodeIO();
+  const doc = await io.read(glbPath);
+  const seen = new Set<string>();
+  for (const m of doc.getRoot().listMaterials()) {
+    seen.add(JSON.stringify(m.getBaseColorFactor()));
+  }
+  return seen.size;
+}
+
+/** Raw material-object count. Retained for diagnostics only — do NOT gate on it;
+ *  see countDistinctColors for why. */
 export async function countMaterials(glbPath: string): Promise<number> {
   const io = new NodeIO();
   const doc = await io.read(glbPath);
@@ -69,14 +92,15 @@ export interface OptimizeOptions {
   repoRoot: string;
   /** Passed through to gltf-transform; see DEFAULT_SIMPLIFY_ERROR. */
   simplifyError?: string;
-  /** Fail if the result has fewer materials than this. Pass 0 to skip. Prefer
-   *  `preserveMaterials` unless you know the model's component count: a
-   *  single-material model is perfectly legitimate, so a fixed floor of 2 would
+  /** Fail if the result has fewer DISTINCT COLOURS than this. Pass 0 to skip.
+   *  Prefer `preserveMaterials` unless you know the model's component count: a
+   *  single-colour model is perfectly legitimate, so a fixed floor of 2 would
    *  reject valid simple models. */
   minMaterials?: number;
-  /** Fail if optimization DROPPED materials relative to the input. This is the
-   *  invariant that actually matters — palette merging flattening per-feature
-   *  colours — and unlike a fixed floor it holds for models of any complexity. */
+  /** Fail if optimization dropped a DISTINCT COLOUR relative to the input. This
+   *  is the invariant that actually matters — palette merging flattening
+   *  per-feature colours. It deliberately tolerates `dedup` collapsing duplicate
+   *  material objects, which is lossless. */
   preserveMaterials?: boolean;
   /** Fail if the result is >= this many bytes. Pass 0 to skip. */
   maxBytes?: number;
@@ -87,6 +111,7 @@ export interface OptimizeOptions {
 
 export interface OptimizeResult {
   bytes: number;
+  /** DISTINCT COLOURS in the output, not raw material-object count. */
   materials: number;
 }
 
@@ -102,7 +127,7 @@ export async function optimizeGlb(
 ): Promise<OptimizeResult> {
   const label = opts.label ?? outPath;
   const bin = gltfTransformBin(opts.repoRoot);
-  const before = opts.preserveMaterials ? await countMaterials(inPath) : 0;
+  const before = opts.preserveMaterials ? await countDistinctColors(inPath) : 0;
 
   execFileSync(
     bin,
@@ -132,17 +157,17 @@ export async function optimizeGlb(
     );
   }
 
-  const materials = await countMaterials(outPath);
+  const materials = await countDistinctColors(outPath);
   if (opts.preserveMaterials && materials < before) {
     throw new Error(
-      `${label}: optimization DROPPED materials ${before} -> ${materials} ` +
-        `(colors flattened — check --palette false).`,
+      `${label}: optimization DROPPED distinct colours ${before} -> ${materials} ` +
+        `(palette flattened — check --palette false).`,
     );
   }
   if (opts.minMaterials && materials < opts.minMaterials) {
     throw new Error(
-      `${label}: optimized GLB has ${materials} material(s); ` +
-        `expected >= ${opts.minMaterials} (colors lost — check --palette false).`,
+      `${label}: optimized GLB has ${materials} distinct colour(s); ` +
+        `expected >= ${opts.minMaterials} (colours lost — check --palette false).`,
     );
   }
 


### PR DESCRIPTION
## Problem

The material-preservation gate I added in #639 blocked the marketing deploy with a **false positive**:

```
build-gallery failed: entry royal-pop-pocket-watch:
  optimization DROPPED materials 93 -> 10 (colors flattened)
```

That drop is **lossless**. Measured on the actual entry:

```
BEFORE materials=93 uniqueColors=10
AFTER  materials=10 uniqueColors=10
```

The model carries 93 material *objects* sharing only 10 distinct colours; gltf-transform's `dedup` collapses the duplicates. Nothing a viewer can see changed — I was counting the wrong thing.

## Fix

Gate on the **colour set**, not the material-object count. `countDistinctColors()` is what both gates now use. `countMaterials()` remains for diagnostics, with a comment telling you not to gate on it.

This is deliberately narrower than "relax the gate": genuine palette flattening still fails, and there's a test asserting exactly that, so loosening it did not blind it.

## Verification

The entry that failed the deploy: `bytes=202572, distinctColors=10, PASS`.

New `optimizeGlb.test.ts` (4 tests) covers:
- 9 objects sharing 3 colours reads as 3
- all-identical materials read as 1
- the real 93→10 dedup case preserves the colour count
- **real palette flattening is still detected**

18 tests pass across optimizeGlb / buildBoardGlbs / build-gallery. eslint clean.

## Note on the original bug

The `spice-dispenser-carousel` size failure from #639 is confirmed fixed — this deploy got past it entirely and failed on a later entry. The 600KB cap and the optimize pass are working; this was purely my gate being wrong.