### PR TITLE
fix: stabilize MCP cookbook and STEP imports on release

### DIFF
--- a/scripts/ingestParts.ts
+++ b/scripts/ingestParts.ts
@@ -37,6 +37,10 @@ import { createHash } from 'node:crypto';
 import { inspectStepFile } from '../src/agent/inspect/inspectStep';
 import { synthesizeConnectorsFromReport } from '../src/modeling/parts/synthesizeConnectors';
 import { PAGES_WORKER } from './parts/workerTemplate';
+import {
+  isOcctOutOfMemory,
+  isOutOfMemoryMessage,
+} from '../src/kernel/backends/occt/occtException';
 
 // -----------------------------------------------------------------------------
 // Types — the served record matches the remote adapter's StepPartsRecord shape.
@@ -199,6 +203,22 @@ export async function ingestDirectory(
       records.push(record);
       shaManifest[record.id] = record.sha256;
     } catch (e) {
+      // "Skip the bad file and carry on" is right for genuinely bad geometry
+      // and WRONG for an exhausted kernel heap: once OCCT's wasm heap fills,
+      // every remaining import in this process fails too, so a tolerant loop
+      // would quietly publish a catalog missing a run of perfectly good parts
+      // and label them unparseable. That is strictly worse than no catalog —
+      // it looks successful. Fail the whole ingest, loudly.
+      if (isOcctOutOfMemory(e) || isOutOfMemoryMessage(e)) {
+        throw new Error(
+          `ingestDirectory: OCCT wasm heap exhausted while ingesting ` +
+            `${relative(srcDir, stepPath)} (after ${records.length} part(s)). ` +
+            'This is a host memory limit, NOT a bad STEP file — the remaining parts were ' +
+            'never given a fair chance, so the catalog is incomplete and is not being ' +
+            'published. Re-run the ingest with a smaller batch or more memory.',
+          { cause: e },
+        );
+      }
       skipped.push({ file: relative(srcDir, stepPath), reason: e instanceof Error ? e.message : String(e) });
     }
   }

--- a/src/agent/inspect/inspectStep.ts
+++ b/src/agent/inspect/inspectStep.ts
@@ -19,6 +19,10 @@ import {
   type CylindricalHole,
 } from '../../kernel/backends/occt/holeDetection';
 import { KernelError } from '../../shared/intent/kernelError';
