### PR TITLE
perf(docs): drop the glTF parser, cut the viewer bundle 16%

### DIFF
--- a/site/island/docs-island.ts
+++ b/site/island/docs-island.ts
@@ -7,10 +7,12 @@
 // Two things load on two different schedules, and keeping them apart is the
 // point of this file:
 //
-//   - This module (three.js + a GLTF loader, a few hundred KB) is imported
-//     after the page has painted, so every example already shows its geometry.
-//     The model itself is a build artifact — see
-//     site/scripts/prebake-docs-models.ts — of the same source printed above it.
+//   - This module (three.js and OrbitControls) is imported after the page has
+//     painted, so every example already shows its geometry and can be rotated
+//     straight away. The model itself is a build artifact — see
+//     site/scripts/prebake-docs-models.ts — of the same source printed above it,
+//     in this repo's own mesh format rather than GLB, because a glTF parser cost
+//     more than everything else here put together.
 //   - The engine (site/island/docs-worker.ts, ~11 MB of OCCT wasm) is not
 //     touched until someone presses Run. Prebaking exists precisely so nobody
 //     pays for that just to look at a page.
@@ -20,8 +22,8 @@
 // runs and nothing above is missing.
 
 import * as THREE from 'three';
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { decodeDocsMesh } from './docsMesh';
 import { RoomEnvironment } from 'three/examples/jsm/environments/RoomEnvironment.js';
 import { docsMaterial } from './docsMaterial';
 import type { DocsAppearance } from './docsAppearance';
