### PR TITLE
fix(cache): validate cached CONTENT, not just that an entry exists

### DIFF
--- a/src/modeling/parts/fetchPart.ts
+++ b/src/modeling/parts/fetchPart.ts
@@ -371,7 +371,10 @@ export async function fetchPartHost(
         'Remote catalog response missing stepUrl; cannot download bytes.',
       );
     }
-    // Cache via userCache; sha256 verified inside getOrFetchAsync.
+    // Cache via userCache. `expectedSha256` gates BOTH the download and any
+    // existing cache entry: entries are keyed by sha256(URL), so without the
+    // content check a catalog rebuild that republishes this same URL would keep
+    // serving pre-rebuild geometry indefinitely (see userCache.ts).
     const path = await getOrFetchAsync({
       consumer: 'parts',
       url: meta.stepUrl,

--- a/src/shared/cache/userCache.test.ts
+++ b/src/shared/cache/userCache.test.ts
@@ -136,4 +136,86 @@ describe('userCache — per-consumer primitives', () => {
     );
     expect(statSync(written).size).toBe(1);
   });
+
+  // ---- Republish / stale-content regression -------------------------------
+  // Entries are keyed by sha256(URL). A catalog rebuild republishes the SAME url
+  // with NEW bytes, so without a content check the stale copy is served forever.
+  // This actually happened: after a rebuild the ESP32-C3 board kept reporting
+  // 11.54mm instead of the republished 5.56mm bare board.
+
+  it('re-fetches when the cached CONTENT no longer matches expectedSha256', async () => {
+    const url = 'https://example.invalid/republished.step';
+    const oldBytes = Buffer.from('OLD-GEOMETRY');
+    const newBytes = Buffer.from('NEW-GEOMETRY');
+    const shaOf = (b: Buffer) => createHash('sha256').update(b).digest('hex');
+
+    const first = await getOrFetchAsync({
+      consumer: 'parts', url, ext: '.step', ttlMs: null,
+      expectedSha256: shaOf(oldBytes),
+      fetcher: async () => oldBytes,
+    });
+    expect(readFileSync(first).toString()).toBe('OLD-GEOMETRY');
+
+    // Same URL, same cache key, but the catalog now advertises new content.
+    __resetUserCacheForTests(); // new process would have an empty memo
+    let fetched = 0;
+    const second = await getOrFetchAsync({
+      consumer: 'parts', url, ext: '.step', ttlMs: null,
+      expectedSha256: shaOf(newBytes),
+      fetcher: async () => { fetched++; return newBytes; },
+    });
+    expect(fetched).toBe(1);
+    expect(readFileSync(second).toString()).toBe('NEW-GEOMETRY');
+  });
+
+  it('still serves the cache when content DOES match (no needless re-fetch)', async () => {
+    const url = 'https://example.invalid/unchanged.step';
+    const bytes = Buffer.from('SAME');
+    const sha = createHash('sha256').update(bytes).digest('hex');
+    await getOrFetchAsync({
+      consumer: 'parts', url, ext: '.step', ttlMs: null,
+      expectedSha256: sha, fetcher: async () => bytes,
+    });
+    __resetUserCacheForTests();
+    let fetched = 0;
+    await getOrFetchAsync({
+      consumer: 'parts', url, ext: '.step', ttlMs: null,
+      expectedSha256: sha,
+      fetcher: async () => { fetched++; return bytes; },
+    });
+    expect(fetched).toBe(0);
+  });
+
+  it('leaves callers without expectedSha256 on the old behaviour (cache hit)', async () => {
+    const url = 'https://example.invalid/no-sha.step';
+    await getOrFetchAsync({
+      consumer: 'parts', url, ext: '.step', ttlMs: null,
+      fetcher: async () => Buffer.from('FIRST'),
+    });
+    __resetUserCacheForTests();
+    let fetched = 0;
+    const p = await getOrFetchAsync({
+      consumer: 'parts', url, ext: '.step', ttlMs: null,
+      fetcher: async () => { fetched++; return Buffer.from('SECOND'); },
+    });
+    expect(fetched).toBe(0);
+    expect(readFileSync(p).toString()).toBe('FIRST');
+  });
+
+  it('the in-process memo does not smuggle stale content past the check', async () => {
+    const url = 'https://example.invalid/memoized.step';
+    const oldBytes = Buffer.from('MEMO-OLD');
+    const newBytes = Buffer.from('MEMO-NEW');
+    const shaOf = (b: Buffer) => createHash('sha256').update(b).digest('hex');
+    await getOrFetchAsync({
+      consumer: 'parts', url, ext: '.step', ttlMs: null,
+      expectedSha256: shaOf(oldBytes), fetcher: async () => oldBytes,
+    });
+    // memo deliberately NOT reset — the memo path must validate too.
+    const p = await getOrFetchAsync({
+      consumer: 'parts', url, ext: '.step', ttlMs: null,
+      expectedSha256: shaOf(newBytes), fetcher: async () => newBytes,
+    });
+    expect(readFileSync(p).toString()).toBe('MEMO-NEW');
+  });
 });

