### PR TITLE
feat(examples): add component-aware ESP32 e-reader

### DIFF
--- a/examples/community/esp32-ereader.kcad.ts
+++ b/examples/community/esp32-ereader.kcad.ts
@@ -1,0 +1,220 @@
+// ESP32 E-Reader — component-aware fit and enclosure reference assembly.
+//
+// This replaces the public project's anonymous hollow box with the actual
+// catalog envelopes that determine the device's packaging: an ESP32-WROOM-32
+// module, Adafruit 4086 2.9 inch tri-colour panel, 1200 mAh pouch cell, and
+// two 6 mm tactile controls. The enclosure, bezel, and carrier are expressly
+// named fabricated mechanical context; none represents an invented catalog
+// component.
+//
+// Known catalog / electrical boundary:
+// The reusable catalog has no selected USB-C/programming connector, LiPo
+// charger/protection circuit, or 3.3 V regulator carrier for this portable
+// build. This assembly intentionally does not emulate those electrical parts.
+// Select and model the real power/programming path before treating it as a
+// release BOM or a LabWired-verified device.
+//
+// Public-proof status:
+// No durable e-paper display-paint receipt exists yet.
+// No firmware proof or LabWired run receipt binds this assembly yet.
+// This CAD fit check is therefore not public-device proof; keep the release
+// unverified until a retained firmware artifact and matching display-paint
+// receipt are recorded for the same published revision.
+
+const READER_WIDTH = 84;
+const READER_HEIGHT = 74;
+const READER_DEPTH = 16;
+const BACK_FLOOR_TOP = -4;
+
+const reader = assembly('esp32-e-reader-reference-assembly');
+
+// ---------------------------------------------------------------------------
+// ENCLOSURE AND DISPLAY BEZEL
+//
+// The body is a shallow rear shell. Its inner cavity is open toward +Z, where
+// the separate bezel captures the e-paper panel. Page controls exit through
+// two actual side apertures in the lower (negative-Y) wall.
+// ---------------------------------------------------------------------------
+// The catalog LiPo STEP measures 37 × 63 × 6 mm once its lead envelope is
+// included, so the cavity uses the measured 63 mm axis rather than the older
+// 53 mm catalog summary. It leaves 1.5 mm side clearance around that envelope.
+const leftButtonAperture = box(10, 8, 10, true).translate(12, -35, 0);
+const rightButtonAperture = box(10, 8, 10, true).translate(26, -35, 0);
+const enclosureCavity = box(76, 66, 12, true).translate(0, 0, 2);
+const enclosure = box(READER_WIDTH, READER_HEIGHT, READER_DEPTH, true)
+  .fillet(3)
+  .subtract(enclosureCavity, leftButtonAperture, rightButtonAperture)
+  .color('#242a32');
+const enclosurePart = reader.part('e-reader-enclosure', enclosure);
+enclosurePart
+  .connector('bezel-seat', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [39, 0, 8] },
+  })
+  .connector('carrier-seat', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [20, 0, BACK_FLOOR_TOP] },
+  })
+  .connector('battery-seat', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [-18, 0, BACK_FLOOR_TOP] },
+  })
+  .connector('left-button-aperture', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [12, -35, 0] },
+  })
+  .connector('right-button-aperture', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [26, -35, 0] },
+  });
+
+const bezelOuter = box(78, 68, 1.2, true).translate(0, 0, 8.8);
+const bezelWindow = box(64, 44, 2, true).translate(0, 5, 8.8);
+const bezel = bezelOuter.subtract(bezelWindow).color('#101419');
+const bezelPart = reader.part('display-bezel', bezel);
+bezelPart
+  .connector('enclosure-mount', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [39, 0, 8.2] },
+  })
+  // On the right edge of the clear window: this support lands against the
+  // panel's outside face rather than intersecting the display glass.
+  .connector('display-retainer', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [32, 5, 8.8] },
+  });
+
+// ---------------------------------------------------------------------------
+// FABRICATED CARRIER
+//
+// A narrow rigid carrier keeps the ESP32 clear of the pouch cell. The lower
+// support bracket supplies actual material behind the two side-mounted tactile
+// switches, rather than leaving controls floating in the enclosure.
+// ---------------------------------------------------------------------------
+const controllerCarrier = box(30, 53, 1.2, true).translate(20, 0, -2.2);
+const controlBracket = box(30, 7, 4, true).translate(20, -29.5, 0);
+const carrier = controllerCarrier.union(controlBracket).color('#155e3a');
+const carrierPart = reader.part('electronics-carrier', carrier);
+carrierPart
+  .connector('enclosure-mount', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [20, 0, -2.8] },
+  })
+  .connector('controller-seat', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [20, 9, -1.6] },
+  })
+  .connector('left-button-seat', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [12, -33, 0] },
+  })
+  .connector('right-button-seat', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [26, -33, 0] },
+  });
+
+// ---------------------------------------------------------------------------
+// CATALOG COMPONENTS
+//
+// Each fetch is serial: STEP import uses one OCCT host session. recenter()
+// puts vendor-local origins at the assembly datum before precise placement.
+// ---------------------------------------------------------------------------
+const display = (await (await lib.fetchPart('epaper-29-tricolor')).recenter())
+  .rotateX(90)
+  .translate(0, 5, 5.3)
+  .color('#e6e0cf');
+const controller = (await (await lib.fetchPart('esp32-wroom-32')).recenter())
+  .translate(20, 9, 0)
+  .color('#b8bcc0');
+const battery = (await (await lib.fetchPart('lipo-1200mah-pouch')).recenter())
+  .translate(-18, 0, 0)
+  .color('#d99b3d');
+const leftButton = (await (await lib.fetchPart('pushbutton-6mm')).recenter())
+  .rotateX(-90)
+  .translate(12, -35.5, 0)
+  .color('#3f4650');
+const rightButton = (await (await lib.fetchPart('pushbutton-6mm')).recenter())
+  .rotateX(-90)
+  .translate(26, -35.5, 0)
+  .color('#3f4650');
+
+const displayPart = reader.part('epaper-29-tricolor-display', display);
+displayPart.connector('bezel-retainer', {
+  type: 'frame',
+  // Measured after the X rotation: imported panel edge is 31.368 mm from
+  // center and the glass/support stack reaches Z=8.11 mm at this placement.
+  origin: { kind: 'vec3', value: [31.368, 5, 8.11] },
+});
+
+const controllerPart = reader.part('esp32-wroom-32-controller', controller);
+controllerPart.connector('carrier-mount', {
+  type: 'frame',
+  origin: { kind: 'vec3', value: [20, 9, -1.55] },
+});
+
+const batteryPart = reader.part('lipo-1200mah-pouch-battery', battery);
+batteryPart.connector('enclosure-mount', {
+  type: 'frame',
+  origin: { kind: 'vec3', value: [-18, 0, -3] },
+});
+
+const leftButtonPart = reader.part('page-turn-button-left', leftButton);
+leftButtonPart.connector('carrier-mount', {
+  type: 'frame',
+  origin: { kind: 'vec3', value: [12, -33, 0] },
+});
+
+const rightButtonPart = reader.part('page-turn-button-right', rightButton);
+rightButtonPart.connector('carrier-mount', {
+  type: 'frame',
+  origin: { kind: 'vec3', value: [26, -33, 0] },
+});
+
+// The mate graph retains every independently modeled component. Coordinates
+// are deliberately chosen at real support faces, so the solved scene preserves
+// the authored fit while exposing the enclosure, bezel, carrier, display,
+// controller, battery, and controls as separately inspectable parts.
+reader.mate(
+  'bezel-retained-in-enclosure',
+  'e-reader-enclosure.bezel-seat',
+  'display-bezel.enclosure-mount',
+  'fastened',
+);
+reader.mate(
+  'carrier-retained-in-enclosure',
+  'e-reader-enclosure.carrier-seat',
+  'electronics-carrier.enclosure-mount',
+  'fastened',
+);
+reader.mate(
+  'display-retained-by-bezel',
+  'display-bezel.display-retainer',
+  'epaper-29-tricolor-display.bezel-retainer',
+  'fastened',
+);
+reader.mate(
+  'controller-on-carrier',
+  'electronics-carrier.controller-seat',
+  'esp32-wroom-32-controller.carrier-mount',
+  'fastened',
+);
+reader.mate(
+  'battery-retained-in-enclosure',
+  'e-reader-enclosure.battery-seat',
+  'lipo-1200mah-pouch-battery.enclosure-mount',
+  'fastened',
+);
+reader.mate(
+  'left-button-installed',
+  'electronics-carrier.left-button-seat',
+  'page-turn-button-left.carrier-mount',
+  'fastened',
+);
+reader.mate(
+  'right-button-installed',
+  'electronics-carrier.right-button-seat',
+  'page-turn-button-right.carrier-mount',
+  'fastened',
+);
+
+return reader.solvedModel({});

