### PR TITLE
feat(parts): add reusable wearable IC packages

### DIFF
--- a/.github/workflows/parts-catalog.yml
+++ b/.github/workflows/parts-catalog.yml
@@ -99,6 +99,16 @@ jobs:
           --manifest scripts/electronics-parts.json
           --base-url https://kernelcad-parts.pages.dev
 
+      # Authored package sources are a required part of this deploy: unlike
+      # third-party upstream models, a failed authored export must never be
+      # silently skipped and published as a catalog omission. This verifies all
+      # five package artifacts, their measured bounds/metadata, and named
+      # components + contacts before any board conversion or Pages deploy.
+      - name: Verify authored electronic package catalog
+        run: >
+          npx tsx scripts/verifyAuthoredElectronicsCatalog.ts catalog
+          --manifest scripts/electronics-parts.json
+
       - name: Build web-ready board GLBs (and drop oversized board STEPs)
         # For every authored dev-board (kcad_source id ending in -board), compile
         # a GLB, decimate it to a few hundred KB (uncompressed, colors preserved),

--- a/scripts/electronics-parts.json
+++ b/scripts/electronics-parts.json
@@ -395,6 +395,106 @@
       "tags": ["switch", "button", "tactile", "pushbutton", "12mm", "keycap", "cap", "b3f", "panel", "input", "maker"],
       "license": "MIT",
       "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "nrf54l15-qfn48",
+      "name": "Nordic nRF54L15 QFN48 (QFAA) SoC package",
+      "family": "MCU",
+      "mpn": "nRF54L15-QFAA",
+      "kcad_source": "scripts/parts/authored/nrf54l15-qfn48.kcad.ts",
+      "tags": ["mcu", "nordic", "nrf54l15", "qfn", "qfn48", "bluetooth", "802.15.4"],
+      "attributes": {
+        "package": "QFN48 (QFAA)",
+        "packageLengthMm": 6,
+        "packageWidthMm": 6,
+        "packageHeightMm": 0.85,
+        "pinCount": 48,
+        "pinPitchMm": 0.4,
+        "pinOneMarker": "top, -X/-Y corner",
+        "dimensionSource": "https://docs.nordicsemi.com/r/bundle/ps_nrf54l15/page/chapters/mec_spec.html-qfn48_package"
+      },
+      "license": "MIT",
+      "attribution": "kernelCAD authored package model; dimensions from Nordic Semiconductor nRF54L15 QFN48 (QFAA) package drawing"
+    },
+    {
+      "id": "bmi270-lga14",
+      "name": "Bosch BMI270 14-pin LGA IMU package",
+      "family": "Sensor",
+      "mpn": "BMI270",
+      "kcad_source": "scripts/parts/authored/bmi270-lga14.kcad.ts",
+      "tags": ["sensor", "imu", "accelerometer", "gyroscope", "bmi270", "lga", "lga14"],
+      "attributes": {
+        "package": "LGA-14",
+        "packageLengthMm": 3,
+        "packageWidthMm": 2.5,
+        "packageHeightMm": 0.83,
+        "pinCount": 14,
+        "pinPitchMm": 0.4,
+        "pinOneMarker": "top, -X/-Y corner",
+        "dimensionSource": "https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmi270-ds000.pdf"
+      },
+      "license": "MIT",
+      "attribution": "kernelCAD authored package model; dimensions from Bosch Sensortec BMI270 datasheet"
+    },
+    {
+      "id": "max30102-optical",
+      "name": "Analog Devices MAX30102 optical biosensor module",
+      "family": "Sensor",
+      "mpn": "MAX30102",
+      "kcad_source": "scripts/parts/authored/max30102-optical.kcad.ts",
+      "tags": ["sensor", "biosensor", "heart-rate", "pulse-oximeter", "max30102", "optical", "i2c"],
+      "attributes": {
+        "package": "optical module",
+        "packageLengthMm": 5.6,
+        "packageWidthMm": 3.3,
+        "packageHeightMm": 1.55,
+        "pinCount": 14,
+        "pinPitchMm": 0.8,
+        "pinOneMarker": "top, -X/-Y corner",
+        "dimensionSource": "https://www.analog.com/media/en/technical-documentation/data-sheets/max30102.pdf"
+      },
+      "license": "MIT",
+      "attribution": "kernelCAD authored package model; dimensions from Analog Devices MAX30102 product data"
+    },
+    {
+      "id": "tmp117-dsbga",
+      "name": "Texas Instruments TMP117 DSBGA-6 (YBG) package",
+      "family": "Sensor",
+      "mpn": "TMP117NAIYBGR",
+      "kcad_source": "scripts/parts/authored/tmp117-dsbga.kcad.ts",
+      "tags": ["sensor", "temperature", "tmp117", "i2c", "dsbga", "ybg"],
+      "attributes": {
+        "package": "DSBGA-6 (YBG)",
+        "packageLengthMm": 1.488,
+        "packageWidthMm": 0.95,
+        "packageHeightMm": 0.531,
+        "pinCount": 6,
+        "pinPitchMm": 0.4,
+        "pinOneMarker": "top, -X/-Y corner",
+        "dimensionSource": "https://www.ti.com/lit/ds/symlink/tmp117.pdf"
+      },
+      "license": "MIT",
+      "attribution": "kernelCAD authored package model; dimensions from Texas Instruments TMP117 YBG package drawing"
+    },
+    {
+      "id": "drv2605-yzf",
+      "name": "Texas Instruments DRV2605 DSBGA-9 (YZF) haptic driver package",
+      "family": "Haptic driver",
+      "mpn": "DRV2605YZF",
+      "kcad_source": "scripts/parts/authored/drv2605-yzf.kcad.ts",
+      "tags": ["haptic", "haptic-driver", "drv2605", "lra", "erm", "dsbga", "yzf"],
+      "attributes": {
+        "package": "DSBGA-9 (YZF)",
+        "packageLengthMm": 1.44,
+        "packageWidthMm": 1.44,
+        "packageHeightMm": 0.625,
+        "pinCount": 9,
+        "pinPitchMm": 0.5,
+        "pinOneMarker": "top, -X/-Y corner",
+        "dimensionSource": "https://www.ti.com/lit/gpn/DRV2605"
+      },
+      "license": "MIT",
+      "attribution": "kernelCAD authored package model; dimensions from Texas Instruments DRV2605 YZF package drawing"
     }
   ]
 }

