### PR TITLE
feat(examples): add component-aware Thermal IO-Link assembly

### DIFF
--- a/examples/community/thermal-iolink-machine-health.kcad.ts
+++ b/examples/community/thermal-iolink-machine-health.kcad.ts
@@ -16,11 +16,36 @@ const thermal = assembly('Thermal IO-Link machine-health reference assembly');
 const enclosureLengthMm = 64.0;
 const enclosureDepthMm = 48.0;
 const enclosureHeightMm = 28.0;
-const carrierY = -17.0;
-const cameraCenterY = -18.6;
-const cameraCenterZ = 0.0;
+const electronicsCavityDepthMm = 40.0;
 const rearPanelY = enclosureDepthMm / 2;
 const frontPanelY = -enclosureDepthMm / 2;
+const enclosureWallDepthMm = (enclosureDepthMm - electronicsCavityDepthMm) / 2;
+const cavityFrontY = frontPanelY + enclosureWallDepthMm;
+const cameraCenterZ = 0.0;
+
+// The catalog MLX90640 model is 11.7 mm deep after rotateX(90). Keep its
+// viewing face 0.15 mm inside the cavity rather than burying it in the front
+// wall, then land the carrier directly on its rear mounting plane.
+const mlx90640DepthAlongYmm = 11.7;
+const cameraFrontClearanceMm = 0.15;
+const cameraCenterY = cavityFrontY + cameraFrontClearanceMm + mlx90640DepthAlongYmm / 2;
+const cameraRearFaceY = cameraCenterY + mlx90640DepthAlongYmm / 2;
+const carrierThicknessMm = 1.6;
+const carrierFrontFaceY = cameraRearFaceY;
+const carrierY = carrierFrontFaceY + carrierThicknessMm / 2;
+const carrierRearFaceY = carrierY + carrierThicknessMm / 2;
+const carrierSupportDepthMm = carrierFrontFaceY - cavityFrontY;
+const carrierSupportCenterY = cavityFrontY + carrierSupportDepthMm / 2;
+const m12RetainerContactRadiusMm = 8.2;
+const m12PanelBoreRadiusMm = 8.3;
+
+// These are the catalog records' post-rotation depths along Y. Position the
+// controller and PHY so their mounting faces meet the carrier's rear face
+// without passing through it.
+const esp32C3DepthAlongYmm = 5.56;
+const max14827DepthAlongYmm = 5.1;
+const esp32CenterY = carrierRearFaceY + esp32C3DepthAlongYmm / 2;
+const max14827CenterY = carrierRearFaceY + max14827DepthAlongYmm / 2;
 
 // ---------------------------------------------------------------------------
 // INDUSTRIAL ENCLOSURE AND EXTERNAL INTERFACES
@@ -32,10 +57,14 @@ const frontPanelY = -enclosureDepthMm / 2;
 // ---------------------------------------------------------------------------
 const outerBody = box(enclosureLengthMm, enclosureDepthMm, enclosureHeightMm, true)
   .fillet(3.0, { parallel: [0, 0, 1] });
-const electronicsCavity = box(58.0, 40.0, 22.0, true).translate(0, 0, 0);
-const thermalAperture = box(12.0, 7.0, 10.0, true)
+const electronicsCavity = box(58.0, electronicsCavityDepthMm, 22.0, true).translate(0, 0, 0);
+// Run the aperture through the 4 mm wall and 0.4 mm into the cavity so the
+// optical path stays open even after boolean tolerance is applied.
+const thermalAperture = box(12.0, enclosureWallDepthMm + 0.4, 10.0, true)
   .translate(0, frontPanelY, cameraCenterZ);
-const m12PanelBore = cylinder(12.0, 7.0, 64)
+// Clear the catalog connector's 16 mm retained barrel with 0.1 mm radial
+// allowance; its larger coupling shell remains outside the service panel.
+const m12PanelBore = cylinder(12.0, m12PanelBoreRadiusMm, 64)
   .alongAxis([0, 1, 0])
   .translate(0, rearPanelY - 6.0, 0);
 const enclosure = outerBody