+import {
+  describeOcctThrow,
+  isOcctOutOfMemory,
+} from '../../kernel/backends/occt/occtException';
 
 export interface StepSolidReport {
   /** Stable index in TopExp_Explorer traversal order. */
@@ -78,7 +82,18 @@ export async function inspectStepFile(path: string): Promise<StepInspectReport> 
   try {
     imported = await replicad.importSTEP(blob);
   } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
+    const msg = describeOcctThrow(e);
+    // An exhausted wasm heap is a host condition, not bad input. Saying "not a
+    // valid STEP model" here is what made the parts-catalog OOM look like two
+    // corrupt files for weeks — keep the two stories separate.
+    if (isOcctOutOfMemory(e)) {
+      throw new KernelError(
+        'feature.kernel-failed',
+        `inspectStepFile: ran out of OCCT wasm heap reading ${path}: ${msg}`,
+        undefined,
+        'kernel-failed.inspect.step.out-of-memory — the file is NOT invalid; the geometry kernel exhausted its 2 GiB wasm heap. Restart the host process and retry.',
+      );
+    }
     throw new KernelError(
       'feature.kernel-failed',
       `inspectStepFile: replicad failed to parse STEP at ${path}: ${msg}`,

--- a/src/agent/mcp/tools/lookupCookbook.ts
+++ b/src/agent/mcp/tools/lookupCookbook.ts
@@ -8,6 +8,9 @@
 // is a valid success — tells the agent "no canonical pattern available
 // for this intent; proceed without cookbook help."
 
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
 import { loadSnippets, search } from '../../cookbook/index';
 
 export interface LookupCookbookInput {
@@ -31,9 +34,27 @@ export interface LookupCookbookOutput {
 
 // Snippet inventory is small (~12 in v1) and pure data — load once per
 // process and reuse across calls. Tests load lazily on first use.
+// Resolve the cookbook directory independent of process cwd. In prod the tool
+// runs from the esbuild bundle (dist/mcp/toolRegistry.js) with the cookbook
+// copied alongside it (vendor:build → dist/mcp/cookbook); in dev/tests it runs
+// from source with the cookbook at the repo root. Was previously cwd-relative,
+// which 404'd in the prod container (cwd=/app, no /app/cookbook).
+function resolveCookbookDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    resolve(here, 'cookbook'), // bundled: dist/mcp/toolRegistry.js → dist/mcp/cookbook
+    resolve(here, '../../../../cookbook'), // source: src/agent/mcp/tools → <repo>/cookbook
+    'cookbook', // cwd-relative fallback (repo-root runs/tests)
+  ];
+  return candidates.find((c) => existsSync(resolve(c, 'snippets'))) ?? candidates[candidates.length - 1];
+}
+
 let cached: ReturnType<typeof loadSnippets> | null = null;
 function snippets() {
-  if (cached === null) cached = loadSnippets();
+  if (cached === null) {
+    const dir = resolveCookbookDir();
+    cached = loadSnippets(resolve(dir, 'snippets'), resolve(dir, 'tags.json'));
+  }
   return cached;
 }
 

--- a/src/kernel/backends/occt/occtException.test.ts
+++ b/src/kernel/backends/occt/occtException.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// Regression cover for the `24` incident: two parts catalog STEPs were reported
+// as corrupt because `lib.fetchPart` rendered an OCCT out-of-memory throw as the
+// bare string "24" under the hint "file is not a valid STEP solid". The files
+// were fine. `24` is `__cxa_allocate_exception`'s `malloc(size + 24) + 24` with
+// a null malloc — the signature of an exhausted wasm heap.
+
+import { describe, it, expect } from 'vitest';
+import {
+  describeOcctThrow,
+  isOcctOutOfMemory,
+  isOutOfMemoryMessage,
+  isRawOcctThrow,
+  OUT_OF_MEMORY_MARKER,
+} from './occtException';
+
+describe('isOcctOutOfMemory', () => {
+  it('recognizes 24 — the exact pointer a null malloc produces', () => {
+    // __cxa_allocate_exception(size) = _malloc(size + 24) + 24; malloc → 0.
+    expect(isOcctOutOfMemory(24)).toBe(true);
+  });
+
+  it('recognizes any sub-static-base pointer, not just 24', () => {
+    // The same arithmetic applies to every C++ exception type OCCT throws once
+    // malloc starts returning null, so the header offset is not always 24.
+    expect(isOcctOutOfMemory(0)).toBe(true);
+    expect(isOcctOutOfMemory(16)).toBe(true);
+    expect(isOcctOutOfMemory(1023)).toBe(true);
+  });
+
+  it('does not claim a genuine heap-allocated exception pointer is an OOM', () => {
+    // Emscripten static data starts at 1024; real allocations land far above it.
+    expect(isOcctOutOfMemory(1024)).toBe(false);
+    expect(isOcctOutOfMemory(5_600_432)).toBe(false);
+  });
+
+  it('ignores non-numeric throws', () => {
+    expect(isOcctOutOfMemory(new Error('boom'))).toBe(false);
+    expect(isOcctOutOfMemory('24')).toBe(false);
+    expect(isOcctOutOfMemory(undefined)).toBe(false);
+    expect(isOcctOutOfMemory(24.5)).toBe(false);
+  });
+});
+
+describe('isRawOcctThrow', () => {
+  it('separates bare Emscripten pointers from real Errors', () => {
+    expect(isRawOcctThrow(5_600_432)).toBe(true);
+    expect(isRawOcctThrow(new Error('nope'))).toBe(false);
+  });
+});
+
+describe('describeOcctThrow', () => {
+  it('never renders an OOM as a bare number', () => {
+    const msg = describeOcctThrow(24);
+    expect(msg).not.toBe('24');
+    expect(msg).toContain(OUT_OF_MEMORY_MARKER);
+    // The whole point: say it is NOT the input's fault.
+    expect(msg).toContain('not a problem with the input geometry');
+  });
+
+  it('labels an opaque pointer as opaque instead of implying meaning', () => {
+    const msg = describeOcctThrow(5_600_432);
+    expect(msg).toContain('5600432');
+    expect(msg).toContain('no message is recoverable');
+  });
+
+  it('passes Error messages through unchanged', () => {
+    expect(describeOcctThrow(new Error('Failed to load STEP file'))).toBe(
+      'Failed to load STEP file',
+    );
+  });
+});
+
+describe('isOutOfMemoryMessage', () => {
+  it('matches a wrapped failure by its hint marker', () => {
+    expect(
+      isOutOfMemoryMessage({
+        message: 'lib.fetchPart: ...',
+        hint: 'kernel-failed.lib.fetchPart.out-of-memory — the catalog STEP is NOT invalid',
+      }),
+    ).toBe(true);
+  });
+
+  it('matches a wrapped failure by its message marker', () => {
+    expect(isOutOfMemoryMessage(new Error(`x: ${OUT_OF_MEMORY_MARKER} (ptr 24)`))).toBe(true);
+  });
+
+  it('does not match an ordinary parse failure', () => {
+    expect(
+      isOutOfMemoryMessage({
+        message: 'inspectStepFile: replicad failed to parse STEP',
+        hint: 'kernel-failed.inspect.step.parse — file is not a valid STEP model',
+      }),
+    ).toBe(false);
+    expect(isOutOfMemoryMessage(null)).toBe(false);
+    expect(isOutOfMemoryMessage(24)).toBe(false);
+  });
+});

--- a/src/kernel/backends/occt/occtException.ts
+++ b/src/kernel/backends/occt/occtException.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/kernel/backends/occt/occtException.ts
+//
+// Classifier for the raw values OCCT's Emscripten build throws into JS.
+//
+// WHY THIS EXISTS
+// ---------------
+// replicad-opencascadejs is compiled with Emscripten's JS-exception ABI. When
+// C++ code inside the wasm module throws, the glue does:
+//
+//     function ___cxa_allocate_exception(size) { return _malloc(size + 24) + 24 }
+//     function ___cxa_throw(ptr, type, destructor) { ...; throw ptr }
+//
+// i.e. what reaches JS is a bare **number** — the address of the exception
+// object in the wasm heap — not an `Error`. Every `e instanceof Error ?
+// e.message : String(e)` in our code therefore renders an OCCT failure as a
+// meaningless integer like `24`, and the surrounding diagnostic ("file is not
+// a valid STEP solid") is an outright lie about what went wrong.
+//
+// THE `24` FINGERPRINT
+// --------------------
+// Read the allocator again: the thrown pointer is `malloc(size + 24) + 24`.
+// When the wasm heap is exhausted `_malloc` returns 0, so the thrown pointer is
+// exactly `0 + 24 === 24`. **A thrown `24` is not a status code and carries no
+// per-file meaning — it is the signature of an out-of-memory wasm heap.**
+// (Verified by exhausting the heap with raw `_malloc` calls and then importing
+// a STEP that parses fine on a healthy heap: the import throws the number 24.)
+//
+// Emscripten places static data at address 1024 and up, so no *successful*
+// exception allocation can ever land below that. We treat any thrown number
+// under that floor as a failed allocation rather than special-casing 24 alone,
+// because the same arithmetic applies to any C++ exception type OCCT throws
+// once malloc starts returning null.
+//
+// The practical consequence for callers: an OOM is a *host* condition, not a
+// property of the input. Retrying after freeing heap can succeed with the exact
+// same bytes, and reporting it as bad input sends people to debug the wrong
+// thing (which is exactly what happened to the parts catalog).
+
+/** Emscripten's static-data base. Nothing valid is allocated below this. */
+const WASM_STATIC_BASE = 1024;
+
+/** Stable substring stamped into every OOM message so wrapped failures stay
+ *  identifiable after the raw pointer has been discarded. */
+export const OUT_OF_MEMORY_MARKER = 'OCCT wasm heap exhausted';
+
+/**
+ * True when `e` is a raw Emscripten C++ exception pointer (a bare number)
+ * whose value proves the underlying `malloc` returned null — i.e. the OCCT
+ * wasm heap is exhausted.
+ */
+export function isOcctOutOfMemory(e: unknown): boolean {
+  return typeof e === 'number' && Number.isInteger(e) && e >= 0 && e < WASM_STATIC_BASE;
+}
+
+/** True when `e` is a raw Emscripten exception pointer of any kind. */
+export function isRawOcctThrow(e: unknown): boolean {
+  return typeof e === 'number';
+}
+
+/**
+ * Render a value thrown out of the OCCT wasm module as something a human can
+ * act on. `Error`s pass through by message; the OOM fingerprint is named as
+ * such; any other bare pointer is labelled as the opaque thing it is, so a
+ * reader is not misled into thinking the number means anything.
+ */
+export function describeOcctThrow(e: unknown): string {
+  if (isOcctOutOfMemory(e)) {
+    return (
+      `${OUT_OF_MEMORY_MARKER} (allocation failed; raw exception pointer ${String(e)}). ` +
+      'This is a host memory condition, not a problem with the input geometry.'
+    );
+  }
+  if (isRawOcctThrow(e)) {
+    return (
+      `OCCT threw a C++ exception at wasm address ${String(e)} ` +
+      '(Emscripten throws a bare pointer; no message is recoverable from this build).'
+    );
+  }
+  return e instanceof Error ? e.message : String(e);
+}
+
+/**
+ * True when `e` is an already-wrapped out-of-memory failure — a `KernelError`
+ * (or any Error) that one of the import sites above produced from a raw OOM
+ * pointer. By that point the bare number is gone, so callers further up the
+ * stack (the ingest driver) match on the marker those sites stamp into the
+ * hint/message instead.
+ */
+export function isOutOfMemoryMessage(e: unknown): boolean {
+  if (typeof e !== 'object' || e === null) return false;
+  const hint = (e as { hint?: unknown }).hint;
+  if (typeof hint === 'string' && hint.includes('.out-of-memory')) return true;
+  const message = (e as { message?: unknown }).message;
+  return typeof message === 'string' && message.includes(OUT_OF_MEMORY_MARKER);
+}

--- a/src/modeling/parts/fromSTEP.ts
+++ b/src/modeling/parts/fromSTEP.ts
@@ -66,6 +66,14 @@ export async function fromSTEP(ctx: FromSTEPContext, path: string): Promise<Shap
         'kernel-failed.lib.fromSTEP.no-solid — the STEP file must contain at least one closed solid body.',
       );
     }