--- a/scripts/electronics-parts.test.ts
+++ b/scripts/electronics-parts.test.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+type ElectronicsPart = {
+  id: string;
+  kcad_source?: string;
+  attributes?: Record<string, string | number>;
+};
+
+const repoRoot = resolve(__dirname, '..');
+const manifest = JSON.parse(
+  readFileSync(resolve(repoRoot, 'scripts/electronics-parts.json'), 'utf8'),
+) as { parts: ElectronicsPart[] };
+
+const requiredUniversalPackages = [
+  {
+    id: 'nrf54l15-qfn48',
+    dimensions: {
+      package: 'QFN48 (QFAA)',
+      packageLengthMm: 6,
+      packageWidthMm: 6,
+      packageHeightMm: 0.85,
+      pinCount: 48,
+      pinPitchMm: 0.4,
+    },
+  },
+  {
+    id: 'bmi270-lga14',
+    dimensions: {
+      package: 'LGA-14',
+      packageLengthMm: 3,
+      packageWidthMm: 2.5,
+      packageHeightMm: 0.83,
+      pinCount: 14,
+      pinPitchMm: 0.4,
+    },
+  },
+  {
+    id: 'max30102-optical',
+    dimensions: {
+      package: 'optical module',
+      packageLengthMm: 5.6,
+      packageWidthMm: 3.3,
+      packageHeightMm: 1.55,
+      pinCount: 14,
+      pinPitchMm: 0.8,
+    },
+  },
+  {
+    id: 'tmp117-dsbga',
+    dimensions: {
+      package: 'DSBGA-6 (YBG)',
+      packageLengthMm: 1.488,
+      packageWidthMm: 0.95,
+      packageHeightMm: 0.531,
+      pinCount: 6,
+      pinPitchMm: 0.4,
+    },
+  },
+  {
+    id: 'drv2605-yzf',
+    dimensions: {
+      package: 'DSBGA-9 (YZF)',
+      packageLengthMm: 1.44,
+      packageWidthMm: 1.44,
+      packageHeightMm: 0.625,
+      pinCount: 9,
+      pinPitchMm: 0.5,
+    },
+  },
+] as const;
+
+describe('electronics parts catalog', () => {
+  it('declares each reusable package with physical metadata and an orientation marker', () => {
+    const byId = new Map(manifest.parts.map((part) => [part.id, part]));
+
+    for (const expected of requiredUniversalPackages) {
+      const part = byId.get(expected.id);
+      expect(part, `missing ${expected.id}`).toBeDefined();
+      expect(part?.attributes).toMatchObject(expected.dimensions);
+      expect(part?.attributes?.dimensionSource).toMatch(/^https:\/\//);
+      expect(part?.kcad_source).toBe(`scripts/parts/authored/${expected.id}.kcad.ts`);
+
+      const source = resolve(repoRoot, part?.kcad_source ?? '');
+      expect(existsSync(source), `missing ${source}`).toBe(true);
+      expect(readFileSync(source, 'utf8')).toContain('pin-1-marker');
+    }
+  });
+});

--- a/scripts/ingestElectronics.ts
+++ b/scripts/ingestElectronics.ts
@@ -62,6 +62,10 @@ interface ManifestPart {
    *  Takes priority over `url` and `model`. */
   kcad_source?: string;
   tags?: string[];
+  /** Package-specific factual metadata retained alongside the measured STEP
+   *  bounds. These values are sourced from the component manufacturer's
+   *  package drawing, while bbox* fields are measured from the generated STEP. */
+  attributes?: Record<string, number | string>;
   /** Per-part license / attribution override (e.g. an MIT Adafruit STEP in an
    *  otherwise CC-BY-SA KiCad manifest). Falls back to the manifest defaults. */
   license?: string;
@@ -166,7 +170,7 @@ export async function ingestElectronics(
           category: 'Electronics',
           family: part.family,
           tags: part.tags ?? ['electronics', part.family],
-          attributes: { mpn: part.mpn },
+          attributes: { mpn: part.mpn, ...(part.attributes ?? {}) },
           license: part.license ?? manifest.license,
           attribution: part.attribution ?? manifest.attribution,
         },

--- a/scripts/ingestParts.test.ts
+++ b/scripts/ingestParts.test.ts
@@ -5,9 +5,53 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { OcctBackend, initOcct } from '../src/kernel/backends/occt/occtBackend';
-import { ingestDirectory } from './ingestParts';
+import { ingestDirectory, measureStepReport } from './ingestParts';
+import type { StepInspectReport } from '../src/agent/inspect/inspectStep';
 
 describe('ingestParts', () => {
+  it('measures assembly bounds without changing dominant-solid volume semantics', () => {
+    const report: StepInspectReport = {
+      file: 'multi-solid-package.step',
+      solidCount: 2,
+      solids: [
+        {
+          index: 0,
+          name: 'body',
+          bboxExact: { min: [0, 0, 0], max: [5.9, 5.9, 0.79] },
+          volumeMm3: 20,
+          faceCount: 6,
+          holes: [],
+        },
+        {
+          index: 1,
+          name: 'contacts-and-marker',
+          bboxExact: { min: [-0.1, -0.1, 0], max: [6, 6, 0.85] },
+          volumeMm3: 3,
+          faceCount: 12,
+          holes: [
+            {
+              axisOrigin: [3, 3, 0.85],
+              axisDirection: [0, 0, -1],
+              diameterMm: 0.4,
+              depthMm: 0.5,
+              kind: 'through',
+              faceCount: 1,
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(measureStepReport(report)).toEqual({
+      bboxXmm: 6.1,
+      bboxYmm: 6.1,
+      bboxZmm: 0.85,
+      volumeMm3: 20,
+      solidCount: 2,
+      holeCount: 0,
+    });
+  });
+
   it('ingests a STEP dir into a /v1/parts catalog with measured attrs + synthesized connectors', async () => {
     await initOcct();
     const src = mkdtempSync(join(tmpdir(), 'kc-ingest-src-'));

--- a/scripts/ingestParts.ts
+++ b/scripts/ingestParts.ts
@@ -34,7 +34,7 @@ import {
 } from 'node:fs';
 import { join, relative, basename, extname, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
-import { inspectStepFile } from '../src/agent/inspect/inspectStep';
+import { inspectStepFile, type StepInspectReport } from '../src/agent/inspect/inspectStep';
 import { synthesizeConnectorsFromReport } from '../src/modeling/parts/synthesizeConnectors';
 import { PAGES_WORKER } from './parts/workerTemplate';
 import {
@@ -123,6 +123,44 @@ function loadSidecar(stepPath: string): IngestSidecar {
   }
 }
 
+/**
+ * Measure the complete imported model rather than only its dominant solid.
+ *
+ * STEP assemblies often retain electrically meaningful solids separately —
+ * contacts, lids, optical windows, and pin-one markers.  Catalog dimensions
+ * must describe the extents a user will actually place, so combine every
+ * inspected solid's exact bounds. Volume and hole metadata deliberately keep
+ * the established dominant-solid semantics: presentation solids can overlap
+ * their body, so summing them would falsely inflate material volume. For
+ * conventional one-solid STEP files every field is identical to the prior
+ * measurement behavior.
+ */
+export function measureStepReport(report: StepInspectReport): Record<string, number> {
+  if (report.solids.length === 0) return { solidCount: report.solidCount };
+
+  const min: [number, number, number] = [Infinity, Infinity, Infinity];
+  const max: [number, number, number] = [-Infinity, -Infinity, -Infinity];
+  let dominantSolid = report.solids[0];
+
+  for (const solid of report.solids) {
+    for (let axis = 0; axis < 3; axis++) {
+      min[axis] = Math.min(min[axis], solid.bboxExact.min[axis]);
+      max[axis] = Math.max(max[axis], solid.bboxExact.max[axis]);
+    }
+    if (solid.volumeMm3 > dominantSolid.volumeMm3) dominantSolid = solid;
+  }
+
+  const rounded = (value: number) => Math.round(value * 100) / 100;
+  return {
+    bboxXmm: rounded(max[0] - min[0]),
+    bboxYmm: rounded(max[1] - min[1]),
+    bboxZmm: rounded(max[2] - min[2]),
+    volumeMm3: rounded(dominantSolid.volumeMm3),
+    solidCount: report.solidCount,
+    holeCount: dominantSolid.holes.length,
+  };
+}
+
 // -----------------------------------------------------------------------------
 // Ingest one STEP → a catalog record (measured attributes + synthesized frames)
 // -----------------------------------------------------------------------------
@@ -146,19 +184,8 @@ export async function ingestStepFile(
   const family = meta.family ?? relParts[relParts.length - 1] ?? category;
 
   const report = await inspectStepFile(stepPath);
-  const solid = [...report.solids].sort((a, b) => b.volumeMm3 - a.volumeMm3)[0];
   const conns = synthesizeConnectorsFromReport(report, id);
-
-  const measured: Record<string, number> = solid
-    ? {
-        bboxXmm: Math.round((solid.bboxExact.max[0] - solid.bboxExact.min[0]) * 100) / 100,
-        bboxYmm: Math.round((solid.bboxExact.max[1] - solid.bboxExact.min[1]) * 100) / 100,
-        bboxZmm: Math.round((solid.bboxExact.max[2] - solid.bboxExact.min[2]) * 100) / 100,
-        volumeMm3: Math.round(solid.volumeMm3 * 100) / 100,
-        solidCount: report.solidCount,
-        holeCount: solid.holes.length,
-      }
-    : { solidCount: report.solidCount };
+  const measured = measureStepReport(report);
 
   const record: CatalogRecord = {
     id,

--- a/scripts/parts/authored/bmi270-lga14.kcad.ts
+++ b/scripts/parts/authored/bmi270-lga14.kcad.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/bmi270-lga14.kcad.ts
+//
+// Bosch Sensortec BMI270, 14-pin LGA package.
+// Nominal external package: 3.0 × 2.5 × 0.83 mm.
+// Dimensions: https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmi270-ds000.pdf
+//
+// The model is a reusable, solder-side LGA package: two seven-contact rows and
+// a top-side pin-one mark, rather than a project-specific sensor breakout.
+
+const PACKAGE_LENGTH = 3.0;
+const PACKAGE_WIDTH = 2.5;
+const PACKAGE_HEIGHT = 0.83;
+const BODY_HEIGHT = 0.76;
+const CONTACT_HEIGHT = 0.07;
+const CONTACT_SIZE = 0.24;
+const CONTACTS_PER_ROW = 7;
+const PIN_PITCH = 0.4;
+const FIRST_CONTACT_X = 0.3;
+const ROW_Y = [0.3, 2.2];
+
+const MOLD_BLACK = '#20232b';
+const CONTACT_GOLD = '#c8a13c';
+const MARKER_YELLOW = '#f2d35a';
+
+const body = box(PACKAGE_LENGTH, PACKAGE_WIDTH, BODY_HEIGHT)
+  .translate(0, 0, CONTACT_HEIGHT)
+  .color(MOLD_BLACK);
+const pinOneMarker = cylinder(0.06, 0.11, 16)
+  .translate(0.35, 0.35, PACKAGE_HEIGHT - 0.06)
+  .color(MARKER_YELLOW);
+
+const asm = assembly('bmi270-lga14');
+asm.part('package-body', body);
+asm.part('pin-1-marker', pinOneMarker);
+
+for (let row = 0; row < ROW_Y.length; row++) {
+  for (let column = 0; column < CONTACTS_PER_ROW; column++) {
+    const contactNumber = row * CONTACTS_PER_ROW + column + 1;
+    const x = FIRST_CONTACT_X + column * PIN_PITCH;
+    asm.part(
+      `contact-${String(contactNumber).padStart(2, '0')}`,
+      box(CONTACT_SIZE, CONTACT_SIZE, CONTACT_HEIGHT)
+        .translate(x - CONTACT_SIZE / 2, ROW_Y[row] - CONTACT_SIZE / 2, 0)
+        .color(CONTACT_GOLD),
+    );
+  }
+}
+
+return asm.model();

--- a/scripts/parts/authored/drv2605-yzf.kcad.ts
+++ b/scripts/parts/authored/drv2605-yzf.kcad.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/drv2605-yzf.kcad.ts
+//
+// Texas Instruments DRV2605 in the nine-ball YZF DSBGA package.
+// Nominal package body: 1.44 × 1.44 mm (1.41–1.47 mm limits), 0.625 mm max
+// height, with 0.5 mm ball pitch.
+// Dimensions: https://www.ti.com/lit/gpn/DRV2605
+
+const PACKAGE_SIDE = 1.44;
+const PACKAGE_HEIGHT = 0.625;
+// YZF specifies 0.25–0.35 mm balls; use the 0.30 mm nominal diameter and
+// stand-off as actual spherical solder balls.
+const BALL_STANDOFF = 0.3;
+const DIE_HEIGHT = PACKAGE_HEIGHT - BALL_STANDOFF;
+const BALL_RADIUS = 0.15;
+const BALL_PITCH = 0.5;
+const FIRST_BALL = 0.22;
+
+const DIE_BLACK = '#20232b';
+const BALL_METAL = '#c8ccd0';
+const MARKER_YELLOW = '#f2d35a';
+
+const die = box(PACKAGE_SIDE, PACKAGE_SIDE, DIE_HEIGHT)
+  .translate(0, 0, BALL_STANDOFF)
+  .color(DIE_BLACK);
+const pinOneMarker = cylinder(0.04, 0.09, 16)
+  .translate(0.22, 0.22, PACKAGE_HEIGHT - 0.04)
+  .color(MARKER_YELLOW);
+
+const asm = assembly('drv2605-yzf');
+asm.part('package-die', die);
+asm.part('pin-1-marker', pinOneMarker);
+
+for (let row = 0; row < 3; row++) {
+  for (let column = 0; column < 3; column++) {
+    const ballNumber = row * 3 + column + 1;
+    asm.part(
+      `ball-${ballNumber}`,
+      sphere(BALL_RADIUS)
+        .translate(FIRST_BALL + column * BALL_PITCH, FIRST_BALL + row * BALL_PITCH, BALL_RADIUS)
+        .color(BALL_METAL),
+    );
+  }
+}
+
+return asm.model();

--- a/scripts/parts/authored/max30102-optical.kcad.ts
+++ b/scripts/parts/authored/max30102-optical.kcad.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/max30102-optical.kcad.ts
+//
+// Analog Devices MAX30102, 14-pin reflective optical biosensor module.
+// Nominal external package: 5.6 × 3.3 × 1.55 mm with integrated cover glass.
+// Dimensions: https://www.analog.com/media/en/technical-documentation/data-sheets/max30102.pdf
+//
+// The reusable module model carries its 14 underside contacts, cover glass and
+// visible optical apertures. Aperture geometry is representational; no
+// unverified internal die layout is claimed.
+
+const PACKAGE_LENGTH = 5.6;
+const PACKAGE_WIDTH = 3.3;
+const PACKAGE_HEIGHT = 1.55;
+const CONTACT_HEIGHT = 0.07;
+// The OESIP solder contacts occupy the bottom 0.07 mm. Keep the molded body
+// above them rather than embedding the terminals in the opaque package solid.
+const MOLD_HEIGHT = 0.98;
+const GLASS_HEIGHT = PACKAGE_HEIGHT - CONTACT_HEIGHT - MOLD_HEIGHT;
+const CONTACTS_PER_SIDE = 7;
+// MAX30102's 14-lead OESIP package uses a 0.8 mm pin pitch. Centre the
+// seven contacts on each long edge so the two outside pads are symmetric.
+const CONTACT_PITCH = 0.8;
+const FIRST_CONTACT_X =
+  (PACKAGE_LENGTH - (CONTACTS_PER_SIDE - 1) * CONTACT_PITCH) / 2;
+
+const CASE_BLACK = '#171a21';
+const CONTACT_GOLD = '#c8a13c';
+const COVER_GLASS = '#29475f';
+const RED_LED = '#c93f3f';
+const IR_LED = '#9c4d9c';
+const PHOTODIODE = '#222a3d';
+const MARKER_YELLOW = '#f2d35a';
+
+const caseBody = box(PACKAGE_LENGTH, PACKAGE_WIDTH, MOLD_HEIGHT)
+  .translate(0, 0, CONTACT_HEIGHT)
+  .color(CASE_BLACK);
+const glassBaseZ = CONTACT_HEIGHT + MOLD_HEIGHT;
+const redLedWindow = cylinder(0.04, 0.32, 20).translate(1.75, 1.65, PACKAGE_HEIGHT - 0.04).color(RED_LED);
+const irLedWindow = cylinder(0.04, 0.32, 20).translate(2.8, 1.65, PACKAGE_HEIGHT - 0.04).color(IR_LED);
+const photodiodeWindow = cylinder(0.04, 0.42, 20).translate(3.95, 1.65, PACKAGE_HEIGHT - 0.04).color(PHOTODIODE);
+// Recess each colored optical element into a matching pocket. The window
+// solids then meet the cover glass at a real interface instead of occupying
+// the same volume — vital for a component model that can be assembled and
+// interference-checked.
+const coverGlass = box(4.2, 2.5, GLASS_HEIGHT)
+  .translate(0.7, 0.4, glassBaseZ)
+  .subtract(redLedWindow)
+  .subtract(irLedWindow)
+  .subtract(photodiodeWindow)
+  .color(COVER_GLASS);
+const pinOneMarker = cylinder(0.05, 0.11, 16)
+  .translate(0.35, 0.35, PACKAGE_HEIGHT - 0.05)
+  .color(MARKER_YELLOW);
+
+const asm = assembly('max30102-optical');
+asm.part('package-body', caseBody);
+asm.part('cover-glass', coverGlass);
+asm.part('red-led-window', redLedWindow);
+asm.part('ir-led-window', irLedWindow);
+asm.part('photodiode-window', photodiodeWindow);
+asm.part('pin-1-marker', pinOneMarker);
+
+for (let index = 0; index < CONTACTS_PER_SIDE; index++) {
+  const centerX = FIRST_CONTACT_X + index * CONTACT_PITCH;
+  const suffix = String(index + 1).padStart(2, '0');
+  asm.part(
+    `contact-bottom-${suffix}`,
+    box(0.28, 0.22, CONTACT_HEIGHT)
+      .translate(centerX - 0.14, 0, 0)
+      .color(CONTACT_GOLD),
+  );
+  asm.part(
+    `contact-top-${suffix}`,
+    box(0.28, 0.22, CONTACT_HEIGHT)
+      .translate(centerX - 0.14, PACKAGE_WIDTH - 0.22, 0)
+      .color(CONTACT_GOLD),
+  );
+}
+
+return asm.model();

--- a/scripts/parts/authored/nrf54l15-qfn48.kcad.ts
+++ b/scripts/parts/authored/nrf54l15-qfn48.kcad.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/nrf54l15-qfn48.kcad.ts
+//
+// Nordic Semiconductor nRF54L15 QFN48 (QFAA).
+// Nominal external package: 6.0 × 6.0 × 0.85 mm, 48 contacts at 0.4 mm pitch.
+// Dimensions: https://docs.nordicsemi.com/r/bundle/ps_nrf54l15/page/chapters/mec_spec.html-qfn48_package
+//
+// This is the soldered SoC package, deliberately not a board-specific module
+// or PCB. The 48 exposed contacts, centre pad, and top-side pin-one dot retain
+// useful orientation and placement information when the catalog part is used
+// in any assembly.
+
+const PACKAGE_SIDE = 6.0;
+const PACKAGE_HEIGHT = 0.85;
+const BODY_SIDE = 5.9;
+const BODY_HEIGHT = 0.79;
+const CONTACTS_PER_SIDE = 12;
+const PIN_PITCH = 0.4;
+// Twelve 0.4 mm-pitch terminals span 4.4 mm. Centre that span in the 6 mm
+// package rather than biasing every terminal toward the pin-one edge.
+const FIRST_CONTACT_CENTER =
+  (PACKAGE_SIDE - (CONTACTS_PER_SIDE - 1) * PIN_PITCH) / 2;
+const CONTACT_WIDTH = 0.2;
+// QFAA nominal terminal length L (the package drawing specifies 0.40 mm).
+const CONTACT_LENGTH = 0.4;
+const CONTACT_HEIGHT = 0.06;
+
+const MOLD_BLACK = '#1d2028';
+const CONTACT_GOLD = '#c8a13c';
+const MARKER_YELLOW = '#f2d35a';
+
+const body = box(BODY_SIDE, BODY_SIDE, BODY_HEIGHT)
+  .translate((PACKAGE_SIDE - BODY_SIDE) / 2, (PACKAGE_SIDE - BODY_SIDE) / 2, CONTACT_HEIGHT)
+  .color(MOLD_BLACK);
+const exposedPad = box(4.6, 4.6, CONTACT_HEIGHT).translate(0.7, 0.7, 0).color(CONTACT_GOLD);
+const pinOneMarker = cylinder(0.07, 0.18, 20)
+  .translate(0.65, 0.65, PACKAGE_HEIGHT - 0.07)
+  .color(MARKER_YELLOW);
+
+const asm = assembly('nrf54l15-qfn48');
+asm.part('package-body', body);
+asm.part('exposed-pad', exposedPad);
+asm.part('pin-1-marker', pinOneMarker);
+
+for (let index = 0; index < CONTACTS_PER_SIDE; index++) {
+  const center = FIRST_CONTACT_CENTER + index * PIN_PITCH;
+  const suffix = String(index + 1).padStart(2, '0');
+  asm.part(
+    `contact-left-${suffix}`,
+    box(CONTACT_WIDTH, CONTACT_LENGTH, CONTACT_HEIGHT)
+      .translate(0, center - CONTACT_LENGTH / 2, 0)
+      .color(CONTACT_GOLD),
+  );
+  asm.part(
+    `contact-right-${suffix}`,
+    box(CONTACT_WIDTH, CONTACT_LENGTH, CONTACT_HEIGHT)
+      .translate(PACKAGE_SIDE - CONTACT_WIDTH, center - CONTACT_LENGTH / 2, 0)
+      .color(CONTACT_GOLD),
+  );
+  asm.part(
+    `contact-bottom-${suffix}`,
+    box(CONTACT_LENGTH, CONTACT_WIDTH, CONTACT_HEIGHT)
+      .translate(center - CONTACT_LENGTH / 2, 0, 0)
+      .color(CONTACT_GOLD),
+  );
+  asm.part(
+    `contact-top-${suffix}`,
+    box(CONTACT_LENGTH, CONTACT_WIDTH, CONTACT_HEIGHT)
+      .translate(center - CONTACT_LENGTH / 2, PACKAGE_SIDE - CONTACT_WIDTH, 0)
+      .color(CONTACT_GOLD),
+  );
+}
+
+return asm.model();

--- a/scripts/parts/authored/tmp117-dsbga.kcad.ts
+++ b/scripts/parts/authored/tmp117-dsbga.kcad.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/tmp117-dsbga.kcad.ts
+//
+// Texas Instruments TMP117 in the six-ball YBG DSBGA package.
+// Nominal external package: 1.488 × 0.95 × 0.531 mm; 0.4 mm ball pitch.
+// Dimensions: https://www.ti.com/lit/ds/symlink/tmp117.pdf
+
+const PACKAGE_LENGTH = 1.488;
+const PACKAGE_WIDTH = 0.95;
+const PACKAGE_HEIGHT = 0.531;
+// The YBG drawing specifies 0.23–0.27 mm balls; model the 0.25 mm nominal
+// diameter as real spheres, including the nominal 0.25 mm stand-off.
+const BALL_STANDOFF = 0.25;
+const DIE_HEIGHT = PACKAGE_HEIGHT - BALL_STANDOFF;
+const BALL_RADIUS = 0.125;
+const BALL_PITCH = 0.4;
+const FIRST_BALL_X = 0.344;
+const ROW_Y = [0.275, 0.675];
+
+const DIE_BLACK = '#20232b';
+const BALL_METAL = '#c8ccd0';
+const MARKER_YELLOW = '#f2d35a';
+
+const die = box(PACKAGE_LENGTH, PACKAGE_WIDTH, DIE_HEIGHT)
+  .translate(0, 0, BALL_STANDOFF)
+  .color(DIE_BLACK);
+const pinOneMarker = cylinder(0.04, 0.09, 16)
+  .translate(0.23, 0.23, PACKAGE_HEIGHT - 0.04)
+  .color(MARKER_YELLOW);
+
+const asm = assembly('tmp117-dsbga');
+asm.part('package-die', die);
+asm.part('pin-1-marker', pinOneMarker);
+
+for (let row = 0; row < ROW_Y.length; row++) {
+  for (let column = 0; column < 3; column++) {
+    const ballNumber = row * 3 + column + 1;
+    asm.part(
+      `ball-${ballNumber}`,
+      sphere(BALL_RADIUS)
+        .translate(FIRST_BALL_X + column * BALL_PITCH, ROW_Y[row], BALL_RADIUS)
+        .color(BALL_METAL),
+    );
+  }
+}
+
+return asm.model();

--- a/scripts/verifyAuthoredElectronicsCatalog.test.ts
+++ b/scripts/verifyAuthoredElectronicsCatalog.test.ts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { runScript } from '../src/modeling/runtime/runScript';
+import {
+  AUTHORED_ELECTRONIC_PACKAGE_SPECS,
+  verifyAuthoredElectronicsCatalog,
+} from './verifyAuthoredElectronicsCatalog';
+
+const repoRoot = resolve(__dirname, '..');
+const manifestPath = join(repoRoot, 'scripts/electronics-parts.json');
+const tempDirs: string[] = [];
+
+function makeCatalogFixture(): string {
+  const catalogDir = mkdtempSync(join(tmpdir(), 'kc-authored-electronics-catalog-'));
+  tempDirs.push(catalogDir);
+  mkdirSync(join(catalogDir, 'step'), { recursive: true });
+  mkdirSync(join(catalogDir, 'v1', 'parts'), { recursive: true });
+  mkdirSync(join(catalogDir, 'v1', 'catalog'), { recursive: true });
+
+  const records = AUTHORED_ELECTRONIC_PACKAGE_SPECS.map((spec) => {
+    const step = Buffer.from(`ISO-10303-21;\nDATA;\n/* ${spec.id} */\nENDSEC;\nEND-ISO-10303-21;\n`);
+    const sha256 = createHash('sha256').update(step).digest('hex');
+    writeFileSync(join(catalogDir, 'step', `${spec.id}.step`), step);
+    const record = {
+      id: spec.id,
+      name: spec.id,
+      category: 'Electronics',
+      family: 'fixture',
+      tags: ['electronics'],
+      attributes: {
+        bboxXmm: spec.bboxMm[0],
+        bboxYmm: spec.bboxMm[1],
+        bboxZmm: spec.bboxMm[2],
+        package: spec.package,
+        pinCount: spec.pinCount,
+        ...(spec.pinPitchMm === undefined ? {} : { pinPitchMm: spec.pinPitchMm }),
+      },
+      stepUrl: `https://parts.example/step/${spec.id}.step`,
+      sha256,
+      byteSize: step.length,
+      license: 'MIT',
+      connectors: [],
+    };
+    writeFileSync(
+      join(catalogDir, 'v1', 'parts', `${spec.id}.json`),
+      JSON.stringify(record, null, 2),
+    );
+    return record;
+  });
+
+  writeFileSync(
+    join(catalogDir, 'v1', 'catalog', 'parts.index.json'),
+    JSON.stringify({ catalog: { partCount: records.length }, items: records }, null, 2),
+  );
+  return catalogDir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+async function assemblyPartBoxZBounds(
+  sourcePath: string,
+  partName: string,
+): Promise<{ min: number; max: number }> {
+  const records = (await runScript({
+    code: readFileSync(sourcePath, 'utf8'),
+    fileName: sourcePath,
+    scriptDir: dirname(sourcePath),
+  })).records;
+  const assemblyPart = records.find(
+    (record) => record.kind === 'assemblyPart' && record.metadata?.partName === partName,
+  );
+  const input = assemblyPart?.inputs.shape;
+  if (!assemblyPart || input?.kind !== 'feature') {
+    throw new Error(`missing assembly part '${partName}'`);
+  }
+  const box = records.find((record) => record.id === input.id);
+  if (!box || box.kind !== 'box') {
+    throw new Error(`assembly part '${partName}' is not backed by a box`);
+  }
+  const height = evaluated(box.params.z);
+  if (height === undefined) throw new Error(`assembly part '${partName}' has no box height`);
+  const centered = evaluated(box.params.centered) === 1;
+  let min = centered ? -height / 2 : 0;
+  let max = centered ? height / 2 : height;
+  for (const transform of box.transforms) {
+    if (transform.op !== 'translate') {
+      throw new Error(`assembly part '${partName}' has a non-translate transform`);
+    }
+    const z = evaluated(transform.vec.z);
+    if (z === undefined) throw new Error(`assembly part '${partName}' has an unresolved Z transform`);
+    min += z;
+    max += z;
+  }
+  return { min, max };
+}
+
+function evaluated(value: unknown): number | undefined {
+  return typeof value === 'object' && value !== null &&
+    typeof (value as { evaluated?: unknown }).evaluated === 'number'
+    ? (value as { evaluated: number }).evaluated
+    : undefined;
+}
+
+describe('verifyAuthoredElectronicsCatalog', () => {
+  it('keeps MAX30102 optical apertures non-overlapping in the physical assembly', () => {
+    const output = execFileSync(
+      process.execPath,
+      ['dist/cli/index.js', 'interference', 'scripts/parts/authored/max30102-optical.kcad.ts'],
+      { cwd: repoRoot, encoding: 'utf8' },
+    );
+
+    expect(output).toContain('No interferences');
+  });
+
+  it('keeps MAX30102 underside solder contacts outside its package body', async () => {
+    const sourcePath = join(repoRoot, 'scripts/parts/authored/max30102-optical.kcad.ts');
+    const body = await assemblyPartBoxZBounds(sourcePath, 'package-body');
+    const contact = await assemblyPartBoxZBounds(sourcePath, 'contact-bottom-01');
+
+    expect(body.min).toBeGreaterThanOrEqual(contact.max - 0.001);
+  });
+
+  it('requires all authored universal packages to be emitted with measured bounds and named component/contact structure', async () => {
+    const catalogDir = makeCatalogFixture();
+
+    await expect(
+      verifyAuthoredElectronicsCatalog({ catalogDir, manifestPath }),
+    ).resolves.toEqual({ verifiedIds: AUTHORED_ELECTRONIC_PACKAGE_SPECS.map((spec) => spec.id) });
+  });
+
+  it('fails before deploy when one authored package was skipped', async () => {
+    const catalogDir = makeCatalogFixture();
+    const missing = AUTHORED_ELECTRONIC_PACKAGE_SPECS[0];
+    rmSync(join(catalogDir, 'step', `${missing.id}.step`));
+
+    await expect(
+      verifyAuthoredElectronicsCatalog({ catalogDir, manifestPath }),
+    ).rejects.toThrow(new RegExp(`${missing.id}.*STEP artifact`, 'i'));
+  });
+});

--- a/scripts/verifyAuthoredElectronicsCatalog.ts
+++ b/scripts/verifyAuthoredElectronicsCatalog.ts
@@ -1,0 +1,555 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// Deployment gate for the authored electronic IC packages. The electronics
+// ingest is intentionally tolerant of one bad upstream model, but these five
+// package sources are authored in this repository and must never silently
+// disappear from a deployed catalog. Validate both sides of that contract:
+// source-level component/contact semantics and the emitted catalog artifacts.
+
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { FeatureRecord } from '../src/shared/intent/featureRecord';
+import { runScript } from '../src/modeling/runtime/runScript';
+
+type Axis = 0 | 1 | 2;
+
+interface ContactRunSpec {
+  readonly names: readonly string[];
+  readonly axis: Axis;
+  readonly pitchMm: number;
+  /** The package extent on the run axis. The first and last contacts must
+   * mirror around its centre, preventing an accidentally edge-biased array. */
+  readonly symmetricSpanMm: number;
+}
+
+interface UndersideContactSpec {
+  /** The non-contact package solid that must sit above the solder interface. */
+  readonly bodyName: string;
+  /** Contacts on the package underside. Their top faces may meet, but never
+   * overlap, the package body. */
+  readonly contactNames: readonly string[];
+}
+
+export interface AuthoredElectronicPackageSpec {
+  readonly id: string;
+  /** Published, two-decimal measured bbox expected after STEP ingest. */
+  readonly bboxMm: readonly [number, number, number];
+  readonly package: string;
+  readonly pinCount: number;
+  readonly pinPitchMm?: number;
+  readonly componentNames: readonly string[];
+  readonly contactNames: readonly string[];
+  readonly contactRuns: readonly ContactRunSpec[];
+  readonly undersideContacts?: UndersideContactSpec;
+}
+
+const numbered = (prefix: string, count: number): readonly string[] =>
+  Array.from({ length: count }, (_, index) => `${prefix}${String(index + 1).padStart(2, '0')}`);
+
+const nrfContacts = [
+  ...numbered('contact-left-', 12),
+  ...numbered('contact-right-', 12),
+  ...numbered('contact-bottom-', 12),
+  ...numbered('contact-top-', 12),
+] as const;
+
+const maxContacts = [
+  ...numbered('contact-bottom-', 7),
+  ...numbered('contact-top-', 7),
+] as const;
+
+const bmiContacts = numbered('contact-', 14);
+const tmpContacts = Array.from({ length: 6 }, (_, index) => `ball-${index + 1}`);
+const drvContacts = Array.from({ length: 9 }, (_, index) => `ball-${index + 1}`);
+
+/**
+ * One deliberate list for both the deploy gate and its fixture tests. These
+ * are reusable package-level parts — no project-specific board geometry.
+ */
+export const AUTHORED_ELECTRONIC_PACKAGE_SPECS: readonly AuthoredElectronicPackageSpec[] = [
+  {
+    id: 'nrf54l15-qfn48',
+    bboxMm: [6, 6, 0.85],
+    package: 'QFN48 (QFAA)',
+    pinCount: 48,
+    pinPitchMm: 0.4,
+    componentNames: ['package-body', 'exposed-pad', 'pin-1-marker'],
+    contactNames: nrfContacts,
+    contactRuns: [
+      { names: numbered('contact-bottom-', 12), axis: 0, pitchMm: 0.4, symmetricSpanMm: 6 },
+      { names: numbered('contact-top-', 12), axis: 0, pitchMm: 0.4, symmetricSpanMm: 6 },
+      { names: numbered('contact-left-', 12), axis: 1, pitchMm: 0.4, symmetricSpanMm: 6 },
+      { names: numbered('contact-right-', 12), axis: 1, pitchMm: 0.4, symmetricSpanMm: 6 },
+    ],
+  },
+  {
+    id: 'bmi270-lga14',
+    bboxMm: [3, 2.5, 0.83],
+    package: 'LGA-14',
+    pinCount: 14,
+    pinPitchMm: 0.4,
+    componentNames: ['package-body', 'pin-1-marker'],
+    contactNames: bmiContacts,
+    contactRuns: [
+      { names: numbered('contact-', 7), axis: 0, pitchMm: 0.4, symmetricSpanMm: 3 },
+      { names: numbered('contact-', 7).map((name, index) => `contact-${String(index + 8).padStart(2, '0')}`), axis: 0, pitchMm: 0.4, symmetricSpanMm: 3 },
+      { names: ['contact-01', 'contact-08'], axis: 1, pitchMm: 1.9, symmetricSpanMm: 2.5 },
+    ],
+  },
+  {
+    id: 'max30102-optical',
+    bboxMm: [5.6, 3.3, 1.55],
+    package: 'optical module',
+    pinCount: 14,
+    pinPitchMm: 0.8,
+    componentNames: [
+      'package-body',
+      'cover-glass',
+      'red-led-window',
+      'ir-led-window',
+      'photodiode-window',
+      'pin-1-marker',
+    ],
+    contactNames: maxContacts,
+    contactRuns: [
+      { names: numbered('contact-bottom-', 7), axis: 0, pitchMm: 0.8, symmetricSpanMm: 5.6 },
+      { names: numbered('contact-top-', 7), axis: 0, pitchMm: 0.8, symmetricSpanMm: 5.6 },
+    ],
+    undersideContacts: { bodyName: 'package-body', contactNames: maxContacts },
+  },
+  {
+    id: 'tmp117-dsbga',
+    bboxMm: [1.49, 0.95, 0.53],
+    package: 'DSBGA-6 (YBG)',
+    pinCount: 6,
+    pinPitchMm: 0.4,
+    componentNames: ['package-die', 'pin-1-marker'],
+    contactNames: tmpContacts,
+    contactRuns: [
+      { names: ['ball-1', 'ball-2', 'ball-3'], axis: 0, pitchMm: 0.4, symmetricSpanMm: 1.488 },
+      { names: ['ball-4', 'ball-5', 'ball-6'], axis: 0, pitchMm: 0.4, symmetricSpanMm: 1.488 },
+      { names: ['ball-1', 'ball-4'], axis: 1, pitchMm: 0.4, symmetricSpanMm: 0.95 },
+    ],
+  },
+  {
+    id: 'drv2605-yzf',
+    bboxMm: [1.44, 1.44, 0.63],
+    package: 'DSBGA-9 (YZF)',
+    pinCount: 9,
+    pinPitchMm: 0.5,
+    componentNames: ['package-die', 'pin-1-marker'],
+    contactNames: drvContacts,
+    contactRuns: [
+      { names: ['ball-1', 'ball-2', 'ball-3'], axis: 0, pitchMm: 0.5, symmetricSpanMm: 1.44 },
+      { names: ['ball-4', 'ball-5', 'ball-6'], axis: 0, pitchMm: 0.5, symmetricSpanMm: 1.44 },
+      { names: ['ball-1', 'ball-4', 'ball-7'], axis: 1, pitchMm: 0.5, symmetricSpanMm: 1.44 },
+    ],
+  },
+];
+
+interface ManifestPart {
+  readonly id: string;
+  readonly kcad_source?: string;
+  readonly attributes?: Readonly<Record<string, string | number>>;
+}
+
+interface CatalogRecordLike {
+  readonly id?: unknown;
+  readonly attributes?: unknown;
+  readonly stepUrl?: unknown;
+  readonly sha256?: unknown;
+}
+
+interface CatalogIndexLike {
+  readonly items?: unknown;
+}
+
+export interface VerifyAuthoredElectronicsCatalogOptions {
+  readonly catalogDir: string;
+  readonly manifestPath: string;
+}
+
+export interface VerifyAuthoredElectronicsCatalogResult {
+  readonly verifiedIds: string[];
+}
+
+/**
+ * Verify every authored reusable package is present in the generated catalog,
+ * has its expected published bounds + package metadata, and still contains
+ * named components and solder contacts in its source model.
+ *
+ * Throws one aggregate error so a failed deploy tells the maintainer every
+ * missing/malformed package in a single CI run.
+ */
+export async function verifyAuthoredElectronicsCatalog(
+  options: VerifyAuthoredElectronicsCatalogOptions,
+): Promise<VerifyAuthoredElectronicsCatalogResult> {
+  const errors: string[] = [];
+  const manifest = readJson<{ parts?: unknown }>(options.manifestPath, errors, 'manifest');
+  const manifestParts = Array.isArray(manifest?.parts) ? manifest.parts as ManifestPart[] : [];
+  if (!Array.isArray(manifest?.parts)) errors.push('manifest: expected a parts array');
+
+  const indexPath = join(options.catalogDir, 'v1', 'catalog', 'parts.index.json');
+  const index = readJson<CatalogIndexLike>(indexPath, errors, 'catalog index');
+  const indexItems = Array.isArray(index?.items) ? index.items as CatalogRecordLike[] : [];
+  if (!Array.isArray(index?.items)) errors.push('catalog index: expected an items array');
+
+  const repoRoot = resolve(dirname(options.manifestPath), '..');
+  for (const spec of AUTHORED_ELECTRONIC_PACKAGE_SPECS) {
+    const manifestPart = manifestParts.find((part) => part.id === spec.id);
+    verifyManifestPart(spec, manifestPart, errors);
+
+    if (manifestPart?.kcad_source) {
+      const sourcePath = resolve(repoRoot, manifestPart.kcad_source);
+      await verifySourceModel(spec, sourcePath, errors);
+    }
+
+    const detailPath = join(options.catalogDir, 'v1', 'parts', `${spec.id}.json`);
+    const detail = readJson<CatalogRecordLike>(detailPath, errors, `${spec.id}: detail record`);
+    verifyCatalogRecord(spec, detail, detailPath, options.catalogDir, errors);
+
+    const indexed = indexItems.find((record) => record.id === spec.id);
+    if (indexed === undefined) {
+      errors.push(`${spec.id}: missing from catalog index`);
+    } else if (detail !== undefined && indexed.sha256 !== detail.sha256) {
+      errors.push(`${spec.id}: catalog index SHA-256 does not match its detail record`);
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Authored electronics catalog verification failed:\n- ${errors.join('\n- ')}`);
+  }
+  return { verifiedIds: AUTHORED_ELECTRONIC_PACKAGE_SPECS.map((spec) => spec.id) };
+}
+
+function verifyManifestPart(
+  spec: AuthoredElectronicPackageSpec,
+  part: ManifestPart | undefined,
+  errors: string[],
+): void {
+  if (!part) {
+    errors.push(`${spec.id}: missing from electronics manifest`);
+    return;
+  }
+  if (part.kcad_source !== `scripts/parts/authored/${spec.id}.kcad.ts`) {
+    errors.push(`${spec.id}: must declare its authored package source`);
+  }
+  const attributes = part.attributes;
+  if (attributes?.package !== spec.package) {
+    errors.push(`${spec.id}: manifest package metadata is not '${spec.package}'`);
+  }
+  if (attributes?.pinCount !== spec.pinCount) {
+    errors.push(`${spec.id}: manifest pinCount is not ${spec.pinCount}`);
+  }
+  if (spec.pinPitchMm !== undefined && attributes?.pinPitchMm !== spec.pinPitchMm) {
+    errors.push(`${spec.id}: manifest pinPitchMm is not ${spec.pinPitchMm}`);
+  }
+}
+
+async function verifySourceModel(
+  spec: AuthoredElectronicPackageSpec,
+  sourcePath: string,
+  errors: string[],
+): Promise<void> {
+  if (!existsSync(sourcePath)) {
+    errors.push(`${spec.id}: missing authored source ${sourcePath}`);
+    return;
+  }
+
+  let records: readonly FeatureRecord[];
+  try {
+    const source = readFileSync(sourcePath, 'utf8');
+    records = (await runScript({
+      code: source,
+      fileName: sourcePath,
+      scriptDir: dirname(sourcePath),
+    })).records;
+  } catch (error) {
+    errors.push(`${spec.id}: authored source did not capture — ${formatError(error)}`);
+    return;
+  }
+
+  const assemblyParts = records.filter((record) => record.kind === 'assemblyPart');
+  const actualNames = assemblyParts
+    .map((record) => record.metadata?.partName)
+    .filter((name): name is string => typeof name === 'string');
+  const expectedNames = [...spec.componentNames, ...spec.contactNames];
+  const actualSet = new Set(actualNames);
+  const expectedSet = new Set(expectedNames);
+
+  if (actualNames.length !== actualSet.size) {
+    errors.push(`${spec.id}: duplicate assembly part names in authored source`);
+  }
+  for (const name of expectedNames) {
+    if (!actualSet.has(name)) errors.push(`${spec.id}: missing component/contact '${name}'`);
+  }
+  for (const name of actualSet) {
+    if (!expectedSet.has(name)) errors.push(`${spec.id}: unexpected assembly part '${name}'`);
+  }
+
+  const partByName = new Map(
+    assemblyParts.flatMap((record) => {
+      const name = record.metadata?.partName;
+      return typeof name === 'string' ? [[name, record] as const] : [];
+    }),
+  );
+  for (const run of spec.contactRuns) {
+    verifyContactRun(spec.id, run, partByName, records, errors);
+  }
+  if (spec.undersideContacts) {
+    verifyUndersideContacts(spec.id, spec.undersideContacts, partByName, records, errors);
+  }
+}
+
+function verifyContactRun(
+  id: string,
+  run: ContactRunSpec,
+  partByName: ReadonlyMap<string, FeatureRecord>,
+  records: readonly FeatureRecord[],
+  errors: string[],
+): void {
+  const centres: number[] = [];
+  for (const name of run.names) {
+    const assemblyPart = partByName.get(name);
+    const centre = assemblyPart === undefined
+      ? undefined
+      : assemblyPartPrimitiveCentre(assemblyPart, records);
+    if (centre === undefined) {
+      errors.push(`${id}: cannot measure authored contact '${name}'`);
+      return;
+    }
+    centres.push(centre[run.axis]);
+  }
+
+  for (let index = 1; index < centres.length; index++) {
+    if (!approximatelyEqual(centres[index] - centres[index - 1], run.pitchMm)) {
+      errors.push(
+        `${id}: ${run.names[index - 1]} → ${run.names[index]} pitch is ` +
+          `${formatNumber(centres[index] - centres[index - 1])} mm, expected ${run.pitchMm} mm`,
+      );
+    }
+  }
+  if (!approximatelyEqual(centres[0] + centres[centres.length - 1], run.symmetricSpanMm)) {
+    errors.push(
+      `${id}: ${run.names[0]} and ${run.names[run.names.length - 1]} are not centred in ` +
+        `the ${run.symmetricSpanMm} mm package span`,
+    );
+  }
+}
+
+function assemblyPartPrimitiveCentre(
+  assemblyPart: FeatureRecord,
+  records: readonly FeatureRecord[],
+): readonly [number, number, number] | undefined {
+  const input = assemblyPart.inputs.shape;
+  if (input?.kind !== 'feature') return undefined;
+  const source = records.find((record) => record.id === input.id);
+  if (!source) return undefined;
+
+  if (source.kind === 'sphere') {
+    const centre: [number, number, number] = [0, 0, 0];
+    for (const transform of source.transforms) {
+      if (transform.op !== 'translate') return undefined;
+      const x = evaluated(transform.vec.x);
+      const y = evaluated(transform.vec.y);
+      const z = evaluated(transform.vec.z);
+      if (x === undefined || y === undefined || z === undefined) return undefined;
+      centre[0] += x;
+      centre[1] += y;
+      centre[2] += z;
+    }
+    return centre;
+  }
+  if (source.kind !== 'box') return undefined;
+
+  const size = [
+    evaluated(source.params.x),
+    evaluated(source.params.y),
+    evaluated(source.params.z),
+  ] as const;
+  if (size.some((value) => value === undefined)) return undefined;
+  const centred = evaluated(source.params.centered) === 1;
+  const centre: [number, number, number] = centred
+    ? [0, 0, 0]
+    : [size[0]! / 2, size[1]! / 2, size[2]! / 2];
+
+  for (const transform of source.transforms) {
+    if (transform.op !== 'translate') return undefined;
+    const x = evaluated(transform.vec.x);
+    const y = evaluated(transform.vec.y);
+    const z = evaluated(transform.vec.z);
+    if (x === undefined || y === undefined || z === undefined) return undefined;
+    centre[0] += x;
+    centre[1] += y;
+    centre[2] += z;
+  }
+  return centre;
+}
+
+function verifyUndersideContacts(
+  id: string,
+  spec: UndersideContactSpec,
+  partByName: ReadonlyMap<string, FeatureRecord>,
+  records: readonly FeatureRecord[],
+  errors: string[],
+): void {
+  const body = partByName.get(spec.bodyName);
+  const bodyBounds = body === undefined ? undefined : assemblyPartBoxZBounds(body, records);
+  if (!bodyBounds) {
+    errors.push(`${id}: cannot measure package body '${spec.bodyName}' for underside-contact clearance`);
+    return;
+  }
+  for (const name of spec.contactNames) {
+    const contact = partByName.get(name);
+    const contactBounds = contact === undefined ? undefined : assemblyPartBoxZBounds(contact, records);
+    if (!contactBounds) {
+      errors.push(`${id}: cannot measure underside contact '${name}'`);
+      continue;
+    }
+    if (contactBounds.max > bodyBounds.min + 0.001) {
+      errors.push(
+        `${id}: underside contact '${name}' overlaps package body ` +
+          `(${formatNumber(contactBounds.max)} mm > body base ${formatNumber(bodyBounds.min)} mm)`,
+      );
+    }
+  }
+}
+
+function assemblyPartBoxZBounds(
+  assemblyPart: FeatureRecord,
+  records: readonly FeatureRecord[],
+): { min: number; max: number } | undefined {
+  const input = assemblyPart.inputs.shape;
+  if (input?.kind !== 'feature') return undefined;
+  const source = records.find((record) => record.id === input.id);
+  if (!source || source.kind !== 'box') return undefined;
+  const height = evaluated(source.params.z);
+  if (height === undefined) return undefined;
+  const centered = evaluated(source.params.centered) === 1;
+  let min = centered ? -height / 2 : 0;
+  let max = centered ? height / 2 : height;
+  for (const transform of source.transforms) {
+    if (transform.op !== 'translate') return undefined;
+    const z = evaluated(transform.vec.z);
+    if (z === undefined) return undefined;
+    min += z;
+    max += z;
+  }
+  return { min, max };
+}
+
+function verifyCatalogRecord(
+  spec: AuthoredElectronicPackageSpec,
+  record: CatalogRecordLike | undefined,
+  detailPath: string,
+  catalogDir: string,
+  errors: string[],
+): void {
+  if (!record) return;
+  if (record.id !== spec.id) errors.push(`${spec.id}: detail record id is incorrect`);
+  const attributes = record.attributes;
+  if (!isRecord(attributes)) {
+    errors.push(`${spec.id}: detail record has no attributes object`);
+    return;
+  }
+  const bbox = [attributes.bboxXmm, attributes.bboxYmm, attributes.bboxZmm];
+  for (let axis = 0; axis < 3; axis++) {
+    if (typeof bbox[axis] !== 'number' || !approximatelyEqual(bbox[axis], spec.bboxMm[axis]!)) {
+      errors.push(
+        `${spec.id}: measured bbox ${['X', 'Y', 'Z'][axis]} is ${String(bbox[axis])} mm, ` +
+          `expected ${spec.bboxMm[axis]} mm`,
+      );
+    }
+  }
+  if (attributes.package !== spec.package) {
+    errors.push(`${spec.id}: emitted package metadata is not '${spec.package}'`);
+  }
+  if (attributes.pinCount !== spec.pinCount) {
+    errors.push(`${spec.id}: emitted pinCount is not ${spec.pinCount}`);
+  }
+  if (spec.pinPitchMm !== undefined && attributes.pinPitchMm !== spec.pinPitchMm) {
+    errors.push(`${spec.id}: emitted pinPitchMm is not ${spec.pinPitchMm}`);
+  }
+
+  const stepPath = join(catalogDir, 'step', `${spec.id}.step`);
+  if (!existsSync(stepPath) || statSync(stepPath).size === 0) {
+    errors.push(`${spec.id}: missing STEP artifact ${stepPath}`);
+    return;
+  }
+  if (record.stepUrl !== undefined && !String(record.stepUrl).endsWith(`/step/${spec.id}.step`)) {
+    errors.push(`${spec.id}: detail record stepUrl does not point at its STEP artifact`);
+  }
+  const stepHash = createHash('sha256').update(readFileSync(stepPath)).digest('hex');
+  if (typeof record.sha256 !== 'string' || record.sha256 !== stepHash) {
+    errors.push(`${spec.id}: detail record SHA-256 does not match its STEP artifact`);
+  }
+  if (!existsSync(detailPath)) errors.push(`${spec.id}: missing detail record ${detailPath}`);
+}
+
+function readJson<T>(path: string, errors: string[], label: string): T | undefined {
+  if (!existsSync(path)) {
+    errors.push(`${label}: missing ${path}`);
+    return undefined;
+  }
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as T;
+  } catch (error) {
+    errors.push(`${label}: invalid JSON — ${formatError(error)}`);
+    return undefined;
+  }
+}
+
+function evaluated(value: unknown): number | undefined {
+  if (!isRecord(value) || typeof value.evaluated !== 'number') return undefined;
+  return value.evaluated;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function approximatelyEqual(actual: number, expected: number): boolean {
+  return Math.abs(actual - expected) <= 0.001;
+}
+
+function formatNumber(value: number): string {
+  return Number(value.toFixed(4)).toString();
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function parseArgs(argv: readonly string[]): VerifyAuthoredElectronicsCatalogOptions {
+  let catalogDir: string | undefined;
+  let manifestPath = 'scripts/electronics-parts.json';
+  for (let index = 0; index < argv.length; index++) {
+    if (argv[index] === '--manifest') {
+      manifestPath = argv[++index] ?? manifestPath;
+    } else if (!argv[index].startsWith('-') && catalogDir === undefined) {
+      catalogDir = argv[index];
+    }
+  }
+  if (!catalogDir) {
+    throw new Error(
+      'Usage: npx tsx scripts/verifyAuthoredElectronicsCatalog.ts <catalogDir> ' +
+        '[--manifest scripts/electronics-parts.json]',
+    );
+  }
+  return { catalogDir, manifestPath };
+}
+
+async function main(): Promise<void> {
+  const result = await verifyAuthoredElectronicsCatalog(parseArgs(process.argv.slice(2)));
+  console.log(`Verified ${result.verifiedIds.length} authored electronic package(s): ${result.verifiedIds.join(', ')}`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  void main().catch((error: unknown) => {
+    console.error(formatError(error));
+    process.exitCode = 1;
+  });
+}

--- a/src/agent/mcp/tools/listFeatures.ts
+++ b/src/agent/mcp/tools/listFeatures.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import type { FeatureKind, Param } from '../../../shared/intent/types';
+import type { CatalogPartMetadata } from '../../../shared/parts/types';
 import { runMcpScript } from '../runMcpScript';
 
 export interface ListFeaturesInput {
@@ -15,6 +16,10 @@ export interface FeatureSummary {
   inputs: Record<string, unknown>;
   transformCount: number;
   suppressed: boolean;
+  /** Present for Shapes imported through lib.fetchPart(). Makes package
+   * identity available through inspect({ of: 'features' }) without exposing
+   * arbitrary feature metadata. */
+  catalogPart?: CatalogPartMetadata;
 }
 
 export interface ListFeaturesOutput {
@@ -50,6 +55,7 @@ export async function listFeaturesTool(
     inputs: r.inputs,
     transformCount: r.transforms.length,
     suppressed: r.suppressed,
+    ...(r.metadata?.catalogPart === undefined ? {} : { catalogPart: r.metadata.catalogPart }),
   }));
 
   return { features };

--- a/src/modeling/capture/assembly.ts
+++ b/src/modeling/capture/assembly.ts
@@ -2669,12 +2669,17 @@ export class Assembly {
   ): Scene {
     const sceneFeatureId = sceneShape.id;
     const session = this.session;
-    const sceneParts: ScenePart[] = this.parts.map((p) => ({
-      name: p.name,
-      shape: p.originalShape,
-      worldTransform: matePartTransforms?.get(p.name) ?? Transform.identity(),
-      ...(p.mateConnectors.length > 0 ? { connectors: [...p.mateConnectors] } : {}),
-    }));
+    const catalogMetadataByShapeId = catalogPartSceneMetadataByShapeId(session);
+    const sceneParts: ScenePart[] = this.parts.map((p) => {
+      const metadata = catalogMetadataByShapeId.get(p.originalShape.id);
+      return {
+        name: p.name,
+        shape: p.originalShape,
+        worldTransform: matePartTransforms?.get(p.name) ?? Transform.identity(),
+        ...(metadata === undefined ? {} : { metadata }),
+        ...(p.mateConnectors.length > 0 ? { connectors: [...p.mateConnectors] } : {}),
+      };
+    });
     return new Scene(
       this.name,
       sceneParts,
@@ -2693,6 +2698,25 @@ export class Assembly {
       this.tendons.length > 0 ? [...this.tendons] : undefined,
     );
   }
+}
+
+/**
+ * Copy catalog identity from a fetched Shape into the public Scene part
+ * metadata.  Other source metadata has its own dedicated Scene fields (for
+ * example color), so only this explicit immutable package snapshot crosses
+ * the assembly boundary.
+ */
+function catalogPartSceneMetadataByShapeId(
+  session: CaptureSession,
+): ReadonlyMap<FeatureId, Readonly<Record<string, unknown>>> {
+  const metadataByShapeId = new Map<FeatureId, Readonly<Record<string, unknown>>>();
+  for (const record of session.getRecords()) {
+    const catalogPart = record.metadata?.catalogPart;
+    if (catalogPart !== undefined) {
+      metadataByShapeId.set(record.id, Object.freeze({ catalogPart }));
+    }
+  }
+  return metadataByShapeId;
 }
 
 export function makeAssembly(name: string | undefined, session: CaptureSession): Assembly {
@@ -2848,15 +2872,18 @@ export class SolvedKinematics {
       );
     }
     const records = this.session.getRecords();
+    const catalogMetadataByShapeId = catalogPartSceneMetadataByShapeId(this.session);
     const sceneParts: ScenePart[] = [];
     for (const part of this.partsByName.values()) {
       const partRecord = records.find(r => r.id === part.id);
       const color = partRecord ? lookupSourceColor(partRecord, records) : undefined;
+      const metadata = catalogMetadataByShapeId.get(part.originalShape.id);
       sceneParts.push({
         name: part.name,
         shape: part.originalShape,
         worldTransform: this.worldT.get(part.id) ?? Transform.identity(),
         ...(color !== undefined ? { color } : {}),
+        ...(metadata === undefined ? {} : { metadata }),
         ...(part.mateConnectors.length > 0 ? { connectors: [...part.mateConnectors] } : {}),
       });
     }

--- a/src/modeling/parts/fetchPart.ts
+++ b/src/modeling/parts/fetchPart.ts
@@ -21,7 +21,7 @@ import {
   RemoteDisabledError,
 } from './remoteClient';
 import { KernelError } from '../../shared/intent/kernelError';
-import type { PartRecord } from '../../shared/parts/types';
+import { snapshotCatalogPart, type PartRecord } from '../../shared/parts/types';
 import { loadConnectorManifest } from '../../shared/parts/connectorManifest';
 import { formatTopoRef } from '../../kernel/naming';
 import { inspectStepFile } from '../../agent/inspect/inspectStep';
@@ -232,6 +232,7 @@ export async function fetchPartFromUrlHost(
       inputs: {},
       metadata: { sourcePath: path, geometryKind: 'mesh' },
     });
+    attachCatalogPartMetadata(ctx, shape, record);
     return { ok: true, kind: 'part', result: { shape, record } };
   }
 
@@ -265,6 +266,7 @@ export async function fetchPartFromUrlHost(
     stepUrl: url,
     redistribution: 'fetch-only',
   };
+  attachCatalogPartMetadata(ctx, shape, record);
   return { ok: true, kind: 'part', result: { shape, record } };
 }
 
@@ -304,6 +306,7 @@ export async function fetchPartHost(
     const bytes = readFileSync(direct.stepPath);
     const shape = await fromStepBytes(ctx, bytes, direct.stepPath);
     attachManifestConnectorsFromSidecar(ctx, shape, direct.stepPath);
+    attachCatalogPartMetadata(ctx, shape, direct.record);
     return { shape, record: direct.record };
   }
 
@@ -319,6 +322,7 @@ export async function fetchPartHost(
     const bytes = readFileSync(r.stepPath);
     const shape = await fromStepBytes(ctx, bytes, r.stepPath);
     attachManifestConnectorsFromSidecar(ctx, shape, r.stepPath);
+    attachCatalogPartMetadata(ctx, shape, r.record);
     return { shape, record: r.record };
   }
   if (matches.length > 1 && opts.strict !== false) {
@@ -390,20 +394,19 @@ export async function fetchPartHost(
     // convention from the geometry itself (bbox faces + detected hole axes).
     // Defensive: a STEP that resists inspection still imports, just without
     // synthesized connectors.
+    let record: PartRecord = { ...meta, source: 'remote' };
     try {
       const report = await inspectStepFile(path);
       const conns = synthesizeConnectorsFromReport(report, shape.id);
       if (conns.length > 0) {
         ctx.session.attachAutoConnectors(shape.id, conns);
-        return {
-          shape,
-          record: { ...meta, source: 'remote', connectors: conns.map((c) => c.name) },
-        };
+        record = { ...record, connectors: conns.map((c) => c.name) };
       }
     } catch {
       // fall through to the unenriched record
     }
-    return { shape, record: { ...meta, source: 'remote' } };
+    attachCatalogPartMetadata(ctx, shape, record);
+    return { shape, record };
   } catch (e) {
     if (e instanceof RemoteDisabledError) throw e;
     throw e;
@@ -442,4 +445,26 @@ function attachManifestConnectorsFromSidecar(
     // A malformed manifest must not break the import; the lowerer survives
     // without the manifest's named connectors.
   }
+}
+
+/**
+ * Retain immutable catalog semantics on the imported feature itself.
+ *
+ * `fetchPartHost()` has a rich `{ shape, record }` result, but the public
+ * `lib.fetchPart()` API intentionally returns only the composable Shape. Put a
+ * frozen record snapshot on the Shape's FeatureRecord before that wrapper is
+ * discarded so assemblies, Studio, and MCP inspection can still identify the
+ * physical package instead of seeing only an imported STEP source path.
+ */
+function attachCatalogPartMetadata(
+  ctx: FetchPartCtx,
+  shape: Shape,
+  record: PartRecord,
+): void {
+  const feature = ctx.session.getRecords().find((candidate) => candidate.id === shape.id);
+  if (!feature) return;
+  feature.metadata = {
+    ...(feature.metadata ?? {}),
+    catalogPart: snapshotCatalogPart(record),
+  };
 }

--- a/src/modeling/parts/fetchPartMetadata.test.ts
+++ b/src/modeling/parts/fetchPartMetadata.test.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// A catalog fetch must not become an anonymous imported STEP feature just
+// because lib.fetchPart() returns Shape rather than fetchPartHost's internal
+// { shape, record } wrapper. Keep this test fully offline: the STEP importer
+// is mocked while the remote metadata and public facade remain real.
+import { createHash } from 'node:crypto';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./fromSTEP', () => ({
+  fromStepBytes: vi.fn(
+    async (
+      ctx: { session: { createShape: (spec: unknown) => { id: string } } },
+      _bytes: Buffer,
+      sourceLabel: string,
+    ) =>
+      ctx.session.createShape({
+        kind: 'importedStep',
+        params: {},
+        inputs: {},
+        metadata: { sourcePath: sourceLabel },
+      }),
+  ),
+}));
+
+vi.mock('../../agent/inspect/inspectStep', () => ({
+  inspectStepFile: vi.fn(async (path: string) => ({ file: path, solidCount: 1, solids: [] })),
+}));
+
+vi.mock('./synthesizeConnectors', () => ({
+  synthesizeConnectorsFromReport: vi.fn(() => []),
+}));
+
+import '../runtime/hostFsNode';
+import { listFeaturesTool } from '../../agent/mcp/tools/listFeatures';
+import { createApi } from '../api';
+import { CaptureSession } from '../capture/captureSession';
+import { __resetUserCacheForTests } from '../../shared/cache/userCache';
+
+const PART_ID = 'max30102-optical';
+const BASE_URL = 'https://parts.example';
+const STEP_URL = `${BASE_URL}/step/${PART_ID}.step`;
+const STEP_BYTES = Buffer.from('ISO-10303-21;\nDATA;\nENDSEC;\nEND-ISO-10303-21;\n');
+const STEP_SHA256 = createHash('sha256').update(STEP_BYTES).digest('hex');
+
+describe('lib.fetchPart catalog semantic identity', () => {
+  let cacheDir: string;
+  let previousCacheDir: string | undefined;
+
+  beforeEach(() => {
+    previousCacheDir = process.env.KERNELCAD_CACHE_DIR;
+    cacheDir = mkdtempSync(join(tmpdir(), 'kc-fetch-part-metadata-'));
+    process.env.KERNELCAD_CACHE_DIR = cacheDir;
+    __resetUserCacheForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (previousCacheDir === undefined) delete process.env.KERNELCAD_CACHE_DIR;
+    else process.env.KERNELCAD_CACHE_DIR = previousCacheDir;
+    rmSync(cacheDir, { recursive: true, force: true });
+    __resetUserCacheForTests();
+  });
+
+  it('preserves remote package attributes through the public Shape facade and into an assembly Scene', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === `${BASE_URL}/v1/parts/${PART_ID}`) {
+        return new Response(
+          JSON.stringify({
+            id: PART_ID,
+            name: 'Analog Devices MAX30102 optical biosensor module',
+            category: 'Electronics',
+            family: 'Sensor',
+            tags: ['sensor', 'optical'],
+            attributes: {
+              package: 'optical module',
+              pinCount: 14,
+              pinPitchMm: 0.8,
+            },
+            stepUrl: STEP_URL,
+            sha256: STEP_SHA256,
+          }),
+          { status: 200 },
+        );
+      }
+      if (url === STEP_URL) {
+        return new Response(STEP_BYTES, { status: 200 });
+      }
+      return new Response('not found', { status: 404 });
+    });
+
+    const session = new CaptureSession();
+    const api = createApi({ session });
+    const sensor = await api.lib.fetchPart(PART_ID, { partsBaseUrl: BASE_URL });
+
+    const imported = session.getRecords().find((record) => record.id === sensor.id);
+    expect(imported?.metadata).toMatchObject({
+      sourcePath: STEP_URL,
+      catalogPart: {
+        id: PART_ID,
+        category: 'Electronics',
+        family: 'Sensor',
+        source: 'remote',
+        attributes: { package: 'optical module', pinCount: 14, pinPitchMm: 0.8 },
+      },
+    });
+    const catalogPart = imported?.metadata?.catalogPart;
+    expect(Object.isFrozen(catalogPart)).toBe(true);
+    expect(Object.isFrozen(catalogPart?.attributes)).toBe(true);
+
+    const scene = api.assembly('catalog-identity').part('sensor', sensor).model();
+    expect(scene.part('sensor').metadata).toMatchObject({
+      catalogPart: {
+        id: PART_ID,
+        attributes: { package: 'optical module', pinCount: 14, pinPitchMm: 0.8 },
+      },
+    });
+
+    const inspected = await listFeaturesTool({
+      code: `
+        const sensor = await lib.fetchPart('${PART_ID}', { partsBaseUrl: '${BASE_URL}' });
+        return sensor;
+      `,
+    });
+    const inspectedPart = inspected.features.find((feature) => feature.kind === 'importedStep');
+    expect(inspectedPart?.catalogPart).toMatchObject({
+      id: PART_ID,
+      attributes: { package: 'optical module', pinCount: 14, pinPitchMm: 0.8 },
+    });
+  });
+});

--- a/src/modeling/validation/scene.ts
+++ b/src/modeling/validation/scene.ts
@@ -45,7 +45,10 @@ export interface ScenePart {
   readonly worldTransform: Transform;
   /** Role token or hex; resolved from the source shape's metadata. */
   readonly color?: string;
-  /** Forward-compat container for material, mass, BOM tags, etc. */
+  /** Forward-compat container for material, mass, BOM tags, etc. Fetched
+   * catalog components expose their immutable `catalogPart` package identity
+   * here (id, attributes, provenance) rather than degrading into anonymous
+   * imported STEP solids. */
   readonly metadata?: Readonly<Record<string, unknown>>;
   /** Mate-style connectors declared on this part via
    *  `partRef.connector(name, opts)` (v0.6 Task 4). Carries the structured

--- a/src/shared/intent/featureRecord.ts
+++ b/src/shared/intent/featureRecord.ts
@@ -10,6 +10,7 @@ import type { PBRMaterial } from './material';
 import type { Curve3DMetadata } from './curve3dRecord';
 import type { VariableSweepMetadata } from './variableSweepRecord';
 import type { FilletContinuity } from './filletContinuityRecord';
+import type { CatalogPartMetadata } from '../parts/types';
 
 export type ShapeTransform =
   | { op: 'translate'; vec: Vec3Param }
@@ -23,6 +24,10 @@ export type ShapeTransform =
 export type FaceLabelsMap = Record<string, CanonicalFace | FaceQuery>;
 
 export interface FeatureMetadata {
+  /** Immutable catalog identity carried by Shapes returned from
+   * `lib.fetchPart()`. This preserves package/dimension/provenance semantics
+   * through the capture graph even though the public call returns a Shape. */
+  catalogPart?: CatalogPartMetadata;
   /** Hex color or CSS color string applied to this feature's mesh. */
   color?: string;
   /** Face-label map for features that support canonical-face naming. */

--- a/src/shared/parts/types.ts
+++ b/src/shared/parts/types.ts
@@ -64,6 +64,61 @@ export interface PartRecord {
   upstream?: UpstreamProvenance;
 }
 
+/**
+ * Immutable catalog identity retained on an imported Shape's FeatureRecord.
+ *
+ * `lib.fetchPart()` intentionally returns a normal composable Shape, but the
+ * Shape must not become anonymous just because the host facade has consumed
+ * its internal `{ shape, record }` result.  This snapshot carries the package
+ * identity, dimensions and provenance into the feature graph and, from there,
+ * into assembly Scene parts and inspectors.
+ */
+export interface CatalogPartMetadata {
+  readonly id: string;
+  readonly name: string;
+  readonly category: string;
+  readonly family: string;
+  readonly standard?: string;
+  readonly tags: readonly string[];
+  readonly attributes: Readonly<Record<string, number | string>>;
+  readonly sha256: string;
+  readonly source: PartSource;
+  readonly license: string;
+  readonly attribution?: string;
+  readonly connectors: readonly string[];
+  readonly stepUrl?: string;
+  readonly glbUrl?: string;
+  readonly licenseClass?: LicenseClass;
+  readonly redistribution?: RedistributionMode;
+  readonly upstream?: Readonly<UpstreamProvenance>;
+}
+
+/** Create a detached, frozen copy of a catalog record for runtime metadata. */
+export function snapshotCatalogPart(record: PartRecord): CatalogPartMetadata {
+  const snapshot: CatalogPartMetadata = {
+    id: record.id,
+    name: record.name,
+    category: record.category,
+    family: record.family,
+    ...(record.standard === undefined ? {} : { standard: record.standard }),
+    tags: Object.freeze([...record.tags]),
+    attributes: Object.freeze({ ...record.attributes }),
+    sha256: record.sha256,
+    source: record.source,
+    license: record.license,
+    ...(record.attribution === undefined ? {} : { attribution: record.attribution }),
+    connectors: Object.freeze([...record.connectors]),
+    ...(record.stepUrl === undefined ? {} : { stepUrl: record.stepUrl }),
+    ...(record.glbUrl === undefined ? {} : { glbUrl: record.glbUrl }),
+    ...(record.licenseClass === undefined ? {} : { licenseClass: record.licenseClass }),
+    ...(record.redistribution === undefined ? {} : { redistribution: record.redistribution }),
+    ...(record.upstream === undefined
+      ? {}
+      : { upstream: Object.freeze({ ...record.upstream }) }),
+  };
+  return Object.freeze(snapshot);
+}
+
 export function isLicenseClass(v: unknown): v is LicenseClass {
   return v === 'permissive' || v === 'share-alike' || v === 'fetch-only';
 }


### PR DESCRIPTION
## What changed

Adds reusable, datasheet-backed KernelCAD catalog packages for the nRF54L15 QFN48, BMI270 LGA14, MAX30102 optical sensor, TMP117 DSBGA-6, and DRV2605 DSBGA-9. Each has named package/contact geometry, package metadata, provenance, and a deploy-time emitted-artifact gate.

`lib.fetchPart()` now retains a frozen catalog-part snapshot through the capture graph, assembly scene, and `inspect({ of: "features" })`, so imported catalog geometry remains component-aware.

## Why

The published Open Source Ring used anonymous/fallback solids instead of reusable physical catalog parts. The new parts are package-level models rather than project-specific boards; the MAX30102 contact stack and optical recesses are explicitly non-overlapping.

## Validation

- Independent review approved with no blockers.
- `npx vitest run scripts/electronics-parts.test.ts scripts/verifyAuthoredElectronicsCatalog.test.ts src/modeling/parts/fetchPartMetadata.test.ts scripts/ingestParts.test.ts` — 8 passed.
- `npm run typecheck`, `npm run build:cli`, `npm run lint`, and `git diff --check` passed.
- `kernelcad interference scripts/parts/authored/max30102-optical.kcad.ts` reports no interferences.
- The five authored sources exported and ingested into an isolated catalog as 5/5, with expected measured envelopes.

The broad `npm test` run was intentionally stopped after its pretest fixture generation because the shared workstation disk was nearly full; it is not claimed as passed here.