### PR TITLE
feat: add read-only Studio embed mode

### DIFF
--- a/src/studio/embedPresentation.ts
+++ b/src/studio/embedPresentation.ts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+export type EmbedPresentation = 'viewer' | 'studio';
+
+/** The plain embed stays the compatibility default; Studio is opt-in per host. */
+export function embedPresentationMode(value: unknown): EmbedPresentation {
+  return value === 'studio' ? 'studio' : 'viewer';
+}

--- a/src/studio/routes/embed.$slug.test.ts
+++ b/src/studio/routes/embed.$slug.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import { describe, expect, it } from 'vitest';
-import { embedPresentationMode } from './embed.$slug';
+import { embedPresentationMode } from '../embedPresentation';
 
 describe('embedPresentationMode', () => {
   it('keeps the default embed model-only', () => {

--- a/src/studio/routes/embed.$slug.test.ts
+++ b/src/studio/routes/embed.$slug.test.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { describe, expect, it } from 'vitest';
+import { embedPresentationMode } from './embed.$slug';
+
+describe('embedPresentationMode', () => {
+  it('keeps the default embed model-only', () => {
+    expect(embedPresentationMode(undefined)).toBe('viewer');
+    expect(embedPresentationMode('anything-else')).toBe('viewer');
+  });
+
+  it('selects the read-only Studio shell only when requested', () => {
+    expect(embedPresentationMode('studio')).toBe('studio');
+  });
+});

--- a/src/studio/routes/embed.$slug.tsx
+++ b/src/studio/routes/embed.$slug.tsx
@@ -22,13 +22,7 @@ import { FunnelViewer } from '../../funnel/components/FunnelViewer';
 import { fetchProjectBySlug, type ProjectRow } from '../../funnel/lib/apiClient';
 import StudioApp from '../App';
 import { StudioConfigProvider } from '../config/StudioConfigContext';
-
-export type EmbedPresentation = 'viewer' | 'studio';
-
-/** The plain embed stays the compatibility default; Studio is opt-in per host. */
-export function embedPresentationMode(value: unknown): EmbedPresentation {
-  return value === 'studio' ? 'studio' : 'viewer';
-}
+import { embedPresentationMode } from '../embedPresentation';
 
 export const Route = createFileRoute('/embed/$slug')({
   validateSearch: (search: Record<string, unknown>) => ({

--- a/src/studio/routes/embed.$slug.tsx
+++ b/src/studio/routes/embed.$slug.tsx
@@ -20,13 +20,26 @@ import { createFileRoute } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 import { FunnelViewer } from '../../funnel/components/FunnelViewer';
 import { fetchProjectBySlug, type ProjectRow } from '../../funnel/lib/apiClient';
+import StudioApp from '../App';
+import { StudioConfigProvider } from '../config/StudioConfigContext';
+
+export type EmbedPresentation = 'viewer' | 'studio';
+
+/** The plain embed stays the compatibility default; Studio is opt-in per host. */
+export function embedPresentationMode(value: unknown): EmbedPresentation {
+  return value === 'studio' ? 'studio' : 'viewer';
+}
 
 export const Route = createFileRoute('/embed/$slug')({
+  validateSearch: (search: Record<string, unknown>) => ({
+    mode: embedPresentationMode(search.mode),
+  }),
   component: EmbedPage,
 });
 
 function EmbedPage() {
   const { slug } = Route.useParams();
+  const { mode } = Route.useSearch();
   const [project, setProject] = useState<ProjectRow | null>(null);
   const [state, setState] = useState<'loading' | 'ready' | 'missing' | 'error'>('loading');
   const [err, setErr] = useState<string | null>(null);
@@ -46,6 +59,13 @@ function EmbedPage() {
   }, [slug]);
 
   if (state === 'ready' && project) {
+    if (mode === 'studio') {
+      return (
+        <StudioConfigProvider value={{ showHeader: false, enableAgentRail: false, enableConnect: false }}>
+          <StudioApp initialCode={project.current_code} viewerMode />
+        </StudioConfigProvider>
+      );
+    }
     return (
       <div className="fixed inset-0">
         <FunnelViewer code={project.current_code} />


### PR DESCRIPTION
Adds an opt-in `?mode=studio` presentation to kernelCAD’s existing public embed route. It reuses the real Studio shell while disabling the header, login surface, agent rail, and Connect link. The default model-only embed remains unchanged.

Validation: focused route test and TypeScript typecheck.