### PR TITLE
fix(render): mesh foreign catalog backends

### DIFF
--- a/src/modeling/capture/featureMeshing.test.ts
+++ b/src/modeling/capture/featureMeshing.test.ts
@@ -2,7 +2,8 @@
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // src/modeling/capture/featureMeshing.test.ts
 import { describe, it, expect, beforeAll } from 'vitest';
-import { initOcct } from '../../kernel/backends/occt/occtBackend';
+import { initOcct, OcctBackend } from '../../kernel/backends/occt/occtBackend';
+import type { ShapeBackend } from '../../kernel/backends/backend';
 import { runScript } from '../runtime/runScript';
 import { meshFeaturesPerFeature } from './featureMeshing';
 
@@ -171,6 +172,35 @@ describe('meshFeaturesPerFeature', () => {
       'link',
       'drive-train',
     ]);
+  });
+
+  it('meshes a SceneBackend part supplied by an export-capable foreign backend', async () => {
+    // Remote catalog code is evaluated in a separate module graph. Its shape
+    // backend is not necessarily `instanceof` this module's OcctBackend, but
+    // it still exposes the public getReplicadShape() capability used by the
+    // mesher. Model that boundary here without a network dependency.
+    const code = `
+      const arm = assembly('foreign-backend-render');
+      arm.part('catalog-part', box(10, 10, 10));
+      return arm.model();
+    `;
+    const { records, paramTable, session } = await runScript({ code, fileName: 'foreign-backend-render.kcad.ts' });
+    const sourceRecord = records.find((record) => record.kind === 'box');
+    if (!sourceRecord) throw new Error('expected assembly source box record');
+
+    const foreignExportBackend = (backend: OcctBackend): ShapeBackend => ({
+      target: 'export-occt',
+      clone: () => foreignExportBackend(backend.clone()),
+      translate: (x: number, y: number, z: number) => foreignExportBackend(backend.translate(x, y, z)),
+      getReplicadShape: () => backend.getReplicadShape(),
+    }) as unknown as ShapeBackend;
+    sourceRecord.kind = 'importedStep';
+    session.importedGeometry.set(sourceRecord.id, foreignExportBackend(OcctBackend.box(10, 10, 10)));
+
+    const result = await meshFeaturesPerFeature(records, paramTable, session);
+
+    expect(result.failedFeatureIds).toEqual([]);
+    expect(result.features.map((feature) => feature.assemblyPartName)).toEqual(['catalog-part']);
   });
 
   describe('material shadowing diagnostic', () => {

--- a/src/modeling/capture/featureMeshing.ts
+++ b/src/modeling/capture/featureMeshing.ts
@@ -33,13 +33,25 @@ function attachPlanarUVs(faces: FaceGeometry[]): void {
   }
 }
 
+/** Shape backends authored by remote catalog code can originate from a
+ * different module graph, making an `instanceof OcctBackend` check unsafe.
+ * The mesher only needs this public capability, so accept any backend that
+ * provides it rather than coupling rendering to one constructor identity. */
+interface ReplicadShapeProvider {
+  getReplicadShape(): unknown;
+}
+
+function isReplicadShapeProvider(backend: ShapeBackend): backend is ShapeBackend & ReplicadShapeProvider {
+  return typeof (backend as Partial<ReplicadShapeProvider>).getReplicadShape === 'function';
+}
+
 /** Extract the raw replicad shape so meshShape() can walk .faces / .meshEdges. */
 function extractRawShape(backend: ShapeBackend): unknown {
-  if (backend instanceof OcctBackend) {
+  if (isReplicadShapeProvider(backend)) {
     return backend.getReplicadShape();
   }
   throw new Error(
-    `meshFeaturesPerFeature: unsupported backend target '${backend.target}' — only OcctBackend is supported`
+    `meshFeaturesPerFeature: unsupported backend target '${backend.target}' — missing getReplicadShape()`
   );
 }
 


### PR DESCRIPTION
## Summary
- replace the renderer's unsafe `instanceof OcctBackend` gate with the public `getReplicadShape()` capability check
- allow valid export-backed catalog shapes from a separate module graph to mesh in previews
- add a hermetic regression covering an export-backed foreign catalog shape in a Scene assembly

## Validation
- `src/modeling/capture/featureMeshing.test.ts` — 20 passed (in the validated implementation worktree)
- targeted eslint and typecheck passed
- Plotter proxy path now meshes 39/39 features with no failed IDs
- `git show --check`

This is intentionally separate from the pending Plotter assembly/catalog work.