@@ -45,7 +74,7 @@ const enclosurePart = thermal.part('industrial-sensor-enclosure', enclosure);
 enclosurePart
   .connector('carrier-support-seat', {
     type: 'frame',
-    origin: { kind: 'vec3', value: [-19.0, carrierY - 3.0, 0] },
+    origin: { kind: 'vec3', value: [-19.0, cavityFrontY, 0] },
   })
   .connector('aperture-bezel-seat', {
     type: 'frame',
@@ -76,7 +105,7 @@ bezelPart.connector('enclosure-mount', {
 const m12ClampOuter = cylinder(4.0, 10.0, 64)
   .alongAxis([0, 1, 0])
   .translate(0, rearPanelY - 8.0, 0);
-const m12ClampBore = cylinder(6.0, 6.2, 64)
+const m12ClampBore = cylinder(6.0, m12RetainerContactRadiusMm, 64)
   .alongAxis([0, 1, 0])
   .translate(0, rearPanelY - 9.0, 0);
 const m12PanelClamp = m12ClampOuter.subtract(m12ClampBore).color('#64748b');
@@ -88,27 +117,28 @@ m12ClampPart
   })
   .connector('m12-retainer-seat', {
     type: 'frame',
-    origin: { kind: 'vec3', value: [0, rearPanelY - 6.0, 0] },
+    // Mate on the annular retaining material, not at the empty bore center.
+    origin: { kind: 'vec3', value: [m12RetainerContactRadiusMm, rearPanelY - 6.0, 0] },
   });
 
 // ---------------------------------------------------------------------------
 // CARRIER
 //
-// This vertical carrier is close to the viewing wall. The camera boards mount
-// against its -Y face, while controller and PHY hardware mount to its +Y face;
-// this prevents a camera board from obstructing the optical opening.
+// This vertical carrier is set behind the MLX90640's actual 11.7 mm package
+// depth. The camera meets its -Y face, while controller and PHY hardware meet
+// its +Y face; no catalog package is embedded in the carrier plate.
 // ---------------------------------------------------------------------------
-// Two rails bridge the 2.2 mm gap between the enclosure's inner front wall and
-// the carrier. They sit outside the MLX90640 board's 25.4 mm width, preserving
-// a clear optical path and a physical load path for the carrier mate.
-const carrierSupportLeft = box(3.0, 2.2, 21.0, true)
-  .translate(-19.0, carrierY - 1.9, 0);
-const carrierSupportRight = box(3.0, 2.2, 21.0, true)
-  .translate(19.0, carrierY - 1.9, 0);
+// Two rails bridge from the enclosure's inner front wall to the carrier. They
+// sit outside the MLX90640 board's 25.4 mm width, preserving a clear optical
+// path and a physical load path for the carrier mate.
+const carrierSupportLeft = box(3.0, carrierSupportDepthMm, 21.0, true)
+  .translate(-19.0, carrierSupportCenterY, 0);
+const carrierSupportRight = box(3.0, carrierSupportDepthMm, 21.0, true)
+  .translate(19.0, carrierSupportCenterY, 0);
 // A crossbar above the 18 mm carrier joins the two rails into one load path
 // without entering the MLX90640 board envelope.
-const carrierSupportCrossbar = box(38.0, 2.2, 1.4, true)
-  .translate(0, carrierY - 1.9, 10.0);
+const carrierSupportCrossbar = box(38.0, carrierSupportDepthMm, 1.4, true)
+  .translate(0, carrierSupportCenterY, 10.0);
 const carrierSupportRails = carrierSupportLeft
   .union(carrierSupportRight)
   .union(carrierSupportCrossbar)
@@ -117,33 +147,33 @@ const carrierSupportPart = thermal.part('carrier-support-rails', carrierSupportR
 carrierSupportPart
   .connector('enclosure-mount', {
     type: 'frame',
-    origin: { kind: 'vec3', value: [-19.0, carrierY - 3.0, 0] },
+    origin: { kind: 'vec3', value: [-19.0, cavityFrontY, 0] },
   })
   .connector('carrier-mount', {
     type: 'frame',
-    origin: { kind: 'vec3', value: [-19.0, carrierY - 0.8, 0] },
+    origin: { kind: 'vec3', value: [-19.0, carrierFrontFaceY, 0] },
   });
 
-const carrier = box(46.0, 1.6, 18.0, true)
+const carrier = box(46.0, carrierThicknessMm, 18.0, true)
   .translate(0, carrierY, 0)
   .color('#166534');
 const carrierPart = thermal.part('electronics-carrier', carrier);
 carrierPart
   .connector('support-mount', {
     type: 'frame',
-    origin: { kind: 'vec3', value: [-19.0, carrierY - 0.8, 0] },
+    origin: { kind: 'vec3', value: [-19.0, carrierFrontFaceY, 0] },
   })
   .connector('mlx90640-seat', {
     type: 'frame',
-    origin: { kind: 'vec3', value: [0, carrierY - 0.8, cameraCenterZ] },
+    origin: { kind: 'vec3', value: [0, carrierFrontFaceY, cameraCenterZ] },
   })
   .connector('esp32-seat', {
     type: 'frame',
-    origin: { kind: 'vec3', value: [-11.5, carrierY + 0.8, 0] },
+    origin: { kind: 'vec3', value: [-11.5, carrierRearFaceY, 0] },
   })
   .connector('max14827-seat', {
     type: 'frame',
-    origin: { kind: 'vec3', value: [12.0, carrierY + 0.8, 0] },
+    origin: { kind: 'vec3', value: [12.0, carrierRearFaceY, 0] },
   });
 
 thermal.mate('carrier-supports-retained-in-enclosure', 'industrial-sensor-enclosure.carrier-support-seat', 'carrier-support-rails.enclosure-mount', 'fastened');
@@ -163,11 +193,11 @@ const mlx90640 = (await (await lib.fetchPart('mlx90640')).recenter())
   .color('#d97706');
 const esp32C3 = (await (await lib.fetchPart('esp32-c3-supermini-board')).recenter())
   .rotateX(-90)
-  .translate(-11.5, carrierY + 1.3, 0)
+  .translate(-11.5, esp32CenterY, 0)
   .color('#1e3a8a');
 const max14827 = (await (await lib.fetchPart('max14827')).recenter())
   .rotateX(-90)
-  .translate(12.0, carrierY + 1.6, 0)
+  .translate(12.0, max14827CenterY, 0)
   .color('#3f3f46');
 // The catalog M12 model is already axial along Y. Its rear portion projects
 // beyond the service face while its mounting barrel passes through the panel
@@ -179,22 +209,22 @@ const m12 = (await (await lib.fetchPart('m12-iolink-5pin')).recenter())
 const mlxPart = thermal.part('mlx90640-thermal-camera', mlx90640);
 mlxPart.connector('carrier-mount', {
   type: 'frame',
-  origin: { kind: 'vec3', value: [0, carrierY - 0.8, cameraCenterZ] },
+  origin: { kind: 'vec3', value: [0, carrierFrontFaceY, cameraCenterZ] },
 });
 const esp32Part = thermal.part('esp32-c3-supermini-controller', esp32C3);
 esp32Part.connector('carrier-mount', {
   type: 'frame',
-  origin: { kind: 'vec3', value: [-11.5, carrierY + 0.8, 0] },
+  origin: { kind: 'vec3', value: [-11.5, carrierRearFaceY, 0] },
 });
 const phyPart = thermal.part('max14827-iolink-phy', max14827);
 phyPart.connector('carrier-mount', {
   type: 'frame',
-  origin: { kind: 'vec3', value: [12.0, carrierY + 0.8, 0] },
+  origin: { kind: 'vec3', value: [12.0, carrierRearFaceY, 0] },
 });
 const m12Part = thermal.part('m12-iolink-5pin-connector', m12);
 m12Part.connector('enclosure-mount', {
   type: 'frame',
-  origin: { kind: 'vec3', value: [0, rearPanelY - 6.0, 0] },
+  origin: { kind: 'vec3', value: [m12RetainerContactRadiusMm, rearPanelY - 6.0, 0] },
 });
 
 thermal.mate('mlx90640-on-carrier', 'electronics-carrier.mlx90640-seat', 'mlx90640-thermal-camera.carrier-mount', 'fastened');

--- a/examples/community/thermal-iolink-machine-health.kcad.ts
+++ b/examples/community/thermal-iolink-machine-health.kcad.ts
@@ -52,7 +52,9 @@ const esp32RearFaceY = esp32CenterY + esp32C3DepthAlongYmm / 2;
 
 // The buck shares neither the sensor plane nor the crowded rear carrier
 // plane. A right-side enclosure shelf carries it 0.4 mm behind the ESP32
-// envelope and well ahead of the M12's internal body.
+// envelope and well ahead of the M12's internal body. Its catalog -Z mating
+// face is oriented toward that rear shelf, leaving components toward the
+// clearance in front of it.
 const buck24v3v3DepthAlongYmm = 5.6;
 const buck24v3v3WidthMm = 24.0;
 const buckBoardClearanceMm = 0.4;
@@ -250,7 +252,7 @@ const m12 = (await (await lib.fetchPart('m12-iolink-5pin')).recenter())
 // This is only a mechanical placement of the reusable power module. Wiring,
 // thermal derating, isolation, and IO-Link behavior remain out of scope.
 const buck24v3v3 = (await (await lib.fetchPart('buck-24v-3v3')).recenter())
-  .rotateX(-90)
+  .rotateX(90)
   .translate(buckCenterX, buckCenterY, 0)
   .color('#0f766e');
 

--- a/examples/community/thermal-iolink-machine-health.kcad.ts
+++ b/examples/community/thermal-iolink-machine-health.kcad.ts
@@ -16,11 +16,13 @@ const thermal = assembly('Thermal IO-Link machine-health reference assembly');
 const enclosureLengthMm = 64.0;
 const enclosureDepthMm = 48.0;
 const enclosureHeightMm = 28.0;
+const electronicsCavityWidthMm = 58.0;
 const electronicsCavityDepthMm = 40.0;
 const rearPanelY = enclosureDepthMm / 2;
 const frontPanelY = -enclosureDepthMm / 2;
 const enclosureWallDepthMm = (enclosureDepthMm - electronicsCavityDepthMm) / 2;
 const cavityFrontY = frontPanelY + enclosureWallDepthMm;
+const cavityRightWallX = electronicsCavityWidthMm / 2;
 const cameraCenterZ = 0.0;
 
 // The catalog MLX90640 model is 11.7 mm deep after rotateX(90). Keep its
@@ -46,6 +48,23 @@ const esp32C3DepthAlongYmm = 5.56;
 const max14827DepthAlongYmm = 5.1;
 const esp32CenterY = carrierRearFaceY + esp32C3DepthAlongYmm / 2;
 const max14827CenterY = carrierRearFaceY + max14827DepthAlongYmm / 2;
+const esp32RearFaceY = esp32CenterY + esp32C3DepthAlongYmm / 2;
+
+// The buck shares neither the sensor plane nor the crowded rear carrier
+// plane. A right-side enclosure shelf carries it 0.4 mm behind the ESP32
+// envelope and well ahead of the M12's internal body.
+const buck24v3v3DepthAlongYmm = 5.6;
+const buck24v3v3WidthMm = 24.0;
+const buckBoardClearanceMm = 0.4;
+const buckFrontFaceY = esp32RearFaceY + buckBoardClearanceMm;
+const buckCenterY = buckFrontFaceY + buck24v3v3DepthAlongYmm / 2;
+const powerShelfFrontY = buckCenterY + buck24v3v3DepthAlongYmm / 2;
+const powerShelfThicknessMm = 1.6;
+const powerShelfY = powerShelfFrontY + powerShelfThicknessMm / 2;
+const powerShelfWidthMm = 28.0;
+const powerShelfX = cavityRightWallX - powerShelfWidthMm / 2;
+const buckRightSideClearanceMm = 4.0;
+const buckCenterX = cavityRightWallX - buckRightSideClearanceMm - buck24v3v3WidthMm / 2;
 
 // ---------------------------------------------------------------------------
 // INDUSTRIAL ENCLOSURE AND EXTERNAL INTERFACES
@@ -57,7 +76,8 @@ const max14827CenterY = carrierRearFaceY + max14827DepthAlongYmm / 2;
 // ---------------------------------------------------------------------------
 const outerBody = box(enclosureLengthMm, enclosureDepthMm, enclosureHeightMm, true)
   .fillet(3.0, { parallel: [0, 0, 1] });
-const electronicsCavity = box(58.0, electronicsCavityDepthMm, 22.0, true).translate(0, 0, 0);
+const electronicsCavity = box(electronicsCavityWidthMm, electronicsCavityDepthMm, 22.0, true)
+  .translate(0, 0, 0);
 // Run the aperture through the 4 mm wall and 0.4 mm into the cavity so the
 // optical path stays open even after boolean tolerance is applied.
 const thermalAperture = box(12.0, enclosureWallDepthMm + 0.4, 10.0, true)
@@ -83,6 +103,10 @@ enclosurePart
   .connector('m12-panel-seat', {
     type: 'frame',
     origin: { kind: 'vec3', value: [0, rearPanelY - 4.0, 0] },
+  })
+  .connector('power-regulator-shelf-seat', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [cavityRightWallX, powerShelfY, 0] },
   });
 
 // A separate face bezel identifies the optical interface and leaves the 12×10
@@ -176,10 +200,28 @@ carrierPart
     origin: { kind: 'vec3', value: [12.0, carrierRearFaceY, 0] },
   });
 