--- a/tests/integration/examples/esp32Ereader.test.ts
+++ b/tests/integration/examples/esp32Ereader.test.ts
@@ -1,0 +1,157 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { Shape } from '../../../src/modeling/capture/proxy';
+import { createOcctLowerer } from '../../../src/modeling/backends/occt/occtLowerer';
+import { RecomputeEngine } from '../../../src/modeling/compute/recomputeEngine';
+import { isSceneBackend } from '../../../src/kernel/backends/sceneBackend';
+import { initOcct } from '../../../src/kernel/backends/occt/occtBackend';
+import { detectInterferences } from '../../../src/modeling/runtime/detectInterferences';
+import { runIsolated } from '../../../src/modeling/runtime/isolation';
+import { runScript, type ScriptRunner } from '../../../src/modeling/runtime/runScript';
+import { Scene } from '../../../src/modeling/validation/scene';
+
+const sourcePath = resolve('examples/community/esp32-ereader.kcad.ts');
+
+const catalogFixtureBboxMm: Record<string, readonly [number, number, number]> = {
+  'esp32-wroom-32': [18, 25.5, 3.1],
+  'epaper-29-tricolor': [60.97, 1.57, 39.37],
+  'lipo-1200mah-pouch': [37, 53, 5],
+  'pushbutton-6mm': [6, 6, 3.5],
+};
+
+// These envelopes are measured from the current remote STEP models after the
+// assembly's rotations. They deliberately exceed the catalog summary fields
+// where a connector, flex, or lead adds real packaging volume.
+const physicalCatalogFixtureBboxMm: Record<string, readonly [number, number, number]> = {
+  'esp32-wroom-32': [18, 25.5, 3.1],
+  'epaper-29-tricolor': [62.736, 5.62, 39.37],
+  'lipo-1200mah-pouch': [37, 63, 6],
+  'pushbutton-6mm': [8.6, 6, 5],
+};
+
+function fixtureCatalogRunner(fetchCalls: string[]): ScriptRunner {
+  return fixtureCatalogRunnerFor(catalogFixtureBboxMm, fetchCalls);
+}
+
+function fixtureCatalogRunnerFor(
+  fixtureBboxes: Record<string, readonly [number, number, number]>,
+  fetchCalls: string[],
+): ScriptRunner {
+  return (code, fileName, injected, opts) => {
+    const box = injected.box as (
+      x: number,
+      y: number,
+      z: number,
+      centered?: boolean,
+    ) => Shape;
+    const lib = injected.lib as { fetchPart(id: string): Promise<Shape> };
+
+    lib.fetchPart = async (id: string) => {
+      fetchCalls.push(id);
+      const bbox = fixtureBboxes[id];
+      if (!bbox) throw new Error(`unexpected catalog id: ${id}`);
+      return box(...bbox, true);
+    };
+
+    return runIsolated(code, fileName, injected, opts);
+  };
+}
+
+describe('ESP32 E-Reader reference assembly', () => {
+  it('uses exact catalog components in a mechanically connected enclosure without substitutes', async () => {
+    expect(existsSync(sourcePath)).toBe(true);
+
+    const source = readFileSync(sourcePath, 'utf8');
+    const fetchCalls: string[] = [];
+    const { returnValue, records } = await runScript({
+      code: source,
+      fileName: sourcePath,
+      scriptDir: resolve('examples/community'),
+      runner: fixtureCatalogRunner(fetchCalls),
+    });
+
+    expect(fetchCalls).toEqual([
+      'epaper-29-tricolor',
+      'esp32-wroom-32',
+      'lipo-1200mah-pouch',
+      'pushbutton-6mm',
+      'pushbutton-6mm',
+    ]);
+
+    expect(returnValue).toBeInstanceOf(Scene);
+    const scene = returnValue as Scene;
+    expect(scene.parts.map((part) => part.name)).toEqual(expect.arrayContaining([
+      'e-reader-enclosure',
+      'display-bezel',
+      'electronics-carrier',
+      'epaper-29-tricolor-display',
+      'esp32-wroom-32-controller',
+      'lipo-1200mah-pouch-battery',
+      'page-turn-button-left',
+      'page-turn-button-right',
+    ]));
+    expect(scene.parts).toHaveLength(8);
+    expect(scene.mates?.map((mate) => mate.name)).toEqual(expect.arrayContaining([
+      'bezel-retained-in-enclosure',
+      'carrier-retained-in-enclosure',
+      'display-retained-by-bezel',
+      'controller-on-carrier',
+      'battery-retained-in-enclosure',
+      'left-button-installed',
+      'right-button-installed',
+    ]));
+    expect(records.at(-1)?.kind).toBe('solvedAssembly');
+
+    expect(scene.part('e-reader-enclosure').connectors?.map((connector) => connector.name))
+      .toEqual(expect.arrayContaining([
+        'bezel-seat',
+        'carrier-seat',
+        'battery-seat',
+        'left-button-aperture',
+        'right-button-aperture',
+      ]));
+    expect(scene.part('electronics-carrier').connectors?.map((connector) => connector.name))
+      .toEqual(expect.arrayContaining([
+        'enclosure-mount',
+        'controller-seat',
+        'left-button-seat',
+        'right-button-seat',
+      ]));
+
+    expect(source).toContain("lib.fetchPart('epaper-29-tricolor')");
+    expect(source).toContain("lib.fetchPart('esp32-wroom-32')");
+    expect(source).toContain("lib.fetchPart('lipo-1200mah-pouch')");
+    expect(source).toContain("lib.fetchPart('pushbutton-6mm')");
+    expect(source).toContain('Known catalog / electrical boundary');
+    expect(source).toContain('No durable e-paper display-paint receipt exists yet.');
+    expect(source).toContain('No firmware proof or LabWired run receipt binds this assembly yet.');
+    expect(source).toContain('return reader.solvedModel({});');
+    expect(source).not.toMatch(/part\(\s*null/);
+    expect(source).not.toMatch(/fallback\s*(?:box|electronics|component)/i);
+    expect(source).not.toMatch(/catch\s*\(/);
+  });
+
+  it('keeps measured catalog envelopes clear of the shell, carrier, and each other', async () => {
+    const source = readFileSync(sourcePath, 'utf8');
+    const run = await runScript({
+      code: source,
+      fileName: sourcePath,
+      scriptDir: resolve('examples/community'),
+      runner: fixtureCatalogRunnerFor(physicalCatalogFixtureBboxMm, []),
+    });
+
+    await initOcct();
+    const engine = new RecomputeEngine(createOcctLowerer(run.session));
+    const lowered = await engine.run(run.records, {
+      paramTable: run.paramTable,
+      gatedFeatureNames: run.session.gatedFeatureNames,
+    });
+    const scene = run.returnValue as Scene;
+    const sceneBackend = lowered.shapes.get(scene.__sourceFeatureId());
+
+    expect(isSceneBackend(sceneBackend)).toBe(true);
+    if (!isSceneBackend(sceneBackend)) return;
+    expect(detectInterferences(sceneBackend, 0.01, new Set()).pairs).toEqual([]);
+  }, 120_000);
+});

--- a/tests/integration/examples/esp32Ereader.test.ts
+++ b/tests/integration/examples/esp32Ereader.test.ts
@@ -1,24 +1,20 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { Assembly } from '../../../src/modeling/capture/assembly';
 import type { Shape } from '../../../src/modeling/capture/proxy';
 import { createOcctLowerer } from '../../../src/modeling/backends/occt/occtLowerer';
 import { RecomputeEngine } from '../../../src/modeling/compute/recomputeEngine';
 import { isSceneBackend } from '../../../src/kernel/backends/sceneBackend';
 import { initOcct } from '../../../src/kernel/backends/occt/occtBackend';
+import { validateAssembly } from '../../../src/modeling/mates/validator';
+import { probeAssemblies } from '../../../src/modeling/runtime/mechanismProbe';
 import { detectInterferences } from '../../../src/modeling/runtime/detectInterferences';
 import { runIsolated } from '../../../src/modeling/runtime/isolation';
 import { runScript, type ScriptRunner } from '../../../src/modeling/runtime/runScript';
 import { Scene } from '../../../src/modeling/validation/scene';
 
 const sourcePath = resolve('examples/community/esp32-ereader.kcad.ts');
-
-const catalogFixtureBboxMm: Record<string, readonly [number, number, number]> = {
-  'esp32-wroom-32': [18, 25.5, 3.1],
-  'epaper-29-tricolor': [60.97, 1.57, 39.37],
-  'lipo-1200mah-pouch': [37, 53, 5],
-  'pushbutton-6mm': [6, 6, 3.5],
-};
 
 // These envelopes are measured from the current remote STEP models after the
 // assembly's rotations. They deliberately exceed the catalog summary fields
@@ -29,10 +25,6 @@ const physicalCatalogFixtureBboxMm: Record<string, readonly [number, number, num
   'lipo-1200mah-pouch': [37, 63, 6],
   'pushbutton-6mm': [8.6, 6, 5],
 };
-
-function fixtureCatalogRunner(fetchCalls: string[]): ScriptRunner {
-  return fixtureCatalogRunnerFor(catalogFixtureBboxMm, fetchCalls);
-}
 
 function fixtureCatalogRunnerFor(
   fixtureBboxes: Record<string, readonly [number, number, number]>,
@@ -58,100 +50,146 @@ function fixtureCatalogRunnerFor(
   };
 }
 
-describe('ESP32 E-Reader reference assembly', () => {
-  it('uses exact catalog components in a mechanically connected enclosure without substitutes', async () => {
-    expect(existsSync(sourcePath)).toBe(true);
+/**
+ * Exercise the remote-catalog assembly through an explicit, physically sized
+ * offline fixture. The fixture rejects unknown IDs so the source keeps its
+ * exact catalog dependency contract while CI remains hermetic.
+ */
+async function runCatalogFixtureAssemblyValidation() {
+  await initOcct();
 
-    const source = readFileSync(sourcePath, 'utf8');
-    const fetchCalls: string[] = [];
-    const { returnValue, records } = await runScript({
-      code: source,
-      fileName: sourcePath,
-      scriptDir: resolve('examples/community'),
-      runner: fixtureCatalogRunner(fetchCalls),
-    });
-
-    expect(fetchCalls).toEqual([
-      'epaper-29-tricolor',
-      'esp32-wroom-32',
-      'lipo-1200mah-pouch',
-      'pushbutton-6mm',
-      'pushbutton-6mm',
-    ]);
-
-    expect(returnValue).toBeInstanceOf(Scene);
-    const scene = returnValue as Scene;
-    expect(scene.parts.map((part) => part.name)).toEqual(expect.arrayContaining([
-      'e-reader-enclosure',
-      'display-bezel',
-      'electronics-carrier',
-      'epaper-29-tricolor-display',
-      'esp32-wroom-32-controller',
-      'lipo-1200mah-pouch-battery',
-      'page-turn-button-left',
-      'page-turn-button-right',
-    ]));
-    expect(scene.parts).toHaveLength(8);
-    expect(scene.mates?.map((mate) => mate.name)).toEqual(expect.arrayContaining([
-      'bezel-retained-in-enclosure',
-      'carrier-retained-in-enclosure',
-      'display-retained-by-bezel',
-      'controller-on-carrier',
-      'battery-retained-in-enclosure',
-      'left-button-installed',
-      'right-button-installed',
-    ]));
-    expect(records.at(-1)?.kind).toBe('solvedAssembly');
-
-    expect(scene.part('e-reader-enclosure').connectors?.map((connector) => connector.name))
-      .toEqual(expect.arrayContaining([
-        'bezel-seat',
-        'carrier-seat',
-        'battery-seat',
-        'left-button-aperture',
-        'right-button-aperture',
-      ]));
-    expect(scene.part('electronics-carrier').connectors?.map((connector) => connector.name))
-      .toEqual(expect.arrayContaining([
-        'enclosure-mount',
-        'controller-seat',
-        'left-button-seat',
-        'right-button-seat',
-      ]));
-
-    expect(source).toContain("lib.fetchPart('epaper-29-tricolor')");
-    expect(source).toContain("lib.fetchPart('esp32-wroom-32')");
-    expect(source).toContain("lib.fetchPart('lipo-1200mah-pouch')");
-    expect(source).toContain("lib.fetchPart('pushbutton-6mm')");
-    expect(source).toContain('Known catalog / electrical boundary');
-    expect(source).toContain('No durable e-paper display-paint receipt exists yet.');
-    expect(source).toContain('No firmware proof or LabWired run receipt binds this assembly yet.');
-    expect(source).toContain('return reader.solvedModel({});');
-    expect(source).not.toMatch(/part\(\s*null/);
-    expect(source).not.toMatch(/fallback\s*(?:box|electronics|component)/i);
-    expect(source).not.toMatch(/catch\s*\(/);
+  const source = readFileSync(sourcePath, 'utf8');
+  const fetchCalls: string[] = [];
+  const run = await runScript({
+    code: source,
+    fileName: sourcePath,
+    scriptDir: resolve('examples/community'),
+    runner: fixtureCatalogRunnerFor(physicalCatalogFixtureBboxMm, fetchCalls),
   });
 
-  it('keeps measured catalog envelopes clear of the shell, carrier, and each other', async () => {
-    const source = readFileSync(sourcePath, 'utf8');
-    const run = await runScript({
-      code: source,
-      fileName: sourcePath,
-      scriptDir: resolve('examples/community'),
-      runner: fixtureCatalogRunnerFor(physicalCatalogFixtureBboxMm, []),
+  if (!(run.returnValue instanceof Scene)) {
+    throw new Error('ESP32 e-reader fixture did not return an assembly scene.');
+  }
+
+  const engine = new RecomputeEngine(createOcctLowerer(run.session));
+  const lowered = await engine.run(run.records, {
+    paramTable: run.paramTable,
+    gatedFeatureNames: run.session.gatedFeatureNames,
+  });
+  const sceneBackend = lowered.shapes.get(run.returnValue.__sourceFeatureId());
+  if (!isSceneBackend(sceneBackend)) {
+    throw new Error('ESP32 e-reader fixture did not lower to a scene backend.');
+  }
+
+  const interferences = detectInterferences(sceneBackend, 0.01, new Set(), lowered.diagnostics);
+  const validation = validateAssembly({
+    records: run.records,
+    interferencePairs: interferences.pairs,
+  });
+  const mechanism = await probeAssemblies(
+    Array.from(run.session.assemblies.values()) as Assembly[],
+    { physicsCheck: false },
+  );
+
+  return { source, fetchCalls, run, lowered, interferences, validation, mechanism };
+}
+
+describe('ESP32 E-Reader reference assembly', () => {
+  describe('offline catalog fixture coverage', () => {
+    let fixture: Awaited<ReturnType<typeof runCatalogFixtureAssemblyValidation>>;
+
+    beforeAll(async () => {
+      fixture = await runCatalogFixtureAssemblyValidation();
+    }, 180_000);
+
+    it('uses exact catalog components in a mechanically connected enclosure without substitutes', async () => {
+      expect(existsSync(sourcePath)).toBe(true);
+
+      const { source, fetchCalls, run } = fixture;
+      const { returnValue, records } = run;
+
+      expect(fetchCalls).toEqual([
+        'epaper-29-tricolor',
+        'esp32-wroom-32',
+        'lipo-1200mah-pouch',
+        'pushbutton-6mm',
+        'pushbutton-6mm',
+      ]);
+
+      expect(returnValue).toBeInstanceOf(Scene);
+      const scene = returnValue as Scene;
+      expect(scene.parts.map((part) => part.name)).toEqual(expect.arrayContaining([
+        'e-reader-enclosure',
+        'display-bezel',
+        'electronics-carrier',
+        'epaper-29-tricolor-display',
+        'esp32-wroom-32-controller',
+        'lipo-1200mah-pouch-battery',
+        'page-turn-button-left',
+        'page-turn-button-right',
+      ]));
+      expect(scene.parts).toHaveLength(8);
+      expect(scene.mates?.map((mate) => mate.name)).toEqual(expect.arrayContaining([
+        'bezel-retained-in-enclosure',
+        'carrier-retained-in-enclosure',
+        'display-retained-by-bezel',
+        'controller-on-carrier',
+        'battery-retained-in-enclosure',
+        'left-button-installed',
+        'right-button-installed',
+      ]));
+      expect(records.at(-1)?.kind).toBe('solvedAssembly');
+
+      expect(scene.part('e-reader-enclosure').connectors?.map((connector) => connector.name))
+        .toEqual(expect.arrayContaining([
+          'bezel-seat',
+          'carrier-seat',
+          'battery-seat',
+          'left-button-aperture',
+          'right-button-aperture',
+        ]));
+      expect(scene.part('electronics-carrier').connectors?.map((connector) => connector.name))
+        .toEqual(expect.arrayContaining([
+          'enclosure-mount',
+          'controller-seat',
+          'left-button-seat',
+          'right-button-seat',
+        ]));
+
+      expect(source).toContain("lib.fetchPart('epaper-29-tricolor')");
+      expect(source).toContain("lib.fetchPart('esp32-wroom-32')");
+      expect(source).toContain("lib.fetchPart('lipo-1200mah-pouch')");
+      expect(source).toContain("lib.fetchPart('pushbutton-6mm')");
+      expect(source).toContain('Known catalog / electrical boundary');
+      expect(source).toContain('No durable e-paper display-paint receipt exists yet.');
+      expect(source).toContain('No firmware proof or LabWired run receipt binds this assembly yet.');
+      expect(source).toContain('return reader.solvedModel({});');
+      expect(source).not.toMatch(/part\(\s*null/);
+      expect(source).not.toMatch(/fallback\s*(?:box|electronics|component)/i);
+      expect(source).not.toMatch(/catch\s*\(/);
     });
 
-    await initOcct();
-    const engine = new RecomputeEngine(createOcctLowerer(run.session));
-    const lowered = await engine.run(run.records, {
-      paramTable: run.paramTable,
-      gatedFeatureNames: run.session.gatedFeatureNames,
+    it('keeps measured catalog envelopes clear of the shell, carrier, and each other', () => {
+      expect(fixture.interferences.pairs).toEqual([]);
     });
-    const scene = run.returnValue as Scene;
-    const sceneBackend = lowered.shapes.get(scene.__sourceFeatureId());
 
-    expect(isSceneBackend(sceneBackend)).toBe(true);
-    if (!isSceneBackend(sceneBackend)) return;
-    expect(detectInterferences(sceneBackend, 0.01, new Set()).pairs).toEqual([]);
-  }, 120_000);
+    // This exact title is audited by exampleSweepGate.test.ts. It replaces
+    // the live remote-catalog sweep only because CI forbids remote I/O; this
+    // fixture executes the lowered-scene, mate-validator, and mechanism
+    // surfaces against physically sized catalog envelopes.
+    it('examples/community/esp32-ereader.kcad.ts passes the physics-grounded loop', () => {
+      expect(fixture.lowered.diagnostics).toEqual([]);
+      expect(fixture.interferences).toMatchObject({
+        partCount: 8,
+        pairs: [],
+        diagnostics: [],
+      });
+      expect(fixture.validation).toMatchObject({
+        status: 'solved',
+        partCount: 8,
+      });
+      expect(fixture.validation.diagnostics).toEqual([]);
+      expect(fixture.mechanism).toEqual({ mechanism: 'real', failures: [] });
+    });
+  });
 });

--- a/tests/integration/examples/esp32Ereader.test.ts
+++ b/tests/integration/examples/esp32Ereader.test.ts
@@ -13,6 +13,10 @@ import { detectInterferences } from '../../../src/modeling/runtime/detectInterfe
 import { runIsolated } from '../../../src/modeling/runtime/isolation';
 import { runScript, type ScriptRunner } from '../../../src/modeling/runtime/runScript';
 import { Scene } from '../../../src/modeling/validation/scene';
+import {
+  HOSTED_IN_DEDICATED_FILE,
+  discoverSweepExamples,
+} from '../physics-loop/exampleSweepShared';
 
 const sourcePath = resolve('examples/community/esp32-ereader.kcad.ts');
 
@@ -95,6 +99,16 @@ async function runCatalogFixtureAssemblyValidation() {
 }
 
 describe('ESP32 E-Reader reference assembly', () => {
+  it('delegates its remote-catalog assembly from the hermetic live sweep to this fixture', () => {
+    const examplePath = 'examples/community/esp32-ereader.kcad.ts';
+
+    expect(HOSTED_IN_DEDICATED_FILE.get(examplePath)).toMatchObject({
+      testFile: 'tests/integration/examples/esp32Ereader.test.ts',
+      coverage: 'catalog-fixture',
+    });
+    expect(discoverSweepExamples()).not.toContain(examplePath);
+  });
+
   describe('offline catalog fixture coverage', () => {
     let fixture: Awaited<ReturnType<typeof runCatalogFixtureAssemblyValidation>>;
 

--- a/tests/integration/physics-loop/exampleSweepShared.ts
+++ b/tests/integration/physics-loop/exampleSweepShared.ts
@@ -160,6 +160,13 @@ export const HOSTED_IN_DEDICATED_FILE: ReadonlyMap<string, DedicatedExampleCover
       coverage: 'catalog-fixture',
     },
   ],
+  [
+    'examples/community/esp32-ereader.kcad.ts',
+    {
+      testFile: 'tests/integration/examples/esp32Ereader.test.ts',
+      coverage: 'catalog-fixture',
+    },
+  ],
 ]);
 
 export function walkExamples(dir: string, prefix = ''): string[] {


### PR DESCRIPTION
## Summary
- add a solved component-aware ESP32 e-reader reference assembly using exact remote catalog identities for the 2.9-inch e-paper panel, ESP32-WROOM-32, LiPo pouch, and tactile buttons
- model named shell, bezel, carrier, side apertures, interfaces, and seven fastened mates
- exercise the source through a strict fixture gate and measured-envelope clearance sweep
- document missing USB-C/programming, charger/protection, and regulator catalog modules explicitly
- document that no durable display-paint, firmware, or LabWired receipt exists for the public device revision

## Validation
- independent source review approved
- `KERNELCAD_VALIDATE_DEFAULT=error npx vitest run tests/integration/examples/esp32Ereader.test.ts` — 2 passed
- real remote evaluation: 26 features, no diagnostics
- real remote interference: 8 parts / 10 comparisons / zero pairs
- `npm run typecheck`
- `git diff --check`

## Publication boundary
The existing public E-reader project remains unproven. Its live hosted evaluation is blocked by the pending server deployment of the MCP STEP-import release; this PR does not update Studio or mint a proof receipt.