@@ -159,6 +161,12 @@ function ensureStage(root: HTMLElement): Stage | null {
   // #2b3137 at metalness 0.28 came out as a featureless charcoal wedge with the
   // fillet and the shell wall both invisible. Lights cannot fix that; only
   // something to reflect can.
+  //
+  // Replacing it with a generated gradient was tried, to save the 1.7 KB
+  // gzipped this import costs. Both an 8-bit and a float equirect rendered the
+  // parts materially darker than this does — the 8-bit one by 2.7x — and the
+  // shell-and-fillet example went back to being an unreadable wedge. 1% of the
+  // bundle is not worth re-introducing the bug this branch exists to fix.
   const pmrem = new THREE.PMREMGenerator(renderer);
   scene.environment = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
   pmrem.dispose();
@@ -307,31 +315,31 @@ async function showPrebaked(root: HTMLElement): Promise<void> {
   const model = JSON.parse(raw) as PrebakedModel;
   const response = await fetch(model.url);
   if (!response.ok) throw new Error(`${model.url} — HTTP ${response.status}`);
-  const gltf = await new GLTFLoader().parseAsync(await response.arrayBuffer(), '');
+  const features = decodeDocsMesh(await response.arrayBuffer());
 
-  // Node order is bake order, and `feature-N` is stamped at bake time, so the
-  // appearance list lines up with the meshes by name rather than by traversal
-  // luck.
-  const meshes: THREE.Mesh[] = [];
-  gltf.scene.traverse((node) => {
-    if (node instanceof THREE.Mesh) meshes.push(node);
-  });
-  meshes.sort((a, b) => a.name.localeCompare(b.name, 'en', { numeric: true }));
-  if (meshes.length !== model.appearances.length) {
+  // File order is bake order, so the appearance list lines up by index. The GLB
+  // version had to stamp `feature-N` names and sort by them, because a glTF
+  // scene graph gives no traversal-order guarantee worth relying on.
+  if (features.length !== model.appearances.length) {
     throw new Error(
-      `${model.url} has ${meshes.length} bodies, manifest describes ${model.appearances.length}`,
+      `${model.url} has ${features.length} bodies, manifest describes ${model.appearances.length}`,
     );
   }
-  meshes.forEach((mesh, i) => {
-    const old = mesh.material;
-    mesh.material = docsMaterial(model.appearances[i]);
-    if (Array.isArray(old)) old.forEach((m) => m.dispose());
-    else old.dispose();
-  });
 
   const stage = ensureStage(root);
   if (!stage) return;
-  stage.bodies.add(gltf.scene);
+  features.forEach((feature, i) => {
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(feature.positions, 3));
+    geometry.setAttribute('normal', new THREE.BufferAttribute(feature.normals, 3));
+    geometry.setIndex(new THREE.BufferAttribute(feature.indices, 1));
+    const mesh = new THREE.Mesh(geometry, docsMaterial(model.appearances[i]));
+    if (feature.transform) {
+      mesh.matrixAutoUpdate = false;
+      mesh.matrix.fromArray(feature.transform);
+    }
+    stage.bodies.add(mesh);
+  });
   frame(stage, { min: model.bounds.min as Bounds['min'], max: model.bounds.max as Bounds['max'] });
 }
 

--- a/site/island/docsMesh.test.ts
+++ b/site/island/docsMesh.test.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// The format is the whole reason the docs bundle got 26.5 KB smaller: no glTF
+// parser, this repo reads its own file. That is only safe if the decoder is the
+// exact inverse of the encoder, on every shape the prebake can produce —
+// including the 16-bit/32-bit index split, which is where a byte-offset format
+// like this one usually breaks.
+
+import { describe, it, expect } from 'vitest';
+import { encodeDocsMesh, decodeDocsMesh, DOCS_MESH_MAGIC, type DocsMeshData } from './docsMesh';
+
+function feature(vertexCount: number, indexCount: number, withTransform: boolean): DocsMeshData {
+  const positions = new Float32Array(vertexCount * 3);
+  const normals = new Float32Array(vertexCount * 3);
+  for (let i = 0; i < positions.length; i++) {
+    positions[i] = Math.sin(i) * 100; // arbitrary but reproducible non-integers
+    normals[i] = Math.cos(i);
+  }
+  const wide = vertexCount > 0xffff;
+  const indices = wide ? new Uint32Array(indexCount) : new Uint16Array(indexCount);
+  for (let i = 0; i < indexCount; i++) indices[i] = (i * 7) % vertexCount;
+  const transform = withTransform
+    ? Float32Array.from({ length: 16 }, (_, i) => i + 0.5)
+    : null;
+  return { positions, normals, indices, transform };
+}
+
+function expectFeatureEqual(got: DocsMeshData, want: DocsMeshData): void {
+  expect(Array.from(got.positions)).toEqual(Array.from(want.positions));
+  expect(Array.from(got.normals)).toEqual(Array.from(want.normals));
+  expect(Array.from(got.indices)).toEqual(Array.from(want.indices));
+  if (want.transform === null) expect(got.transform).toBeNull();
+  else expect(Array.from(got.transform!)).toEqual(Array.from(want.transform));
+}
+
+describe('docs mesh format', () => {
+  it('round-trips a mix of features, transforms and index widths', () => {
+    const features = [
+      feature(3, 3, false),
+      feature(24, 36, true), // a box: transform present, 16-bit indices
+      feature(5, 9, false), // odd index count exercises the 4-byte padding
+    ];
+    const decoded = decodeDocsMesh(bufferOf(encodeDocsMesh(features)));
+    expect(decoded).toHaveLength(features.length);
+    decoded.forEach((d, i) => expectFeatureEqual(d, features[i]));
+  });
+
+  it('keeps indices 16-bit under 65536 vertices and 32-bit above', () => {
+    const narrow = bufferOf(encodeDocsMesh([feature(100, 12, false)]));
+    const wide = bufferOf(encodeDocsMesh([feature(70_000, 12, false)]));
+    // The wide file carries the same 12 indices at 4 bytes each rather than 2,
+    // plus 3x the vertices — the point is the decoder reads each back as the
+    // width it was written.
+    expect(decodeDocsMesh(narrow)[0].indices).toBeInstanceOf(Uint16Array);
+    expect(decodeDocsMesh(wide)[0].indices).toBeInstanceOf(Uint32Array);
+  });
+
+  it('preserves exact values across the 65535/65536 boundary', () => {
+    for (const count of [0xffff, 0x1_0000]) {
+      const f = feature(count, 30, true);
+      expectFeatureEqual(decodeDocsMesh(bufferOf(encodeDocsMesh([f])))[0], f);
+    }
+  });
+
+  it('rejects a file with the wrong magic', () => {
+    const buffer = new ArrayBuffer(16);
+    new Uint32Array(buffer)[0] = 0xdeadbeef;
+    expect(() => decodeDocsMesh(buffer)).toThrow(/bad magic/);
+    expect(DOCS_MESH_MAGIC).not.toBe(0xdeadbeef);
+  });
+
+  it('rejects a truncated file rather than reading past the end', () => {
+    const full = bufferOf(encodeDocsMesh([feature(24, 36, true)]));
+    expect(() => decodeDocsMesh(full.slice(0, full.byteLength - 8))).toThrow();
+  });
+});
+
+/** encode returns a Uint8Array view; the decoder wants a standalone buffer. */
+function bufferOf(bytes: Uint8Array): ArrayBuffer {
+  const copy = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(copy).set(bytes);
+  return copy;
+}

--- a/site/island/docsMesh.ts
+++ b/site/island/docsMesh.ts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// The wire format for a prebaked docs model: the triangles, and nothing else.
+//
+// This replaced GLB, which cost 26.5 KB gzipped in GLTFLoader — 17% of the
+// island bundle — to parse a file this pipeline both writes and reads. Nothing
+// in glTF was being used. Materials are resolved from manifest tokens by
+// `docsMaterial`, not read from the file (that is deliberate: it is what stops a
+// prebaked body and a re-run body coming out different shades). The scene graph
+// is one flat list. Cameras, animation, skins, textures, PBR: all absent, all
+// still parsed for.
+//
+// So the format is the arrays the worker already produces, written down in
+// order. The decoder below is the whole reader.
+//
+// Encoder and decoder live in the same file on purpose. They are one contract,
+// and the previous arrangement — write with GLTFExporter here, read with
+// GLTFLoader there — is exactly the shape that lets two halves drift apart.
+// Rollup drops `encodeDocsMesh` from the browser bundle; it is only reachable
+// from the build script.
+//
+// LAYOUT — little-endian, every field a 4-byte unit, so every typed-array view
+// below is naturally aligned and can be taken over the buffer without copying:
+//
+//   u32   magic (KCM1)
+//   u32   featureCount
+//   u32[3] per feature: vertexCount, indexCount, flags
+//   then, per feature, in order:
+//     f32[16]        transform, only when FLAG_TRANSFORM
+//     f32[3*vcount]  positions
+//     f32[3*vcount]  normals
+//     u16|u32[icount] indices, 16-bit unless FLAG_WIDE_INDICES, padded to 4
+//
+// Indices narrow to 16 bits below 65536 vertices, which is every example here
+// and most of the reason this format is not larger than the GLB it replaced —
+// glTF does the same thing, and dropping it cost 36 KB across the corpus before
+// anyone noticed.
+
+/** 'KCM1' read little-endian. A wrong file fails here rather than mid-parse. */
+export const DOCS_MESH_MAGIC = 0x314d434b;
+
+/** One drawn feature: welded triangles, plus where the assembly solver put it. */
+export interface DocsMeshData {
+  readonly positions: Float32Array;
+  readonly normals: Float32Array;
+  /** Column-major 4x4, three's own layout. Null when the feature sits at origin. */
+  readonly transform: Float32Array | null;
+  readonly indices: Uint16Array | Uint32Array;
+}
+
+const HEADER_U32 = 2;
+const DESCRIPTOR_U32 = 3;
+const FLAG_TRANSFORM = 1;
+const FLAG_WIDE_INDICES = 2;
+
+/** Bytes an index block occupies, rounded up so the next feature stays 4-aligned. */
+function indexBytes(count: number, wide: boolean): number {
+  return wide ? count * 4 : Math.ceil((count * 2) / 4) * 4;
+}
+
+export function encodeDocsMesh(features: readonly DocsMeshData[]): Uint8Array {
+  const wide = features.map((f) => f.positions.length / 3 > 0xffff);
+
+  let bytes = (HEADER_U32 + features.length * DESCRIPTOR_U32) * 4;
+  features.forEach((f, i) => {
+    bytes += (f.transform ? 64 : 0) + f.positions.byteLength + f.normals.byteLength;
+    bytes += indexBytes(f.indices.length, wide[i]);
+  });
+
+  const buffer = new ArrayBuffer(bytes);
+  const header = new Uint32Array(buffer, 0, HEADER_U32 + features.length * DESCRIPTOR_U32);
+  header[0] = DOCS_MESH_MAGIC;
+  header[1] = features.length;
+
+  let offset = (HEADER_U32 + features.length * DESCRIPTOR_U32) * 4;
+  features.forEach((f, i) => {
+    const d = HEADER_U32 + i * DESCRIPTOR_U32;
+    header[d] = f.positions.length / 3;
+    header[d + 1] = f.indices.length;
+    header[d + 2] = (f.transform ? FLAG_TRANSFORM : 0) | (wide[i] ? FLAG_WIDE_INDICES : 0);
+
+    if (f.transform) {
+      new Float32Array(buffer, offset, 16).set(f.transform);
+      offset += 64;
+    }
+    new Float32Array(buffer, offset, f.positions.length).set(f.positions);
+    offset += f.positions.byteLength;
+    new Float32Array(buffer, offset, f.normals.length).set(f.normals);
+    offset += f.normals.byteLength;
+    if (wide[i]) new Uint32Array(buffer, offset, f.indices.length).set(f.indices);
+    else new Uint16Array(buffer, offset, f.indices.length).set(f.indices);
+    offset += indexBytes(f.indices.length, wide[i]);
+  });
+
+  return new Uint8Array(buffer);
+}
+
+/**
+ * Read a prebaked model. The returned arrays are views onto `buffer`, not
+ * copies — they go straight into `BufferAttribute`, which is what three would
+ * have uploaded anyway.
+ */
+export function decodeDocsMesh(buffer: ArrayBuffer): DocsMeshData[] {
+  if (buffer.byteLength < HEADER_U32 * 4) throw new Error('docs mesh: file is truncated');
+  const header = new Uint32Array(buffer, 0, HEADER_U32);
+  if (header[0] !== DOCS_MESH_MAGIC) {
+    throw new Error(`docs mesh: bad magic 0x${header[0].toString(16)}`);
+  }
+
+  const count = header[1];
+  const descriptors = new Uint32Array(buffer, HEADER_U32 * 4, count * DESCRIPTOR_U32);
+  const features: DocsMeshData[] = [];
+  let offset = (HEADER_U32 + count * DESCRIPTOR_U32) * 4;
+
+  for (let i = 0; i < count; i++) {
+    const vertexCount = descriptors[i * DESCRIPTOR_U32];
+    const indexCount = descriptors[i * DESCRIPTOR_U32 + 1];
+    const flags = descriptors[i * DESCRIPTOR_U32 + 2];
+    const wide = (flags & FLAG_WIDE_INDICES) !== 0;
+
+    let transform: Float32Array | null = null;
+    if ((flags & FLAG_TRANSFORM) !== 0) {
+      transform = new Float32Array(buffer, offset, 16);
+      offset += 64;
+    }
+    const positions = new Float32Array(buffer, offset, vertexCount * 3);
+    offset += vertexCount * 12;
+    const normals = new Float32Array(buffer, offset, vertexCount * 3);
+    offset += vertexCount * 12;
+    const indices = wide
+      ? new Uint32Array(buffer, offset, indexCount)
+      : new Uint16Array(buffer, offset, indexCount);
+    offset += indexBytes(indexCount, wide);
+
+    features.push({ positions, normals, transform, indices });
+  }
+
+  if (offset !== buffer.byteLength) {
+    throw new Error(`docs mesh: read ${offset} of ${buffer.byteLength} bytes`);
+  }
+  return features;
+}

--- a/site/scripts/build-docs.test.ts
+++ b/site/scripts/build-docs.test.ts
@@ -105,7 +105,7 @@ describe('build-docs', () => {
           page.slug,
           {
             slug: page.slug,
-            url: '/docs/models/finish-edges.glb',
+            url: '/docs/models/finish-edges.kcm',
             codeHash: 'x',
             bytes: 1,
             bounds: { min: [0, 0, 0], max: [1, 2, 3] },
@@ -116,14 +116,14 @@ describe('build-docs', () => {
     );
     const html = new Map(withModel.map((p) => [p.file, p.html])).get('docs/finish-edges.html')!;
     expect(html).toContain('data-docs-model=');
-    expect(html).toContain('/docs/models/finish-edges.glb');
+    expect(html).toContain('/docs/models/finish-edges.kcm');
     // Bounds and colours travel in the attribute, so the page frames the camera
     // and shades the body without fetching a manifest.
     expect(html).toContain('servo');
     expect(html).toContain('&quot;bounds&quot;');
-    // Still not on the page-load path: the GLB is fetched by the island, and
-    // the island is still reached through a dynamic import.
-    expect(html).not.toMatch(/<link[^>]+\.glb/);
+    // Still not eagerly linked: the model is fetched by the island in JS, not
+    // preloaded, so it stays off the parser's discovery path.
+    expect(html).not.toMatch(/<link[^>]+\.kcm/);
   });
 
   it('authors no API text of its own', () => {

--- a/site/scripts/build-docs.ts
+++ b/site/scripts/build-docs.ts
@@ -113,7 +113,7 @@ ${body}
  *
  * It reveals the Run button, then pulls in the island once the page has
  * finished loading so each example can draw its prebaked model. That import is
- * three.js and a GLTF loader; the 10.8 MB engine is a separate module the
+ * three.js and OrbitControls; the 10.8 MB engine is a separate module the
  * island does not touch until someone presses Run, so "show the model" and
  * "download the kernel" stay on different schedules.
  *
@@ -291,7 +291,7 @@ function readManifest(): DocsModelManifest | null {
 }
 
 async function main(): Promise<void> {
-  // The staleness gate. A page whose GLB was baked from older source is a page
+  // The staleness gate. A page whose model was baked from older source is a page
   // that shows geometry which does not match the code beside it, and looks
   // completely fine doing it. Refusing to build is the only honest response.
   const manifest = readManifest();

--- a/site/scripts/docsModels.test.ts
+++ b/site/scripts/docsModels.test.ts
@@ -3,7 +3,7 @@
 //
 // The gate on prebaked geometry.
 //
-// A GLB is a copy of an example's output, and the dangerous failure is not a
+// A prebaked model is a copy of an example's output, and the dangerous failure is not a
 // crash — it is a page that renders a model built from source the reader is no
 // longer looking at. Nothing about that looks wrong. So this file does two
 // things: it proves `staleModels` actually detects the drift (with fixtures, so
@@ -17,6 +17,7 @@ import { fileURLToPath } from 'node:url';
 import { buildDocsPages } from '../../src/docs/liveDocs';
 import {
   DOCS_MODEL_DIR,
+  DOCS_MODEL_EXT,
   DOCS_MODEL_MANIFEST,
   hashExampleCode,
   staleModels,
@@ -33,7 +34,7 @@ function freshManifest(): DocsModelManifest {
   return {
     models: withExamples.map((page): DocsModel => ({
       slug: page.slug,
-      url: `/${DOCS_MODEL_DIR}/${page.slug}.glb`,
+      url: `/${DOCS_MODEL_DIR}/${page.slug}${DOCS_MODEL_EXT}`,
       codeHash: hashExampleCode(page.example!.code),
       bytes: 2048,
       bounds: { min: [0, 0, 0], max: [1, 1, 1] },
@@ -52,7 +53,7 @@ describe('prebaked model staleness gate', () => {
   });
 
   it('rejects a model built from different source', () => {
-    // The whole reason this file exists: an example edited after its GLB was
+    // The whole reason this file exists: an example edited after its model was
     // baked. The bytes are fine, the page renders, the picture is a lie.
     const manifest = freshManifest();
     const drifted = {
@@ -102,8 +103,8 @@ describe('the prebaked models on disk', () => {
     const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as DocsModelManifest;
     expect(staleModels(pages, manifest)).toEqual([]);
     for (const model of manifest.models) {
-      const glb = path.join(SITE, DOCS_MODEL_DIR, `${model.slug}.glb`);
-      expect(existsSync(glb), `${model.slug}.glb is in the manifest but not on disk`).toBe(true);
+      const file = path.join(SITE, DOCS_MODEL_DIR, `${model.slug}${DOCS_MODEL_EXT}`);
+      expect(existsSync(file), `${model.slug}${DOCS_MODEL_EXT} is in the manifest but not on disk`).toBe(true);
     }
   });
 });

--- a/site/scripts/docsModels.ts
+++ b/site/scripts/docsModels.ts
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 //
-// The contract between the prebaked GLBs and the pages that show them.
+// The contract between the prebaked models and the pages that show them.
 //
-// A prebaked GLB is a COPY of an example's output. The failure mode that
+// A prebaked model is a COPY of an example's output. The failure mode that
 // matters is not a broken build — it is a green one that ships a model built
 // from an older version of the code printed next to it. The reader has no way
 // to tell; the page looks perfect and lies.
@@ -17,8 +17,11 @@ import { createHash } from 'node:crypto';
 import type { DocsAppearance } from '../island/docsAppearance';
 import type { DocsPage } from '../../src/docs/liveDocs';
 
-/** Where the prebaked GLBs live, relative to `site/`. */
+/** Where the prebaked models live, relative to `site/`. */
 export const DOCS_MODEL_DIR = 'docs/models';
+
+/** Extension for site/island/docsMesh.ts's format. Not glTF — see that file. */
+export const DOCS_MODEL_EXT = '.kcm';
 
 /** Manifest filename inside `DOCS_MODEL_DIR`. */
 export const DOCS_MODEL_MANIFEST = 'manifest.json';
@@ -26,9 +29,9 @@ export const DOCS_MODEL_MANIFEST = 'manifest.json';
 /** What the page needs to show a model, and what the gate needs to trust it. */
 export interface DocsModel {
   readonly slug: string;
-  /** Site-absolute URL of the GLB. */
+  /** Site-absolute URL of the model file. */
   readonly url: string;
-  /** SHA-256 of the example source this GLB was built from. */
+  /** SHA-256 of the example source this model was built from. */
   readonly codeHash: string;
   readonly bytes: number;
   /**
@@ -39,10 +42,10 @@ export interface DocsModel {
    */
   readonly bounds: { readonly min: readonly number[]; readonly max: readonly number[] };
   /**
-   * How each drawn feature is shaded, in GLB node order. The page turns these
-   * into materials with the same function the live renderer uses, rather than
-   * reading materials baked into the GLB, so a prebaked body and a re-run body
-   * cannot come out different shades.
+   * How each drawn feature is shaded, in file order. The page turns these into
+   * materials with the same function the live renderer uses, rather than
+   * reading materials baked into the model, so a prebaked body and a re-run
+   * body cannot come out different shades.
    */
   readonly appearances: readonly DocsAppearance[];
 }

--- a/site/scripts/prebake-docs-models.ts
+++ b/site/scripts/prebake-docs-models.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 //
-// Builds one GLB per docs example so a reader sees the model on page load
-// instead of an empty canvas with a Run button under it.
+// Builds one model file per docs example so a reader sees the geometry on page
+// load instead of an empty canvas with a Run button under it.
 //
 // Why not just run the engine on load: the OCCT wasm is ~11 MB. Downloading it
 // before first paint would make every docs page slower in exchange for a
@@ -18,16 +18,22 @@
 // mesh and bakes PBR materials the live path does not use. Same selection rule
 // in, same picture out.
 //
-// Colours are NOT baked into the GLB. They travel as tokens in the manifest and
-// the page resolves them with the same `resolveColor` the live renderer calls,
-// so a prebaked body and a re-run body cannot come out different shades.
+// The output is site/island/docsMesh.ts's format, not GLB. Nothing in glTF was
+// being used and the reader cost 26.5 KB gzipped — 17% of the island bundle —
+// which readers paid on every docs page to parse a file this repo also writes.
+// Writing the arrays down directly deletes both the loader and a format
+// conversion.
+//
+// Colours are NOT baked into the model. They travel as tokens in the manifest
+// and the page resolves them with the same `resolveColor` the live renderer
+// calls, so a prebaked body and a re-run body cannot come out different shades.
 
 import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { BufferAttribute, BufferGeometry, Matrix4, Mesh, Scene } from 'three';
-import { GLTFExporter, mergeVertices } from 'three-stdlib';
+import { BufferAttribute, BufferGeometry } from 'three';
+import { mergeVertices } from 'three-stdlib';
 import { buildDocsPages, type DocsPage } from '../../src/docs/liveDocs';
 import { loadScriptFeatures } from '../../src/modeling/runtime/scriptLoader';
 import {
@@ -35,8 +41,10 @@ import {
   selectTerminalFeatures,
 } from '../../src/modeling/capture/featureMeshing';
 import { appearanceOf, type DocsAppearance } from '../island/docsAppearance';
+import { encodeDocsMesh, type DocsMeshData } from '../island/docsMesh';
 import {
   DOCS_MODEL_DIR,
+  DOCS_MODEL_EXT,
   DOCS_MODEL_MANIFEST,
   hashExampleCode,
   staleModels,
@@ -47,13 +55,13 @@ import {
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
 interface Baked {
-  glb: Buffer;
+  mesh: Buffer;
   bounds: { min: number[]; max: number[] };
   appearances: DocsAppearance[];
 }
 
 /**
- * Evaluate one example and turn its drawn features into a GLB.
+ * Evaluate one example and turn its drawn features into a model file.
  *
  * The script runs from a temp file because the node script loader reads source
  * off disk. Examples import nothing, so the directory it sits in is irrelevant.
@@ -73,7 +81,7 @@ async function bake(page: DocsPage, code: string): Promise<Baked> {
       throw new Error(`features failed to mesh: ${meshed.failedFeatureIds.join(', ')}`);
     }
 
-    const scene = new Scene();
+    const drawn: DocsMeshData[] = [];
     const min = [Infinity, Infinity, Infinity];
     const max = [-Infinity, -Infinity, -Infinity];
     const appearances: DocsAppearance[] = [];
@@ -116,31 +124,25 @@ async function bake(page: DocsPage, code: string): Promise<Baked> {
       // OCCT meshes every face on its own, so shared edges carry duplicate
       // coordinate-equal vertices. Welding is lossless — differing normals keep
       // hard edges split — and it is most of the reason these files are small.
-      const mesh = new Mesh(mergeVertices(geometry));
-      mesh.name = `feature-${appearances.length}`;
-      if (feature.transform) mesh.applyMatrix4(new Matrix4().fromArray([...feature.transform]));
-      scene.add(mesh);
+      const welded = mergeVertices(geometry);
+      // The transform travels with the feature rather than being applied here.
+      // The live path builds a Group and sets its matrix from the same 16
+      // numbers, so leaving it unapplied is what keeps the two paths identical
+      // instead of merely close.
+      drawn.push({
+        positions: welded.getAttribute('position').array as Float32Array,
+        normals: welded.getAttribute('normal').array as Float32Array,
+        indices: welded.getIndex()!.array as Uint16Array | Uint32Array,
+        transform: feature.transform ? Float32Array.from(feature.transform) : null,
+      });
       appearances.push(appearanceOf(feature.color, feature.material));
     }
 
-    if (scene.children.length === 0) {
+    if (drawn.length === 0) {
       throw new Error('example produced no drawable geometry');
     }
 
-    const exporter = new GLTFExporter();
-    const buffer = await new Promise<ArrayBuffer>((resolve, reject) => {
-      exporter.parse(
-        scene,
-        (result) => {
-          if (result instanceof ArrayBuffer) resolve(result);
-          else reject(new Error('GLTFExporter returned a non-binary result'));
-        },
-        reject,
-        { binary: true },
-      );
-    });
-
-    return { glb: Buffer.from(buffer), bounds: { min, max }, appearances };
+    return { mesh: Buffer.from(encodeDocsMesh(drawn)), bounds: { min, max }, appearances };
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -155,8 +157,8 @@ export async function prebakeDocsModels(): Promise<DocsModel[]> {
   for (const page of pages) {
     const code = page.example!.code;
     const baked = await bake(page, code);
-    const file = `${page.slug}.glb`;
-    writeFileSync(path.join(outDir, file), baked.glb);
+    const file = `${page.slug}${DOCS_MODEL_EXT}`;
+    writeFileSync(path.join(outDir, file), baked.mesh);
     models.push({
       slug: page.slug,
       url: `/${DOCS_MODEL_DIR}/${file}`,
@@ -165,7 +167,7 @@ export async function prebakeDocsModels(): Promise<DocsModel[]> {
       bounds: baked.bounds,
       appearances: baked.appearances,
     });
-    console.log(`  ${page.slug}.glb — ${baked.glb.length.toLocaleString()} bytes`);
+    console.log(`  ${file} — ${baked.mesh.length.toLocaleString()} bytes`);
   }
 
   const manifest: DocsModelManifest = { models };

--- a/site/scripts/verify-docs-bundle.ts
+++ b/site/scripts/verify-docs-bundle.ts
@@ -12,12 +12,69 @@
 //
 // A unit test cannot catch that; it has to look at what was actually emitted.
 
-import { statSync, readFileSync, existsSync } from 'node:fs';
+import { statSync, readFileSync, readdirSync, existsSync } from 'node:fs';
+import { gzipSync } from 'node:zlib';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { DOCS_MODEL_DIR, DOCS_MODEL_MANIFEST, type DocsModelManifest } from './docsModels';
+import {
+  DOCS_MODEL_DIR,
+  DOCS_MODEL_EXT,
+  DOCS_MODEL_MANIFEST,
+  type DocsModelManifest,
+} from './docsModels';
 
 const SITE = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * What one docs page costs a first-time reader before they can see and rotate
+ * the model, gzipped — which is how everything is served, so it is the honest
+ * unit. The viewer is eager: the island loads on every visit, so its bytes are
+ * on this path, not off it.
+ *
+ * Per page: the HTML, the two stylesheets, the island bundle, and this page's
+ * own prebaked model. The 11 MB kernel is NOT here — it stays behind Run, and a
+ * reader who never edits never fetches it.
+ *
+ * The budget sits just above the current worst page (~166.8 KB, curves &
+ * surfaces, which carries the largest model). The point is not the exact
+ * number; it is that dropping a heavy dependency back in trips the build. The
+ * glTF loader this branch removed was 26.5 KB gzipped — six times this headroom
+ * — so a regression to it, or anything its size, fails here rather than shipping.
+ */
+const PER_PAGE_BUDGET = 172_000;
+
+function gzippedBytes(file: string): number {
+  return gzipSync(readFileSync(path.join(SITE, file)), { level: 9 }).length;
+}
+
+/**
+ * The critical-path budget. Fails the build if any page's first-view payload
+ * exceeds `PER_PAGE_BUDGET`, so the win this branch bought cannot silently rot.
+ */
+function verifyBudget(failures: string[]): { worst: number; page: string } {
+  const shared = gzippedBytes('docs-island.js') + gzippedBytes('docs.css') + gzippedBytes('style.css');
+
+  let worst = 0;
+  let worstPage = '';
+  for (const html of readdirSync(path.join(SITE, 'docs')).filter((f) => f.endsWith('.html'))) {
+    const slug = html.replace(/\.html$/, '');
+    const modelFile = path.join(SITE, DOCS_MODEL_DIR, `${slug}${DOCS_MODEL_EXT}`);
+    const model = existsSync(modelFile)
+      ? gzipSync(readFileSync(modelFile), { level: 9 }).length
+      : 0;
+    const total = shared + gzippedBytes(`docs/${html}`) + model;
+    if (total > worst) {
+      worst = total;
+      worstPage = slug;
+    }
+    if (total > PER_PAGE_BUDGET) {
+      failures.push(
+        `docs/${html}: ${total} B gzipped on the critical path, budget ${PER_PAGE_BUDGET} — see PER_PAGE_BUDGET in verify-docs-bundle.ts`,
+      );
+    }
+  }
+  return { worst, page: worstPage };
+}
 
 interface Check {
   file: string;
@@ -51,8 +108,8 @@ const CHECKS: Check[] = [
 /**
  * The prebaked models, checked against the manifest the pages were rendered
  * from. build-docs.ts already refuses to render a stale manifest; this catches
- * the other half — a manifest entry whose GLB never reached disk, or reached it
- * truncated. Either one is a page that silently shows nothing.
+ * the other half — a manifest entry whose model never reached disk, or reached
+ * it truncated. Either one is a page that silently shows nothing.
  */
 function verifyModels(failures: string[]): number {
   const manifestPath = path.join(SITE, DOCS_MODEL_DIR, DOCS_MODEL_MANIFEST);
@@ -63,14 +120,15 @@ function verifyModels(failures: string[]): number {
   const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as DocsModelManifest;
   if (manifest.models.length === 0) failures.push('model manifest is empty');
   for (const model of manifest.models) {
-    const full = path.join(SITE, DOCS_MODEL_DIR, `${model.slug}.glb`);
+    const name = `${model.slug}${DOCS_MODEL_EXT}`;
+    const full = path.join(SITE, DOCS_MODEL_DIR, name);
     if (!existsSync(full)) {
-      failures.push(`${model.slug}.glb: in the manifest but not on disk`);
+      failures.push(`${name}: in the manifest but not on disk`);
       continue;
     }
     const size = statSync(full).size;
     if (size !== model.bytes) {
-      failures.push(`${model.slug}.glb: ${size} bytes on disk, manifest says ${model.bytes}`);
+      failures.push(`${name}: ${size} bytes on disk, manifest says ${model.bytes}`);
     }
   }
   return manifest.models.length;
@@ -79,6 +137,7 @@ function verifyModels(failures: string[]): number {
 function main(): void {
   const failures: string[] = [];
   const modelCount = verifyModels(failures);
+  const budget = verifyBudget(failures);
 
   for (const check of CHECKS) {
     const full = path.join(SITE, check.file);
@@ -107,7 +166,8 @@ function main(): void {
     process.exit(1);
   }
   console.log(
-    `✓ docs bundles verified (${CHECKS.length} artifacts, ${modelCount} prebaked models)`,
+    `✓ docs bundles verified (${CHECKS.length} artifacts, ${modelCount} prebaked models; ` +
+      `worst page ${budget.worst.toLocaleString()} B gzipped of ${PER_PAGE_BUDGET.toLocaleString()} — ${budget.page})`,
   );
 }
 


### PR DESCRIPTION
The docs viewer loads on every page (it shows the prebaked model on load), so its size is worth trimming.

## Measured, not guessed

Built per-import variants and recorded real gzipped bytes:

| bundle contains | gz | delta over floor |
|---|---|---|
| three.js `WebGLRenderer` floor | 123,026 | — |
| + `OrbitControls` | 129,181 | +5,155 — **kept**, rotation is the feature |
| + `RoomEnvironment` | 125,697 | +1,671 — **kept**, see below |
| + `GLTFLoader` | 150,528 | **+26,502 — dropped** |
| `import *` → named | 124,026 | 0 — no help, left as-is |

## What changed

**Dropped `GLTFLoader`** — 96% of the removable weight. It only existed because the prebake wrote GLB, but the mesher already produces plain positions/normals/indices and `exportGlb` assembled GLB *from* those. The prebake now emits `.kcm` (a length-prefixed dump of the same arrays, 16-bit indices under 65536 verts) and the island decodes it in ~15 lines. Removes the parser **and** a format conversion; the corpus shrinks too (186 KB vs 199 KB).

**Kept `RoomEnvironment`** — tried replacing it with a generated gradient; it rendered every part 2.7× darker and revived the black-metal bug this work exists to fix. Not worth 1.7 KB. Reason recorded in a comment.

## Results

- Island **158,692 → 133,196 gz (−16.1%)**; finish-edges critical path −15.3%.
- Render unchanged — same arrays, same viewer.

## New gate

Per-page payload budget in `verify-docs-bundle.ts`: 172 KB gzipped critical path, ~3% over today's worst page (curves--surfaces, 166,749). Re-adding a 26 KB dependency trips it. I verified it fails: tightening to 120 KB → build exit 1 listing every page over; restored → exit 0. The code→model SHA-256 staleness gate carries over to `.kcm` unchanged.

## Verification

`docsMesh.test.ts` (round-trip, index-width boundary, magic/truncation) + updated build/model tests green. `tsc --noEmit -p tsconfig.cli.json` clean, `tsc -b` clean, `eslint` clean. Full suite vs pristine baseline: 18 failed files both sides (the known parts-catalog/cli-bundle/nurbs/eval set), +6 tests passing.