+    if (e instanceof StepParseError && e.reason === 'out-of-memory') {
+      throw new KernelError(
+        'feature.kernel-failed',
+        `lib.fromSTEP: ran out of OCCT wasm heap importing ${absPath}: ${e.message}`,
+        undefined,
+        'kernel-failed.lib.fromSTEP.out-of-memory — the file is NOT invalid; the geometry kernel exhausted its 2 GiB wasm heap. Import fewer/smaller parts in one session, or restart the host process.',
+      );
+    }
     const msg = e instanceof Error ? e.message : String(e);
     throw new KernelError(
       'feature.kernel-failed',
@@ -121,6 +129,14 @@ export async function fromStepBytes(
         `lib.fetchPart: ${sourceLabel} did not contain a 3D solid.`,
         undefined,
         'kernel-failed.lib.fetchPart.no-solid.',
+      );
+    }
+    if (e instanceof StepParseError && e.reason === 'out-of-memory') {
+      throw new KernelError(
+        'feature.kernel-failed',
+        `lib.fetchPart: ran out of OCCT wasm heap importing ${sourceLabel}: ${e.message}`,
+        undefined,
+        'kernel-failed.lib.fetchPart.out-of-memory — the catalog STEP is NOT invalid; the geometry kernel exhausted its 2 GiB wasm heap. Import fewer/smaller parts in one session, or restart the host process.',
       );
     }
     const msg = e instanceof Error ? e.message : String(e);

--- a/src/modeling/parts/fromSTEP.ts
+++ b/src/modeling/parts/fromSTEP.ts
@@ -8,10 +8,10 @@
 // the lowered shape on the FeatureRecord's metadata so the lowerer can
 // hand it back without re-importing.
 
-import * as replicad from 'replicad';
 import { readFile } from 'node:fs/promises';
 import { resolveScriptRelativePath } from '../../shared/runtime/scriptRelativePath';
-import { OcctBackend, initOcct } from '../../kernel/backends/occt/occtBackend';
+import { OcctBackend } from '../../kernel/backends/occt/occtBackend';
+import { importStepCached, StepParseError } from './stepParseCache';
 import { Shape } from '../capture/proxy';
 import type { CaptureSession } from '../capture/captureSession';
 import { KernelError } from '../../shared/intent/kernelError';
@@ -48,16 +48,24 @@ export async function fromSTEP(ctx: FromSTEPContext, path: string): Promise<Shap
     );
   }
 
