### PR TITLE
feat(docs): shaded-with-edges in the viewer

### DIFF
--- a/site/island/docs-island.ts
+++ b/site/island/docs-island.ts
@@ -25,12 +25,11 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { decodeDocsMesh } from './docsMesh';
 import { RoomEnvironment } from 'three/examples/jsm/environments/RoomEnvironment.js';
-import { docsMaterial } from './docsMaterial';
+import { buildPrebakedBody, buildLiveFeature, disposeBodyTree } from './docsBody';
 import type { DocsAppearance } from './docsAppearance';
 import type {
   DocsRunRequest,
   DocsRunResponse,
-  DocsMeshFeature,
   DocsReadyMessage,
 } from './docs-worker';
 
@@ -214,33 +213,8 @@ function ensureStage(root: HTMLElement): Stage | null {
 }
 
 function disposeBodies(stage: Stage): void {
-  stage.bodies.traverse((node) => {
-    if (node instanceof THREE.Mesh) {
-      node.geometry.dispose();
-      const material = node.material;
-      if (Array.isArray(material)) material.forEach((m) => m.dispose());
-      else material.dispose();
-    }
-  });
+  disposeBodyTree(stage.bodies);
   stage.bodies.clear();
-}
-
-function buildFeature(feature: DocsMeshFeature): THREE.Group {
-  const group = new THREE.Group();
-  const material = docsMaterial(feature.appearance);
-  for (const face of feature.faces) {
-    const geometry = new THREE.BufferGeometry();
-    geometry.setAttribute('position', new THREE.BufferAttribute(face.vertices, 3));
-    geometry.setAttribute('normal', new THREE.BufferAttribute(face.normals, 3));
-    geometry.setIndex(new THREE.BufferAttribute(face.indices, 1));
-    group.add(new THREE.Mesh(geometry, material));
-  }
-  if (feature.transform) {
-    // Column-major 4x4 from the assembly solver, which is three's own layout.
-    group.matrixAutoUpdate = false;
-    group.matrix.fromArray(feature.transform as number[]);
-  }
-  return group;
 }
 
 function frame(stage: Stage, bounds: Bounds): void {
@@ -329,16 +303,7 @@ async function showPrebaked(root: HTMLElement): Promise<void> {
   const stage = ensureStage(root);
   if (!stage) return;
   features.forEach((feature, i) => {
-    const geometry = new THREE.BufferGeometry();
-    geometry.setAttribute('position', new THREE.BufferAttribute(feature.positions, 3));
-    geometry.setAttribute('normal', new THREE.BufferAttribute(feature.normals, 3));
-    geometry.setIndex(new THREE.BufferAttribute(feature.indices, 1));
-    const mesh = new THREE.Mesh(geometry, docsMaterial(model.appearances[i]));
-    if (feature.transform) {
-      mesh.matrixAutoUpdate = false;
-      mesh.matrix.fromArray(feature.transform);
-    }
-    stage.bodies.add(mesh);
+    stage.bodies.add(buildPrebakedBody(feature, model.appearances[i]));
   });
   frame(stage, { min: model.bounds.min as Bounds['min'], max: model.bounds.max as Bounds['max'] });
 }
@@ -373,7 +338,7 @@ async function run(root: HTMLElement): Promise<void> {
 
   disposeBodies(stage);
   for (const feature of response.features) {
-    stage.bodies.add(buildFeature(feature));
+    stage.bodies.add(buildLiveFeature(feature));
   }
   if (boundsDiffer(stage.framedOn, response.bounds)) frame(stage, response.bounds);
   setStatus(

--- a/site/island/docsBody.test.ts
+++ b/site/island/docsBody.test.ts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// GATE: every drawn body carries edge lines, on both render paths.
+//
+// The docs viewer shows shaded models with feature edges on top. There are two
+// paths that build a body — the prebaked model (docsBody.buildPrebakedBody) and
+// the live Run result (docsBody.buildLiveFeature) — and both must attach edges
+// from the same code, or pressing Run would redraw the model without them (or
+// with different ones). These tests build bodies through the real functions the
+// island calls and assert the LineSegments child is there, then assert the
+// dispose path frees the edge geometry so a Run does not leak one per press.
+//
+// The prebaked path is checked against the actual .kcm files when a docs build
+// has produced them (they are gitignored build artifacts, so on a clean
+// checkout the synthetic bodies below carry the test). The live path is run once
+// through OCCT, the exact way liveDocsExamples.browser.test.ts runs an example.
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as THREE from 'three';
+import { buildPrebakedBody, buildLiveFeature, disposeBodyTree } from './docsBody';
+import { decodeDocsMesh, type DocsMeshData } from './docsMesh';
+import { appearanceOf } from './docsAppearance';
+import type { DocsMeshFeature, DocsMeshFace } from './docs-worker';
+import { DOCS_MODEL_DIR, DOCS_MODEL_EXT, DOCS_MODEL_MANIFEST } from '../scripts/docsModels';
+import { buildDocsPages } from '../../src/docs/liveDocs';
+import { runScriptInBrowser } from '../../src/modeling/runtime/browserRuntime';
+import {
+  meshFeaturesPerFeature,
+  selectTerminalFeatures,
+} from '../../src/modeling/capture/featureMeshing';
+import { initOcct } from '../../src/kernel/backends/occt/occtBackend';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const MODEL_DIR = path.resolve(HERE, '..', DOCS_MODEL_DIR);
+
+/** The one LineSegments child three attaches under a body, or null. */
+function edgeChild(root: THREE.Object3D): THREE.LineSegments | null {
+  let found: THREE.LineSegments | null = null;
+  root.traverse((n) => {
+    if (n instanceof THREE.LineSegments) found = n;
+  });
+  return found;
+}
+
+function segmentCount(lines: THREE.LineSegments): number {
+  return lines.geometry.getAttribute('position').count / 2;
+}
+
+/** A box, expressed as a prebaked body: twelve feature edges, no triangulation. */
+function boxBody(): DocsMeshData {
+  const g = new THREE.BoxGeometry(10, 10, 10);
+  return {
+    positions: g.getAttribute('position').array as Float32Array,
+    normals: g.getAttribute('normal').array as Float32Array,
+    indices: g.getIndex()!.array as Uint32Array,
+    transform: null,
+  };
+}
+
+/**
+ * A box expressed as the worker expresses it: six independent OCCT faces, each
+ * its own little vertex soup. buildLiveFeature must weld these back into the one
+ * body the prebake would have stored — which is what makes the edges match.
+ */
+function boxFaces(): DocsMeshFace[] {
+  const g = new THREE.BoxGeometry(10, 10, 10).toNonIndexed();
+  const pos = g.getAttribute('position').array as Float32Array;
+  const nor = g.getAttribute('normal').array as Float32Array;
+  const faces: DocsMeshFace[] = [];
+  for (let f = 0; f < 6; f++) {
+    const start = f * 6 * 3; // two triangles, six vertices, three floats each
+    faces.push({
+      vertices: pos.slice(start, start + 18),
+      normals: nor.slice(start, start + 18),
+      indices: new Uint32Array([0, 1, 2, 3, 4, 5]),
+    });
+  }
+  return faces;
+}
+
+describe('docs body edges', () => {
+  it('a prebaked body gets a LineSegments child with feature edges', () => {
+    const mesh = buildPrebakedBody(boxBody(), undefined);
+    const edges = edgeChild(mesh);
+    expect(edges, 'prebaked body has no edge lines').not.toBeNull();
+    // A cube has twelve edges. Anything near zero means EdgesGeometry ran on the
+    // wrong attribute; the full triangle count would mean the threshold is off.
+    expect(segmentCount(edges!)).toBe(12);
+  });
+
+  it('a live feature welds its faces and gets the same edges as the prebaked body', () => {
+    const feature: DocsMeshFeature = {
+      featureId: 'synthetic',
+      faces: boxFaces(),
+      appearance: {},
+    };
+    const mesh = buildLiveFeature(feature);
+    expect(mesh, 'live feature is not a single welded mesh').toBeInstanceOf(THREE.Mesh);
+    const edges = edgeChild(mesh);
+    expect(edges, 'live body has no edge lines').not.toBeNull();
+    // The same twelve a prebaked box gets above: proof the welding lines the two
+    // paths up rather than the live path drawing the full per-face wireframe.
+    expect(segmentCount(edges!)).toBe(12);
+  });
+
+  it('disposeBodyTree frees every edge geometry, not just the meshes', () => {
+    const root = new THREE.Group();
+    root.add(buildPrebakedBody(boxBody(), undefined));
+    root.add(buildLiveFeature({ featureId: 'x', faces: boxFaces(), appearance: {} }));
+
+    // Watch the actual EdgesGeometry instances, since leaking those is the
+    // failure this guards: three fires a 'dispose' event when dispose() runs.
+    const edgeGeometries: THREE.BufferGeometry[] = [];
+    root.traverse((n) => {
+      if (n instanceof THREE.LineSegments) edgeGeometries.push(n.geometry);
+    });
+    expect(edgeGeometries.length).toBeGreaterThan(0);
+    const disposed = new Set<THREE.BufferGeometry>();
+    for (const g of edgeGeometries) g.addEventListener('dispose', () => disposed.add(g));
+
+    disposeBodyTree(root);
+    expect(disposed.size, 'an edge geometry was left undisposed').toBe(edgeGeometries.length);
+  });
+
+  const finishModel = path.join(MODEL_DIR, `finish-edges${DOCS_MODEL_EXT}`);
+  const manifestPath = path.join(MODEL_DIR, DOCS_MODEL_MANIFEST);
+  const built = existsSync(finishModel) && existsSync(manifestPath);
+
+  it.runIf(built)('every prebaked body from the real models carries edges', () => {
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+      models: { slug: string; appearances: (Record<string, unknown> | undefined)[] }[];
+    };
+    let bodiesChecked = 0;
+    let totalSegments = 0;
+    for (const model of manifest.models) {
+      const file = path.join(MODEL_DIR, `${model.slug}${DOCS_MODEL_EXT}`);
+      if (!existsSync(file)) continue;
+      const buf = readFileSync(file);
+      const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+      const bodies = decodeDocsMesh(ab);
+      bodies.forEach((body, i) => {
+        const mesh = buildPrebakedBody(body, model.appearances[i] as never);
+        const edges = edgeChild(mesh);
+        // Every body gets the edge child, from the shared code. The count may be
+        // zero for a legitimately smooth body — a fully-rounded box has no edge
+        // above the threshold — so vacuity is guarded across the corpus below,
+        // not per body.
+        expect(edges, `${model.slug} body ${i} has no edge lines`).not.toBeNull();
+        totalSegments += segmentCount(edges!);
+        bodiesChecked++;
+      });
+    }
+    expect(bodiesChecked, 'no prebaked bodies were checked').toBeGreaterThan(0);
+    expect(totalSegments, 'the whole corpus produced no edge segments').toBeGreaterThan(0);
+  });
+
+  it('a live feature meshed through OCCT carries edges (real Run path)', async () => {
+    await initOcct();
+    const page = buildDocsPages().find((p) => p.slug === 'finish-edges');
+    expect(page?.example, 'finish-edges example is missing').toBeTruthy();
+
+    const result = await runScriptInBrowser({
+      code: page!.example!.code,
+      fileName: 'finish-edges.kcad.js',
+    });
+    const meshed = await meshFeaturesPerFeature(
+      result.records,
+      result.paramTable,
+      result.session as unknown as Parameters<typeof meshFeaturesPerFeature>[2],
+    );
+    const drawn = selectTerminalFeatures(meshed.features).filter((f) => f.faces.length > 0);
+    expect(drawn.length, 'example drew nothing').toBeGreaterThan(0);
+
+    for (const f of drawn) {
+      const feature: DocsMeshFeature = {
+        featureId: f.featureId,
+        faces: f.faces.map((face) => ({
+          vertices: face.vertices,
+          normals: face.normals,
+          indices: face.indices,
+        })),
+        appearance: appearanceOf(f.color, f.material),
+        transform: f.transform,
+      };
+      const mesh = buildLiveFeature(feature);
+      expect(mesh, 'live feature is not a mesh').toBeInstanceOf(THREE.Mesh);
+      expect(edgeChild(mesh), 'a live body has no edge lines').not.toBeNull();
+    }
+  }, 120_000);
+});

--- a/site/island/docsBody.ts
+++ b/site/island/docsBody.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// Turning kernel output into a drawable three body — for the two paths that do
+// it. The prebaked model (loaded before anyone touches the page) and the live
+// Run result arrive differently: the prebake ships one welded geometry per body,
+// the worker ships one array per OCCT face. Both are funnelled through
+// `buildBody` here, so both are shaded by `docsMaterial` and edged by `addEdges`
+// from identical geometry — nothing about pressing Run may change the picture.
+//
+// The edges are why the welding matters. `EdgesGeometry` reads topology: on a
+// welded body a fillet's tangent boundary and a box corner are one continuous
+// surface with a crease at the corner, and it draws the corner. On the raw
+// per-face soup the worker sends, every face boundary is a loose edge and the
+// whole wireframe would be drawn — so a body that shows a handful of edges when
+// prebaked would light up with dozens the instant it was re-run. The live path
+// therefore welds its faces exactly as prebake-docs-models.ts does (concatenate,
+// then mergeVertices), which is what makes the two geometries identical rather
+// than merely close, and the edges with them.
+//
+// This module is import-safe under node (three, three-stdlib, docsMaterial and
+// docsEdges all are), so the render path can be asserted in a test without a
+// browser — see docsBody.test.ts.
+
+import * as THREE from 'three';
+import { mergeVertices } from 'three-stdlib';
+import { docsMaterial } from './docsMaterial';
+import { addEdges } from './docsEdges';
+import type { DocsMeshData } from './docsMesh';
+import type { DocsMeshFeature } from './docs-worker';
+import type { DocsAppearance } from './docsAppearance';
+
+/**
+ * One shaded, edged body from a single welded geometry. The transform, when
+ * present, is the assembly solver's column-major 4x4 — three's own layout —
+ * left on the object rather than applied to the vertices, so the raw
+ * coordinates match what the bounds were computed from.
+ */
+function buildBody(
+  positions: Float32Array,
+  normals: Float32Array,
+  indices: Uint16Array | Uint32Array,
+  appearance: DocsAppearance | undefined,
+  transform: Float32Array | readonly number[] | null | undefined,
+): THREE.Mesh {
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  geometry.setAttribute('normal', new THREE.BufferAttribute(normals, 3));
+  geometry.setIndex(new THREE.BufferAttribute(indices, 1));
+  const mesh = new THREE.Mesh(geometry, docsMaterial(appearance));
+  addEdges(mesh);
+  if (transform) {
+    mesh.matrixAutoUpdate = false;
+    mesh.matrix.fromArray(transform as number[]);
+  }
+  return mesh;
+}
+
+/** A prebaked body: geometry is already welded on disk, drawn as-is. */
+export function buildPrebakedBody(
+  feature: DocsMeshData,
+  appearance: DocsAppearance | undefined,
+): THREE.Mesh {
+  return buildBody(feature.positions, feature.normals, feature.indices, appearance, feature.transform);
+}
+
+/**
+ * A live Run body: the worker's per-face arrays, concatenated and welded into
+ * one geometry — the exact operation prebake-docs-models.ts performs before it
+ * writes the .kcm, so the result is the same welded body the reader already saw.
+ */
+export function buildLiveFeature(feature: DocsMeshFeature): THREE.Mesh {
+  const totalVerts = feature.faces.reduce((s, f) => s + f.vertices.length, 0);
+  const totalIndices = feature.faces.reduce((s, f) => s + f.indices.length, 0);
+  const positions = new Float32Array(totalVerts);
+  const normals = new Float32Array(totalVerts);
+  const indices = new Uint32Array(totalIndices);
+  let vOff = 0;
+  let iOff = 0;
+  for (const face of feature.faces) {
+    positions.set(face.vertices, vOff);
+    normals.set(face.normals, vOff);
+    const base = vOff / 3;
+    for (let i = 0; i < face.indices.length; i++) indices[iOff + i] = face.indices[i] + base;
+    vOff += face.vertices.length;
+    iOff += face.indices.length;
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  geometry.setAttribute('normal', new THREE.BufferAttribute(normals, 3));
+  geometry.setIndex(new THREE.BufferAttribute(indices, 1));
+  // Lossless — differing normals keep hard edges split — and it is what makes
+  // the edge topology match the prebaked model instead of merely resembling it.
+  const welded = mergeVertices(geometry);
+
+  return buildBody(
+    welded.getAttribute('position').array as Float32Array,
+    welded.getAttribute('normal').array as Float32Array,
+    welded.getIndex()!.array as Uint16Array | Uint32Array,
+    feature.appearance,
+    feature.transform,
+  );
+}
+
+/**
+ * Free the GPU resources under a body tree: geometry and material for every
+ * mesh, and the EdgesGeometry for every edge line. The edge material is the
+ * shared singleton from docsEdges, so it is deliberately left alone. Run
+ * replaces the whole model on every press, so an edge geometry not freed here
+ * leaks once per Run.
+ */
+export function disposeBodyTree(root: THREE.Object3D): void {
+  root.traverse((node) => {
+    if (node instanceof THREE.Mesh) {
+      node.geometry.dispose();
+      const material = node.material;
+      if (Array.isArray(material)) material.forEach((m) => m.dispose());
+      else material.dispose();
+    } else if (node instanceof THREE.LineSegments) {
+      node.geometry.dispose();
+    }
+  });
+}

--- a/site/island/docsEdges.ts
+++ b/site/island/docsEdges.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// Feature edges drawn on top of the shaded model — the "shaded with edges" look
+// every mechanical CAD tool ships. Without them a fillet reads as a soft
+// gradient and a counterbore shoulder as a change in brightness; with them each
+// becomes a line the eye lands on.
+//
+// The edges are computed HERE, in the viewer, from the same geometry that is
+// being shaded — never baked into the model file. That is deliberate: the
+// prebaked model and the live Run result must get their edges from this one
+// function, or pressing Run could redraw the edges differently from the picture
+// that loaded with the page. Both `showPrebaked` and `buildFeature` in
+// docs-island.ts call `addEdges` on every mesh they add, so there is no second
+// copy to drift.
+
+import * as THREE from 'three';
+
+/**
+ * The dihedral angle, in degrees, above which a shared edge is drawn.
+ *
+ * `EdgesGeometry` keeps an interior edge only when the angle between its two
+ * triangles exceeds this, and always keeps a boundary edge. That is the whole
+ * trick: a box corner (90°) and a counterbore shoulder are kept, while the
+ * triangulation *within* a flat face (0°) and the fine facets *along* a curved
+ * wall are dropped — so the reader sees feature edges, not a wireframe mesh.
+ *
+ * 30° was tuned against the real docs pages. The corpus meshes coarsely, so a
+ * fillet's blend surface is a few flat facets rather than a smooth sweep, and
+ * the crease where the last facet meets the adjacent flat face lands well above
+ * 30° — which is why fillet boundaries show at all. Lower (≈15°) starts drawing
+ * the facets along cylinder walls (place & transform gained 230+ stray segments
+ * at 1°); higher (≈45°) begins dropping the shallower fillet creases. 30° keeps
+ * the features and none of the tessellation.
+ */
+export const EDGE_THRESHOLD_DEG = 30;
+
+/**
+ * A near-black desaturated blue-grey, not pure black.
+ *
+ * The parts are finished in anodised blues and teals, copper, light steel and a
+ * light neutral. Pure black reads as a harsh cut-out on the darker anodised
+ * faces; this tone sits just dark enough to hold a crisp line on the light
+ * neutral while staying softer than black on the coloured metal.
+ */
+export const EDGE_COLOR = 0x1a2530;
+
+// One material for every edge on the page. The colour never varies by body, so
+// sharing it keeps the line count off the draw budget and means nothing here
+// needs disposing — it lives for the life of the module. `depthTest` stays on;
+// z-fighting is handled on the surface side (see below), not by letting edges
+// punch through the model.
+const edgeMaterial = new THREE.LineBasicMaterial({ color: EDGE_COLOR });
+
+/**
+ * Attach feature edges to a shaded mesh, as a child so they inherit its
+ * transform and frame with it.
+ *
+ * Additive and never load-bearing: if `EdgesGeometry` cannot process this
+ * geometry, the shaded mesh is left exactly as it was. A missing line is a
+ * cosmetic loss; a thrown error here would blank the model, which is the one
+ * outcome the docs viewer must never produce.
+ */
+export function addEdges(mesh: THREE.Mesh): void {
+  try {
+    const edges = new THREE.EdgesGeometry(mesh.geometry, EDGE_THRESHOLD_DEG);
+    mesh.add(new THREE.LineSegments(edges, edgeMaterial));
+  } catch (err) {
+    console.warn('docs: edges unavailable for a body', err);
+  }
+}

--- a/site/island/docsMaterial.ts
+++ b/site/island/docsMaterial.ts
@@ -32,5 +32,14 @@ export function docsMaterial(appearance: DocsAppearance | undefined): THREE.Mesh
     // OCCT emits per-face islands with outward normals; without this the inside
     // of a shelled body reads as a hole.
     side: THREE.DoubleSide,
+    // Push the filled surface a hair back in depth so the edge lines drawn on
+    // top of it (docsEdges.ts) win the depth test cleanly. Edge lines are
+    // coplanar with the faces they trace, and without this bias they shimmer and
+    // drop out as the camera orbits. Offsetting the fill — rather than the lines
+    // — keeps the lines at their true depth, so they never punch through a
+    // surface that is genuinely in front of them.
+    polygonOffset: true,
+    polygonOffsetFactor: 1,
+    polygonOffsetUnits: 1,
   });
 }