--- a/src/shared/cache/userCache.ts
+++ b/src/shared/cache/userCache.ts
@@ -31,7 +31,10 @@ export interface GetOrFetchOpts {
   ext: string;
   /** Milliseconds; `null` = no TTL (bytes never expire). */
   ttlMs: number | null;
-  /** Hex sha256. When provided, downloaded bytes are verified BEFORE writing. */
+  /** Hex sha256 of the expected CONTENT. When provided it is enforced twice:
+   *  downloaded bytes are verified before writing, AND an existing cache entry
+   *  whose content no longer matches is treated as a miss and re-fetched.
+   *  Without it, entries keyed by sha256(URL) can never notice a republish. */
   expectedSha256?: string;
   /** Bytes fetcher — typically Node's built-in fetch. Pure-function shape so
    *  tests can stub without spinning up a server. */
@@ -89,15 +92,45 @@ function sha256(input: Buffer | string): string {
   return createHash('sha256').update(input).digest('hex');
 }
 
+/** True when a cache entry exists but its CONTENT no longer matches what the
+ *  caller expects.
+ *
+ *  Entries are keyed by sha256(URL), which says nothing about the bytes behind
+ *  that URL. A republished artifact reuses the same key, so the stale copy is
+ *  served forever. `expectedSha256` is the only signal that the content moved —
+ *  so when the caller supplies it, it has to gate the cache HIT, not merely the
+ *  download. */
+function cachedContentIsStale(path: string, expectedSha256?: string): boolean {
+  if (expectedSha256 === undefined) return false;
+  try {
+    return sha256(readFileSync(path)) !== expectedSha256.toLowerCase();
+  } catch {
+    return true; // unreadable entry — treat as a miss and re-fetch
+  }
+}
+
 export async function getOrFetchAsync(opts: GetOrFetchOpts): Promise<string> {
   const key = `${opts.consumer}:${opts.url}`;
   const memoed = memo.get(key);
-  if (memoed && existsSync(memoed)) return memoed;
+  if (
+    memoed &&
+    existsSync(memoed) &&
+    !cachedContentIsStale(memoed, opts.expectedSha256)
+  ) {
+    return memoed;
+  }
 
   ensureConsumerDir(opts.consumer);
   const path = cachePathFor(opts.consumer, sha256(opts.url), opts.ext);
 
-  if (existsSync(path)) {
+  // Content check comes FIRST: a stale entry must miss regardless of TTL policy.
+  // Parts pass ttlMs: null, so previously an existing file was returned with no
+  // validation whatsoever, and every catalog rebuild was invisible to any
+  // consumer that had fetched the part once. Observed in the wild: after a
+  // rebuild the ESP32-C3 board kept serving 11.54mm-tall geometry instead of the
+  // republished 5.56mm bare board, and the 1.5" OLED served 44.5x37 instead of
+  // the corrected 47x34 — silently invalidating fit checks made against them.
+  if (existsSync(path) && !cachedContentIsStale(path, opts.expectedSha256)) {
     if (opts.ttlMs === null) {
       memo.set(key, path);
       return path;


### PR DESCRIPTION
## The bug

Cache entries live at `~/.cache/kernelcad/<consumer>/<sha256(url)><ext>`. The key is the **URL** — which says nothing about the bytes behind it. A catalog rebuild republishes the same URL with new bytes, so the stale copy is served **forever**.

`fetchPart` already passed `expectedSha256`, with a comment claiming *"sha256 verified inside getOrFetchAsync"*. It wasn't. `expectedSha256` only gated **downloaded** bytes before writing; on a cache hit with `ttlMs: null` — exactly what parts use — the existing file was returned with no validation at all:

```ts
if (existsSync(path)) {
  if (opts.ttlMs === null) { memo.set(key, path); return path; }  // never checks content
```

The comment described a check that never ran on the path that mattered.

## What it cost

Observed today, after republishing the catalog:

| part | served from cache | actually published |
|---|---|---|
| ESP32-C3 SuperMini board | 11.54 mm (with headers) | **5.56 mm** (bare) |
| 1.5" SSD1327 OLED | 44.5 × 37 | **47 × 34** |

Every fit check made against those parts was quietly measuring old geometry, and the only cure was deleting `~/.cache` by hand. Anyone who fetched a part before a rebuild silently keeps the pre-rebuild model.

## The fix

`expectedSha256` now gates the cache **hit** as well as the download — including the in-process memo, which could otherwise smuggle a stale path past the check. Callers that pass no `expectedSha256` keep the previous behaviour exactly, and a matching entry is still served without a re-fetch.

## Tests — verified non-vacuous

4 added. With the fix reverted, **2 fail** (the stale-content case and the memo case) and pass again once restored. The other 2 guard against over-correcting: no needless re-fetch when content matches, and unchanged behaviour for callers with no expected hash.

`src/modeling/parts` shows 7 pre-existing failures in a fresh worktree (missing bundled assets) — identical **7 failed / 73 passed** with and without this change.