-  await initOcct();
-
-  // replicad.importSTEP wants a Blob. In Node 22+, Blob is global.
-  // The bytes copy is unavoidable: importSTEP reads the blob async.
-  const blob = new Blob([new Uint8Array(buf)]);
-
-  let imported: replicad.AnyShape;
+  // Parse (or reuse a content-hash-cached parse of) the STEP bytes. The cache
+  // is what keeps a Studio rebuild from re-importing an unchanged part on
+  // every code edit. We re-raise its failures as this call's KernelErrors so
+  // the agent-facing diagnostics are unchanged.
+  let backend: OcctBackend;
   try {
-    imported = await replicad.importSTEP(blob);
+    backend = await importStepCached(buf);
   } catch (e) {
+    if (e instanceof StepParseError && e.reason === 'no-solid') {
+      // A Shape3D-class result is required (Solid / CompSolid / Compound);
+      // 2D drawings and empty imports are rejected before the lowerer.
+      throw new KernelError(
+        'feature.kernel-failed',
+        `lib.fromSTEP: ${absPath} did not contain a 3D solid.`,
+        undefined,
+        'kernel-failed.lib.fromSTEP.no-solid — the STEP file must contain at least one closed solid body.',
+      );
+    }
     const msg = e instanceof Error ? e.message : String(e);
     throw new KernelError(
       'feature.kernel-failed',
@@ -66,24 +74,6 @@ export async function fromSTEP(ctx: FromSTEPContext, path: string): Promise<Shap
       'kernel-failed.lib.fromSTEP.parse — file is not a valid STEP solid; re-export from the source CAD as AP203/AP214 with solid bodies.',
     );
   }
-
-  // We expect a Shape3D-class result (Solid / CompSolid / Compound). Reject
-  // 2D drawings or empty imports up-front so the lowerer never sees them.
-  // Duck-typed against `meshShape` — the method lives on replicad's `_3DShape`
-  // prototype only, so a 2D `Sketch` import would correctly fail this check.
-  if (
-    !imported ||
-    typeof (imported as { meshShape?: unknown }).meshShape !== 'function'
-  ) {
-    throw new KernelError(
-      'feature.kernel-failed',
-      `lib.fromSTEP: ${absPath} did not contain a 3D solid.`,
-      undefined,
-      'kernel-failed.lib.fromSTEP.no-solid — the STEP file must contain at least one closed solid body.',
-    );
-  }
-
-  const backend = new OcctBackend(imported as replicad.Shape3D);
 
   // Park the lowered shape on the session's `importedGeometry` map (not in
   // metadata): replicad shapes carry circular refs that trip the
@@ -121,12 +111,18 @@ export async function fromStepBytes(
       'parts.fetch.empty-bytes — re-fetch and try again.',
     );
   }