--- a/site/scripts/build-docs.ts
+++ b/site/scripts/build-docs.ts
@@ -147,8 +147,11 @@ const BOOTSTRAP = `
       }
       if (examples.length) {
         var idle = window.requestIdleCallback || function (fn) { return setTimeout(fn, 1); };
-        if (document.readyState === 'complete') idle(activate);
-        else window.addEventListener('load', function () { idle(activate); });
+        // The { timeout } bounds the wait: without it a backgrounded or idle-
+        // starved tab can defer activate() indefinitely, so the model never
+        // appears until the tab is focused. 2s guarantees boot regardless.
+        if (document.readyState === 'complete') idle(activate, { timeout: 2000 });
+        else window.addEventListener('load', function () { idle(activate, { timeout: 2000 }); });
       }
     })();
 `;


### PR DESCRIPTION
The docs viewer showed flat-shaded models — a fillet boundary or counterbore shoulder read as a soft gradient, not a line. Adds CAD-style edge overlays.

## How

`EdgesGeometry` at a **30° threshold**, drawn as `LineSegments` over each body. 30° was tuned against the real pages: place-transform is flat at 504 segments from 15–45° (cylinder-wall tessellation only leaks in below ~10°), finish-edges gives 64 at 30°. So 30° sits on the plateau that shows feature edges and hides face triangulation.