+// This shelf is a project-specific mechanical interface. It spans from the
+// enclosure's right inner wall to the catalog buck footprint without
+// displacing the universal sensor, controller, PHY, or connector models.
+const powerShelf = box(powerShelfWidthMm, powerShelfThicknessMm, 14.0, true)
+  .translate(powerShelfX, powerShelfY, 0)
+  .color('#475569');
+const powerShelfPart = thermal.part('power-regulator-shelf', powerShelf);
+powerShelfPart
+  .connector('enclosure-mount', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [cavityRightWallX, powerShelfY, 0] },
+  })
+  .connector('buck-seat', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [buckCenterX, powerShelfFrontY, 0] },
+  });
+
 thermal.mate('carrier-supports-retained-in-enclosure', 'industrial-sensor-enclosure.carrier-support-seat', 'carrier-support-rails.enclosure-mount', 'fastened');
 thermal.mate('carrier-retained-on-supports', 'carrier-support-rails.carrier-mount', 'electronics-carrier.support-mount', 'fastened');
 thermal.mate('bezel-retained-in-enclosure', 'industrial-sensor-enclosure.aperture-bezel-seat', 'thermal-aperture-bezel.enclosure-mount', 'fastened');
 thermal.mate('m12-clamp-retained-in-enclosure', 'industrial-sensor-enclosure.m12-panel-seat', 'm12-panel-clamp.enclosure-mount', 'fastened');
+thermal.mate('power-regulator-shelf-retained-in-enclosure', 'industrial-sensor-enclosure.power-regulator-shelf-seat', 'power-regulator-shelf.enclosure-mount', 'fastened');
 
 // ---------------------------------------------------------------------------
 // CATALOG ELECTRONICS
@@ -205,6 +247,12 @@ const max14827 = (await (await lib.fetchPart('max14827')).recenter())
 const m12 = (await (await lib.fetchPart('m12-iolink-5pin')).recenter())
   .translate(0, rearPanelY + 4.0, 0)
   .color('#a16207');