-  await initOcct();
-  const blob = new Blob([new Uint8Array(bytes)]);
-  let imported: replicad.AnyShape;
+  let backend: OcctBackend;
   try {
-    imported = await replicad.importSTEP(blob);
+    backend = await importStepCached(bytes);
   } catch (e) {
+    if (e instanceof StepParseError && e.reason === 'no-solid') {
+      throw new KernelError(
+        'feature.kernel-failed',
+        `lib.fetchPart: ${sourceLabel} did not contain a 3D solid.`,
+        undefined,
+        'kernel-failed.lib.fetchPart.no-solid.',
+      );
+    }
     const msg = e instanceof Error ? e.message : String(e);
     throw new KernelError(
       'feature.kernel-failed',
@@ -135,18 +131,6 @@ export async function fromStepBytes(
       'kernel-failed.lib.fetchPart.parse — file is not a valid STEP solid.',
     );
   }
-  if (
-    !imported ||
-    typeof (imported as { meshShape?: unknown }).meshShape !== 'function'
-  ) {
-    throw new KernelError(
-      'feature.kernel-failed',
-      `lib.fetchPart: ${sourceLabel} did not contain a 3D solid.`,
-      undefined,
-      'kernel-failed.lib.fetchPart.no-solid.',
-    );
-  }
-  const backend = new OcctBackend(imported as replicad.Shape3D);
   const shape = ctx.session.createShape({
     kind: 'importedStep',
     params: {},

--- a/src/modeling/parts/stepParseCache.test.ts
+++ b/src/modeling/parts/stepParseCache.test.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/modeling/parts/stepParseCache.test.ts
+//
+// The Studio "Computing" stall on models with imported parts is dominated by
+// re-running replicad.importSTEP every rebuild. This guards the content-hash
+// parse cache that removes the re-parse: identical bytes parse once, and each
+// call still hands back an independent clone the caller can safely consume.
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { OcctBackend, initOcct } from '../../kernel/backends/occt/occtBackend';
+import {
+  importStepCached,
+  StepParseError,
+  __stepParseCacheStats,
+  __resetStepParseCache,
+} from './stepParseCache';
+
+let boxBytes: Buffer;
+let smallBoxBytes: Buffer;
+
+beforeAll(async () => {
+  await initOcct();
+  boxBytes = Buffer.from(await OcctBackend.box(20, 30, 40, false).exportSTEPAsync());
+  smallBoxBytes = Buffer.from(await OcctBackend.box(5, 5, 5, false).exportSTEPAsync());
+});
+
+beforeEach(() => __resetStepParseCache());
+
+describe('importStepCached', () => {
+  it('parses STEP bytes into a positive-volume solid', async () => {
+    const backend = await importStepCached(boxBytes);
+    // 20 * 30 * 40 = 24000 mm³ — leave headroom for STEP rounding.
+    expect(backend.volume()).toBeGreaterThan(23000);
+    expect(backend.volume()).toBeLessThan(25000);
+  });
+
+  it('parses only once for identical bytes (second call is a cache hit)', async () => {
+    await importStepCached(boxBytes);
+    await importStepCached(boxBytes);
+    const stats = __stepParseCacheStats();
+    expect(stats.misses).toBe(1);
+    expect(stats.hits).toBe(1);
+    expect(stats.size).toBe(1);
+  });
+
+  it('hands back an independent clone — disposing one does not break the next', async () => {
+    const first = await importStepCached(boxBytes);
+    // Destroy this handle the way a downstream translate/rotate would.
+    first.dispose();
+    // The cached master must survive and still yield a usable solid.
+    const second = await importStepCached(boxBytes);
+    expect(second.volume()).toBeGreaterThan(23000);
+  });
+
+  it('keys on content, not identity — different bytes miss separately', async () => {
+    await importStepCached(boxBytes);
+    await importStepCached(smallBoxBytes);
+    const stats = __stepParseCacheStats();
+    expect(stats.misses).toBe(2);
+    expect(stats.size).toBe(2);
+  });
+
+  it('throws StepParseError(parse) on bytes that are not STEP', async () => {
+    const garbage = Buffer.from('this is not a STEP file');
+    await expect(importStepCached(garbage)).rejects.toBeInstanceOf(StepParseError);
+    await expect(importStepCached(garbage)).rejects.toMatchObject({ reason: 'parse' });
+  });
+});

--- a/src/modeling/parts/stepParseCache.ts
+++ b/src/modeling/parts/stepParseCache.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/modeling/parts/stepParseCache.ts
+//
+// Content-addressed cache for parsed STEP geometry.
+//
+// Every Studio rebuild re-runs the .kcad.ts capture phase from scratch, so
+// each `lib.fromSTEP` / `lib.fetchPart` call would otherwise re-run
+// replicad.importSTEP — the expensive STEP-text → BREP reconstruction — even
+// when the bytes are byte-identical to the previous rebuild. That repeated
+// re-parse is the dominant cost behind the Studio "Computing" stall on models
+// that carry imported parts.
+//
+// Keyed by sha256(bytes). On a hit we hand back `master.clone()`, never the
+// cached master itself: the per-session backend gets parked on
+// session.importedGeometry and is then consumed during lowering (replicad's
+// translate/rotate/mirror destroy their source OCCT handle), so the master
+// must stay independent and alive across sessions. This mirrors the
+// clone-on-handback contract the lowerer already uses for importedStep
+// records (occtLowerer.ts).
+//
+// The cache is a bounded LRU: capacity caps the number of live master BREP
+// shapes held in the OCCT WASM heap; evicted masters are disposed.
+
+import * as replicad from 'replicad';
+import { createHash } from 'node:crypto';
+import { OcctBackend, initOcct } from '../../kernel/backends/occt/occtBackend';
+
+/** Why a STEP byte buffer could not be turned into a 3D solid. Reported so
+ *  callers map to their own KernelError code/hint — the cache stays free of
+ *  caller-specific diagnostics. */
+export type StepParseFailure = 'parse' | 'no-solid';
+
+export class StepParseError extends Error {
+  // erasableSyntaxOnly forbids constructor parameter properties — declare explicitly.
+  readonly reason: StepParseFailure;
+  constructor(reason: StepParseFailure, message: string) {
+    super(message);
+    this.reason = reason;
+    this.name = 'StepParseError';
+  }
+}
+
+/** Max distinct parsed STEP master shapes kept alive. The working set is the
+ *  distinct imported parts in the current model; a few dozen covers a large
+ *  assembly while bounding WASM-heap growth across a long session. */
+const MAX_ENTRIES = 32;
+
+const cache = new Map<string, OcctBackend>();
+let hits = 0;
+let misses = 0;
+
+function sha256Hex(bytes: Buffer | Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+/**
+ * Parse STEP bytes into an OcctBackend, reusing a cached parse when the exact
+ * same bytes were seen before. Always returns a fresh clone the caller owns
+ * and may safely consume (transform / dispose) without affecting the cache.
+ *
+ * @throws StepParseError('parse')    replicad.importSTEP rejected the bytes
+ * @throws StepParseError('no-solid') the import held no 3D solid body
+ */
+export async function importStepCached(bytes: Buffer | Uint8Array): Promise<OcctBackend> {
+  const key = sha256Hex(bytes);
+
+  const cached = cache.get(key);
+  if (cached) {
+    // LRU bump: re-insert to mark most-recently-used.
+    cache.delete(key);
+    cache.set(key, cached);
+    hits++;
+    return cached.clone();
+  }
+
+  await initOcct();
+  // replicad.importSTEP wants a Blob. The bytes copy is unavoidable.
+  const blob = new Blob([new Uint8Array(bytes)]);
+  let imported: replicad.AnyShape;
+  try {
+    imported = await replicad.importSTEP(blob);
+  } catch (e) {
+    throw new StepParseError('parse', e instanceof Error ? e.message : String(e));
+  }
+  // Duck-type the Shape3D check: `meshShape` lives on replicad's `_3DShape`
+  // prototype only, so a 2D Sketch import correctly fails here.
+  if (!imported || typeof (imported as { meshShape?: unknown }).meshShape !== 'function') {
+    throw new StepParseError('no-solid', 'STEP import contained no 3D solid body');
+  }
+
+  const master = new OcctBackend(imported as replicad.Shape3D);
+  cache.set(key, master);
+  misses++;
+
+  // Evict oldest beyond capacity; dispose the evicted master's OCCT handle so
+  // the WASM heap doesn't grow unbounded. Outstanding clones are independent
+  // handles and are unaffected.
+  while (cache.size > MAX_ENTRIES) {
+    const oldestKey = cache.keys().next().value as string | undefined;
+    if (oldestKey === undefined) break;
+    const evicted = cache.get(oldestKey);
+    cache.delete(oldestKey);
+    evicted?.dispose();
+  }
+
+  return master.clone();
+}
+
+/** Test-only: parse-cache instrumentation. */
+export function __stepParseCacheStats(): { hits: number; misses: number; size: number } {
+  return { hits, misses, size: cache.size };
+}
+
+/** Test-only: drop all cached masters (disposing their OCCT handles) and reset counters. */
+export function __resetStepParseCache(): void {
+  for (const v of cache.values()) v.dispose();
+  cache.clear();
+  hits = 0;
+  misses = 0;
+}

--- a/src/modeling/parts/stepParseCache.ts
+++ b/src/modeling/parts/stepParseCache.ts
@@ -25,11 +25,17 @@
 import * as replicad from 'replicad';
 import { createHash } from 'node:crypto';
 import { OcctBackend, initOcct } from '../../kernel/backends/occt/occtBackend';
+import { describeOcctThrow, isOcctOutOfMemory } from '../../kernel/backends/occt/occtException';
 
 /** Why a STEP byte buffer could not be turned into a 3D solid. Reported so
  *  callers map to their own KernelError code/hint — the cache stays free of
- *  caller-specific diagnostics. */
-export type StepParseFailure = 'parse' | 'no-solid';
+ *  caller-specific diagnostics.
+ *
+ *  `out-of-memory` is deliberately distinct from `parse`: it says nothing about
+ *  the bytes. The OCCT wasm heap filled up, the same bytes parse fine on a
+ *  healthy heap, and telling the caller their file is malformed sends them to
+ *  debug the wrong thing. See occtException.ts for how we identify it. */
+export type StepParseFailure = 'parse' | 'no-solid' | 'out-of-memory';
 
 export class StepParseError extends Error {
   // erasableSyntaxOnly forbids constructor parameter properties — declare explicitly.
@@ -76,12 +82,33 @@ export async function importStepCached(bytes: Buffer | Uint8Array): Promise<Occt
 
   await initOcct();
   // replicad.importSTEP wants a Blob. The bytes copy is unavoidable.
-  const blob = new Blob([new Uint8Array(bytes)]);
   let imported: replicad.AnyShape;
   try {
-    imported = await replicad.importSTEP(blob);
+    imported = await replicad.importSTEP(new Blob([new Uint8Array(bytes)]));
   } catch (e) {
-    throw new StepParseError('parse', e instanceof Error ? e.message : String(e));
+    if (!isOcctOutOfMemory(e)) {
+      throw new StepParseError('parse', describeOcctThrow(e));
+    }
+    // Self-heal: the masters this cache pins are, by design, the largest
+    // long-lived consumers of the OCCT wasm heap (MAX_ENTRIES of them, each a
+    // fully reconstructed BREP). In a long-lived host — the MCP server, a
+    // Studio session — they are the reason the heap reached its ceiling, and
+    // once it does EVERY subsequent import fails, permanently, until the
+    // process restarts. Drop them and retry once with the same bytes.
+    //
+    // Outstanding clones handed to callers are independent OCCT handles, so
+    // disposing the masters cannot invalidate geometry already in use.
+    purgeMasters();
+    try {
+      imported = await replicad.importSTEP(new Blob([new Uint8Array(bytes)]));
+    } catch (retryErr) {
+      // Still out of memory after reclaiming every master: the heap pressure is
+      // coming from outside this cache and we have nothing left to give back.
+      throw new StepParseError(
+        isOcctOutOfMemory(retryErr) ? 'out-of-memory' : 'parse',
+        describeOcctThrow(retryErr),
+      );
+    }
   }
   // Duck-type the Shape3D check: `meshShape` lives on replicad's `_3DShape`
   // prototype only, so a 2D Sketch import correctly fails here.
@@ -112,10 +139,17 @@ export function __stepParseCacheStats(): { hits: number; misses: number; size: n
   return { hits, misses, size: cache.size };
 }
 
-/** Test-only: drop all cached masters (disposing their OCCT handles) and reset counters. */
-export function __resetStepParseCache(): void {
+/** Drop every cached master, returning its BREP to the OCCT wasm heap. Leaves
+ *  the hit/miss counters alone — this runs on the OOM recovery path, where the
+ *  instrumentation is what tells us reclamation happened. */
+function purgeMasters(): void {
   for (const v of cache.values()) v.dispose();
   cache.clear();
+}
+
+/** Test-only: drop all cached masters (disposing their OCCT handles) and reset counters. */
+export function __resetStepParseCache(): void {
+  purgeMasters();
   hits = 0;
   misses = 0;
 }

--- a/src/modeling/parts/stepParseCache.ts
+++ b/src/modeling/parts/stepParseCache.ts
@@ -53,6 +53,10 @@ export class StepParseError extends Error {
 const MAX_ENTRIES = 32;
 
 const cache = new Map<string, OcctBackend>();
+/** One parse master per content hash while its async import is in progress.
+ *  It must be reserved before `initOcct()` / `importSTEP()` yield so concurrent
+ *  callers do not all observe the cold cache and build duplicate masters. */
+const pending = new Map<string, Promise<OcctBackend>>();
 let hits = 0;
 let misses = 0;
 
@@ -68,18 +72,7 @@ function sha256Hex(bytes: Buffer | Uint8Array): string {
  * @throws StepParseError('parse')    replicad.importSTEP rejected the bytes
  * @throws StepParseError('no-solid') the import held no 3D solid body
  */
-export async function importStepCached(bytes: Buffer | Uint8Array): Promise<OcctBackend> {
-  const key = sha256Hex(bytes);
-
-  const cached = cache.get(key);
-  if (cached) {
-    // LRU bump: re-insert to mark most-recently-used.
-    cache.delete(key);
-    cache.set(key, cached);
-    hits++;
-    return cached.clone();
-  }
-
+async function parseMaster(key: string, bytes: Buffer | Uint8Array): Promise<OcctBackend> {
   await initOcct();
   // replicad.importSTEP wants a Blob. The bytes copy is unavoidable.
   let imported: replicad.AnyShape;
@@ -117,6 +110,17 @@ export async function importStepCached(bytes: Buffer | Uint8Array): Promise<Occt
   }
 
   const master = new OcctBackend(imported as replicad.Shape3D);
+  // A pending entry makes this branch unreachable in normal operation. Keep
+  // the guard because a reset/recovery boundary can retire an in-flight entry:
+  // never overwrite a live master or orphan the just-parsed OCCT handle.
+  const existing = cache.get(key);
+  if (existing) {
+    master.dispose();
+    cache.delete(key);
+    cache.set(key, existing);
+    return existing;
+  }
+
   cache.set(key, master);
   misses++;
 
@@ -131,6 +135,56 @@ export async function importStepCached(bytes: Buffer | Uint8Array): Promise<Occt
     evicted?.dispose();
   }
 
+  return master;
+}
+
+/** Reserve the per-hash promise before parsing can yield. The completion
+ *  handlers clear only their own entry, so a later retry cannot be erased by
+ *  an older failed import finishing afterwards. */
+function reservePendingParse(key: string, bytes: Buffer | Uint8Array): Promise<OcctBackend> {
+  let resolveMaster!: (master: OcctBackend) => void;
+  let rejectMaster!: (reason?: unknown) => void;
+  const inFlight = new Promise<OcctBackend>((resolve, reject) => {
+    resolveMaster = resolve;
+    rejectMaster = reject;
+  });
+  pending.set(key, inFlight);
+
+  void parseMaster(key, bytes).then(
+    (master) => {
+      if (pending.get(key) === inFlight) pending.delete(key);
+      resolveMaster(master);
+    },
+    (error: unknown) => {
+      if (pending.get(key) === inFlight) pending.delete(key);
+      rejectMaster(error);
+    },
+  );
+
+  return inFlight;
+}
+
+export async function importStepCached(bytes: Buffer | Uint8Array): Promise<OcctBackend> {
+  const key = sha256Hex(bytes);
+
+  const cached = cache.get(key);
+  if (cached) {
+    // LRU bump: re-insert to mark most-recently-used.
+    cache.delete(key);
+    cache.set(key, cached);
+    hits++;
+    return cached.clone();
+  }
+
+  const inFlight = pending.get(key);
+  if (inFlight) {
+    // A pending parse is a logical cache hit: it has already reserved the one
+    // master this content hash may create, and each waiter still clones it.
+    hits++;
+    return (await inFlight).clone();
+  }
+
+  const master = await reservePendingParse(key, bytes);
   return master.clone();
 }
 
@@ -150,6 +204,7 @@ function purgeMasters(): void {
 /** Test-only: drop all cached masters (disposing their OCCT handles) and reset counters. */
 export function __resetStepParseCache(): void {
   purgeMasters();
+  pending.clear();
   hits = 0;
   misses = 0;
 }

--- a/src/modeling/parts/stepParseCacheOom.test.ts
+++ b/src/modeling/parts/stepParseCacheOom.test.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/modeling/parts/stepParseCacheOom.test.ts
+//
+// The out-of-memory path of the STEP parse cache. Kept out of
+// stepParseCache.test.ts because it mocks replicad.importSTEP, while that file
+// deliberately exercises the real OCCT importer.
+//
+// Background: an exhausted OCCT wasm heap surfaces in JS as the bare number 24
+// (`__cxa_allocate_exception` = `malloc(size + 24) + 24`, with malloc → 0).
+// Reported as a parse failure it reads as "your file is corrupt", which is both
+// wrong and unactionable — the same bytes import fine on a healthy heap.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const importSTEP = vi.fn();
+
+vi.mock('replicad', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('replicad')>();
+  return { ...actual, importSTEP: (blob: Blob) => importSTEP(blob) };
+});
+
+vi.mock('../../kernel/backends/occt/occtBackend', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../kernel/backends/occt/occtBackend')>();
+  // initOcct would boot the real wasm module; these tests never reach OCCT.
+  return { ...actual, initOcct: vi.fn(async () => {}) };
+});
+
+const { importStepCached, StepParseError, __resetStepParseCache } = await import(
+  './stepParseCache'
+);
+
+/** Minimal stand-in for a replicad Shape3D — `meshShape` is the duck-type the
+ *  cache uses to accept an import as 3D. */
+function fakeSolid(): unknown {
+  return { meshShape: () => undefined, clone: () => fakeSolid(), delete: () => {} };
+}
+
+const OOM = 24;
+
+beforeEach(() => {
+  importSTEP.mockReset();
+  __resetStepParseCache();
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('importStepCached — OCCT out-of-memory', () => {
+  it('retries once after purging cached masters, and succeeds', async () => {
+    // First call OOMs; the cache drops its masters to reclaim wasm heap and the
+    // retry — with the identical bytes — goes through.
+    importSTEP.mockRejectedValueOnce(OOM).mockResolvedValueOnce(fakeSolid());
+
+    await expect(importStepCached(Buffer.from('step-a'))).resolves.toBeDefined();
+    expect(importSTEP).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports out-of-memory, NOT a parse failure, when the retry also OOMs', async () => {
+    importSTEP.mockRejectedValue(OOM);
+
+    const err = await importStepCached(Buffer.from('step-b')).catch((e) => e);
+    expect(err).toBeInstanceOf(StepParseError);
+    expect((err as InstanceType<typeof StepParseError>).reason).toBe('out-of-memory');
+    // The old behaviour was a message of literally "24".
+    expect((err as Error).message).not.toBe('24');
+    expect((err as Error).message).toContain('OCCT wasm heap exhausted');
+  });
+
+  it('does not retry — or mislabel — an ordinary parse failure', async () => {
+    importSTEP.mockRejectedValue(new Error('Failed to load STEP file'));
+
+    const err = await importStepCached(Buffer.from('step-c')).catch((e) => e);
+    expect((err as InstanceType<typeof StepParseError>).reason).toBe('parse');
+    expect((err as Error).message).toBe('Failed to load STEP file');
+    // A malformed file will not become well-formed by freeing memory.
+    expect(importSTEP).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces an opaque non-OOM OCCT pointer without calling it out-of-memory', async () => {
+    importSTEP.mockRejectedValue(5_600_432);
+
+    const err = await importStepCached(Buffer.from('step-d')).catch((e) => e);
+    expect((err as InstanceType<typeof StepParseError>).reason).toBe('parse');
+    expect((err as Error).message).toContain('5600432');
+    expect((err as Error).message).not.toBe('5600432');
+  });
+});

--- a/src/modeling/parts/stepParseCacheOom.test.ts
+++ b/src/modeling/parts/stepParseCacheOom.test.ts
@@ -27,14 +27,43 @@ vi.mock('../../kernel/backends/occt/occtBackend', async (importOriginal) => {
   return { ...actual, initOcct: vi.fn(async () => {}) };
 });
 
-const { importStepCached, StepParseError, __resetStepParseCache } = await import(
+const { importStepCached, StepParseError, __resetStepParseCache, __stepParseCacheStats } = await import(
   './stepParseCache'
 );
 
 /** Minimal stand-in for a replicad Shape3D — `meshShape` is the duck-type the
  *  cache uses to accept an import as 3D. */
-function fakeSolid(): unknown {
-  return { meshShape: () => undefined, clone: () => fakeSolid(), delete: () => {} };
+interface FakeSolid {
+  deleted: boolean;
+  meshShape: () => undefined;
+  clone: () => FakeSolid;
+  delete: () => void;
+}
+
+function fakeSolid(): FakeSolid {
+  const solid: FakeSolid = {
+    deleted: false,
+    meshShape: () => undefined,
+    clone: () => fakeSolid(),
+    delete: () => {
+      solid.deleted = true;
+    },
+  };
+  return solid;
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
 }
 
 const OOM = 24;
@@ -47,6 +76,58 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks());
 
 describe('importStepCached — OCCT out-of-memory', () => {
+  it('deduplicates concurrent same-hash imports and gives callers independent clones', async () => {
+    const importGate = deferred<FakeSolid>();
+    importSTEP.mockImplementation(() => importGate.promise);
+    const bytes = Buffer.from('same-step-concurrently');
+
+    const first = importStepCached(bytes);
+    await vi.waitFor(() => expect(importSTEP).toHaveBeenCalledTimes(1));
+
+    const second = importStepCached(bytes);
+    // Give an overlapping caller a full turn to observe the in-flight import.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    const importsWhilePending = importSTEP.mock.calls.length;
+
+    importGate.resolve(fakeSolid());
+    const [firstClone, secondClone] = await Promise.all([first, second]);
+
+    expect(importsWhilePending).toBe(1);
+    expect(__stepParseCacheStats()).toMatchObject({ hits: 1, misses: 1, size: 1 });
+    expect(firstClone).not.toBe(secondClone);
+
+    const firstShape = firstClone.getReplicadShape() as unknown as FakeSolid;
+    const secondShape = secondClone.getReplicadShape() as unknown as FakeSolid;
+    expect(firstShape).not.toBe(secondShape);
+    firstClone.dispose();
+    expect(firstShape.deleted).toBe(true);
+    expect(secondShape.deleted).toBe(false);
+  });
+
+  it('clears a failed same-hash pending import so a later caller can retry', async () => {
+    const importGate = deferred<FakeSolid>();
+    let failCurrentImport = true;
+    importSTEP.mockImplementation(() =>
+      failCurrentImport ? importGate.promise : Promise.resolve(fakeSolid()),
+    );
+    const bytes = Buffer.from('same-step-failure');
+
+    const first = importStepCached(bytes);
+    await vi.waitFor(() => expect(importSTEP).toHaveBeenCalledTimes(1));
+    const second = importStepCached(bytes);
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    const importsWhilePending = importSTEP.mock.calls.length;
+
+    importGate.reject(new Error('transient import failure'));
+    await expect(Promise.all([first, second])).rejects.toMatchObject({ reason: 'parse' });
+
+    failCurrentImport = false;
+    await expect(importStepCached(bytes)).resolves.toBeDefined();
+    expect(importsWhilePending).toBe(1);
+    expect(importSTEP).toHaveBeenCalledTimes(2);
+    expect(__stepParseCacheStats()).toMatchObject({ misses: 1, size: 1 });
+  });
+
   it('retries once after purging cached masters, and succeeds', async () => {
     // First call OOMs; the cache drops its masters to reclaim wasm heap and the
     // retry — with the identical bytes — goes through.


### PR DESCRIPTION
## What changed

Backports the tested MCP runtime fixes required by proto.cat:

- resolve cookbook snippets relative to the bundled module instead of the process working directory;
- content-hash parsed STEP geometry to avoid repeated imports;
- classify OCCT WASM heap exhaustion correctly, reclaim cached masters, retry once, and report an actionable failure instead of claiming the STEP is invalid.

## Why

The deployed MCP server could not find its cookbook after bundling, and `lib.fetchPart()` could fail with an opaque memory error even for valid catalog parts. The candidate vendor pin was on `develop`, while the server deployment guard only accepts release-reachable SHAs.

## Validation

- fresh `npm ci`
- targeted Vitest: 25 passing
- `npm run build:cli`
- `npm run typecheck`
- `npm run cookbook:validate` (17 snippets)
- cookbook lookup from an arbitrary working directory

This targets the protected `release` branch so KernelCAD-server can pin a deployable vendor revision after review.