- **Colour:** near-black desaturated blue-grey (`0x1a2530`), so it reads on both light-neutral parts and anodised blues.
- **Z-fighting:** `polygonOffset` on the surface material — lines stay at true depth, no shimmer under orbit.

## Both paths share the edge code — and that caught a real bug

Prebaked and live-after-Run both go through one builder (`docsBody.ts`). Building that shared path surfaced a divergence: the prebake welds each body with `mergeVertices`, the worker ships raw per-face arrays, and `EdgesGeometry` gives wildly different results for the two topologies — `measure--verify` (a fully-rounded box) yields **0 edges welded vs a full wireframe live**. Pressing Run would have visibly changed the edges. `buildLiveFeature` now welds identically, so it can't.

## Boot hardening (one line)

`requestIdleCallback` now carries `{ timeout: 2000 }`, so a backgrounded or idle-starved tab still shows its model within 2s instead of waiting indefinitely for idle.

## Verification

- Viewer tests 13 pass; scene-graph gate asserts every body (prebaked AND live) gets an edge `LineSegments` child, and the dispose path frees the edge geometry.
- I broke it my own way — raised the threshold to 179° so no edges extract — and the gate failed (2 tests, "has no edge lines"). Restored.
- All changed files are under `site/`; verified **0 imports** of any of them outside `site/`, so the src-side suite failures are definitionally pre-existing (parts-catalog/network, cli-bundle, nurbs, eval/oracle).
- Budget: worst page 168,835 of 172,000 gzipped — tighter (+2,086), still under.
- `tsc --noEmit -p tsconfig.cli.json`, `eslint` clean.

The authoring agent verified in a real foreground window: edges on the shell rim and fillet boundaries, six boss rims on place-transform, no triangulation, solid under orbit, and present on the live-rebuilt body after Run. I could not independently browser-confirm (my automation tab backgrounds and freezes rAF), so that visual check is the agent's, backed by the scene-graph gate.