+// This is only a mechanical placement of the reusable power module. Wiring,
+// thermal derating, isolation, and IO-Link behavior remain out of scope.
+const buck24v3v3 = (await (await lib.fetchPart('buck-24v-3v3')).recenter())
+  .rotateX(-90)
+  .translate(buckCenterX, buckCenterY, 0)
+  .color('#0f766e');
 
 const mlxPart = thermal.part('mlx90640-thermal-camera', mlx90640);
 mlxPart.connector('carrier-mount', {
@@ -226,16 +274,16 @@ m12Part.connector('enclosure-mount', {
   type: 'frame',
   origin: { kind: 'vec3', value: [m12RetainerContactRadiusMm, rearPanelY - 6.0, 0] },
 });
+const buckPart = thermal.part('buck-24v-3v3-power-regulator', buck24v3v3);
+buckPart.connector('shelf-mount', {
+  type: 'frame',
+  origin: { kind: 'vec3', value: [buckCenterX, powerShelfFrontY, 0] },
+});
 
 thermal.mate('mlx90640-on-carrier', 'electronics-carrier.mlx90640-seat', 'mlx90640-thermal-camera.carrier-mount', 'fastened');
 thermal.mate('esp32-on-carrier', 'electronics-carrier.esp32-seat', 'esp32-c3-supermini-controller.carrier-mount', 'fastened');
 thermal.mate('max14827-on-carrier', 'electronics-carrier.max14827-seat', 'max14827-iolink-phy.carrier-mount', 'fastened');
 thermal.mate('m12-retained-by-panel-clamp', 'm12-panel-clamp.m12-retainer-seat', 'm12-iolink-5pin-connector.enclosure-mount', 'fastened');
-
-// The public device also needs a 24 V→3.3 V power converter. Its authored
-// catalog source exists as `buck-24v-3v3`, but the deployed catalog does not
-// currently serve it. This assembly deliberately does not invent a solid for
-// that missing part; deploy and validate the catalog record before adding its
-// placement and calling this a complete physical BOM.
+thermal.mate('buck-24v-3v3-on-power-shelf', 'power-regulator-shelf.buck-seat', 'buck-24v-3v3-power-regulator.shelf-mount', 'fastened');
 
 return thermal.solvedModel({});

--- a/examples/community/thermal-iolink-machine-health.kcad.ts
+++ b/examples/community/thermal-iolink-machine-health.kcad.ts
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT
+// Thermal IO-Link machine-health sensor — component-aware reference assembly.
+//
+// This is a fit-and-layout reference for the public proto.cat device. Every
+// electrical item represented here is loaded through the catalog rather than
+// represented by a generic solid. The enclosure, carrier, and aperture bezel
+// are intentionally project-specific mechanical interfaces.
+//
+// Coordinate convention: +Y is the field/service side (M12 cable side), -Y is
+// the thermal viewing side, and +Z is up. The MLX90640 array faces -Y through
+// the front aperture. This model makes no environmental, isolation, thermal
+// accuracy, or IO-Link conformance claim.
+
+const thermal = assembly('Thermal IO-Link machine-health reference assembly');
+
+const enclosureLengthMm = 64.0;
+const enclosureDepthMm = 48.0;
+const enclosureHeightMm = 28.0;
+const carrierY = -17.0;
+const cameraCenterY = -18.6;
+const cameraCenterZ = 0.0;
+const rearPanelY = enclosureDepthMm / 2;
+const frontPanelY = -enclosureDepthMm / 2;
+
+// ---------------------------------------------------------------------------
+// INDUSTRIAL ENCLOSURE AND EXTERNAL INTERFACES
+//
+// The hollow body has a real through-aperture in the viewing face and a M12
+// panel bore in the service face. The camera can see out through the former;
+// the latter carries the actual catalog connector rather than an imprecise
+// connector-shaped cutout.
+// ---------------------------------------------------------------------------
+const outerBody = box(enclosureLengthMm, enclosureDepthMm, enclosureHeightMm, true)
+  .fillet(3.0, { parallel: [0, 0, 1] });
+const electronicsCavity = box(58.0, 40.0, 22.0, true).translate(0, 0, 0);
+const thermalAperture = box(12.0, 7.0, 10.0, true)
+  .translate(0, frontPanelY, cameraCenterZ);
+const m12PanelBore = cylinder(12.0, 7.0, 64)
+  .alongAxis([0, 1, 0])
+  .translate(0, rearPanelY - 6.0, 0);
+const enclosure = outerBody
+  .subtract(electronicsCavity, thermalAperture, m12PanelBore)
+  .color('#334155');
+const enclosurePart = thermal.part('industrial-sensor-enclosure', enclosure);
+enclosurePart
+  .connector('carrier-support-seat', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [-19.0, carrierY - 3.0, 0] },
+  })
+  .connector('aperture-bezel-seat', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [0, frontPanelY, cameraCenterZ] },
+  })
+  .connector('m12-panel-seat', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [0, rearPanelY - 4.0, 0] },
+  });
+
+// A separate face bezel identifies the optical interface and leaves the 12×10
+// mm thermal opening clear. It seats on the enclosure rather than covering the
+// sensor with an opaque slab.
+const bezelOuter = box(18.0, 1.6, 15.0, true)
+  .translate(0, frontPanelY - 0.8, cameraCenterZ);
+const bezelOpening = box(12.0, 3.0, 10.0, true)
+  .translate(0, frontPanelY - 0.8, cameraCenterZ);
+const apertureBezel = bezelOuter.subtract(bezelOpening).color('#111827');
+const bezelPart = thermal.part('thermal-aperture-bezel', apertureBezel);
+bezelPart.connector('enclosure-mount', {
+  type: 'frame',
+  origin: { kind: 'vec3', value: [0, frontPanelY, cameraCenterZ] },
+});
+
+// The internal retaining collar supplies the material interface that a panel
+// M12 connector needs. Its clear bore deliberately leaves the catalog
+// connector barrel free while the collar's outer face bears on the enclosure.
+const m12ClampOuter = cylinder(4.0, 10.0, 64)
+  .alongAxis([0, 1, 0])
+  .translate(0, rearPanelY - 8.0, 0);
+const m12ClampBore = cylinder(6.0, 6.2, 64)
+  .alongAxis([0, 1, 0])
+  .translate(0, rearPanelY - 9.0, 0);
+const m12PanelClamp = m12ClampOuter.subtract(m12ClampBore).color('#64748b');
+const m12ClampPart = thermal.part('m12-panel-clamp', m12PanelClamp);
+m12ClampPart
+  .connector('enclosure-mount', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [0, rearPanelY - 4.0, 0] },
+  })
+  .connector('m12-retainer-seat', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [0, rearPanelY - 6.0, 0] },
+  });
+
+// ---------------------------------------------------------------------------
+// CARRIER
+//
+// This vertical carrier is close to the viewing wall. The camera boards mount
+// against its -Y face, while controller and PHY hardware mount to its +Y face;
+// this prevents a camera board from obstructing the optical opening.
+// ---------------------------------------------------------------------------
+// Two rails bridge the 2.2 mm gap between the enclosure's inner front wall and
+// the carrier. They sit outside the MLX90640 board's 25.4 mm width, preserving
+// a clear optical path and a physical load path for the carrier mate.
+const carrierSupportLeft = box(3.0, 2.2, 21.0, true)
+  .translate(-19.0, carrierY - 1.9, 0);
+const carrierSupportRight = box(3.0, 2.2, 21.0, true)
+  .translate(19.0, carrierY - 1.9, 0);
+// A crossbar above the 18 mm carrier joins the two rails into one load path
+// without entering the MLX90640 board envelope.
+const carrierSupportCrossbar = box(38.0, 2.2, 1.4, true)
+  .translate(0, carrierY - 1.9, 10.0);
+const carrierSupportRails = carrierSupportLeft
+  .union(carrierSupportRight)
+  .union(carrierSupportCrossbar)
+  .color('#64748b');
+const carrierSupportPart = thermal.part('carrier-support-rails', carrierSupportRails);
+carrierSupportPart
+  .connector('enclosure-mount', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [-19.0, carrierY - 3.0, 0] },
+  })
+  .connector('carrier-mount', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [-19.0, carrierY - 0.8, 0] },
+  });
+
+const carrier = box(46.0, 1.6, 18.0, true)
+  .translate(0, carrierY, 0)
+  .color('#166534');
+const carrierPart = thermal.part('electronics-carrier', carrier);
+carrierPart
+  .connector('support-mount', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [-19.0, carrierY - 0.8, 0] },
+  })
+  .connector('mlx90640-seat', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [0, carrierY - 0.8, cameraCenterZ] },
+  })
+  .connector('esp32-seat', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [-11.5, carrierY + 0.8, 0] },
+  })
+  .connector('max14827-seat', {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [12.0, carrierY + 0.8, 0] },
+  });
+
+thermal.mate('carrier-supports-retained-in-enclosure', 'industrial-sensor-enclosure.carrier-support-seat', 'carrier-support-rails.enclosure-mount', 'fastened');
+thermal.mate('carrier-retained-on-supports', 'carrier-support-rails.carrier-mount', 'electronics-carrier.support-mount', 'fastened');
+thermal.mate('bezel-retained-in-enclosure', 'industrial-sensor-enclosure.aperture-bezel-seat', 'thermal-aperture-bezel.enclosure-mount', 'fastened');
+thermal.mate('m12-clamp-retained-in-enclosure', 'industrial-sensor-enclosure.m12-panel-seat', 'm12-panel-clamp.enclosure-mount', 'fastened');
+
+// ---------------------------------------------------------------------------
+// CATALOG ELECTRONICS
+//
+// Import serially: STEP import shares the OCCT kernel session. recenter() makes
+// placement independent of each vendor STEP's native coordinate origin.
+// ---------------------------------------------------------------------------
+const mlx90640 = (await (await lib.fetchPart('mlx90640')).recenter())
+  .rotateX(90)
+  .translate(0, cameraCenterY, cameraCenterZ)
+  .color('#d97706');
+const esp32C3 = (await (await lib.fetchPart('esp32-c3-supermini-board')).recenter())
+  .rotateX(-90)
+  .translate(-11.5, carrierY + 1.3, 0)
+  .color('#1e3a8a');
+const max14827 = (await (await lib.fetchPart('max14827')).recenter())
+  .rotateX(-90)
+  .translate(12.0, carrierY + 1.6, 0)
+  .color('#3f3f46');
+// The catalog M12 model is already axial along Y. Its rear portion projects
+// beyond the service face while its mounting barrel passes through the panel
+// bore and is retained by the modeled internal collar.
+const m12 = (await (await lib.fetchPart('m12-iolink-5pin')).recenter())
+  .translate(0, rearPanelY + 4.0, 0)
+  .color('#a16207');
+
+const mlxPart = thermal.part('mlx90640-thermal-camera', mlx90640);
+mlxPart.connector('carrier-mount', {
+  type: 'frame',
+  origin: { kind: 'vec3', value: [0, carrierY - 0.8, cameraCenterZ] },
+});
+const esp32Part = thermal.part('esp32-c3-supermini-controller', esp32C3);
+esp32Part.connector('carrier-mount', {
+  type: 'frame',
+  origin: { kind: 'vec3', value: [-11.5, carrierY + 0.8, 0] },
+});
+const phyPart = thermal.part('max14827-iolink-phy', max14827);
+phyPart.connector('carrier-mount', {
+  type: 'frame',
+  origin: { kind: 'vec3', value: [12.0, carrierY + 0.8, 0] },
+});
+const m12Part = thermal.part('m12-iolink-5pin-connector', m12);
+m12Part.connector('enclosure-mount', {
+  type: 'frame',
+  origin: { kind: 'vec3', value: [0, rearPanelY - 6.0, 0] },
+});
+
+thermal.mate('mlx90640-on-carrier', 'electronics-carrier.mlx90640-seat', 'mlx90640-thermal-camera.carrier-mount', 'fastened');
+thermal.mate('esp32-on-carrier', 'electronics-carrier.esp32-seat', 'esp32-c3-supermini-controller.carrier-mount', 'fastened');
+thermal.mate('max14827-on-carrier', 'electronics-carrier.max14827-seat', 'max14827-iolink-phy.carrier-mount', 'fastened');
+thermal.mate('m12-retained-by-panel-clamp', 'm12-panel-clamp.m12-retainer-seat', 'm12-iolink-5pin-connector.enclosure-mount', 'fastened');
+
+// The public device also needs a 24 V→3.3 V power converter. Its authored
+// catalog source exists as `buck-24v-3v3`, but the deployed catalog does not
+// currently serve it. This assembly deliberately does not invent a solid for
+// that missing part; deploy and validate the catalog record before adding its
+// placement and calling this a complete physical BOM.
+
+return thermal.solvedModel({});

--- a/tests/integration/examples/thermalIoLinkMachineHealth.test.ts
+++ b/tests/integration/examples/thermalIoLinkMachineHealth.test.ts
@@ -1,0 +1,49 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const sourcePath = resolve('examples/community/thermal-iolink-machine-health.kcad.ts');
+
+describe('Thermal IO-Link machine-health reference assembly', () => {
+  it('uses named catalog components and physical interfaces instead of fallback electronics', () => {
+    expect(existsSync(sourcePath)).toBe(true);
+
+    const source = readFileSync(sourcePath, 'utf8');
+
+    for (const id of [
+      'esp32-c3-supermini-board',
+      'mlx90640',
+      'max14827',
+      'm12-iolink-5pin',
+    ]) {
+      expect(source).toContain(`await lib.fetchPart('${id}')`);
+    }
+
+    for (const partName of [
+      'industrial-sensor-enclosure',
+      'm12-panel-clamp',
+      'electronics-carrier',
+      'carrier-support-rails',
+      'thermal-aperture-bezel',
+      'esp32-c3-supermini-controller',
+      'mlx90640-thermal-camera',
+      'max14827-iolink-phy',
+      'm12-iolink-5pin-connector',
+    ]) {
+      expect(source).toContain(`thermal.part('${partName}'`);
+    }
+
+    expect(source).toContain("thermal.mate('carrier-supports-retained-in-enclosure'");
+    expect(source).toContain("thermal.mate('carrier-retained-on-supports'");
+    expect(source).toContain('carrierSupportCrossbar');
+    expect(source).toContain("thermal.mate('mlx90640-on-carrier'");
+    expect(source).toContain("thermal.mate('max14827-on-carrier'");
+    expect(source).toContain("thermal.mate('esp32-on-carrier'");
+    expect(source).toContain("thermal.mate('m12-clamp-retained-in-enclosure'");
+    expect(source).toContain("thermal.mate('m12-retained-by-panel-clamp'");
+    expect(source).toContain('return thermal.solvedModel({});');
+
+    expect(source).not.toMatch(/part\(\s*null/);
+    expect(source).not.toMatch(/fallback\s*(?:box|electronics|component)/i);
+  });
+});

--- a/tests/integration/examples/thermalIoLinkMachineHealth.test.ts
+++ b/tests/integration/examples/thermalIoLinkMachineHealth.test.ts
@@ -190,6 +190,19 @@ describe('Thermal IO-Link machine-health reference assembly', () => {
       expect(source).not.toMatch(/fallback\s*(?:box|electronics|component)/i);
     });
 
+    it('orients the buck PCB mating face toward its shelf', () => {
+      const { source } = fixture;
+
+      // The deployed buck record declares its mounting face at -Z. With the
+      // rear shelf at +Y, rotateX(90) maps that face onto powerShelfFrontY.
+      expect(source).toMatch(
+        /const buck24v3v3 = \(await \(await lib\.fetchPart\('buck-24v-3v3'\)\)\.recenter\(\)\)\s*\.rotateX\(90\)\s*\.translate\(buckCenterX, buckCenterY, 0\)/,
+      );
+      expect(source).toMatch(
+        /buckPart\.connector\('shelf-mount', \{\s*type: 'frame',\s*origin: \{ kind: 'vec3', value: \[buckCenterX, powerShelfFrontY, 0\] \},\s*\}\);/,
+      );
+    });
+
     // This literal title is checked by exampleSweepGate.test.ts. It replaces
     // the live runValidateCli sweep only because this test explicitly lowers,
     // clash-checks, validates, and probes the same assembly through a

--- a/tests/integration/examples/thermalIoLinkMachineHealth.test.ts
+++ b/tests/integration/examples/thermalIoLinkMachineHealth.test.ts
@@ -21,7 +21,7 @@ import {
 const examplePath = 'examples/community/thermal-iolink-machine-health.kcad.ts';
 const sourcePath = resolve(examplePath);
 
-// Deterministic envelopes for the four exact remote catalog identities. The
+// Deterministic envelopes for the five exact remote catalog identities. The
 // M12 fixture models its retained cylindrical barrel rather than the external
 // coupling shell, so the test exercises the panel/clamp placement without
 // pretending that the whole connector is a solid rectangular block.
@@ -29,6 +29,7 @@ const catalogFixtureBboxMm: Record<string, readonly [number, number, number]> = 
   'esp32-c3-supermini-board': [24.31, 18, 5.56],
   'mlx90640': [25.4, 17.78, 11.7],
   'max14827': [12, 19, 5.1],
+  'buck-24v-3v3': [24, 12, 5.6],
 };
 
 function fixtureCatalogRunner(fetchCalls: string[]): ScriptRunner {
@@ -137,6 +138,7 @@ describe('Thermal IO-Link machine-health reference assembly', () => {
         'esp32-c3-supermini-board',
         'max14827',
         'm12-iolink-5pin',
+        'buck-24v-3v3',
       ]);
       expect(returnValue).toBeInstanceOf(Scene);
       const scene = returnValue as Scene;
@@ -146,12 +148,14 @@ describe('Thermal IO-Link machine-health reference assembly', () => {
         'm12-panel-clamp',
         'carrier-support-rails',
         'electronics-carrier',
+        'power-regulator-shelf',
         'mlx90640-thermal-camera',
         'esp32-c3-supermini-controller',
         'max14827-iolink-phy',
         'm12-iolink-5pin-connector',
+        'buck-24v-3v3-power-regulator',
       ]));
-      expect(scene.parts).toHaveLength(9);
+      expect(scene.parts).toHaveLength(11);
       expect(records.at(-1)?.kind).toBe('solvedAssembly');
       expect(scene.part('electronics-carrier').connectors?.map((connector) => connector.name))
         .toEqual(expect.arrayContaining([
@@ -160,19 +164,28 @@ describe('Thermal IO-Link machine-health reference assembly', () => {
           'esp32-seat',
           'max14827-seat',
         ]));
+      expect(scene.part('power-regulator-shelf').connectors?.map((connector) => connector.name))
+        .toEqual(expect.arrayContaining([
+          'enclosure-mount',
+          'buck-seat',
+        ]));
       expect(scene.mates?.map((mate) => mate.name)).toEqual(expect.arrayContaining([
         'carrier-supports-retained-in-enclosure',
         'carrier-retained-on-supports',
+        'power-regulator-shelf-retained-in-enclosure',
         'mlx90640-on-carrier',
         'esp32-on-carrier',
         'max14827-on-carrier',
         'm12-retained-by-panel-clamp',
+        'buck-24v-3v3-on-power-shelf',
       ]));
 
       expect(source).toContain("await lib.fetchPart('mlx90640')");
       expect(source).toContain("await lib.fetchPart('esp32-c3-supermini-board')");
       expect(source).toContain("await lib.fetchPart('max14827')");
       expect(source).toContain("await lib.fetchPart('m12-iolink-5pin')");
+      expect(source).toContain("await lib.fetchPart('buck-24v-3v3')");
+      expect(source).not.toContain('does not currently serve it');
       expect(source).not.toMatch(/part\(\s*null/);
       expect(source).not.toMatch(/fallback\s*(?:box|electronics|component)/i);
     });
@@ -184,13 +197,13 @@ describe('Thermal IO-Link machine-health reference assembly', () => {
     it('examples/community/thermal-iolink-machine-health.kcad.ts passes the physics-grounded loop', () => {
       expect(fixture.recompute.diagnostics).toEqual([]);
       expect(fixture.interferences).toMatchObject({
-        partCount: 9,
+        partCount: 11,
         pairs: [],
         diagnostics: [],
       });
       expect(fixture.validation).toMatchObject({
         status: 'solved',
-        partCount: 9,
+        partCount: 11,
       });
       expect(fixture.validation.diagnostics).toEqual([]);
       expect(fixture.mechanism).toEqual({ mechanism: 'real', failures: [] });

--- a/tests/integration/examples/thermalIoLinkMachineHealth.test.ts
+++ b/tests/integration/examples/thermalIoLinkMachineHealth.test.ts
@@ -1,49 +1,199 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { Assembly } from '../../../src/modeling/capture/assembly';
+import type { Shape } from '../../../src/modeling/capture/proxy';
+import { createOcctLowerer } from '../../../src/modeling/backends/occt/occtLowerer';
+import { initOcct } from '../../../src/kernel/backends/occt/occtBackend';
+import { isSceneBackend } from '../../../src/kernel/backends/sceneBackend';
+import { RecomputeEngine } from '../../../src/modeling/compute/recomputeEngine';
+import { validateAssembly } from '../../../src/modeling/mates/validator';
+import { runIsolated } from '../../../src/modeling/runtime/isolation';
+import { probeAssemblies } from '../../../src/modeling/runtime/mechanismProbe';
+import { detectInterferences } from '../../../src/modeling/runtime/detectInterferences';
+import { runScript, type ScriptRunner } from '../../../src/modeling/runtime/runScript';
+import { Scene } from '../../../src/modeling/validation/scene';
+import {
+  HOSTED_IN_DEDICATED_FILE,
+  discoverSweepExamples,
+} from '../physics-loop/exampleSweepShared';
 
-const sourcePath = resolve('examples/community/thermal-iolink-machine-health.kcad.ts');
+const examplePath = 'examples/community/thermal-iolink-machine-health.kcad.ts';
+const sourcePath = resolve(examplePath);
+
+// Deterministic envelopes for the four exact remote catalog identities. The
+// M12 fixture models its retained cylindrical barrel rather than the external
+// coupling shell, so the test exercises the panel/clamp placement without
+// pretending that the whole connector is a solid rectangular block.
+const catalogFixtureBboxMm: Record<string, readonly [number, number, number]> = {
+  'esp32-c3-supermini-board': [24.31, 18, 5.56],
+  'mlx90640': [25.4, 17.78, 11.7],
+  'max14827': [12, 19, 5.1],
+};
+
+function fixtureCatalogRunner(fetchCalls: string[]): ScriptRunner {
+  return (code, fileName, injected, opts) => {
+    const box = injected.box as (
+      x: number,
+      y: number,
+      z: number,
+      centered?: boolean,
+    ) => Shape;
+    const cylinder = injected.cylinder as (
+      height: number,
+      radius: number,
+      segments?: number,
+    ) => Shape;
+    const lib = injected.lib as { fetchPart(id: string): Promise<Shape> };
+
+    lib.fetchPart = async (id: string) => {
+      fetchCalls.push(id);
+      const shape = id === 'm12-iolink-5pin'
+        ? await cylinder(28.9, 8.2, 64).alongAxis([0, 1, 0]).recenter()
+        : (() => {
+            const bbox = catalogFixtureBboxMm[id];
+            if (!bbox) throw new Error('unexpected catalog id: ' + id);
+            return box(...bbox, true);
+          })();
+      // The fixture envelope is already centered. Production source still
+      // calls recenter() on the imported vendor STEP geometry.
+      const catalogShape = Object.create(shape) as Shape;
+      catalogShape.recenter = async () => shape;
+      return catalogShape;
+    };
+
+    return runIsolated(code, fileName, injected, opts);
+  };
+}
+
+/**
+ * Run the same assembly / clash / mechanism surfaces as the live sweep, but
+ * supply only the exact remote catalog imports through a deterministic
+ * offline fixture. Unknown identities fail hard, so a source edit cannot
+ * silently replace a catalog part with an ad-hoc solid.
+ */
+async function runCatalogFixtureAssemblyValidation() {
+  await initOcct();
+
+  const source = readFileSync(sourcePath, 'utf8');
+  const fetchCalls: string[] = [];
+  const run = await runScript({
+    code: source,
+    fileName: sourcePath,
+    scriptDir: resolve('examples/community'),
+    runner: fixtureCatalogRunner(fetchCalls),
+  });
+
+  if (!(run.returnValue instanceof Scene)) {
+    throw new Error('Thermal IO-Link fixture did not return an assembly scene.');
+  }
+
+  const recompute = await new RecomputeEngine(createOcctLowerer(run.session)).run(run.records, {
+    paramTable: run.paramTable,
+  });
+  const targetId = run.returnValue.__sourceFeatureId();
+  const lowered = recompute.shapes.get(targetId);
+  if (!isSceneBackend(lowered)) {
+    throw new Error('Thermal IO-Link fixture did not lower to a scene backend.');
+  }
+
+  const interferences = detectInterferences(lowered, 0.01, new Set(), recompute.diagnostics);
+  const validation = validateAssembly({
+    records: run.records,
+    interferencePairs: interferences.pairs,
+  });
+  const mechanism = await probeAssemblies(
+    Array.from(run.session.assemblies.values()) as Assembly[],
+    { physicsCheck: false },
+  );
+
+  return { source, fetchCalls, run, recompute, interferences, validation, mechanism };
+}
 
 describe('Thermal IO-Link machine-health reference assembly', () => {
-  it('uses named catalog components and physical interfaces instead of fallback electronics', () => {
-    expect(existsSync(sourcePath)).toBe(true);
+  it('delegates its remote-catalog assembly from the hermetic live sweep to this fixture', () => {
+    expect(HOSTED_IN_DEDICATED_FILE.get(examplePath)).toMatchObject({
+      testFile: 'tests/integration/examples/thermalIoLinkMachineHealth.test.ts',
+      coverage: 'catalog-fixture',
+    });
+    expect(discoverSweepExamples()).not.toContain(examplePath);
+  });
 
-    const source = readFileSync(sourcePath, 'utf8');
+  describe('offline catalog fixture coverage', () => {
+    let fixture: Awaited<ReturnType<typeof runCatalogFixtureAssemblyValidation>>;
 
-    for (const id of [
-      'esp32-c3-supermini-board',
-      'mlx90640',
-      'max14827',
-      'm12-iolink-5pin',
-    ]) {
-      expect(source).toContain(`await lib.fetchPart('${id}')`);
-    }
+    beforeAll(async () => {
+      fixture = await runCatalogFixtureAssemblyValidation();
+    }, 180_000);
 
-    for (const partName of [
-      'industrial-sensor-enclosure',
-      'm12-panel-clamp',
-      'electronics-carrier',
-      'carrier-support-rails',
-      'thermal-aperture-bezel',
-      'esp32-c3-supermini-controller',
-      'mlx90640-thermal-camera',
-      'max14827-iolink-phy',
-      'm12-iolink-5pin-connector',
-    ]) {
-      expect(source).toContain(`thermal.part('${partName}'`);
-    }
+    it('uses exact catalog identities and named sensor interfaces', () => {
+      expect(existsSync(sourcePath)).toBe(true);
 
-    expect(source).toContain("thermal.mate('carrier-supports-retained-in-enclosure'");
-    expect(source).toContain("thermal.mate('carrier-retained-on-supports'");
-    expect(source).toContain('carrierSupportCrossbar');
-    expect(source).toContain("thermal.mate('mlx90640-on-carrier'");
-    expect(source).toContain("thermal.mate('max14827-on-carrier'");
-    expect(source).toContain("thermal.mate('esp32-on-carrier'");
-    expect(source).toContain("thermal.mate('m12-clamp-retained-in-enclosure'");
-    expect(source).toContain("thermal.mate('m12-retained-by-panel-clamp'");
-    expect(source).toContain('return thermal.solvedModel({});');
+      const { source, fetchCalls, run } = fixture;
+      const { returnValue, records } = run;
 
-    expect(source).not.toMatch(/part\(\s*null/);
-    expect(source).not.toMatch(/fallback\s*(?:box|electronics|component)/i);
+      expect(fetchCalls).toEqual([
+        'mlx90640',
+        'esp32-c3-supermini-board',
+        'max14827',
+        'm12-iolink-5pin',
+      ]);
+      expect(returnValue).toBeInstanceOf(Scene);
+      const scene = returnValue as Scene;
+      expect(scene.parts.map((part) => part.name)).toEqual(expect.arrayContaining([
+        'industrial-sensor-enclosure',
+        'thermal-aperture-bezel',
+        'm12-panel-clamp',
+        'carrier-support-rails',
+        'electronics-carrier',
+        'mlx90640-thermal-camera',
+        'esp32-c3-supermini-controller',
+        'max14827-iolink-phy',
+        'm12-iolink-5pin-connector',
+      ]));
+      expect(scene.parts).toHaveLength(9);
+      expect(records.at(-1)?.kind).toBe('solvedAssembly');
+      expect(scene.part('electronics-carrier').connectors?.map((connector) => connector.name))
+        .toEqual(expect.arrayContaining([
+          'support-mount',
+          'mlx90640-seat',
+          'esp32-seat',
+          'max14827-seat',
+        ]));
+      expect(scene.mates?.map((mate) => mate.name)).toEqual(expect.arrayContaining([
+        'carrier-supports-retained-in-enclosure',
+        'carrier-retained-on-supports',
+        'mlx90640-on-carrier',
+        'esp32-on-carrier',
+        'max14827-on-carrier',
+        'm12-retained-by-panel-clamp',
+      ]));
+
+      expect(source).toContain("await lib.fetchPart('mlx90640')");
+      expect(source).toContain("await lib.fetchPart('esp32-c3-supermini-board')");
+      expect(source).toContain("await lib.fetchPart('max14827')");
+      expect(source).toContain("await lib.fetchPart('m12-iolink-5pin')");
+      expect(source).not.toMatch(/part\(\s*null/);
+      expect(source).not.toMatch(/fallback\s*(?:box|electronics|component)/i);
+    });
+
+    // This literal title is checked by exampleSweepGate.test.ts. It replaces
+    // the live runValidateCli sweep only because this test explicitly lowers,
+    // clash-checks, validates, and probes the same assembly through a
+    // deterministic catalog fixture.
+    it('examples/community/thermal-iolink-machine-health.kcad.ts passes the physics-grounded loop', () => {
+      expect(fixture.recompute.diagnostics).toEqual([]);
+      expect(fixture.interferences).toMatchObject({
+        partCount: 9,
+        pairs: [],
+        diagnostics: [],
+      });
+      expect(fixture.validation).toMatchObject({
+        status: 'solved',
+        partCount: 9,
+      });
+      expect(fixture.validation.diagnostics).toEqual([]);
+      expect(fixture.mechanism).toEqual({ mechanism: 'real', failures: [] });
+    });
   });
 });

--- a/tests/integration/physics-loop/exampleSweepShared.ts
+++ b/tests/integration/physics-loop/exampleSweepShared.ts
@@ -167,6 +167,13 @@ export const HOSTED_IN_DEDICATED_FILE: ReadonlyMap<string, DedicatedExampleCover
       coverage: 'catalog-fixture',
     },
   ],
+  [
+    'examples/community/thermal-iolink-machine-health.kcad.ts',
+    {
+      testFile: 'tests/integration/examples/thermalIoLinkMachineHealth.test.ts',
+      coverage: 'catalog-fixture',
+    },
+  ],
 ]);
 
 export function walkExamples(dir: string, prefix = ''): string[] {


### PR DESCRIPTION
## Summary

- Adds a component-aware Thermal IO-Link machine-health reference assembly using the exact catalog identities for ESP32-C3 SuperMini, MLX90640, MAX14827, M12 IO-Link connector, and `buck-24v-3v3`.
- Corrects the MLX/front-wall, carrier, controller/PHY, and M12 panel/clamp geometry so the assembly has a real optical path and no modeled interference.
- Places the reusable catalog buck module on an enclosure-supported shelf with a named mechanical mate. Its catalog −Z mating face is oriented toward the rear shelf, leaving the component side toward the front clearance; this remains a fit/layout model only and makes no electrical, thermal, isolation, or IO-Link conformance claim.
- Registers the remote-catalog example with the shared audited `catalog-fixture` sweep mode and validates its lowered scene, clash surface, mate validator, and mechanism probe offline.

## Validation

- `npx vitest run tests/integration/examples/thermalIoLinkMachineHealth.test.ts tests/integration/physics-loop/exampleSweepGate.test.ts` — 8/8 passed
- Targeted ESLint and `npm run typecheck`
- Deployed-catalog collision/validator run with `includeInterference: true`, `physical: false`: 11 parts, no diagnostics/interference pairs, mechanism `real`
- The optional `physical: true` plausibility surface reports disconnected-solid warnings inherent to detailed multi-solid catalog electronics; it does not report an assembly clash or a broken mechanism.

## Release status

This PR does not publish a ProtoCat device, update Studio, or mint a labwired proof/receipt.