### PR TITLE
feat(catalog): add universal motor-control components

### DIFF
--- a/.github/workflows/parts-catalog.yml
+++ b/.github/workflows/parts-catalog.yml
@@ -99,12 +99,12 @@ jobs:
           --manifest scripts/electronics-parts.json
           --base-url https://kernelcad-parts.pages.dev
 
-      # Authored package sources are a required part of this deploy: unlike
-      # third-party upstream models, a failed authored export must never be
-      # silently skipped and published as a catalog omission. This verifies all
-      # five package artifacts, their measured bounds/metadata, and named
-      # components + contacts before any board conversion or Pages deploy.
-      - name: Verify authored electronic package catalog
+      # Required authored sources are a required part of this deploy: unlike
+      # third-party upstream models, a failed A4988/SG90 export must never be
+      # silently skipped and published as a catalog omission. This verifies the
+      # five package artifacts plus the two motor-control components and their
+      # hash-bound authored interfaces before any board conversion or deploy.
+      - name: Verify required authored electronics catalog
         run: >
           npx tsx scripts/verifyAuthoredElectronicsCatalog.ts catalog
           --manifest scripts/electronics-parts.json

--- a/docs/superpowers/plans/2026-07-22-catalog-connector-manifests.md
+++ b/docs/superpowers/plans/2026-07-22-catalog-connector-manifests.md
@@ -328,7 +328,7 @@ git commit -m "feat(catalog): attach verified authored interfaces"
 - Modify: `src/modeling/capture/assembly.ts`
 - Create: `src/modeling/capture/assembly.catalogConnectors.test.ts`
 
-- [ ] **Step 1: Write the failing assembly-promotion tests**
+- [x] **Step 1: Write the failing assembly-promotion tests**
 
 Create a `CaptureSession`, attach a factual connector to a box before it enters an assembly, then assert that it is usable by both connector APIs:
 
@@ -344,13 +344,13 @@ expect(part.mateConnectors).toContainEqual(expect.objectContaining({ name: 'pwm-
 
 Add a second assertion that `arm.mate('signal', 'servo.pwm-contact', 'socket.signal', 'fastened')` resolves after a normal explicit `socket.signal` frame is declared. Add a third test that stores only a legacy `session.attachAutoConnectors(... 'mating-face' ...)` value and confirms it is not promoted. Add a rigid-transform test that calls `source.translate(10, 0, 0).rotateZ(90)` before `assembly.part()` and expects the promoted origin/direction to be transformed. Add scale, reflection, and ParamRef-transform tests that reject rather than silently desynchronizing a physical interface. Finally import the catalog part through `subAssembly()` and assert its interfaces are neither duplicated nor rejected.
 
-- [ ] **Step 2: Run the assembly-promotion tests and verify RED**
+- [x] **Step 2: Run the assembly-promotion tests and verify RED**
 
 Run: `npx vitest run src/modeling/capture/assembly.catalogConnectors.test.ts`
 
 Expected: `part.connector('pwm-contact')` throws because the auto-connector cache is not currently merged into assembly connectors.
 
-- [ ] **Step 3: Add typed authored-interface promotion**
+- [x] **Step 3: Add typed authored-interface promotion**
 
 In `Assembly.part`, read `session.catalogConnectors.get(shape.id)`, validate each exact `ConnectorEntry`, and apply the feature record's rigid transforms in declared order. For a translate use `Transform.translation(...)`; for a rotation use `Transform.rotationAroundPivot(...)`; compose each new transform to the left of the previous total. Reject `scale` and `reflect` for a catalog-attached Shape. Merge the result before `resolvePartPlacement`:
 
@@ -386,13 +386,13 @@ Keep catalog-interface promotion private to the first direct `assembly.part()` c
 route it through an internal no-repromotion path so an imported subassembly cannot create
 duplicate names or entries.
 
-- [ ] **Step 4: Run the assembly-promotion tests and verify GREEN**
+- [x] **Step 4: Run the assembly-promotion tests and verify GREEN**
 
 Run: `npx vitest run src/modeling/capture/assembly.catalogConnectors.test.ts src/modeling/capture/assembly.chaining.test.ts tests/integration/parts/partsAutoConnectors.test.ts`
 
 Expected: factual catalog frames work in `connector()` and `mate()`, while generic synthesized frames retain their existing non-mating behavior.
 
-- [ ] **Step 5: Commit the assembly bridge**
+- [x] **Step 5: Commit the assembly bridge**
 
 ```bash
 git add src/modeling/capture/assembly.ts src/modeling/capture/assembly.catalogConnectors.test.ts
@@ -420,7 +420,7 @@ expect(sceneToConnectorManifest(scene, loweredScene, run.records, { partId: 'ser
   });
 ```
 
-Also assert `sceneToWorldFrameParts(loweredScene)[0].shape.boundingBox().min` is `[10, 20, 30]`, proving the geometry and manifest use the same placement. Add cases that reject duplicate names, a topology origin, `planar`, `ball`, mates, and joint-driven source records.
+Also assert `sceneToWorldFrameParts(loweredScene)[0].shape.boundingBox().min` is `[10, 20, 30]`, proving the geometry and manifest use the same placement. Add a ParamRef-driven `at` fixture (the helper must receive resolved records), a synthetic non-identity backend-world-transform case, and cases that reject duplicate names, a topology origin, `planar`, `ball`, mates, and joint-driven source records. Include an unrelated same-named part in a different assembly to prove lookup is scoped to the returned Scene's source feature.
 
 - [ ] **Step 2: Run helper tests and verify RED**
 
@@ -430,7 +430,7 @@ Expected: module-not-found failure.
 
 - [ ] **Step 3: Implement the pure extractor**
 
-Create `sceneToConnectorManifest` using the recomputed `SceneBackend`, the direct `assemblyPart` records, and the existing `Transform.point` and `Transform.axisDir` APIs. For each capture Scene part, find one matching `SceneBackend` part and one `assemblyPart` FeatureRecord by unique part name. Decode `metadata.at` from its evaluated `Vec3Param` values. The exact transform used by STEP export is:
+Create `sceneToConnectorManifest` using the recomputed `SceneBackend`, resolved direct `assemblyPart` records, and the existing `Transform.point` and `Transform.axisDir` APIs. Do not globally match by part name: use `scene.__sourceFeatureId()` to find the exact `assemblyModel` source record, then its `metadata.partIds` to select its matching `assemblyPart` records. Require count, order, and name agreement with `SceneBackend.parts`; fail closed on ambiguity. Pass `resolveParams(run.records, run.paramTable)` into the helper so ParamRef placements use the same values as the lowerer. Decode `metadata.at` from those resolved `Vec3Param` values. The exact transform used by STEP export is:
 
 ```ts
 const transform = backendPart.worldTransform.compose(
@@ -438,23 +438,25 @@ const transform = backendPart.worldTransform.compose(
 );
 ```
 
+Scope the dynamic rejection to the returned Scene's source assembly so an unrelated assembly elsewhere in the script cannot block export. Do not replay arbitrary `Shape.transforms` in this helper: the matching backend shape already contains that geometry; replaying them would double-transform interfaces.
+
 The helper signature and core loop are:
 
 ```ts
 export function sceneToConnectorManifest(
   scene: Scene,
   lowered: SceneBackend,
-  records: readonly FeatureRecord[],
+  resolvedRecords: readonly FeatureRecord[],
   identity: { partId: string; family: string },
 ): ConnectorManifest {
-  if ((scene.mates?.length ?? 0) > 0 || records.some((record) => record.kind === 'assemblyJoint')) {
+  if (sourceRecord.kind !== 'assemblyModel' || (scene.mates?.length ?? 0) > 0 || sourceAssemblyHasJoints(sourceRecord, resolvedRecords)) {
     throw new Error('connector-manifest export requires a mate-free, joint-free assembly');
   }
   const connectors: ConnectorEntry[] = [];
   const names = new Set<string>();
-  for (const part of scene.parts) for (const connector of part.connectors ?? []) {
+  for (const [partIndex, part] of scene.parts.entries()) for (const connector of part.connectors ?? []) {
     const backendPart = singleByName(lowered.parts, part.name, 'lowered scene part');
-    const assemblyPart = singleByName(assemblyPartRecords(records), part.name, 'assembly part record');
+    const assemblyPart = sourceAssemblyPartByIndex(sourceRecord, resolvedRecords, partIndex);
     const at = readAssemblyPartAt(assemblyPart);
     const transform = backendPart.worldTransform.compose(Transform.translation(at[0], at[1], at[2]));
     if (connector.type !== 'frame' && connector.type !== 'axis') throw new Error(...);
@@ -477,7 +479,7 @@ export function sceneToConnectorManifest(
 
 - [ ] **Step 4: Thread an optional manifest request through export and CLI**
 
-Add `connectorManifest?: { partId: string; family: string }` to runtime `ExportInput` and `connectorManifest?: ConnectorManifest` to `ExportResult`. If requested, require `format === 'step'`, a returned `Scene`, and the same successful lowered `SceneBackend` used by `exportSceneToSTEPAsync`; call `sceneToConnectorManifest(scene, lowered, run.records, identity)` and include it in the successful result.
+Add `connectorManifest?: { partId: string; family: string }` to runtime `ExportInput` and `connectorManifest?: ConnectorManifest` to `ExportResult`. If requested, require `format === 'step'`, a returned `Scene`, and the same successful lowered `SceneBackend` used by `exportSceneToSTEPAsync`; call `sceneToConnectorManifest(scene, lowered, resolveParams(run.records, run.paramTable), identity)` and include it in the successful result. If `feature_id` is supplied, require it exactly matches `scene.__sourceFeatureId()` so the STEP and manifest cannot silently describe different features.
 
 Add CLI options:
 

--- a/docs/superpowers/plans/2026-07-22-catalog-connector-manifests.md
+++ b/docs/superpowers/plans/2026-07-22-catalog-connector-manifests.md
@@ -576,17 +576,17 @@ connector fallback.
 - Modify: `scripts/electronics-parts.json`
 - Create: `scripts/universalElectronicsParts.test.ts`
 
-- [ ] **Step 1: Write source-level factual-interface tests**
+- [x] **Step 1: Write source-level factual-interface tests**
 
-Assert that A4988 declares `carrier-solder-face`, `en-contact`, `step-contact`, `dir-contact`, `vmot-contact`, and its other actual plated-hole contacts; assert that SG90 declares `ground-contact`, `vplus-contact`, `pwm-contact`, and `output-axis-envelope`; assert neither source declares `mount-hole`, `universal-spline`, `x-motor`, or `y-motor`.
+Assert that A4988 declares `carrier-solder-face`, `en-contact`, `step-contact`, `dir-contact`, `vmot-contact`, and its other actual plated-hole contacts. Assert that SG90 declares only its `ground-contact`, `vplus-contact`, and `pwm-contact` canonical plug-contact proxies; the cited product-specific drawing lacks a shaft XY datum and fastening geometry, so it must not declare an output-axis or mounting interface. Assert neither source declares `mount-hole`, `universal-spline`, `x-motor`, or `y-motor`.
 
-- [ ] **Step 2: Run the source tests and verify RED**
+- [x] **Step 2: Run the source tests and verify RED**
 
 Run: `npx vitest run scripts/universalElectronicsParts.test.ts`
 
 Expected: missing sources/records or missing connector declarations.
 
-- [ ] **Step 3: Model interfaces on real modeled solids**
+- [x] **Step 3: Model interfaces on real modeled solids**
 
 For A4988, call `.connector()` on the PCB/actual pad parts with:
 
@@ -599,24 +599,29 @@ padRef.connector(`${pin.name}-contact`, {
 });
 ```
 
-For SG90, attach the cable contacts to their modeled contact faces and declare only an envelope axis:
+For SG90, model the documented `32.0 × 12.4 × 26.7 mm` mechanical envelope and attach the cable contacts to canonical plug-contact proxy faces. Do not model an output shaft, horn, spline, cable exit, plug housing, or mounting datum without a product-specific source:
 
 ```ts
-housingRef.connector('pwm-contact', {
-  type: 'frame', origin: { kind: 'vec3', value: [cableHousingX + 2.64, pwmY, leadZ] }, normal: [1, 0, 0],
-});
-housingRef.connector('output-axis-envelope', {
-  type: 'axis', origin: { kind: 'vec3', value: [OUTPUT_X, OUTPUT_Y, CASE_H + BOSS_H] }, axis: [0, 0, 1],
+leadRef.connector(`${lead.name}-contact`, {
+  type: 'frame',
+  origin: { kind: 'vec3', value: [CABLE_CONTACT_X, lead.y, CABLE_Z] },
+  normal: [1, 0, 0],
 });
 ```
 
 Add each part to `scripts/electronics-parts.json` using its real manufacturer/source attribution and `kcad_source`; do not add fixture-only board, power, mounting, or project-specific fields.
 
-- [ ] **Step 4: Run source tests and a narrow catalog export test**
+- [x] **Step 4: Run source tests and a narrow catalog export test**
 
 Run: `npx vitest run scripts/universalElectronicsParts.test.ts`
 
 Expected: factual interface declarations pass source-level coverage. If disk headroom is at least 1 GiB, run `npx tsx scripts/ingestElectronics.ts <fresh-temp-out> --manifest scripts/electronics-parts.json`; otherwise defer the generated catalog export to CI.
+
+Completed with the full in-memory STEP/manifest export path for both sources,
+plus zero-interference assembly checks. The SG90 is intentionally a sourced
+outer envelope plus documented canonical harness-contact proxies: the Luxor
+87897 drawing does not locate its output shaft. The generated catalog ingest
+remains deferred to CI because local free disk is below 1 GiB.
 
 - [ ] **Step 5: Commit universal component sources**
 
@@ -636,11 +641,14 @@ Run: `git diff origin/develop...HEAD --check`
 
 Expected: no whitespace errors and no changes outside the manifest pipeline, universal parts, and their tests.
 
-- [ ] **Step 2: Run focused tests without the artifact-generating `pretest` hook**
+- [x] **Step 2: Run focused tests without the artifact-generating `pretest` hook**
 
-Run: `npx vitest run src/shared/parts/connectorManifest.test.ts src/modeling/parts/stepPartsAdapter.test.ts scripts/ingestParts.test.ts src/modeling/parts/fetchPart.test.ts src/modeling/parts/fetchPartMetadata.test.ts src/modeling/capture/assembly.catalogConnectors.test.ts src/agent/script-runtime/connectorManifestExport.test.ts scripts/ingestElectronics.test.ts scripts/universalElectronicsParts.test.ts`
+Run: `npx vitest run src/shared/parts/connectorManifest.test.ts src/modeling/parts/stepPartsAdapter.test.ts scripts/ingestParts.test.ts src/modeling/parts/fetchPart.test.ts src/modeling/parts/fetchPartMetadata.test.ts src/modeling/capture/assembly.catalogConnectors.test.ts src/agent/script-runtime/connectorManifestExport.test.ts scripts/ingestElectronics.test.ts scripts/universalElectronicsParts.test.ts scripts/verifyAuthoredElectronicsCatalog.test.ts`
 
 Expected: all listed focused suites pass.
+
+Completed: 11 files / 110 tests passed with the listed suites plus
+`scripts/electronics-parts.test.ts`.
 
 - [ ] **Step 3: Run type verification if disk capacity permits**
 
@@ -648,9 +656,15 @@ Run: `npm run typecheck`
 
 Expected: exit code 0. If free disk remains below 1 GiB, do not create build artifacts locally; push the tested branch and use required remote CI for the full type/build gate.
 
-- [ ] **Step 4: Perform two reviews**
+Local free space remains below 1 GiB, so artifact-generating `npm run typecheck`
+is deferred to remote CI. `npx tsc --noEmit -p tsconfig.cli.json` passed locally.
+
+- [x] **Step 4: Perform two reviews**
 
 First review against this plan: no manual connector-coordinate copy, no generic synthesis when an authored manifest is present, no fictional universal interfaces. Second review for TypeScript/API quality and compatibility with no-manifest third-party records.
+
+Completed: independent factual/assembly and TypeScript/gate reviews cleared the
+final SG90 envelope/proxy contract and exact-manifest gate.
 
 - [ ] **Step 5: Push and open a draft pull request**
 

--- a/docs/superpowers/plans/2026-07-22-catalog-connector-manifests.md
+++ b/docs/superpowers/plans/2026-07-22-catalog-connector-manifests.md
@@ -12,13 +12,14 @@
 
 ## File map
 
-- `src/shared/parts/connectorManifest.ts` — authoring and hash-bound manifest types and validation.
+- `src/shared/parts/connectorManifest.ts` — Node-only local-sidecar loader and public re-exports.
+- `src/shared/parts/connectorManifestSchema.ts` — browser-safe manifest schema and validation used by catalog metadata.
 - `src/shared/parts/connectorManifest.test.ts` — manifest contract regression coverage.
 - `src/shared/parts/types.ts` — canonical remote `PartRecord` transport field.
 - `src/modeling/parts/stepPartsAdapter.ts` — raw remote JSON to canonical record mapping.
 - `src/modeling/parts/stepPartsAdapter.test.ts` — mapped-manifest regression coverage.
 - `scripts/ingestParts.ts` and `scripts/ingestParts.test.ts` — bind an authored sidecar to emitted STEP bytes.
-- `src/modeling/parts/fetchPart.ts` and `src/modeling/parts/fetchPart.test.ts` — attach verified manifest frames before generic synthesis.
+- `src/modeling/parts/fetchPart.ts` and `src/modeling/parts/fetchPartMetadata.test.ts` — attach verified manifest frames before generic synthesis.
 - `src/modeling/capture/captureSession.ts` — typed, verified catalog-interface store keyed by fetched Shape id.
 - `src/modeling/capture/assembly.ts` and `src/modeling/capture/assembly.catalogConnectors.test.ts` — promote factual catalog interfaces into both assembly mating APIs.
 - `src/agent/script-runtime/connectorManifestExport.ts` and `.test.ts` — convert numeric authored `Scene` connectors into a portable sidecar.
@@ -32,12 +33,13 @@
 
 **Files:**
 - Modify: `src/shared/parts/connectorManifest.ts`
+- Create: `src/shared/parts/connectorManifestSchema.ts`
 - Modify: `src/shared/parts/connectorManifest.test.ts`
 - Modify: `src/shared/parts/types.ts`
 - Modify: `src/modeling/parts/stepPartsAdapter.ts`
 - Modify: `src/modeling/parts/stepPartsAdapter.test.ts`
 
-- [ ] **Step 1: Write the failing mapper test**
+- [x] **Step 1: Write the failing mapper test**
 
 Append this fixture and assertion to `src/modeling/parts/stepPartsAdapter.test.ts`:
 
@@ -61,13 +63,13 @@ it('preserves a valid hash-bound authored manifest and exposes its names', () =>
 });
 ```
 
-- [ ] **Step 2: Run the focused test and verify RED**
+- [x] **Step 2: Run the focused test and verify RED**
 
 Run: `npx vitest run src/modeling/parts/stepPartsAdapter.test.ts`
 
 Expected: the new assertion fails because `connectorManifest` does not exist on `PartRecord` and the mapper returns `connectors: []`.
 
-- [ ] **Step 3: Write the failing validation test**
+- [x] **Step 3: Write the failing validation test**
 
 Append this test to `src/shared/parts/connectorManifest.test.ts`:
 
@@ -85,15 +87,15 @@ it('rejects a hash-bound manifest whose expected STEP hash differs', () => {
 });
 ```
 
-- [ ] **Step 4: Run the validation test and verify RED**
+- [x] **Step 4: Run the validation test and verify RED**
 
 Run: `npx vitest run src/shared/parts/connectorManifest.test.ts`
 
 Expected: import failure because `validateHashBoundConnectorManifest` is not exported.
 
-- [ ] **Step 5: Implement the minimal shared contract**
+- [x] **Step 5: Implement the minimal shared contract**
 
-In `src/shared/parts/connectorManifest.ts`, add the bound type and helper while retaining `validateConnectorManifest` for bundled sidecars:
+Put the bound type and strict browser-safe helper in `src/shared/parts/connectorManifestSchema.ts`, retaining `connectorManifest.ts` as the Node-only bundled-sidecar loader/re-export:
 
 ```ts
 export interface HashBoundConnectorManifest extends ConnectorManifest {
@@ -118,7 +120,7 @@ export function validateHashBoundConnectorManifest(
 
 Also make `validateConnectorManifest` reject duplicate names, non-finite three-vectors, and a zero frame normal or axis before the new helper invokes it.
 
-- [ ] **Step 6: Add canonical record fields and mapper behavior**
+- [x] **Step 6: Add canonical record fields and mapper behavior**
 
 Import `HashBoundConnectorManifest` into `src/shared/parts/types.ts` and add:
 
@@ -126,13 +128,16 @@ Import `HashBoundConnectorManifest` into `src/shared/parts/types.ts` and add:
 connectorManifest?: HashBoundConnectorManifest;
 ```
 
-to `PartRecord` and `CatalogPartMetadata`; preserve it in `snapshotCatalogPart`. Update `isPartRecord` to call `validateHashBoundConnectorManifest` when that optional field is present and return `false` on validation failure. In `src/modeling/parts/stepPartsAdapter.ts`, declare the optional raw field, validate it against `raw.id`, `raw.family`, and `raw.sha256 ?? ''`, then build the record as:
+to `PartRecord` and `CatalogPartMetadata`; preserve it in `snapshotCatalogPart`. Update `isPartRecord` to call `validateHashBoundConnectorManifest` when that optional field is present and return `false` on validation failure. In `src/modeling/parts/stepPartsAdapter.ts`, declare the optional raw field as `unknown`, require a lowercase 64-hex SHA on every manifest-bearing raw record, and validate it against `raw.id`, `raw.family`, and that exact SHA before building the record as:
 
 ```ts
 const connectorManifest = raw.connectorManifest;
 if (connectorManifest !== undefined) {
+  if (typeof raw.sha256 !== 'string' || !/^[a-f0-9]{64}$/.test(raw.sha256)) {
+    throw new Error('step.parts: connectorManifest requires a lowercase record sha256');
+  }
   validateHashBoundConnectorManifest(connectorManifest, {
-    partId: raw.id, family: raw.family, geometrySha256: raw.sha256 ?? '',
+    partId: raw.id, family: raw.family, geometrySha256: raw.sha256,
   });
 }
 const record: PartRecord = {
@@ -142,16 +147,16 @@ const record: PartRecord = {
 };
 ```
 
-- [ ] **Step 7: Run the focused contract suite and verify GREEN**
+- [x] **Step 7: Run the focused contract suite and verify GREEN**
 
 Run: `npx vitest run src/shared/parts/connectorManifest.test.ts src/modeling/parts/stepPartsAdapter.test.ts`
 
 Expected: both files pass; no-manifest adapter fixtures still produce an empty connector list.
 
-- [ ] **Step 8: Commit the transport slice**
+- [x] **Step 8: Commit the transport slice**
 
 ```bash
-git add src/shared/parts/connectorManifest.ts src/shared/parts/connectorManifest.test.ts src/shared/parts/types.ts src/modeling/parts/stepPartsAdapter.ts src/modeling/parts/stepPartsAdapter.test.ts
+git add src/shared/parts/connectorManifest.ts src/shared/parts/connectorManifestSchema.ts src/shared/parts/connectorManifest.test.ts src/shared/parts/types.ts src/modeling/parts/stepPartsAdapter.ts src/modeling/parts/stepPartsAdapter.test.ts src/modeling/parts/remoteClient.ts
 git commit -m "feat(catalog): transport hash-bound connector manifests"
 ```
 
@@ -161,7 +166,7 @@ git commit -m "feat(catalog): transport hash-bound connector manifests"
 - Modify: `scripts/ingestParts.ts`
 - Modify: `scripts/ingestParts.test.ts`
 
-- [ ] **Step 1: Write the failing ingestion test**
+- [x] **Step 1: Write the failing ingestion test**
 
 Create a fixture `.meta.json` with an unbound manifest and assert the record uses the emitted STEP digest:
 
@@ -176,13 +181,13 @@ expect(record.connectors).toEqual(['carrier-solder-face']);
 
 Also retain the current no-sidecar-manifest assertion that generic connector synthesis creates the prior `mating-face` name.
 
-- [ ] **Step 2: Run the ingestion test and verify RED**
+- [x] **Step 2: Run the ingestion test and verify RED**
 
 Run: `npx vitest run scripts/ingestParts.test.ts`
 
 Expected: `connectorManifest` is absent and generic names are returned even with a supplied authored sidecar.
 
-- [ ] **Step 3: Add a raw sidecar field and validate/bind it**
+- [x] **Step 3: Add a raw sidecar field and validate/bind it**
 
 Add `connectorManifest?: ConnectorManifest` to `IngestSidecar`, and `connectorManifest?: HashBoundConnectorManifest` to `CatalogRecord`. Define an `AuthoredManifestError` subclass and rethrow it from `ingestDirectory` rather than recording it in `skipped.json`; bad authored interface data must stop that catalog release. After computing `sha256`, use:
 
@@ -209,24 +214,31 @@ connectors: connectorManifest === undefined
 ...(connectorManifest === undefined ? {} : { connectorManifest }),
 ```
 
-- [ ] **Step 4: Run the ingestion test and verify GREEN**
+- [x] **Step 4: Run the ingestion test and verify GREEN**
 
 Run: `npx vitest run scripts/ingestParts.test.ts`
 
 Expected: manifest names replace generic names only for the authored fixture and carry the exact computed hash.
 
-- [ ] **Step 5: Commit the ingest slice**
+- [x] **Step 5: Commit the ingest slice**
 
 ```bash
 git add scripts/ingestParts.ts scripts/ingestParts.test.ts
 git commit -m "feat(catalog): bind authored interfaces to STEP bytes"
 ```
 
+Implementation hardening accepted during review: ingestion independently hashes the copied
+`out/step/<id>.step` in its regression, rejects malformed JSON/manifest data as an
+`AuthoredManifestError`, and preflights all resolved catalog IDs before creating output
+directories. The resolver rejects non-string sidecar IDs and duplicate derived or explicit
+IDs, preventing a later STEP from overwriting bytes described by an earlier bound manifest.
+
 ### Task 3: Consume verified manifests during remote fetch
 
 **Files:**
 - Modify: `src/modeling/parts/fetchPart.ts`
-- Modify: `src/modeling/parts/fetchPart.test.ts`
+- Modify: `src/modeling/parts/fetchPartMetadata.test.ts`
+- Modify: `src/modeling/capture/captureSession.ts`
 
 - [ ] **Step 1: Write the failing remote-fetch tests**
 
@@ -246,7 +258,7 @@ Add a second case whose manifest hash differs from `meta.sha256` and expect `fet
 
 - [ ] **Step 2: Run the remote-fetch tests and verify RED**
 
-Run: `npx vitest run src/modeling/parts/fetchPart.test.ts`
+Run: `npx vitest run src/modeling/parts/fetchPartMetadata.test.ts`
 
 Expected: the valid-manifest case receives generic generated frames or none; the mismatch does not reject.
 
@@ -273,6 +285,11 @@ function attachManifestConnectors(
 }
 ```
 
+This task owns the typed prerequisite as well: add `catalogConnectors` and
+`attachCatalogConnectors()` to `CaptureSession` before the fetch helper calls it. Store an
+immutable copy of the already validated entries; do not treat the lossy `autoConnectors`
+projection as the factual interface source.
+
 Keep bundled sidecar attachment best-effort by loading and validating v1 inside its current `try/catch`. For remote data, after `getOrFetchAsync` and before `inspectStepFile`, execute:
 
 ```ts
@@ -289,21 +306,20 @@ if (meta.connectorManifest !== undefined) {
 
 - [ ] **Step 4: Run remote-fetch tests and verify GREEN**
 
-Run: `npx vitest run src/modeling/parts/fetchPart.test.ts src/modeling/parts/fetchPartMetadata.test.ts`
+Run: `npx vitest run src/modeling/parts/fetchPartMetadata.test.ts`
 
 Expected: exact authored frames attach, mismatch rejects, and existing no-manifest metadata tests retain the generic path.
 
 - [ ] **Step 5: Commit the remote-fetch slice**
 
 ```bash
-git add src/modeling/parts/fetchPart.ts src/modeling/parts/fetchPart.test.ts
+git add src/modeling/parts/fetchPart.ts src/modeling/parts/fetchPartMetadata.test.ts src/modeling/capture/captureSession.ts
 git commit -m "feat(catalog): attach verified authored interfaces"
 ```
 
 ### Task 4: Promote factual catalog interfaces into assembly mating
 
 **Files:**
-- Modify: `src/modeling/capture/captureSession.ts`
 - Modify: `src/modeling/capture/assembly.ts`
 - Create: `src/modeling/capture/assembly.catalogConnectors.test.ts`
 
@@ -321,7 +337,7 @@ expect(part.connector('pwm-contact')).toMatchObject({ partName: 'servo', connect
 expect(part.mateConnectors).toContainEqual(expect.objectContaining({ name: 'pwm-contact', type: 'frame' }));
 ```
 
-Add a second assertion that `arm.mate('signal', 'servo.pwm-contact', 'socket.signal', 'fastened')` resolves after a normal explicit `socket.signal` frame is declared. Add a third test that stores only a legacy `session.attachAutoConnectors(... 'mating-face' ...)` value and confirms it is not promoted. Add a rigid-transform test that calls `source.translate(10, 0, 0).rotateZ(90)` before `assembly.part()` and expects the promoted origin/direction to be transformed. Add a scale test that expects a diagnostic rather than a silently distorted catalog interface.
+Add a second assertion that `arm.mate('signal', 'servo.pwm-contact', 'socket.signal', 'fastened')` resolves after a normal explicit `socket.signal` frame is declared. Add a third test that stores only a legacy `session.attachAutoConnectors(... 'mating-face' ...)` value and confirms it is not promoted. Add a rigid-transform test that calls `source.translate(10, 0, 0).rotateZ(90)` before `assembly.part()` and expects the promoted origin/direction to be transformed. Add scale, reflection, and ParamRef-transform tests that reject rather than silently desynchronizing a physical interface. Finally import the catalog part through `subAssembly()` and assert its interfaces are neither duplicated nor rejected.
 
 - [ ] **Step 2: Run the assembly-promotion tests and verify RED**
 
@@ -330,15 +346,6 @@ Run: `npx vitest run src/modeling/capture/assembly.catalogConnectors.test.ts`
 Expected: `part.connector('pwm-contact')` throws because the auto-connector cache is not currently merged into assembly connectors.
 
 - [ ] **Step 3: Add typed authored-interface promotion**
-
-In `CaptureSession`, add:
-
-```ts
-readonly catalogConnectors: Map<string, readonly ConnectorEntry[]> = new Map();
-attachCatalogConnectors(shapeId: string, connectors: readonly ConnectorEntry[]): void {
-  this.catalogConnectors.set(shapeId, connectors);
-}
-```
 
 In `Assembly.part`, read `session.catalogConnectors.get(shape.id)`, validate each exact `ConnectorEntry`, and apply the feature record's rigid transforms in declared order. For a translate use `Transform.translation(...)`; for a rotation use `Transform.rotationAroundPivot(...)`; compose each new transform to the left of the previous total. Reject `scale` and `reflect` for a catalog-attached Shape. Merge the result before `resolvePartPlacement`:
 
@@ -369,6 +376,11 @@ for (const connector of transformedCatalogConnectors) {
 
 Do not read or promote the legacy generic `autoConnectors` map.
 
+Keep catalog-interface promotion private to the first direct `assembly.part()` call. The
+`subAssembly()` copy path already brings forward promoted legacy and mate-style connectors;
+route it through an internal no-repromotion path so an imported subassembly cannot create
+duplicate names or entries.
+
 - [ ] **Step 4: Run the assembly-promotion tests and verify GREEN**
 
 Run: `npx vitest run src/modeling/capture/assembly.catalogConnectors.test.ts src/modeling/capture/assembly.chaining.test.ts tests/integration/parts/partsAutoConnectors.test.ts`
@@ -378,7 +390,7 @@ Expected: factual catalog frames work in `connector()` and `mate()`, while gener
 - [ ] **Step 5: Commit the assembly bridge**
 
 ```bash
-git add src/modeling/capture/captureSession.ts src/modeling/capture/assembly.ts src/modeling/capture/assembly.catalogConnectors.test.ts
+git add src/modeling/capture/assembly.ts src/modeling/capture/assembly.catalogConnectors.test.ts
 git commit -m "feat(assembly): promote authored catalog interfaces"
 ```
 

--- a/docs/superpowers/plans/2026-07-22-catalog-connector-manifests.md
+++ b/docs/superpowers/plans/2026-07-22-catalog-connector-manifests.md
@@ -240,7 +240,7 @@ IDs, preventing a later STEP from overwriting bytes described by an earlier boun
 - Modify: `src/modeling/parts/fetchPartMetadata.test.ts`
 - Modify: `src/modeling/capture/captureSession.ts`
 
-- [ ] **Step 1: Write the failing remote-fetch tests**
+- [x] **Step 1: Write the failing remote-fetch tests**
 
 Mock a remote record that advertises a valid hash-bound `pwm-contact` manifest, then assert:
 
@@ -256,13 +256,13 @@ expect(synthesizeConnectorsFromReport).not.toHaveBeenCalled();
 
 Add a second case whose manifest hash differs from `meta.sha256` and expect `fetchPartHost` to reject with `geometrySha256` rather than calling synthesis.
 
-- [ ] **Step 2: Run the remote-fetch tests and verify RED**
+- [x] **Step 2: Run the remote-fetch tests and verify RED**
 
 Run: `npx vitest run src/modeling/parts/fetchPartMetadata.test.ts`
 
 Expected: the valid-manifest case receives generic generated frames or none; the mismatch does not reject.
 
-- [ ] **Step 3: Extract a strict attachment helper**
+- [x] **Step 3: Extract a strict attachment helper**
 
 Keep the legacy `AutoConnector` cache unchanged for discovery compatibility. Replace the local sidecar-only conversion with a typed catalog attachment plus the existing lossy auto-connector attachment:
 
@@ -304,13 +304,18 @@ if (meta.connectorManifest !== undefined) {
 }
 ```
 
-- [ ] **Step 4: Run remote-fetch tests and verify GREEN**
+The production branch must validate against a fresh SHA-256 of the raw bytes returned
+from the cache, not only the metadata digest passed into cache lookup. Keep that logic in
+a small helper used immediately before `fromStepBytes`, with a direct differing-bytes
+regression so the post-cache integrity check is covered independently of adapter validation.
+
+- [x] **Step 4: Run remote-fetch tests and verify GREEN**
 
 Run: `npx vitest run src/modeling/parts/fetchPartMetadata.test.ts`
 
 Expected: exact authored frames attach, mismatch rejects, and existing no-manifest metadata tests retain the generic path.
 
-- [ ] **Step 5: Commit the remote-fetch slice**
+- [x] **Step 5: Commit the remote-fetch slice**
 
 ```bash
 git add src/modeling/parts/fetchPart.ts src/modeling/parts/fetchPartMetadata.test.ts src/modeling/capture/captureSession.ts

--- a/docs/superpowers/plans/2026-07-22-catalog-connector-manifests.md
+++ b/docs/superpowers/plans/2026-07-22-catalog-connector-manifests.md
@@ -407,7 +407,7 @@ git commit -m "feat(assembly): promote authored catalog interfaces"
 - Modify: `src/agent/script-runtime/export.ts`
 - Modify: `src/agent/cli/commands/export.ts`
 
-- [ ] **Step 1: Write the failing pure-helper tests**
+- [x] **Step 1: Write the failing pure-helper tests**
 
 Run a real `assembly.part(..., { at: [10, 20, 30] })` fixture through `runScript` and `RecomputeEngine`, then assert that the capture Scene and lowerer differ in the intended way and the extracted manifest follows the STEP frame:
 
@@ -422,13 +422,13 @@ expect(sceneToConnectorManifest(scene, loweredScene, run.records, { partId: 'ser
 
 Also assert `sceneToWorldFrameParts(loweredScene)[0].shape.boundingBox().min` is `[10, 20, 30]`, proving the geometry and manifest use the same placement. Add a ParamRef-driven `at` fixture (the helper must receive resolved records), a synthetic non-identity backend-world-transform case, and cases that reject duplicate names, a topology origin, `planar`, `ball`, mates, and joint-driven source records. Include an unrelated same-named part in a different assembly to prove lookup is scoped to the returned Scene's source feature.
 
-- [ ] **Step 2: Run helper tests and verify RED**
+- [x] **Step 2: Run helper tests and verify RED**
 
 Run: `npx vitest run src/agent/script-runtime/connectorManifestExport.test.ts`
 
 Expected: module-not-found failure.
 
-- [ ] **Step 3: Implement the pure extractor**
+- [x] **Step 3: Implement the pure extractor**
 
 Create `sceneToConnectorManifest` using the recomputed `SceneBackend`, resolved direct `assemblyPart` records, and the existing `Transform.point` and `Transform.axisDir` APIs. Do not globally match by part name: use `scene.__sourceFeatureId()` to find the exact `assemblyModel` source record, then its `metadata.partIds` to select its matching `assemblyPart` records. Require count, order, and name agreement with `SceneBackend.parts`; fail closed on ambiguity. Pass `resolveParams(run.records, run.paramTable)` into the helper so ParamRef placements use the same values as the lowerer. Decode `metadata.at` from those resolved `Vec3Param` values. The exact transform used by STEP export is:
 
@@ -477,7 +477,7 @@ export function sceneToConnectorManifest(
 }
 ```
 
-- [ ] **Step 4: Thread an optional manifest request through export and CLI**
+- [x] **Step 4: Thread an optional manifest request through export and CLI**
 
 Add `connectorManifest?: { partId: string; family: string }` to runtime `ExportInput` and `connectorManifest?: ConnectorManifest` to `ExportResult`. If requested, require `format === 'step'`, a returned `Scene`, and the same successful lowered `SceneBackend` used by `exportSceneToSTEPAsync`; call `sceneToConnectorManifest(scene, lowered, resolveParams(run.records, run.paramTable), identity)` and include it in the successful result. If `feature_id` is supplied, require it exactly matches `scene.__sourceFeatureId()` so the STEP and manifest cannot silently describe different features.
 
@@ -491,18 +491,28 @@ Add CLI options:
 
 Require all three options together, write the returned manifest JSON with the existing file-write diagnostic path, and reject their use with formats other than `step`.
 
-- [ ] **Step 5: Run helper and focused CLI tests and verify GREEN**
+- [x] **Step 5: Run helper and focused CLI tests and verify GREEN**
 
 Run: `npx vitest run src/agent/script-runtime/connectorManifestExport.test.ts src/agent/mcp/tools/export.test.ts`
 
 Expected: transformed numeric frames are stable, unsupported connectors reject, and existing export behavior remains unchanged.
 
-- [ ] **Step 6: Commit the export slice**
+- [x] **Step 6: Commit the export slice**
 
 ```bash
 git add src/agent/script-runtime/connectorManifestExport.ts src/agent/script-runtime/connectorManifestExport.test.ts src/agent/script-runtime/export.ts src/agent/cli/commands/export.ts
 git commit -m "feat(export): emit authored connector manifests"
 ```
+
+Implementation hardening: manifest publication resolves a current-user/root-owned
+POSIX ancestry, rejects a group/world-writable final parent, uses a private
+`0700` staging directory and `0600` staged file, and atomically publishes with
+same-filesystem `link` so it never replaces a concurrent sidecar or exposes
+partial JSON. A sticky writable ancestor is allowed only when it is owned by
+the current user or root and its next child is owned by the current user. Node
+does not expose portable ACL inspection, so this boundary is mode/ownership
+based. If publication fails after STEP export, the CLI reports the preserved
+STEP bytes and does not emit a manifest.
 
 ### Task 6: Request manifests for authored electronics catalog parts
 
@@ -510,7 +520,7 @@ git commit -m "feat(export): emit authored connector manifests"
 - Modify: `scripts/ingestElectronics.ts`
 - Create: `scripts/ingestElectronics.test.ts`
 
-- [ ] **Step 1: Write the failing command-construction test**
+- [x] **Step 1: Write the failing command-construction test**
 
 Extract a pure helper and test its exact command line:
 
@@ -524,13 +534,13 @@ expect(authoredExportArgs('/repo/dist/cli/index.js', '/repo/part.kcad.ts', '/tmp
 ]);
 ```
 
-- [ ] **Step 2: Run the test and verify RED**
+- [x] **Step 2: Run the test and verify RED**
 
 Run: `npx vitest run scripts/ingestElectronics.test.ts`
 
 Expected: module export is missing.
 
-- [ ] **Step 3: Implement command construction and sidecar transfer**
+- [x] **Step 3: Implement command construction and sidecar transfer**
 
 For each `kcad_source`, set `manifestOut = join(src, `${part.id}.connector-manifest.json`)`, pass the helper output to `execFileSync`, require that the command created this file, parse it as a `ConnectorManifest`, and include it in the generated `<id>.meta.json`:
 
@@ -540,18 +550,23 @@ connectorManifest: loadConnectorManifest(manifestOut),
 
 Do not add a manifest for downloaded third-party STEP files.
 
-- [ ] **Step 4: Run the test and verify GREEN**
+- [x] **Step 4: Run the test and verify GREEN**
 
 Run: `npx vitest run scripts/ingestElectronics.test.ts scripts/ingestParts.test.ts`
 
 Expected: authored commands request the sidecar, and ingestion binds it to the final STEP hash.
 
-- [ ] **Step 5: Commit the electronics ingest slice**
+- [x] **Step 5: Commit the electronics ingest slice**
 
 ```bash
 git add scripts/ingestElectronics.ts scripts/ingestElectronics.test.ts
 git commit -m "feat(catalog): preserve authored electronics interfaces"
 ```
+
+Hardening accepted during review: an authored source that writes STEP but
+omits, corrupts, mismatches, or fails while exporting its connector manifest
+raises `AuthoredManifestError` before `ingestDirectory` can create a generic
+connector fallback.
 
 ### Task 7: Add universal A4988 and SG90 catalog components
 

--- a/docs/superpowers/plans/2026-07-22-catalog-connector-manifests.md
+++ b/docs/superpowers/plans/2026-07-22-catalog-connector-manifests.md
@@ -1,0 +1,635 @@
+# Catalog Connector Manifests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve source-authored, physically meaningful connector frames from universal KernelCAD components through catalog ingestion and remote `fetch_part`.
+
+**Architecture:** Keep `ConnectorManifest` v1 as the local authoring-sidecar contract. Add a strictly validated `HashBoundConnectorManifest` to bind remote interfaces to exact exported STEP bytes. Existing parts without a manifest retain generic STEP-derived connectors; records that advertise a bad manifest fail instead of silently degrading.
+
+**Tech Stack:** TypeScript, Vitest, Node `crypto`/filesystem, KernelCAD capture `Scene`, OCCT STEP export, Cloudflare-compatible catalog JSON.
+
+---
+
+## File map
+
+- `src/shared/parts/connectorManifest.ts` — authoring and hash-bound manifest types and validation.
+- `src/shared/parts/connectorManifest.test.ts` — manifest contract regression coverage.
+- `src/shared/parts/types.ts` — canonical remote `PartRecord` transport field.
+- `src/modeling/parts/stepPartsAdapter.ts` — raw remote JSON to canonical record mapping.
+- `src/modeling/parts/stepPartsAdapter.test.ts` — mapped-manifest regression coverage.
+- `scripts/ingestParts.ts` and `scripts/ingestParts.test.ts` — bind an authored sidecar to emitted STEP bytes.
+- `src/modeling/parts/fetchPart.ts` and `src/modeling/parts/fetchPart.test.ts` — attach verified manifest frames before generic synthesis.
+- `src/modeling/capture/captureSession.ts` — typed, verified catalog-interface store keyed by fetched Shape id.
+- `src/modeling/capture/assembly.ts` and `src/modeling/capture/assembly.catalogConnectors.test.ts` — promote factual catalog interfaces into both assembly mating APIs.
+- `src/agent/script-runtime/connectorManifestExport.ts` and `.test.ts` — convert numeric authored `Scene` connectors into a portable sidecar.
+- `src/agent/script-runtime/export.ts` — request and return a sidecar during STEP export.
+- `src/agent/cli/commands/export.ts` — expose the sidecar write path as CLI options.
+- `scripts/ingestElectronics.ts` and `scripts/ingestElectronics.test.ts` — request a sidecar for `kcad_source` parts.
+- `scripts/parts/authored/a4988-stepstick-carrier.kcad.ts` and `sg90-micro-servo.kcad.ts` — universal model interfaces only.
+- `scripts/electronics-parts.json` — catalog records for the two authored universal components.
+
+### Task 1: Define and transport a hash-bound remote manifest
+
+**Files:**
+- Modify: `src/shared/parts/connectorManifest.ts`
+- Modify: `src/shared/parts/connectorManifest.test.ts`
+- Modify: `src/shared/parts/types.ts`
+- Modify: `src/modeling/parts/stepPartsAdapter.ts`
+- Modify: `src/modeling/parts/stepPartsAdapter.test.ts`
+
+- [ ] **Step 1: Write the failing mapper test**
+
+Append this fixture and assertion to `src/modeling/parts/stepPartsAdapter.test.ts`:
+
+```ts
+it('preserves a valid hash-bound authored manifest and exposes its names', () => {
+  const raw: StepPartsRecord = {
+    ...REAL,
+    connectorManifest: {
+      schemaVersion: 1,
+      partId: REAL.id,
+      family: REAL.family,
+      geometrySha256: REAL.sha256!,
+      connectors: [{
+        name: 'driver-step', type: 'frame', origin: [1, 2, 3], normal: [0, 0, 1],
+      }],
+    },
+  };
+  const mapped = mapStepPartsRecord(raw);
+  expect(mapped.connectorManifest).toEqual(raw.connectorManifest);
+  expect(mapped.connectors).toEqual(['driver-step']);
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `npx vitest run src/modeling/parts/stepPartsAdapter.test.ts`
+
+Expected: the new assertion fails because `connectorManifest` does not exist on `PartRecord` and the mapper returns `connectors: []`.
+
+- [ ] **Step 3: Write the failing validation test**
+
+Append this test to `src/shared/parts/connectorManifest.test.ts`:
+
+```ts
+it('rejects a hash-bound manifest whose expected STEP hash differs', () => {
+  const m = {
+    schemaVersion: 1 as const,
+    partId: 'carrier', family: 'stepper-driver',
+    geometrySha256: 'a'.repeat(64),
+    connectors: [{ name: 'solder-face', type: 'frame' as const, origin: [0, 0, 0] as [number, number, number], normal: [0, 0, -1] as [number, number, number] }],
+  };
+  expect(() => validateHashBoundConnectorManifest(m, {
+    partId: 'carrier', family: 'stepper-driver', geometrySha256: 'b'.repeat(64),
+  })).toThrow(/geometrySha256/);
+});
+```
+
+- [ ] **Step 4: Run the validation test and verify RED**
+
+Run: `npx vitest run src/shared/parts/connectorManifest.test.ts`
+
+Expected: import failure because `validateHashBoundConnectorManifest` is not exported.
+
+- [ ] **Step 5: Implement the minimal shared contract**
+
+In `src/shared/parts/connectorManifest.ts`, add the bound type and helper while retaining `validateConnectorManifest` for bundled sidecars:
+
+```ts
+export interface HashBoundConnectorManifest extends ConnectorManifest {
+  geometrySha256: string;
+}
+
+export function validateHashBoundConnectorManifest(
+  manifest: HashBoundConnectorManifest,
+  expected: { partId: string; family: string; geometrySha256: string },
+): void {
+  validateConnectorManifest(manifest);
+  if (!/^[0-9a-f]{64}$/.test(manifest.geometrySha256)) {
+    throw new Error('manifest: geometrySha256 must be lowercase 64-character hex');
+  }
+  if (manifest.partId !== expected.partId) throw new Error('manifest: partId does not match catalog record');
+  if (manifest.family !== expected.family) throw new Error('manifest: family does not match catalog record');
+  if (manifest.geometrySha256 !== expected.geometrySha256) {
+    throw new Error('manifest: geometrySha256 does not match catalog record');
+  }
+}
+```
+
+Also make `validateConnectorManifest` reject duplicate names, non-finite three-vectors, and a zero frame normal or axis before the new helper invokes it.
+
+- [ ] **Step 6: Add canonical record fields and mapper behavior**
+
+Import `HashBoundConnectorManifest` into `src/shared/parts/types.ts` and add:
+
+```ts
+connectorManifest?: HashBoundConnectorManifest;
+```
+
+to `PartRecord` and `CatalogPartMetadata`; preserve it in `snapshotCatalogPart`. Update `isPartRecord` to call `validateHashBoundConnectorManifest` when that optional field is present and return `false` on validation failure. In `src/modeling/parts/stepPartsAdapter.ts`, declare the optional raw field, validate it against `raw.id`, `raw.family`, and `raw.sha256 ?? ''`, then build the record as:
+
+```ts
+const connectorManifest = raw.connectorManifest;
+if (connectorManifest !== undefined) {
+  validateHashBoundConnectorManifest(connectorManifest, {
+    partId: raw.id, family: raw.family, geometrySha256: raw.sha256 ?? '',
+  });
+}
+const record: PartRecord = {
+  // existing fields
+  connectors: connectorManifest?.connectors.map((connector) => connector.name) ?? [],
+  ...(connectorManifest === undefined ? {} : { connectorManifest }),
+};
+```
+
+- [ ] **Step 7: Run the focused contract suite and verify GREEN**
+
+Run: `npx vitest run src/shared/parts/connectorManifest.test.ts src/modeling/parts/stepPartsAdapter.test.ts`
+
+Expected: both files pass; no-manifest adapter fixtures still produce an empty connector list.
+
+- [ ] **Step 8: Commit the transport slice**
+
+```bash
+git add src/shared/parts/connectorManifest.ts src/shared/parts/connectorManifest.test.ts src/shared/parts/types.ts src/modeling/parts/stepPartsAdapter.ts src/modeling/parts/stepPartsAdapter.test.ts
+git commit -m "feat(catalog): transport hash-bound connector manifests"
+```
+
+### Task 2: Bind authoring sidecars during STEP ingestion
+
+**Files:**
+- Modify: `scripts/ingestParts.ts`
+- Modify: `scripts/ingestParts.test.ts`
+
+- [ ] **Step 1: Write the failing ingestion test**
+
+Create a fixture `.meta.json` with an unbound manifest and assert the record uses the emitted STEP digest:
+
+```ts
+expect(record.connectorManifest).toMatchObject({
+  partId: 'fixture-part', family: 'fixture-family',
+  geometrySha256: record.sha256,
+  connectors: [{ name: 'carrier-solder-face', type: 'frame' }],
+});
+expect(record.connectors).toEqual(['carrier-solder-face']);
+```
+
+Also retain the current no-sidecar-manifest assertion that generic connector synthesis creates the prior `mating-face` name.
+
+- [ ] **Step 2: Run the ingestion test and verify RED**
+
+Run: `npx vitest run scripts/ingestParts.test.ts`
+
+Expected: `connectorManifest` is absent and generic names are returned even with a supplied authored sidecar.
+
+- [ ] **Step 3: Add a raw sidecar field and validate/bind it**
+
+Add `connectorManifest?: ConnectorManifest` to `IngestSidecar`, and `connectorManifest?: HashBoundConnectorManifest` to `CatalogRecord`. Define an `AuthoredManifestError` subclass and rethrow it from `ingestDirectory` rather than recording it in `skipped.json`; bad authored interface data must stop that catalog release. After computing `sha256`, use:
+
+```ts
+let connectorManifest: HashBoundConnectorManifest | undefined;
+if (meta.connectorManifest !== undefined) {
+  validateConnectorManifest(meta.connectorManifest);
+  if (meta.connectorManifest.partId !== id || meta.connectorManifest.family !== family) {
+    throw new Error(`ingest: manifest identity does not match ${id}/${family}`);
+  }
+  connectorManifest = { ...meta.connectorManifest, geometrySha256: sha256 };
+}
+```
+
+Select connector output with:
+
+```ts
+connectors: connectorManifest === undefined
+  ? conns.map((c) => ({ name: c.name, origin: c.origin, axis: c.axis }))
+  : connectorManifest.connectors.map((c) => ({
+      name: c.name, origin: c.origin,
+      axis: c.type === 'axis' ? c.axis : c.normal,
+    })),
+...(connectorManifest === undefined ? {} : { connectorManifest }),
+```
+
+- [ ] **Step 4: Run the ingestion test and verify GREEN**
+
+Run: `npx vitest run scripts/ingestParts.test.ts`
+
+Expected: manifest names replace generic names only for the authored fixture and carry the exact computed hash.
+
+- [ ] **Step 5: Commit the ingest slice**
+
+```bash
+git add scripts/ingestParts.ts scripts/ingestParts.test.ts
+git commit -m "feat(catalog): bind authored interfaces to STEP bytes"
+```
+
+### Task 3: Consume verified manifests during remote fetch
+
+**Files:**
+- Modify: `src/modeling/parts/fetchPart.ts`
+- Modify: `src/modeling/parts/fetchPart.test.ts`
+
+- [ ] **Step 1: Write the failing remote-fetch tests**
+
+Mock a remote record that advertises a valid hash-bound `pwm-contact` manifest, then assert:
+
+```ts
+expect(session.catalogConnectors.get(shape.id)).toEqual([{
+  name: 'pwm-contact', type: 'frame', origin: [1, 2, 3], normal: [1, 0, 0],
+}]);
+expect(session.autoConnectors.get(shape.id)).toEqual(expect.arrayContaining([
+  expect.objectContaining({ name: 'pwm-contact', origin: [1, 2, 3], axis: [1, 0, 0] }),
+]));
+expect(synthesizeConnectorsFromReport).not.toHaveBeenCalled();
+```
+
+Add a second case whose manifest hash differs from `meta.sha256` and expect `fetchPartHost` to reject with `geometrySha256` rather than calling synthesis.
+
+- [ ] **Step 2: Run the remote-fetch tests and verify RED**
+
+Run: `npx vitest run src/modeling/parts/fetchPart.test.ts`
+
+Expected: the valid-manifest case receives generic generated frames or none; the mismatch does not reject.
+
+- [ ] **Step 3: Extract a strict attachment helper**
+
+Keep the legacy `AutoConnector` cache unchanged for discovery compatibility. Replace the local sidecar-only conversion with a typed catalog attachment plus the existing lossy auto-connector attachment:
+
+```ts
+function attachManifestConnectors(
+  ctx: FetchPartCtx,
+  shape: Shape,
+  manifest: ConnectorManifest,
+): string[] {
+  ctx.session.attachCatalogConnectors(shape.id, manifest.connectors);
+  const conns = manifest.connectors.map((c) => ({
+    name: c.name,
+    ref: formatTopoRef({ owner: shape.id, kind: 'connector', segments: [c.name] }),
+    origin: c.origin,
+    axis: c.type === 'axis' ? c.axis : c.normal,
+    type: 'frame' as const,
+  }));
+  ctx.session.attachAutoConnectors(shape.id, conns);
+  return conns.map((connector) => connector.name);
+}
+```
+
+Keep bundled sidecar attachment best-effort by loading and validating v1 inside its current `try/catch`. For remote data, after `getOrFetchAsync` and before `inspectStepFile`, execute:
+
+```ts
+if (meta.connectorManifest !== undefined) {
+  validateHashBoundConnectorManifest(meta.connectorManifest, {
+    partId: meta.id, family: meta.family, geometrySha256: meta.sha256,
+  });
+  const connectors = attachManifestConnectors(ctx, shape, meta.connectorManifest);
+  record = { ...record, connectors };
+} else {
+  // existing inspectStepFile + synthesizeConnectorsFromReport fallback
+}
+```
+
+- [ ] **Step 4: Run remote-fetch tests and verify GREEN**
+
+Run: `npx vitest run src/modeling/parts/fetchPart.test.ts src/modeling/parts/fetchPartMetadata.test.ts`
+
+Expected: exact authored frames attach, mismatch rejects, and existing no-manifest metadata tests retain the generic path.
+
+- [ ] **Step 5: Commit the remote-fetch slice**
+
+```bash
+git add src/modeling/parts/fetchPart.ts src/modeling/parts/fetchPart.test.ts
+git commit -m "feat(catalog): attach verified authored interfaces"
+```
+
+### Task 4: Promote factual catalog interfaces into assembly mating
+
+**Files:**
+- Modify: `src/modeling/capture/captureSession.ts`
+- Modify: `src/modeling/capture/assembly.ts`
+- Create: `src/modeling/capture/assembly.catalogConnectors.test.ts`
+
+- [ ] **Step 1: Write the failing assembly-promotion tests**
+
+Create a `CaptureSession`, attach a factual connector to a box before it enters an assembly, then assert that it is usable by both connector APIs:
+
+```ts
+const source = kcad.box(4, 4, 2);
+session.attachCatalogConnectors(source.id, [{
+  name: 'pwm-contact', type: 'frame', origin: [4, 2, 1], normal: [1, 0, 0],
+}]);
+const part = arm.part('servo', source);
+expect(part.connector('pwm-contact')).toMatchObject({ partName: 'servo', connector: 'pwm-contact' });
+expect(part.mateConnectors).toContainEqual(expect.objectContaining({ name: 'pwm-contact', type: 'frame' }));
+```
+
+Add a second assertion that `arm.mate('signal', 'servo.pwm-contact', 'socket.signal', 'fastened')` resolves after a normal explicit `socket.signal` frame is declared. Add a third test that stores only a legacy `session.attachAutoConnectors(... 'mating-face' ...)` value and confirms it is not promoted. Add a rigid-transform test that calls `source.translate(10, 0, 0).rotateZ(90)` before `assembly.part()` and expects the promoted origin/direction to be transformed. Add a scale test that expects a diagnostic rather than a silently distorted catalog interface.
+
+- [ ] **Step 2: Run the assembly-promotion tests and verify RED**
+
+Run: `npx vitest run src/modeling/capture/assembly.catalogConnectors.test.ts`
+
+Expected: `part.connector('pwm-contact')` throws because the auto-connector cache is not currently merged into assembly connectors.
+
+- [ ] **Step 3: Add typed authored-interface promotion**
+
+In `CaptureSession`, add:
+
+```ts
+readonly catalogConnectors: Map<string, readonly ConnectorEntry[]> = new Map();
+attachCatalogConnectors(shapeId: string, connectors: readonly ConnectorEntry[]): void {
+  this.catalogConnectors.set(shapeId, connectors);
+}
+```
+
+In `Assembly.part`, read `session.catalogConnectors.get(shape.id)`, validate each exact `ConnectorEntry`, and apply the feature record's rigid transforms in declared order. For a translate use `Transform.translation(...)`; for a rotation use `Transform.rotationAroundPivot(...)`; compose each new transform to the left of the previous total. Reject `scale` and `reflect` for a catalog-attached Shape. Merge the result before `resolvePartPlacement`:
+
+```ts
+for (const connector of transformedCatalogConnectors) {
+  if (connectors[connector.name] !== undefined) {
+    throw new KernelError('feature.invalid-args', `assembly connector '${connector.name}' is declared both by the catalog part and assembly.part options.`, shape.id);
+  }
+  connectors[connector.name] = {
+    origin: toVec3Param(connector.origin, 'mm'),
+    axis: toVec3Param(connector.type === 'axis' ? connector.axis : connector.normal, 'unitless'),
+  };
+}
+const mateConnectors: Connector[] = [];
+```
+
+Pass the populated `connectors` map and empty `mateConnectors` array to `session.assemblyPart` / `makePartRef`. Immediately after the part ref is built, register each transformed entry through the existing validator path:
+
+```ts
+for (const connector of transformedCatalogConnectors) {
+  part.connector(connector.name, {
+    type: connector.type,
+    origin: { kind: 'vec3', value: connector.origin },
+    ...(connector.type === 'axis' ? { axis: connector.axis } : { normal: connector.normal }),
+  });
+}
+```
+
+Do not read or promote the legacy generic `autoConnectors` map.
+
+- [ ] **Step 4: Run the assembly-promotion tests and verify GREEN**
+
+Run: `npx vitest run src/modeling/capture/assembly.catalogConnectors.test.ts src/modeling/capture/assembly.chaining.test.ts tests/integration/parts/partsAutoConnectors.test.ts`
+
+Expected: factual catalog frames work in `connector()` and `mate()`, while generic synthesized frames retain their existing non-mating behavior.
+
+- [ ] **Step 5: Commit the assembly bridge**
+
+```bash
+git add src/modeling/capture/captureSession.ts src/modeling/capture/assembly.ts src/modeling/capture/assembly.catalogConnectors.test.ts
+git commit -m "feat(assembly): promote authored catalog interfaces"
+```
+
+### Task 5: Export numeric authored Scene connectors without copying coordinates
+
+**Files:**
+- Create: `src/agent/script-runtime/connectorManifestExport.ts`
+- Create: `src/agent/script-runtime/connectorManifestExport.test.ts`
+- Modify: `src/agent/script-runtime/export.ts`
+- Modify: `src/agent/cli/commands/export.ts`
+
+- [ ] **Step 1: Write the failing pure-helper tests**
+
+Run a real `assembly.part(..., { at: [10, 20, 30] })` fixture through `runScript` and `RecomputeEngine`, then assert that the capture Scene and lowerer differ in the intended way and the extracted manifest follows the STEP frame:
+
+```ts
+expect(loweredPart.worldTransform.point([1, 1, 1])).toEqual([1, 1, 1]);
+expect(sceneToConnectorManifest(scene, loweredScene, run.records, { partId: 'servo', family: 'micro-servo' }))
+  .toMatchObject({
+    partId: 'servo', family: 'micro-servo',
+    connectors: [{ name: 'pwm-contact', type: 'frame', origin: [11, 21, 31], normal: [1, 0, 0] }],
+  });
+```
+
+Also assert `sceneToWorldFrameParts(loweredScene)[0].shape.boundingBox().min` is `[10, 20, 30]`, proving the geometry and manifest use the same placement. Add cases that reject duplicate names, a topology origin, `planar`, `ball`, mates, and joint-driven source records.
+
+- [ ] **Step 2: Run helper tests and verify RED**
+
+Run: `npx vitest run src/agent/script-runtime/connectorManifestExport.test.ts`
+
+Expected: module-not-found failure.
+
+- [ ] **Step 3: Implement the pure extractor**
+
+Create `sceneToConnectorManifest` using the recomputed `SceneBackend`, the direct `assemblyPart` records, and the existing `Transform.point` and `Transform.axisDir` APIs. For each capture Scene part, find one matching `SceneBackend` part and one `assemblyPart` FeatureRecord by unique part name. Decode `metadata.at` from its evaluated `Vec3Param` values. The exact transform used by STEP export is:
+
+```ts
+const transform = backendPart.worldTransform.compose(
+  Transform.translation(at.x.evaluated, at.y.evaluated, at.z.evaluated),
+);
+```
+
+The helper signature and core loop are:
+
+```ts
+export function sceneToConnectorManifest(
+  scene: Scene,
+  lowered: SceneBackend,
+  records: readonly FeatureRecord[],
+  identity: { partId: string; family: string },
+): ConnectorManifest {
+  if ((scene.mates?.length ?? 0) > 0 || records.some((record) => record.kind === 'assemblyJoint')) {
+    throw new Error('connector-manifest export requires a mate-free, joint-free assembly');
+  }
+  const connectors: ConnectorEntry[] = [];
+  const names = new Set<string>();
+  for (const part of scene.parts) for (const connector of part.connectors ?? []) {
+    const backendPart = singleByName(lowered.parts, part.name, 'lowered scene part');
+    const assemblyPart = singleByName(assemblyPartRecords(records), part.name, 'assembly part record');
+    const at = readAssemblyPartAt(assemblyPart);
+    const transform = backendPart.worldTransform.compose(Transform.translation(at[0], at[1], at[2]));
+    if (connector.type !== 'frame' && connector.type !== 'axis') throw new Error(...);
+    if (connector.origin.kind !== 'vec3') throw new Error(...);
+    if (names.has(connector.name)) throw new Error(...);
+    names.add(connector.name);
+    const origin = tuple(transform.point(connector.origin.value));
+    const direction = tuple(transform.axisDir(
+      connector.type === 'axis' ? connector.axis ?? [0, 0, 1] : connector.normal ?? [0, 0, 1],
+    ));
+    connectors.push(connector.type === 'axis'
+      ? { name: connector.name, type: 'axis', origin, axis: direction }
+      : { name: connector.name, type: 'frame', origin, normal: direction });
+  }
+  const manifest = { schemaVersion: 1, ...identity, connectors } as const;
+  validateConnectorManifest(manifest);
+  return manifest;
+}
+```
+
+- [ ] **Step 4: Thread an optional manifest request through export and CLI**
+
+Add `connectorManifest?: { partId: string; family: string }` to runtime `ExportInput` and `connectorManifest?: ConnectorManifest` to `ExportResult`. If requested, require `format === 'step'`, a returned `Scene`, and the same successful lowered `SceneBackend` used by `exportSceneToSTEPAsync`; call `sceneToConnectorManifest(scene, lowered, run.records, identity)` and include it in the successful result.
+
+Add CLI options:
+
+```ts
+.option('--connector-manifest <path>', 'write numeric authored connector manifest beside a STEP export')
+.option('--manifest-part-id <id>', 'catalog part id for --connector-manifest')
+.option('--manifest-family <family>', 'catalog family for --connector-manifest')
+```
+
+Require all three options together, write the returned manifest JSON with the existing file-write diagnostic path, and reject their use with formats other than `step`.
+
+- [ ] **Step 5: Run helper and focused CLI tests and verify GREEN**
+
+Run: `npx vitest run src/agent/script-runtime/connectorManifestExport.test.ts src/agent/mcp/tools/export.test.ts`
+
+Expected: transformed numeric frames are stable, unsupported connectors reject, and existing export behavior remains unchanged.
+
+- [ ] **Step 6: Commit the export slice**
+
+```bash
+git add src/agent/script-runtime/connectorManifestExport.ts src/agent/script-runtime/connectorManifestExport.test.ts src/agent/script-runtime/export.ts src/agent/cli/commands/export.ts
+git commit -m "feat(export): emit authored connector manifests"
+```
+
+### Task 6: Request manifests for authored electronics catalog parts
+
+**Files:**
+- Modify: `scripts/ingestElectronics.ts`
+- Create: `scripts/ingestElectronics.test.ts`
+
+- [ ] **Step 1: Write the failing command-construction test**
+
+Extract a pure helper and test its exact command line:
+
+```ts
+expect(authoredExportArgs('/repo/dist/cli/index.js', '/repo/part.kcad.ts', '/tmp/part.step', '/tmp/part.manifest.json', {
+  id: 'a4988-stepstick-carrier', family: 'stepper-driver',
+})).toEqual([
+  '/repo/dist/cli/index.js', 'export', 'step', '/repo/part.kcad.ts', '-o', '/tmp/part.step',
+  '--connector-manifest', '/tmp/part.manifest.json',
+  '--manifest-part-id', 'a4988-stepstick-carrier', '--manifest-family', 'stepper-driver',
+]);
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run: `npx vitest run scripts/ingestElectronics.test.ts`
+
+Expected: module export is missing.
+
+- [ ] **Step 3: Implement command construction and sidecar transfer**
+
+For each `kcad_source`, set `manifestOut = join(src, `${part.id}.connector-manifest.json`)`, pass the helper output to `execFileSync`, require that the command created this file, parse it as a `ConnectorManifest`, and include it in the generated `<id>.meta.json`:
+
+```ts
+connectorManifest: loadConnectorManifest(manifestOut),
+```
+
+Do not add a manifest for downloaded third-party STEP files.
+
+- [ ] **Step 4: Run the test and verify GREEN**
+
+Run: `npx vitest run scripts/ingestElectronics.test.ts scripts/ingestParts.test.ts`
+
+Expected: authored commands request the sidecar, and ingestion binds it to the final STEP hash.
+
+- [ ] **Step 5: Commit the electronics ingest slice**
+
+```bash
+git add scripts/ingestElectronics.ts scripts/ingestElectronics.test.ts
+git commit -m "feat(catalog): preserve authored electronics interfaces"
+```
+
+### Task 7: Add universal A4988 and SG90 catalog components
+
+**Files:**
+- Create: `scripts/parts/authored/a4988-stepstick-carrier.kcad.ts`
+- Create: `scripts/parts/authored/sg90-micro-servo.kcad.ts`
+- Modify: `scripts/electronics-parts.json`
+- Create: `scripts/universalElectronicsParts.test.ts`
+
+- [ ] **Step 1: Write source-level factual-interface tests**
+
+Assert that A4988 declares `carrier-solder-face`, `en-contact`, `step-contact`, `dir-contact`, `vmot-contact`, and its other actual plated-hole contacts; assert that SG90 declares `ground-contact`, `vplus-contact`, `pwm-contact`, and `output-axis-envelope`; assert neither source declares `mount-hole`, `universal-spline`, `x-motor`, or `y-motor`.
+
+- [ ] **Step 2: Run the source tests and verify RED**
+
+Run: `npx vitest run scripts/universalElectronicsParts.test.ts`
+
+Expected: missing sources/records or missing connector declarations.
+
+- [ ] **Step 3: Model interfaces on real modeled solids**
+
+For A4988, call `.connector()` on the PCB/actual pad parts with:
+
+```ts
+pcbRef.connector('carrier-solder-face', {
+  type: 'frame', origin: { kind: 'vec3', value: [PCB_X / 2, PCB_Y / 2, 0] }, normal: [0, 0, -1],
+});
+padRef.connector(`${pin.name}-contact`, {
+  type: 'frame', origin: { kind: 'vec3', value: [pin.x, pin.y, PCB_T + 0.08] }, normal: [0, 0, 1],
+});
+```
+
+For SG90, attach the cable contacts to their modeled contact faces and declare only an envelope axis:
+
+```ts
+housingRef.connector('pwm-contact', {
+  type: 'frame', origin: { kind: 'vec3', value: [cableHousingX + 2.64, pwmY, leadZ] }, normal: [1, 0, 0],
+});
+housingRef.connector('output-axis-envelope', {
+  type: 'axis', origin: { kind: 'vec3', value: [OUTPUT_X, OUTPUT_Y, CASE_H + BOSS_H] }, axis: [0, 0, 1],
+});
+```
+
+Add each part to `scripts/electronics-parts.json` using its real manufacturer/source attribution and `kcad_source`; do not add fixture-only board, power, mounting, or project-specific fields.
+
+- [ ] **Step 4: Run source tests and a narrow catalog export test**
+
+Run: `npx vitest run scripts/universalElectronicsParts.test.ts`
+
+Expected: factual interface declarations pass source-level coverage. If disk headroom is at least 1 GiB, run `npx tsx scripts/ingestElectronics.ts <fresh-temp-out> --manifest scripts/electronics-parts.json`; otherwise defer the generated catalog export to CI.
+
+- [ ] **Step 5: Commit universal component sources**
+
+```bash
+git add scripts/parts/authored/a4988-stepstick-carrier.kcad.ts scripts/parts/authored/sg90-micro-servo.kcad.ts scripts/electronics-parts.json scripts/universalElectronicsParts.test.ts
+git commit -m "feat(catalog): add universal motor-control components"
+```
+
+### Task 8: Verify, review, publish, and only then use components in projects
+
+**Files:**
+- Verify: files modified in Tasks 1–6
+
+- [ ] **Step 1: Check the exact change set**
+
+Run: `git diff origin/develop...HEAD --check`
+
+Expected: no whitespace errors and no changes outside the manifest pipeline, universal parts, and their tests.
+
+- [ ] **Step 2: Run focused tests without the artifact-generating `pretest` hook**
+
+Run: `npx vitest run src/shared/parts/connectorManifest.test.ts src/modeling/parts/stepPartsAdapter.test.ts scripts/ingestParts.test.ts src/modeling/parts/fetchPart.test.ts src/modeling/parts/fetchPartMetadata.test.ts src/modeling/capture/assembly.catalogConnectors.test.ts src/agent/script-runtime/connectorManifestExport.test.ts scripts/ingestElectronics.test.ts scripts/universalElectronicsParts.test.ts`
+
+Expected: all listed focused suites pass.
+
+- [ ] **Step 3: Run type verification if disk capacity permits**
+
+Run: `npm run typecheck`
+
+Expected: exit code 0. If free disk remains below 1 GiB, do not create build artifacts locally; push the tested branch and use required remote CI for the full type/build gate.
+
+- [ ] **Step 4: Perform two reviews**
+
+First review against this plan: no manual connector-coordinate copy, no generic synthesis when an authored manifest is present, no fictional universal interfaces. Second review for TypeScript/API quality and compatibility with no-manifest third-party records.
+
+- [ ] **Step 5: Push and open a draft pull request**
+
+```bash
+git push -u origin agent/catalog-connector-manifests
+```
+
+Open a draft PR describing the fallback behavior, the strict remote integrity rule, the disk-constrained local verification, and CI evidence.
+
+- [ ] **Step 6: Merge only after CI and catalog deployment validate the exact SHA**
+
+Use the GitHub merge workflow after all required checks pass. Trigger/observe the catalog deployment, then fetch a deployed A4988/SG90 record through the hosted MCP and confirm the returned connector names are authored names rather than `mating-face`.
+
+- [ ] **Step 7: Keep incomplete consumer devices unlisted**
+
+Do not publish the Plotter or Ereader merely because their catalog parts now exist. The Plotter still needs a real mechanism graph and physical hardware decisions; the Ereader still needs the missing power/charging/programming BOM and durable LabWired evidence.

--- a/docs/superpowers/plans/2026-07-22-catalog-connector-manifests.md
+++ b/docs/superpowers/plans/2026-07-22-catalog-connector-manifests.md
@@ -623,23 +623,28 @@ outer envelope plus documented canonical harness-contact proxies: the Luxor
 87897 drawing does not locate its output shaft. The generated catalog ingest
 remains deferred to CI because local free disk is below 1 GiB.
 
-- [ ] **Step 5: Commit universal component sources**
+- [x] **Step 5: Commit universal component sources**
 
 ```bash
 git add scripts/parts/authored/a4988-stepstick-carrier.kcad.ts scripts/parts/authored/sg90-micro-servo.kcad.ts scripts/electronics-parts.json scripts/universalElectronicsParts.test.ts
 git commit -m "feat(catalog): add universal motor-control components"
 ```
 
+Completed as `542bf61 feat(catalog): add universal motor-control components`.
+
 ### Task 8: Verify, review, publish, and only then use components in projects
 
 **Files:**
 - Verify: files modified in Tasks 1–6
 
-- [ ] **Step 1: Check the exact change set**
+- [x] **Step 1: Check the exact change set**
 
 Run: `git diff origin/develop...HEAD --check`
 
 Expected: no whitespace errors and no changes outside the manifest pipeline, universal parts, and their tests.
+
+Completed after the component commit: `git diff origin/develop...HEAD --check`
+reported no whitespace errors.
 
 - [x] **Step 2: Run focused tests without the artifact-generating `pretest` hook**
 

--- a/docs/superpowers/specs/2026-07-22-catalog-connector-manifests-design.md
+++ b/docs/superpowers/specs/2026-07-22-catalog-connector-manifests-design.md
@@ -48,9 +48,22 @@ Validation rules:
 
 The initial version deliberately supports only numeric `frame` and `axis` connectors. Topology-backed, `planar`, and `ball` connector origins cannot remain stable outside the originating capture graph and are rejected by authored export.
 
+## Assembly mating bridge
+
+An attached interface must be more than a display label. The existing session auto-connector map is a lossy discovery cache and is not automatically part of an assembly's mate resolver. A separate typed `catalogConnectors` map, keyed by fetched Shape id, stores the verified `ConnectorEntry[]` exactly as declared in the manifest. It keeps `frame` versus `axis` semantics and never mixes a factual catalog interface with a generic generated frame. When `assembly.part(name, fetchedShape)` is called, KernelCAD promotes only that typed payload into both compatible assembly connector forms:
+
+- the legacy inline frame map, so `partRef.connector(name)` can be used for connection placement;
+- the mate-style connector array, so `assembly.mate('...', 'part.interface', 'other.interface', ...)` resolves directly.
+
+Generic STEP-synthesized connectors remain discovery aids and are not promoted automatically. This distinction prevents a guessed bounding-box face from being represented as a factual component interface. A duplicate between an explicit assembly connector and an authored catalog interface is a capture-time error, so neither source silently overrides the other.
+
+The bridge applies any existing rigid `Shape.translate()` and `Shape.rotate()` transforms to catalog frames before registering them. It rejects scale and reflection on a catalog-attached Shape because they would invalidate a universal component's physical interface rather than merely place it. Boolean, mirror, pattern, and other derived shapes have a new feature id and intentionally do not inherit catalog interfaces in this first slice.
+
 ## Authoring and universal-component policy
 
-The export helper reads the returned `Scene`, converts each numeric connector to the exported world coordinate system using `ScenePart.worldTransform`, and writes a manifest with globally unique names. This avoids copying coordinates by hand while preserving the same world frame used in the STEP export.
+The export helper derives coordinates from the recomputed `SceneBackend` and the matching `assemblyPart` records, not from capture-time `ScenePart.worldTransform` alone. `assembly.part(..., { at })` is baked into the lowered part shape before the SceneBackend applies its world transform, so the exact transform used by STEP export is `worldTransform ∘ translate(assemblyPart.at)`. The helper applies that transform to every numeric origin and direction. It rejects a connector that cannot be mapped unambiguously to one direct assembly part.
+
+Version 1 permits direct, mate-free component assemblies only. It rejects scenes with mates or joint-driven source records rather than emitting potentially stale frames. This supports multi-solid universal component models and explicit `at` placements while avoiding a false claim that a dynamic mechanism has one fixed catalog interface pose.
 
 The first universal components that use this path are the A4988 StepStick-compatible carrier and SG90-class micro servo. Their interfaces describe only modeled and source-supported features:
 

--- a/docs/superpowers/specs/2026-07-22-catalog-connector-manifests-design.md
+++ b/docs/superpowers/specs/2026-07-22-catalog-connector-manifests-design.md
@@ -23,7 +23,7 @@ authored Scene .connector() frames
   -> catalog detail/index record
   -> remote adapter validation
   -> verified STEP download
-  -> exact session auto-connectors
+  -> exact typed session catalog interfaces (plus a legacy discovery projection)
 ```
 
 If a record has no manifest, the existing geometry inspection and generic connector synthesis remain unchanged. If a manifest is present but invalid, mismatched with the record identity, or bound to a different SHA-256, ingest/fetch must fail rather than silently replace it with guessed frames.
@@ -39,7 +39,7 @@ interface HashBoundConnectorManifest extends ConnectorManifest {
 Validation rules:
 
 - schema version remains exactly `1`;
-- `partId`, `family`, and all connector names are non-empty and safe for the existing topology-reference grammar;
+- `partId` and `family` are non-empty and exactly match the consuming catalog record; all connector names are safe for the existing topology-reference grammar;
 - connector names are unique globally within a manifest;
 - each origin and frame/axis direction is a finite numeric three-vector;
 - every normal/axis is non-zero;
@@ -57,7 +57,7 @@ An attached interface must be more than a display label. The existing session au
 
 Generic STEP-synthesized connectors remain discovery aids and are not promoted automatically. This distinction prevents a guessed bounding-box face from being represented as a factual component interface. A duplicate between an explicit assembly connector and an authored catalog interface is a capture-time error, so neither source silently overrides the other.
 
-The bridge applies any existing rigid `Shape.translate()` and `Shape.rotate()` transforms to catalog frames before registering them. It rejects scale and reflection on a catalog-attached Shape because they would invalidate a universal component's physical interface rather than merely place it. Boolean, mirror, pattern, and other derived shapes have a new feature id and intentionally do not inherit catalog interfaces in this first slice.
+The bridge applies any existing literal rigid `Shape.translate()` and `Shape.rotate()` transforms to catalog frames before registering them. It rejects scale, reflection, and parameter-driven transforms on a catalog-attached Shape because they would invalidate or later desynchronize a universal component's physical interface rather than merely place it. Boolean, mirror, pattern, and other derived shapes have a new feature id and intentionally do not inherit catalog interfaces in this first slice. `subAssembly()` carries already-promoted interfaces forward without attempting a second promotion.
 
 ## Authoring and universal-component policy
 

--- a/docs/superpowers/specs/2026-07-22-catalog-connector-manifests-design.md
+++ b/docs/superpowers/specs/2026-07-22-catalog-connector-manifests-design.md
@@ -1,0 +1,79 @@
+# Catalog Connector Manifests Design
+
+**Decision status:** Approved by the user's repeated direction to implement universal, component-aware catalog parts and to proceed autonomously.
+
+**Problem:** A catalog part can be a real imported STEP model but lose its authored mating interfaces when it crosses the ingest, remote-catalog, and fetch boundaries. The runtime then invents generic box and hole frames from the exported geometry. That is useful only as a fallback; it does not make an electronic carrier, servo, or other universal catalog component component-aware.
+
+## Options considered
+
+1. **Keep generic STEP synthesis only.** It needs no schema changes but cannot represent electrical contacts, board seating planes, or a servo output axis honestly.
+2. **Hand-maintain unbound JSON frames in each remote record.** It is easy to add, but a regenerated STEP can silently move the geometry while retaining stale frames.
+3. **Use a hash-bound authored connector manifest (selected).** A source model exports numeric, named frame/axis connectors to a sidecar; ingestion binds the sidecar to the exact STEP SHA-256; the remote fetcher verifies and attaches those interfaces. Generic synthesis remains available only where no authored manifest exists.
+
+## Architecture
+
+`ConnectorManifest` remains the version-1 authoring format for local bundled sidecars. A `HashBoundConnectorManifest` adds `geometrySha256`; it is the only form a remote catalog may advertise. The canonical remote record carries it alongside the existing discovery-only `connectors` string list.
+
+The source-to-runtime path is:
+
+```text
+authored Scene .connector() frames
+  -> numeric manifest sidecar
+  -> STEP export + SHA-256 binding during ingest
+  -> catalog detail/index record
+  -> remote adapter validation
+  -> verified STEP download
+  -> exact session auto-connectors
+```
+
+If a record has no manifest, the existing geometry inspection and generic connector synthesis remain unchanged. If a manifest is present but invalid, mismatched with the record identity, or bound to a different SHA-256, ingest/fetch must fail rather than silently replace it with guessed frames.
+
+## Manifest contract
+
+```ts
+interface HashBoundConnectorManifest extends ConnectorManifest {
+  geometrySha256: string;
+}
+```
+
+Validation rules:
+
+- schema version remains exactly `1`;
+- `partId`, `family`, and all connector names are non-empty and safe for the existing topology-reference grammar;
+- connector names are unique globally within a manifest;
+- each origin and frame/axis direction is a finite numeric three-vector;
+- every normal/axis is non-zero;
+- `geometrySha256` is lowercase hexadecimal with exactly 64 characters;
+- the bound part id, family, and geometry hash exactly match the catalog record being consumed.
+
+The initial version deliberately supports only numeric `frame` and `axis` connectors. Topology-backed, `planar`, and `ball` connector origins cannot remain stable outside the originating capture graph and are rejected by authored export.
+
+## Authoring and universal-component policy
+
+The export helper reads the returned `Scene`, converts each numeric connector to the exported world coordinate system using `ScenePart.worldTransform`, and writes a manifest with globally unique names. This avoids copying coordinates by hand while preserving the same world frame used in the STEP export.
+
+The first universal components that use this path are the A4988 StepStick-compatible carrier and SG90-class micro servo. Their interfaces describe only modeled and source-supported features:
+
+- A4988: actual plated through-hole contacts and the carrier solder-side seating plane; no fictional mounting holes or project-specific X/Y motor labels.
+- SG90: the three modeled cable-contact faces and an explicitly envelope-only output-axis alignment; no universal horn spline, torque, or mounting-hole claim until a selected, source-verified variant supports one.
+
+## Error handling and compatibility
+
+Bundled local sidecars still use unbound `ConnectorManifest` and retain their existing best-effort attachment semantics. Remote manifests are a stronger contract: they are verified after byte integrity verification and before import enrichment. A malformed or mismatched advertised manifest is a catalog integrity failure, not a reason to fall back to generic frames.
+
+Third-party records that do not advertise a manifest remain compatible and receive the existing generic synthesized connectors at fetch time.
+
+## Testing strategy
+
+Each behavior is driven test-first:
+
+- shared manifest tests cover hashes, binding, duplicate names, finite vectors, and zero directions;
+- adapter tests prove a valid remote manifest survives mapping and exposes authored names;
+- ingest tests prove a raw sidecar becomes bound to the exact emitted STEP hash;
+- fetch tests prove manifest-backed parts attach exact interfaces without running generic synthesis, while no-manifest parts keep synthesis;
+- Scene-export tests prove transforms are applied and unsupported connector origins reject;
+- authored-part tests assert the A4988/SG90 manifests contain only factual, stable interfaces.
+
+## Scope boundary
+
+This design fixes catalog interface provenance. It does not claim that a device is LabWired-proven, does not alter ProtoCat publication state, and does not fabricate unavailable power, charger, programmer, belt, or mounting hardware. Those are separate evidence and hardware-design decisions.

--- a/scripts/electronics-parts.json
+++ b/scripts/electronics-parts.json
@@ -407,6 +407,26 @@
       "attribution": "kernelCAD authored model (kernelCAD contributors)"
     },
     {
+      "id": "a4988-stepstick-carrier",
+      "name": "A4988 StepStick carrier (Pololu #2128 Black Edition)",
+      "family": "stepper-driver",
+      "mpn": "Pololu #2128",
+      "kcad_source": "scripts/parts/authored/a4988-stepstick-carrier.kcad.ts",
+      "tags": ["stepper-driver", "a4988", "stepstick", "carrier", "motor-control", "pololu"],
+      "license": "MIT",
+      "attribution": "kernelCAD authored mechanical model; dimensions and pinout from Pololu #2128: https://www.pololu.com/product/2128, https://www.pololu.com/file/0J1081/a4988-stepper-motor-driver-carrier-black-edition-dimension-diagram.pdf, and https://www.pololu.com/file/0J1225/a4988-stepper-motor-driver-carrier-black-edition.step"
+    },
+    {
+      "id": "sg90-micro-servo",
+      "name": "SG90 micro servo (Luxor Parts 87897)",
+      "family": "micro-servo",
+      "mpn": "Luxor Parts 87897 (SG90)",
+      "kcad_source": "scripts/parts/authored/sg90-micro-servo.kcad.ts",
+      "tags": ["servo", "micro-servo", "sg90", "pwm", "actuator"],
+      "license": "MIT",
+      "attribution": "kernelCAD authored conservative mechanical envelope and canonical harness-contact proxies; dimensions and cable convention from Luxor Parts 87897 data sheet (which does not establish a shaft or mounting datum): https://www.kjell.com/globalassets/mediaassets/701916_87897_datasheet_en.pdf"
+    },
+    {
       "id": "nrf54l15-qfn48",
       "name": "Nordic nRF54L15 QFN48 (QFAA) SoC package",
       "family": "MCU",

--- a/scripts/ingestElectronics.test.ts
+++ b/scripts/ingestElectronics.test.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  execFileSync: vi.fn(),
+  ingestDirectory: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({ execFileSync: mocks.execFileSync }));
+vi.mock('./ingestParts', () => ({ ingestDirectory: mocks.ingestDirectory }));
+
+import { authoredExportArgs, ingestElectronics } from './ingestElectronics';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  mocks.execFileSync.mockReset();
+  mocks.ingestDirectory.mockReset();
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function createTemporaryDirectory(prefix: string): string {
+  const directory = mkdtempSync(join(tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+describe('ingestElectronics', () => {
+  it('requests a connector manifest when exporting an authored catalog part', () => {
+    expect(authoredExportArgs(
+      '/repo/dist/cli/index.js',
+      '/repo/part.kcad.ts',
+      '/tmp/part.step',
+      '/tmp/part.manifest.json',
+      { id: 'a4988-stepstick-carrier', family: 'stepper-driver' },
+    )).toEqual([
+      '/repo/dist/cli/index.js',
+      'export',
+      'step',
+      '/repo/part.kcad.ts',
+      '-o',
+      '/tmp/part.step',
+      '--connector-manifest',
+      '/tmp/part.manifest.json',
+      '--manifest-part-id',
+      'a4988-stepstick-carrier',
+      '--manifest-family',
+      'stepper-driver',
+    ]);
+  });
+
+  it('places the CLI-produced authored manifest in the generated ingest sidecar', async () => {
+    const repoRoot = createTemporaryDirectory('kc-electronics-authored-');
+    const manifestPath = join(repoRoot, 'scripts', 'electronics-parts.json');
+    const outDir = createTemporaryDirectory('kc-electronics-out-');
+    const exportedManifest = {
+      schemaVersion: 1,
+      partId: 'a4988-stepstick-carrier',
+      family: 'stepper-driver',
+      connectors: [{
+        name: 'carrier-solder-face',
+        type: 'frame',
+        origin: [1, 2, 3],
+        normal: [0, 0, 1],
+      }],
+    };
+    mkdirSync(join(repoRoot, 'scripts'), { recursive: true });
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        baseModelUrl: 'https://parts.example',
+        license: 'CC-BY-4.0',
+        attribution: 'fixture',
+        parts: [{
+          id: 'a4988-stepstick-carrier',
+          name: 'A4988 carrier',
+          family: 'stepper-driver',
+          mpn: 'A4988',
+          kcad_source: 'scripts/parts/authored/a4988-stepstick-carrier.kcad.ts',
+        }],
+      }),
+    );
+
+    mocks.execFileSync.mockImplementation((_: string, args: string[]) => {
+      const stepOut = args[args.indexOf('-o') + 1];
+      writeFileSync(stepOut, 'ISO-10303-21;\nEND-ISO-10303-21;\n');
+      const manifestIndex = args.indexOf('--connector-manifest');
+      if (manifestIndex >= 0) {
+        writeFileSync(args[manifestIndex + 1], JSON.stringify(exportedManifest));
+      }
+    });
+
+    let generatedSidecar: unknown;
+    mocks.ingestDirectory.mockImplementation(async (src: string, temporaryOut: string) => {
+      temporaryDirectories.push(src, temporaryOut);
+      generatedSidecar = JSON.parse(
+        readFileSync(join(src, 'a4988-stepstick-carrier.meta.json'), 'utf8'),
+      );
+      return [];
+    });
+
+    await ingestElectronics(manifestPath, outDir, 'https://catalog.example');
+
+    expect(generatedSidecar).toMatchObject({
+      id: 'a4988-stepstick-carrier',
+      family: 'stepper-driver',
+      connectorManifest: exportedManifest,
+    });
+  });
+});

--- a/scripts/ingestElectronics.test.ts
+++ b/scripts/ingestElectronics.test.ts
@@ -11,7 +11,10 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('node:child_process', () => ({ execFileSync: mocks.execFileSync }));
-vi.mock('./ingestParts', () => ({ ingestDirectory: mocks.ingestDirectory }));
+vi.mock('./ingestParts', () => ({
+  AuthoredManifestError: class AuthoredManifestError extends Error {},
+  ingestDirectory: mocks.ingestDirectory,
+}));
 
 import { authoredExportArgs, ingestElectronics } from './ingestElectronics';
 
@@ -113,5 +116,137 @@ describe('ingestElectronics', () => {
       family: 'stepper-driver',
       connectorManifest: exportedManifest,
     });
+  });
+
+  it('fails the release when an authored STEP lacks its required connector manifest', async () => {
+    const repoRoot = createTemporaryDirectory('kc-electronics-missing-manifest-');
+    const manifestPath = join(repoRoot, 'scripts', 'electronics-parts.json');
+    const outDir = createTemporaryDirectory('kc-electronics-out-');
+    mkdirSync(join(repoRoot, 'scripts'), { recursive: true });
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        baseModelUrl: 'https://parts.example',
+        license: 'CC-BY-4.0',
+        attribution: 'fixture',
+        parts: [{
+          id: 'a4988-stepstick-carrier',
+          name: 'A4988 carrier',
+          family: 'stepper-driver',
+          mpn: 'A4988',
+          kcad_source: 'scripts/parts/authored/a4988-stepstick-carrier.kcad.ts',
+        }],
+      }),
+    );
+    mocks.execFileSync.mockImplementation((_: string, args: string[]) => {
+      const stepOut = args[args.indexOf('-o') + 1];
+      writeFileSync(stepOut, 'ISO-10303-21;\nEND-ISO-10303-21;\n');
+    });
+    mocks.ingestDirectory.mockResolvedValue([]);
+
+    await expect(ingestElectronics(manifestPath, outDir, 'https://catalog.example'))
+      .rejects.toThrow(/authored connector manifest/i);
+    expect(mocks.ingestDirectory).not.toHaveBeenCalled();
+  });
+
+  it('fails the release before ingestion when an authored manifest has another part identity', async () => {
+    const repoRoot = createTemporaryDirectory('kc-electronics-wrong-manifest-');
+    const manifestPath = join(repoRoot, 'scripts', 'electronics-parts.json');
+    const outDir = createTemporaryDirectory('kc-electronics-out-');
+    mkdirSync(join(repoRoot, 'scripts'), { recursive: true });
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        baseModelUrl: 'https://parts.example',
+        license: 'CC-BY-4.0',
+        attribution: 'fixture',
+        parts: [{
+          id: 'a4988-stepstick-carrier',
+          name: 'A4988 carrier',
+          family: 'stepper-driver',
+          mpn: 'A4988',
+          kcad_source: 'scripts/parts/authored/a4988-stepstick-carrier.kcad.ts',
+        }],
+      }),
+    );
+    mocks.execFileSync.mockImplementation((_: string, args: string[]) => {
+      const stepOut = args[args.indexOf('-o') + 1];
+      const sidecarOut = args[args.indexOf('--connector-manifest') + 1];
+      writeFileSync(stepOut, 'ISO-10303-21;\nEND-ISO-10303-21;\n');
+      writeFileSync(sidecarOut, JSON.stringify({
+        schemaVersion: 1,
+        partId: 'different-part',
+        family: 'stepper-driver',
+        connectors: [],
+      }));
+    });
+    mocks.ingestDirectory.mockResolvedValue([]);
+
+    await expect(ingestElectronics(manifestPath, outDir, 'https://catalog.example'))
+      .rejects.toThrow(/does not match catalog identity/i);
+    expect(mocks.ingestDirectory).not.toHaveBeenCalled();
+  });
+
+  it('fails the release when a failed authored CLI export has already written STEP', async () => {
+    const repoRoot = createTemporaryDirectory('kc-electronics-cli-after-step-');
+    const manifestPath = join(repoRoot, 'scripts', 'electronics-parts.json');
+    const outDir = createTemporaryDirectory('kc-electronics-out-');
+    mkdirSync(join(repoRoot, 'scripts'), { recursive: true });
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        baseModelUrl: 'https://parts.example',
+        license: 'CC-BY-4.0',
+        attribution: 'fixture',
+        parts: [{
+          id: 'a4988-stepstick-carrier',
+          name: 'A4988 carrier',
+          family: 'stepper-driver',
+          mpn: 'A4988',
+          kcad_source: 'scripts/parts/authored/a4988-stepstick-carrier.kcad.ts',
+        }],
+      }),
+    );
+    mocks.execFileSync.mockImplementation((_: string, args: string[]) => {
+      const stepOut = args[args.indexOf('-o') + 1];
+      writeFileSync(stepOut, 'ISO-10303-21;\nEND-ISO-10303-21;\n');
+      throw new Error('connector sidecar export failed');
+    });
+
+    await expect(ingestElectronics(manifestPath, outDir, 'https://catalog.example'))
+      .rejects.toThrow(/without a successful connector-manifest export/i);
+    expect(mocks.ingestDirectory).not.toHaveBeenCalled();
+  });
+
+  it('fails the release before ingestion when an authored manifest is malformed', async () => {
+    const repoRoot = createTemporaryDirectory('kc-electronics-malformed-manifest-');
+    const manifestPath = join(repoRoot, 'scripts', 'electronics-parts.json');
+    const outDir = createTemporaryDirectory('kc-electronics-out-');
+    mkdirSync(join(repoRoot, 'scripts'), { recursive: true });
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        baseModelUrl: 'https://parts.example',
+        license: 'CC-BY-4.0',
+        attribution: 'fixture',
+        parts: [{
+          id: 'a4988-stepstick-carrier',
+          name: 'A4988 carrier',
+          family: 'stepper-driver',
+          mpn: 'A4988',
+          kcad_source: 'scripts/parts/authored/a4988-stepstick-carrier.kcad.ts',
+        }],
+      }),
+    );
+    mocks.execFileSync.mockImplementation((_: string, args: string[]) => {
+      const stepOut = args[args.indexOf('-o') + 1];
+      const sidecarOut = args[args.indexOf('--connector-manifest') + 1];
+      writeFileSync(stepOut, 'ISO-10303-21;\nEND-ISO-10303-21;\n');
+      writeFileSync(sidecarOut, '{not JSON');
+    });
+
+    await expect(ingestElectronics(manifestPath, outDir, 'https://catalog.example'))
+      .rejects.toThrow(/invalid authored connector manifest/i);
+    expect(mocks.ingestDirectory).not.toHaveBeenCalled();
   });
 });

--- a/scripts/ingestElectronics.ts
+++ b/scripts/ingestElectronics.ts
@@ -24,7 +24,11 @@ import { join, resolve, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { unzipSync } from 'fflate';
-import { ingestDirectory, type CatalogRecord } from './ingestParts';
+import {
+  AuthoredManifestError,
+  ingestDirectory,
+  type CatalogRecord,
+} from './ingestParts';
 import {
   loadConnectorManifest,
   type ConnectorManifest,
@@ -155,16 +159,41 @@ export async function ingestElectronics(
           authoredExportArgs(cliPath, scriptPath, stepOut, manifestOut, part),
           { stdio: ['ignore', 'pipe', 'pipe'], timeout: 120_000 },
         );
-        if (!existsSync(manifestOut)) {
-          throw new Error(`kernelcad export did not write connector manifest ${manifestOut}`);
-        }
-        connectorManifest = loadConnectorManifest(manifestOut);
       } catch (e) {
+        if (existsSync(stepOut)) {
+          throw new AuthoredManifestError(
+            `ingestElectronics: authored STEP '${part.id}' was written without a successful connector-manifest export`,
+            { cause: e },
+          );
+        }
         const err = e as { stderr?: Buffer; message?: string };
         const detail = err.stderr?.toString().trim() || err.message || String(e);
         console.warn(`SKIP ${part.id}: kernelcad export failed — ${detail}`);
         continue;
       }
+      if (!existsSync(manifestOut)) {
+        throw new AuthoredManifestError(
+          `ingestElectronics: authored connector manifest missing for '${part.id}'`,
+        );
+      }
+      let loadedManifest: ConnectorManifest;
+      try {
+        loadedManifest = loadConnectorManifest(manifestOut);
+      } catch (e) {
+        throw new AuthoredManifestError(
+          `ingestElectronics: invalid authored connector manifest for '${part.id}'`,
+          { cause: e },
+        );
+      }
+      if (
+        loadedManifest.partId !== part.id ||
+        loadedManifest.family !== part.family
+      ) {
+        throw new AuthoredManifestError(
+          `ingestElectronics: authored connector manifest identity ${loadedManifest.partId}/${loadedManifest.family} does not match catalog identity ${part.id}/${part.family}`,
+        );
+      }
+      connectorManifest = loadedManifest;
       buf = readFileSync(stepOut);
       if (!buf.subarray(0, 64).toString('latin1').includes('ISO-10303-21')) {
         console.warn(`SKIP ${part.id}: exported file is not a STEP file`);

--- a/scripts/ingestElectronics.ts
+++ b/scripts/ingestElectronics.ts
@@ -25,6 +25,10 @@ import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { unzipSync } from 'fflate';
 import { ingestDirectory, type CatalogRecord } from './ingestParts';
+import {
+  loadConnectorManifest,
+  type ConnectorManifest,
+} from '../src/shared/parts/connectorManifest';
 
 /**
  * Some vendors (e.g. Raspberry Pi) serve their STEP model inside a ZIP rather
@@ -78,6 +82,30 @@ interface Manifest {
   parts: ManifestPart[];
 }
 
+/** Build the exact CLI request that exports an authored STEP and its interfaces. */
+export function authoredExportArgs(
+  cliPath: string,
+  scriptPath: string,
+  stepOut: string,
+  manifestOut: string,
+  part: { id: string; family: string },
+): string[] {
+  return [
+    cliPath,
+    'export',
+    'step',
+    scriptPath,
+    '-o',
+    stepOut,
+    '--connector-manifest',
+    manifestOut,
+    '--manifest-part-id',
+    part.id,
+    '--manifest-family',
+    part.family,
+  ];
+}
+
 function parseArgs(argv: string[]) {
   const out = { outDir: '', manifest: 'scripts/electronics-parts.json', baseUrl: 'https://kernelcad-parts.pages.dev' };
   const rest: string[] = [];
@@ -112,19 +140,25 @@ export async function ingestElectronics(
   let ok = 0;
   for (const part of manifest.parts) {
     let buf: Buffer;
+    let connectorManifest: ConnectorManifest | undefined;
 
     if (part.kcad_source) {
       // Authored model: compile the .kcad.ts script to STEP using the kernelCAD CLI.
       const scriptPath = resolve(repoRoot, part.kcad_source);
       const stepOut = join(src, `${part.id}.step`);
+      const manifestOut = join(src, `${part.id}.connector-manifest.json`);
       try {
         // CLI signature is positional: `export <format> <file> -o <out>`
         // (there is no `-f` flag). Capture stderr into the warning on failure.
         execFileSync(
           process.execPath,
-          [cliPath, 'export', 'step', scriptPath, '-o', stepOut],
+          authoredExportArgs(cliPath, scriptPath, stepOut, manifestOut, part),
           { stdio: ['ignore', 'pipe', 'pipe'], timeout: 120_000 },
         );
+        if (!existsSync(manifestOut)) {
+          throw new Error(`kernelcad export did not write connector manifest ${manifestOut}`);
+        }
+        connectorManifest = loadConnectorManifest(manifestOut);
       } catch (e) {
         const err = e as { stderr?: Buffer; message?: string };
         const detail = err.stderr?.toString().trim() || err.message || String(e);
@@ -173,6 +207,7 @@ export async function ingestElectronics(
           attributes: { mpn: part.mpn, ...(part.attributes ?? {}) },
           license: part.license ?? manifest.license,
           attribution: part.attribution ?? manifest.attribution,
+          ...(connectorManifest === undefined ? {} : { connectorManifest }),
         },
         null,
         2,

--- a/scripts/ingestParts.test.ts
+++ b/scripts/ingestParts.test.ts
@@ -11,16 +11,19 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { createHash } from 'node:crypto';
 import { OcctBackend, initOcct } from '../src/kernel/backends/occt/occtBackend';
 import { ingestDirectory, measureStepReport } from './ingestParts';
 import type { StepInspectReport } from '../src/agent/inspect/inspectStep';
 
 let tinyStepBytes: Buffer;
+let alternateTinyStepBytes: Buffer;
 const temporaryDirectories: string[] = [];
 
 beforeAll(async () => {
   await initOcct();
   tinyStepBytes = Buffer.from(await OcctBackend.box(4, 3, 2).exportSTEPAsync());
+  alternateTinyStepBytes = Buffer.from(await OcctBackend.box(5, 3, 2).exportSTEPAsync());
 });
 
 afterEach(() => {
@@ -36,15 +39,25 @@ function createTemporaryCatalogDirectories(): { src: string; out: string } {
   return { src, out };
 }
 
-function writeTinyStepFixture(src: string, sidecar?: unknown | string): void {
-  const partDir = join(src, 'electronics', 'driver');
+function writeStepFixture(
+  src: string,
+  pathParts: string[],
+  name: string,
+  bytes: Buffer,
+  sidecar?: unknown | string,
+): void {
+  const partDir = join(src, ...pathParts);
   mkdirSync(partDir, { recursive: true });
-  writeFileSync(join(partDir, 'driver.step'), tinyStepBytes);
+  writeFileSync(join(partDir, `${name}.step`), bytes);
   if (sidecar === undefined) return;
   writeFileSync(
-    join(partDir, 'driver.meta.json'),
+    join(partDir, `${name}.meta.json`),
     typeof sidecar === 'string' ? sidecar : JSON.stringify(sidecar),
   );
+}
+
+function writeTinyStepFixture(src: string, sidecar?: unknown | string): void {
+  writeStepFixture(src, ['electronics', 'driver'], 'driver', tinyStepBytes, sidecar);
 }
 
 const INGEST_OPTS = {
@@ -172,6 +185,10 @@ describe('ingestParts', () => {
       ...connectorManifest,
       geometrySha256: record.sha256,
     });
+    const emittedStepSha256 = createHash('sha256')
+      .update(readFileSync(join(out, 'step', 'driver.step')))
+      .digest('hex');
+    expect(emittedStepSha256).toBe(record.connectorManifest?.geometrySha256);
     expect(record.connectors).toEqual([
       { name: 'mount-face', origin: [1, 2, 3], axis: [0, 0, 1] },
       { name: 'pin-axis', origin: [4, 5, 6], axis: [1, 0, 0] },
@@ -235,5 +252,29 @@ describe('ingestParts', () => {
 
   it('rejects malformed sidecar JSON instead of skipping the part', async () => {
     await expectAuthoredSidecarFailure('{ this is not JSON }');
+  });
+
+  it('fails before writing output when different folders derive the same catalog ID', async () => {
+    const { src, out } = createTemporaryCatalogDirectories();
+    writeStepFixture(src, ['electronics', 'driver-a'], 'shared', tinyStepBytes);
+    writeStepFixture(src, ['mechanical', 'driver-b'], 'shared', alternateTinyStepBytes);
+
+    await expect(ingestDirectory(src, out, INGEST_OPTS)).rejects.toMatchObject({
+      name: 'DuplicateCatalogIdError',
+    });
+    expect(existsSync(join(out, 'step'))).toBe(false);
+    expect(existsSync(join(out, 'v1', 'catalog', 'parts.index.json'))).toBe(false);
+  });
+
+  it('fails before writing output when sidecars assign the same catalog ID', async () => {
+    const { src, out } = createTemporaryCatalogDirectories();
+    writeStepFixture(src, ['electronics', 'driver-a'], 'first', tinyStepBytes, { id: 'shared' });
+    writeStepFixture(src, ['mechanical', 'driver-b'], 'second', alternateTinyStepBytes, { id: 'shared' });
+
+    await expect(ingestDirectory(src, out, INGEST_OPTS)).rejects.toMatchObject({
+      name: 'DuplicateCatalogIdError',
+    });
+    expect(existsSync(join(out, 'step'))).toBe(false);
+    expect(existsSync(join(out, 'v1', 'catalog', 'parts.index.json'))).toBe(false);
   });
 });

--- a/scripts/ingestParts.test.ts
+++ b/scripts/ingestParts.test.ts
@@ -1,12 +1,57 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
-import { describe, it, expect } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { afterEach, beforeAll, describe, it, expect } from 'vitest';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { OcctBackend, initOcct } from '../src/kernel/backends/occt/occtBackend';
 import { ingestDirectory, measureStepReport } from './ingestParts';
 import type { StepInspectReport } from '../src/agent/inspect/inspectStep';
+
+let tinyStepBytes: Buffer;
+const temporaryDirectories: string[] = [];
+
+beforeAll(async () => {
+  await initOcct();
+  tinyStepBytes = Buffer.from(await OcctBackend.box(4, 3, 2).exportSTEPAsync());
+});
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function createTemporaryCatalogDirectories(): { src: string; out: string } {
+  const src = mkdtempSync(join(tmpdir(), 'kc-ingest-src-'));
+  const out = mkdtempSync(join(tmpdir(), 'kc-ingest-out-'));
+  temporaryDirectories.push(src, out);
+  return { src, out };
+}
+
+function writeTinyStepFixture(src: string, sidecar?: unknown | string): void {
+  const partDir = join(src, 'electronics', 'driver');
+  mkdirSync(partDir, { recursive: true });
+  writeFileSync(join(partDir, 'driver.step'), tinyStepBytes);
+  if (sidecar === undefined) return;
+  writeFileSync(
+    join(partDir, 'driver.meta.json'),
+    typeof sidecar === 'string' ? sidecar : JSON.stringify(sidecar),
+  );
+}
+
+const INGEST_OPTS = {
+  baseUrl: 'https://parts.test',
+  license: 'CC-BY-3.0',
+  attribution: 'fixture',
+};
 
 describe('ingestParts', () => {
   it('measures assembly bounds without changing dominant-solid volume semantics', () => {
@@ -53,9 +98,7 @@ describe('ingestParts', () => {
   });
 
   it('ingests a STEP dir into a /v1/parts catalog with measured attrs + synthesized connectors', async () => {
-    await initOcct();
-    const src = mkdtempSync(join(tmpdir(), 'kc-ingest-src-'));
-    const out = mkdtempSync(join(tmpdir(), 'kc-ingest-out-'));
+    const { src, out } = createTemporaryCatalogDirectories();
 
     // A bored plate (through-hole) so synthesis emits bbox faces + a bore.
     const plate = OcctBackend.box(40, 40, 5).subtract(
@@ -66,11 +109,7 @@ describe('ingestParts', () => {
     mkdirSync(join(src, 'bracket', 'mount'), { recursive: true });
     writeFileSync(join(src, 'bracket', 'mount', 'mount-plate.step'), Buffer.from(bytes));
 
-    const records = await ingestDirectory(src, out, {
-      baseUrl: 'https://parts.test',
-      license: 'CC-BY-3.0',
-      attribution: 'fixture',
-    });
+    const records = await ingestDirectory(src, out, INGEST_OPTS);
 
     expect(records).toHaveLength(1);
     const r = records[0];
@@ -89,6 +128,7 @@ describe('ingestParts', () => {
     expect(r.connectors.map((c) => c.name)).toEqual(
       expect.arrayContaining(['mating-face', 'top-face', 'bore']),
     );
+    expect(r.connectorManifest).toBeUndefined();
 
     // Deployable tree.
     expect(existsSync(join(out, 'step', 'mount-plate.step'))).toBe(true);
@@ -101,5 +141,99 @@ describe('ingestParts', () => {
     expect(index.items[0].id).toBe('mount-plate');
     const sha = JSON.parse(readFileSync(join(out, 'sha256-manifest.json'), 'utf8'));
     expect(sha['mount-plate']).toBe(r.sha256);
+  });
+
+  it('binds an authored connector sidecar to the emitted STEP bytes', async () => {
+    const { src, out } = createTemporaryCatalogDirectories();
+    const connectorManifest = {
+      schemaVersion: 1 as const,
+      partId: 'driver',
+      family: 'driver',
+      connectors: [
+        {
+          name: 'mount-face',
+          type: 'frame' as const,
+          origin: [1, 2, 3] as [number, number, number],
+          normal: [0, 0, 1] as [number, number, number],
+        },
+        {
+          name: 'pin-axis',
+          type: 'axis' as const,
+          origin: [4, 5, 6] as [number, number, number],
+          axis: [1, 0, 0] as [number, number, number],
+        },
+      ],
+    };
+    writeTinyStepFixture(src, { connectorManifest });
+
+    const [record] = await ingestDirectory(src, out, INGEST_OPTS);
+
+    expect(record.connectorManifest).toEqual({
+      ...connectorManifest,
+      geometrySha256: record.sha256,
+    });
+    expect(record.connectors).toEqual([
+      { name: 'mount-face', origin: [1, 2, 3], axis: [0, 0, 1] },
+      { name: 'pin-axis', origin: [4, 5, 6], axis: [1, 0, 0] },
+    ]);
+    expect(record.connectors.map((connector) => connector.name)).not.toContain('mating-face');
+
+    const detail = JSON.parse(
+      readFileSync(join(out, 'v1', 'parts', 'driver.json'), 'utf8'),
+    ) as { connectorManifest?: unknown };
+    const index = JSON.parse(
+      readFileSync(join(out, 'v1', 'catalog', 'parts.index.json'), 'utf8'),
+    ) as { items: Array<{ connectorManifest?: unknown }> };
+    expect(detail.connectorManifest).toEqual(record.connectorManifest);
+    expect(index.items[0].connectorManifest).toEqual(record.connectorManifest);
+  });
+
+  async function expectAuthoredSidecarFailure(sidecar: unknown | string): Promise<void> {
+    const { src, out } = createTemporaryCatalogDirectories();
+    writeTinyStepFixture(src, sidecar);
+
+    await expect(ingestDirectory(src, out, INGEST_OPTS)).rejects.toMatchObject({
+      name: 'AuthoredManifestError',
+    });
+    expect(existsSync(join(out, 'skipped.json'))).toBe(false);
+  }
+
+  it('rejects a malformed authored connector manifest instead of skipping it', async () => {
+    await expectAuthoredSidecarFailure({
+      connectorManifest: {
+        schemaVersion: 1,
+        partId: 'driver',
+        family: 'driver',
+        connectors: [
+          {
+            name: 'mount-face',
+            type: 'frame',
+            origin: [0, 0, 0],
+            normal: [0, 0, 0],
+          },
+        ],
+      },
+    });
+  });
+
+  it.each([
+    ['part id', 'other-driver', 'driver'],
+    ['family', 'driver', 'other-driver'],
+  ])(
+    'rejects an authored connector manifest with a mismatched %s',
+    async (_, partId, family) => {
+      await expectAuthoredSidecarFailure({
+        connectorManifest: {
+          schemaVersion: 1,
+          partId,
+          family,
+          connectors: [],
+        },
+      });
+    },
+  );
+
+  it('rejects malformed sidecar JSON instead of skipping the part', async () => {
+    await expectAuthoredSidecarFailure('{ this is not JSON }');
   });
 });

--- a/scripts/ingestParts.test.ts
+++ b/scripts/ingestParts.test.ts
@@ -277,4 +277,16 @@ describe('ingestParts', () => {
     expect(existsSync(join(out, 'step'))).toBe(false);
     expect(existsSync(join(out, 'v1', 'catalog', 'parts.index.json'))).toBe(false);
   });
+
+  it('rejects a numeric sidecar catalog ID before it can collide with a string ID', async () => {
+    const { src, out } = createTemporaryCatalogDirectories();
+    writeStepFixture(src, ['electronics', 'driver-a'], 'first', tinyStepBytes, { id: 1 });
+    writeStepFixture(src, ['mechanical', 'driver-b'], 'second', alternateTinyStepBytes, { id: '1' });
+
+    await expect(ingestDirectory(src, out, INGEST_OPTS)).rejects.toMatchObject({
+      name: 'AuthoredManifestError',
+    });
+    expect(existsSync(join(out, 'step'))).toBe(false);
+    expect(existsSync(join(out, 'v1', 'catalog', 'parts.index.json'))).toBe(false);
+  });
 });

--- a/scripts/ingestParts.ts
+++ b/scripts/ingestParts.ts
@@ -162,6 +162,17 @@ function loadSidecar(stepPath: string): IngestSidecar {
   }
 }
 
+/** Resolve the exact output ID and reject JSON values TypeScript cannot enforce. */
+function resolveCatalogId(stepPath: string, meta: IngestSidecar): string {
+  if (meta.id === undefined) return slugify(basename(stepPath, extname(stepPath)));
+  if (typeof meta.id !== 'string') {
+    throw new AuthoredManifestError(
+      `ingest: sidecar ${sidecarPathFor(stepPath)} id must be a string when provided`,
+    );
+  }
+  return meta.id;
+}
+
 /**
  * Refuse ambiguous output names before creating any catalog files.  The
  * sidecar is deliberately read here because an explicit id overrides the
@@ -171,7 +182,7 @@ function assertUniqueCatalogIds(stepFiles: string[], srcRoot: string): void {
   const pathsById = new Map<string, string>();
   for (const stepPath of stepFiles) {
     const meta = loadSidecar(stepPath);
-    const id = meta.id ?? slugify(basename(stepPath, extname(stepPath)));
+    const id = resolveCatalogId(stepPath, meta);
     const firstPath = pathsById.get(id);
     if (firstPath !== undefined) {
       throw new DuplicateCatalogIdError(id, firstPath, stepPath, srcRoot);
@@ -265,7 +276,7 @@ export async function ingestStepFile(
   const meta = loadSidecar(stepPath);
 
   const baseName = basename(stepPath, extname(stepPath));
-  const id = meta.id ?? slugify(baseName);
+  const id = resolveCatalogId(stepPath, meta);
   // Derive category/family from the source folder layout when no sidecar:
   // <srcRoot>/<category>/<family>/part.step
   const relParts = relative(srcRoot, dirname(stepPath)).split(/[\\/]/).filter(Boolean);

--- a/scripts/ingestParts.ts
+++ b/scripts/ingestParts.ts
@@ -36,6 +36,11 @@ import { join, relative, basename, extname, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
 import { inspectStepFile, type StepInspectReport } from '../src/agent/inspect/inspectStep';
 import { synthesizeConnectorsFromReport } from '../src/modeling/parts/synthesizeConnectors';
+import {
+  validateConnectorManifest,
+  validateHashBoundConnectorManifest,
+  type HashBoundConnectorManifest,
+} from '../src/shared/parts/connectorManifestSchema';
 import { PAGES_WORKER } from './parts/workerTemplate';
 import {
   isOcctOutOfMemory,
@@ -57,6 +62,16 @@ export interface IngestSidecar {
   attributes?: Record<string, number | string>;
   license?: string;
   attribution?: string;
+  /** Raw authoring-sidecar data; validated only after catalog identity is derived. */
+  connectorManifest?: unknown;
+}
+
+/** A bad authored interface must stop a catalog release instead of becoming a skip. */
+export class AuthoredManifestError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'AuthoredManifestError';
+  }
 }
 
 export interface CatalogRecord {
@@ -77,9 +92,11 @@ export interface CatalogRecord {
   byteSize: number;
   license: string;
   attribution?: string;
-  /** Pre-synthesized so a consumer can skip re-inspection; the runtime adapter
-   *  still re-synthesizes on fetch, so this is richness, not a contract. */
+  /** Legacy connector shape derived from authored interfaces when present, or
+   *  synthesized from geometry otherwise. */
   connectors: { name: string; origin: [number, number, number]; axis: [number, number, number] }[];
+  /** Authored interfaces bound to the exact emitted STEP bytes. */
+  connectorManifest?: HashBoundConnectorManifest;
 }
 
 export interface IngestOpts {
@@ -113,13 +130,57 @@ function listStepFiles(dir: string): string[] {
   return out;
 }
 
+function sidecarPathFor(stepPath: string): string {
+  return stepPath.replace(/\.(step|stp)$/i, '.meta.json');
+}
+
 function loadSidecar(stepPath: string): IngestSidecar {
-  const sidecar = stepPath.replace(/\.(step|stp)$/i, '.meta.json');
+  const sidecar = sidecarPathFor(stepPath);
   if (!existsSync(sidecar)) return {};
   try {
-    return JSON.parse(readFileSync(sidecar, 'utf8')) as IngestSidecar;
-  } catch {
-    return {};
+    const parsed = JSON.parse(readFileSync(sidecar, 'utf8')) as unknown;
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new AuthoredManifestError(`ingest: sidecar ${sidecar} must contain a JSON object`);
+    }
+    return parsed as IngestSidecar;
+  } catch (error) {
+    if (error instanceof AuthoredManifestError) throw error;
+    throw new AuthoredManifestError(`ingest: invalid JSON sidecar ${sidecar}`, {
+      cause: error,
+    });
+  }
+}
+
+function bindAuthoredConnectorManifest(
+  rawManifest: unknown,
+  stepPath: string,
+  id: string,
+  family: string,
+  sha256: string,
+): HashBoundConnectorManifest | undefined {
+  if (rawManifest === undefined) return undefined;
+  try {
+    validateConnectorManifest(rawManifest);
+    if (rawManifest.partId !== id || rawManifest.family !== family) {
+      throw new Error(
+        `manifest identity ${rawManifest.partId}/${rawManifest.family} does not match ${id}/${family}`,
+      );
+    }
+    const manifest: HashBoundConnectorManifest = {
+      ...rawManifest,
+      geometrySha256: sha256,
+    };
+    validateHashBoundConnectorManifest(manifest, {
+      partId: id,
+      family,
+      geometrySha256: sha256,
+    });
+    return manifest;
+  } catch (error) {
+    throw new AuthoredManifestError(
+      `ingest: invalid authored connector manifest in ${sidecarPathFor(stepPath)}`,
+      { cause: error },
+    );
   }
 }
 
@@ -182,10 +243,27 @@ export async function ingestStepFile(
   const rootName = slugify(basename(srcRoot)) || 'imported';
   const category = meta.category ?? relParts[0] ?? rootName;
   const family = meta.family ?? relParts[relParts.length - 1] ?? category;
+  const connectorManifest = bindAuthoredConnectorManifest(
+    meta.connectorManifest,
+    stepPath,
+    id,
+    family,
+    sha256,
+  );
 
   const report = await inspectStepFile(stepPath);
-  const conns = synthesizeConnectorsFromReport(report, id);
   const measured = measureStepReport(report);
+  const connectors = connectorManifest === undefined
+    ? synthesizeConnectorsFromReport(report, id).map((connector) => ({
+        name: connector.name,
+        origin: connector.origin,
+        axis: connector.axis,
+      }))
+    : connectorManifest.connectors.map((connector) => ({
+        name: connector.name,
+        origin: connector.origin,
+        axis: connector.type === 'axis' ? connector.axis : connector.normal,
+      }));
 
   const record: CatalogRecord = {
     id,
@@ -198,7 +276,8 @@ export async function ingestStepFile(
     sha256,
     byteSize: bytes.length,
     license: meta.license ?? opts.license,
-    connectors: conns.map((c) => ({ name: c.name, origin: c.origin, axis: c.axis })),
+    connectors,
+    ...(connectorManifest === undefined ? {} : { connectorManifest }),
   };
   if (meta.standard) record.standard = meta.standard;
   const attribution = meta.attribution ?? opts.attribution;
@@ -235,6 +314,7 @@ export async function ingestDirectory(
       records.push(record);
       shaManifest[record.id] = record.sha256;
     } catch (e) {
+      if (e instanceof AuthoredManifestError) throw e;
       // "Skip the bad file and carry on" is right for genuinely bad geometry
       // and WRONG for an exhausted kernel heap: once OCCT's wasm heap fills,
       // every remaining import in this process fails too, so a tolerant loop

--- a/scripts/ingestParts.ts
+++ b/scripts/ingestParts.ts
@@ -74,6 +74,17 @@ export class AuthoredManifestError extends Error {
   }
 }
 
+/** Duplicate output IDs would overwrite a STEP and make the catalog ambiguous. */
+export class DuplicateCatalogIdError extends Error {
+  constructor(id: string, firstPath: string, secondPath: string, srcRoot: string) {
+    super(
+      `ingestDirectory: duplicate catalog id '${id}' for ` +
+        `${relative(srcRoot, firstPath)} and ${relative(srcRoot, secondPath)}`,
+    );
+    this.name = 'DuplicateCatalogIdError';
+  }
+}
+
 export interface CatalogRecord {
   id: string;
   name: string;
@@ -148,6 +159,24 @@ function loadSidecar(stepPath: string): IngestSidecar {
     throw new AuthoredManifestError(`ingest: invalid JSON sidecar ${sidecar}`, {
       cause: error,
     });
+  }
+}
+
+/**
+ * Refuse ambiguous output names before creating any catalog files.  The
+ * sidecar is deliberately read here because an explicit id overrides the
+ * filename-derived default used by the emitted STEP and detail paths.
+ */
+function assertUniqueCatalogIds(stepFiles: string[], srcRoot: string): void {
+  const pathsById = new Map<string, string>();
+  for (const stepPath of stepFiles) {
+    const meta = loadSidecar(stepPath);
+    const id = meta.id ?? slugify(basename(stepPath, extname(stepPath)));
+    const firstPath = pathsById.get(id);
+    if (firstPath !== undefined) {
+      throw new DuplicateCatalogIdError(id, firstPath, stepPath, srcRoot);
+    }
+    pathsById.set(id, stepPath);
   }
 }
 
@@ -296,6 +325,7 @@ export async function ingestDirectory(
   opts: IngestOpts,
 ): Promise<CatalogRecord[]> {
   const stepFiles = listStepFiles(srcDir);
+  assertUniqueCatalogIds(stepFiles, srcDir);
   mkdirSync(join(outDir, 'step'), { recursive: true });
   mkdirSync(join(outDir, 'v1', 'parts'), { recursive: true });
   mkdirSync(join(outDir, 'v1', 'catalog'), { recursive: true });

--- a/scripts/parts/authored/a4988-stepstick-carrier.kcad.ts
+++ b/scripts/parts/authored/a4988-stepstick-carrier.kcad.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// Pololu #2128 A4988 StepStick stepper-motor-driver carrier, Black Edition.
+//
+// DIMENSION / INTERFACE SOURCES
+//   Carrier outline, plated-hole locations, 2.54 mm pitch, and board thickness:
+//   https://www.pololu.com/file/0J1081/a4988-stepper-motor-driver-carrier-black-edition-dimension-diagram.pdf
+//   Carrier identity, pinout, and header installation option:
+//   https://www.pololu.com/product/2128
+//   Vendor STEP for fitted-component placement and external envelopes:
+//   https://www.pololu.com/file/0J1225/a4988-stepper-motor-driver-carrier-black-edition.step
+//   A4988 28-contact QFN package envelope (5 × 5 × 0.90 mm):
+//   https://www.allegromicro.com/~/media/files/datasheets/a4988-datasheet.pdf
+//
+// The board ships with headers supplied but not fitted. This model therefore
+// exposes the actual plated through-hole pads, not imaginary installed pins.
+// Its connectors are the physical solder/contact faces; no plotter- or
+// machine-specific motor/controller abstraction is present.
+
+const PCB_X = 15.24;
+const PCB_Y = 20.32;
+const PCB_T = 1.57;
+const HOLE_D = 1.02;
+const PAD_D = 1.70;
+const ROW_LEFT_X = 1.27;
+const ROW_RIGHT_X = 13.97;
+const TOP_PIN_Y = 19.05;
+const PIN_PITCH = 2.54;
+
+const PCB_BLACK = '#17191d';
+const COPPER = '#c8a040';
+const IC_BLACK = '#17171c';
+const TRIMMER_BLUE = '#315b8a';
+
+// The official assembled STEP is the placement source for these external
+// envelopes. It puts the 5 × 5 mm QFN at (3.342, 8.803) and its 1.00 mm
+// assembled height above the PCB; the current-limit trimmer is a 1.5 mm
+// radius, 1.15 mm-high envelope at (8.727, 2.7905).
+const QFN_X = 3.342;
+const QFN_Y = 8.803;
+const QFN_H = 1.00;
+const TRIMMER_X = 8.727;
+const TRIMMER_Y = 2.7905;
+const TRIMMER_RADIUS = 1.5;
+const TRIMMER_H = 1.15;
+
+type CarrierPin = {
+  silkscreen: string;
+  part: string;
+  connector: string;
+  x: number;
+  y: number;
+};
+
+// The four phase terminals retain their printed labels in `silkscreen`, while
+// their authored connector names start with a letter as required by the
+// topology-name grammar.
+const pins: CarrierPin[] = [
+  { silkscreen: 'EN', part: 'contact-en', connector: 'en-contact', x: ROW_LEFT_X, y: TOP_PIN_Y },
+  { silkscreen: 'VMOT', part: 'contact-vmot', connector: 'vmot-contact', x: ROW_RIGHT_X, y: TOP_PIN_Y },
+  { silkscreen: 'MS1', part: 'contact-ms1', connector: 'ms1-contact', x: ROW_LEFT_X, y: TOP_PIN_Y - PIN_PITCH },
+  { silkscreen: 'GND', part: 'contact-gnd-motor', connector: 'gnd-motor-contact', x: ROW_RIGHT_X, y: TOP_PIN_Y - PIN_PITCH },
+  { silkscreen: 'MS2', part: 'contact-ms2', connector: 'ms2-contact', x: ROW_LEFT_X, y: TOP_PIN_Y - 2 * PIN_PITCH },
+  { silkscreen: '2B', part: 'contact-motor-2b', connector: 'motor-2b-contact', x: ROW_RIGHT_X, y: TOP_PIN_Y - 2 * PIN_PITCH },
+  { silkscreen: 'MS3', part: 'contact-ms3', connector: 'ms3-contact', x: ROW_LEFT_X, y: TOP_PIN_Y - 3 * PIN_PITCH },
+  { silkscreen: '2A', part: 'contact-motor-2a', connector: 'motor-2a-contact', x: ROW_RIGHT_X, y: TOP_PIN_Y - 3 * PIN_PITCH },
+  { silkscreen: 'RESET', part: 'contact-reset', connector: 'reset-contact', x: ROW_LEFT_X, y: TOP_PIN_Y - 4 * PIN_PITCH },
+  { silkscreen: '1A', part: 'contact-motor-1a', connector: 'motor-1a-contact', x: ROW_RIGHT_X, y: TOP_PIN_Y - 4 * PIN_PITCH },
+  { silkscreen: 'SLEEP', part: 'contact-sleep', connector: 'sleep-contact', x: ROW_LEFT_X, y: TOP_PIN_Y - 5 * PIN_PITCH },
+  { silkscreen: '1B', part: 'contact-motor-1b', connector: 'motor-1b-contact', x: ROW_RIGHT_X, y: TOP_PIN_Y - 5 * PIN_PITCH },
+  { silkscreen: 'STEP', part: 'contact-step', connector: 'step-contact', x: ROW_LEFT_X, y: TOP_PIN_Y - 6 * PIN_PITCH },
+  { silkscreen: 'GND', part: 'contact-gnd-logic', connector: 'gnd-logic-contact', x: ROW_RIGHT_X, y: TOP_PIN_Y - 6 * PIN_PITCH },
+  { silkscreen: 'DIR', part: 'contact-dir', connector: 'dir-contact', x: ROW_LEFT_X, y: TOP_PIN_Y - 7 * PIN_PITCH },
+  { silkscreen: 'VDD', part: 'contact-vdd', connector: 'vdd-contact', x: ROW_RIGHT_X, y: TOP_PIN_Y - 7 * PIN_PITCH },
+];
+
+const platedHoles = pins.map((pin) =>
+  cylinder(PCB_T + 2, HOLE_D / 2, 24).translate(pin.x, pin.y, -1),
+);
+const pcb = box(PCB_X, PCB_Y, PCB_T).subtract(...platedHoles).color(PCB_BLACK);
+
+function contactPad(pin: CarrierPin) {
+  // The annular ring is a modeled copper contact on the populated face. It
+  // deliberately stays separate from the board body so the interface has a
+  // factual owning solid even without an installed header.
+  return cylinder(0.08, PAD_D / 2, 32)
+    .subtract(cylinder(0.18, HOLE_D / 2, 24).translate(0, 0, -0.05))
+    .color(COPPER)
+    .translate(pin.x, pin.y, PCB_T);
+}
+
+// The package size is data-sheet sourced; its fitted placement is taken from
+// the official carrier STEP. No electrical connector is inferred from either.
+const a4988Qfn = box(5.0, 5.0, QFN_H)
+  .color(IC_BLACK)
+  .translate(QFN_X, QFN_Y, PCB_T);
+
+// The vendor STEP establishes this trimmer's external envelope. A separate
+// adjustment screw is deliberately omitted because the cited source does not
+// provide a distinct, reusable screw geometry for this carrier variant.
+const currentLimitTrimmer = cylinder(TRIMMER_H, TRIMMER_RADIUS, 32)
+  .color(TRIMMER_BLUE)
+  .translate(TRIMMER_X, TRIMMER_Y, PCB_T);
+
+const asm = assembly('a4988-stepstick-carrier');
+const pcbRef = asm.part('pcb', pcb);
+pcbRef.connector('carrier-solder-face', {
+  type: 'frame',
+  origin: { kind: 'vec3', value: [PCB_X / 2, PCB_Y / 2, 0] },
+  normal: [0, 0, -1],
+});
+for (const pin of pins) {
+  const padRef = asm.part(pin.part, contactPad(pin));
+  // A plated pad is annular, but a header or soldered lead mates on its bore
+  // axis. This explicit through-hole centerline convention keeps the frame at
+  // the factual 1.02 mm drill center while the pad remains its owning copper
+  // solid; it does not imply an installed pin.
+  padRef.connector(pin.connector, {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [pin.x, pin.y, PCB_T + 0.08] },
+    normal: [0, 0, 1],
+  });
+}
+asm.part('a4988-qfn-envelope', a4988Qfn);
+asm.part('current-limit-trimmer', currentLimitTrimmer);
+
+return asm.model();

--- a/scripts/parts/authored/sg90-micro-servo.kcad.ts
+++ b/scripts/parts/authored/sg90-micro-servo.kcad.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// Luxor Parts 87897 SG90 micro-servo mechanical and cable-interface envelope.
+//
+// DIMENSION / INTERFACE SOURCE
+//   https://www.kjell.com/globalassets/mediaassets/701916_87897_datasheet_en.pdf
+//
+// The product-specific drawing specifies a 32.0 × 12.4 × 26.7 mm outside
+// envelope, a 22.8 mm case dimension, a 250 mm harness, a JR/Futaba/GWS
+// connector, 2.54 mm three-way contact pitch, and brown/red/orange
+// ground/V+/PWM order. It does *not* dimension a shaft XY datum, horn/spline,
+// mould details, cable exit, or connector cross-section. This model therefore
+// exports no shaft/mounting mating interface and no fictitious plug housing.
+//
+// The box is deliberately a conservative mechanical envelope, rather than a
+// claim about the detailed mould. It uses a canonical straightened harness pose
+// built from documented cable facts. Its endpoint frames are canonical
+// plug-contact proxy endpoints at the documented pitch and color/order, not
+// literal bare-wire ends or an assertion about installed cable routing.
+
+const ENVELOPE_X = 32.0;
+const ENVELOPE_Y = 12.4;
+const ENVELOPE_Z = 26.7;
+
+const CABLE_PITCH = 2.54;
+const CABLE_LENGTH = 250.0;
+// These coordinates put source-backed cable facts into a canonical catalog pose.
+// They are not a claim about the product's cable exit or routed shape.
+const CABLE_CONTACT_X = ENVELOPE_X + CABLE_LENGTH;
+const CABLE_CENTER_Y = ENVELOPE_Y / 2;
+const CABLE_Z = ENVELOPE_Z / 2;
+// KernelCAD frames need an owning solid. This radius is a canonical
+// contact-carrier proxy only, not a claimed conductor or insulation diameter.
+const LEAD_PROXY_RADIUS = 0.16;
+
+const SERVO_BLUE = '#2a5e9b';
+const BROWN = '#6b4128';
+const RED = '#c83030';
+const ORANGE = '#e07a22';
+
+const servoEnvelope = box(ENVELOPE_X, ENVELOPE_Y, ENVELOPE_Z)
+  .color(SERVO_BLUE);
+
+type Lead = { name: 'ground' | 'vplus' | 'pwm'; color: string; y: number };
+const leads: Lead[] = [
+  { name: 'ground', color: BROWN, y: CABLE_CENTER_Y - CABLE_PITCH },
+  { name: 'vplus', color: RED, y: CABLE_CENTER_Y },
+  { name: 'pwm', color: ORANGE, y: CABLE_CENTER_Y + CABLE_PITCH },
+];
+
+const asm = assembly('sg90-micro-servo');
+asm.part('servo-datasheet-envelope', servoEnvelope);
+for (const lead of leads) {
+  const leadShape = cylinder(CABLE_LENGTH, LEAD_PROXY_RADIUS, 16)
+    .alongAxis([1, 0, 0])
+    .translate(ENVELOPE_X, lead.y, CABLE_Z)
+    .color(lead.color);
+  const leadRef = asm.part(`lead-${lead.name}`, leadShape);
+  leadRef.connector(`${lead.name}-contact`, {
+    type: 'frame',
+    origin: { kind: 'vec3', value: [CABLE_CONTACT_X, lead.y, CABLE_Z] },
+    normal: [1, 0, 0],
+  });
+}
+
+return asm.model();

--- a/scripts/universalElectronicsParts.test.ts
+++ b/scripts/universalElectronicsParts.test.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+type CatalogPart = {
+  id: string;
+  name: string;
+  family: string;
+  kcad_source?: string;
+  license?: string;
+  attribution?: string;
+};
+
+const repoRoot = resolve(__dirname, '..');
+const manifestPath = resolve(repoRoot, 'scripts/electronics-parts.json');
+const authoredDirectory = resolve(repoRoot, 'scripts/parts/authored');
+const a4988Path = resolve(authoredDirectory, 'a4988-stepstick-carrier.kcad.ts');
+const sg90Path = resolve(authoredDirectory, 'sg90-micro-servo.kcad.ts');
+const a4988ContactNames = [
+  'en-contact', 'ms1-contact', 'ms2-contact', 'ms3-contact',
+  'reset-contact', 'sleep-contact', 'step-contact', 'dir-contact',
+  'vmot-contact', 'gnd-motor-contact', 'motor-2b-contact',
+  'motor-2a-contact', 'motor-1a-contact', 'motor-1b-contact',
+  'gnd-logic-contact', 'vdd-contact',
+] as const;
+const forbiddenInterfaceNames = ['mount-hole', 'universal-spline', 'x-motor', 'y-motor'];
+
+function source(path: string): string {
+  expect(existsSync(path), `missing authored source ${path}`).toBe(true);
+  return readFileSync(path, 'utf8');
+}
+
+function catalogPart(id: string): CatalogPart {
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { parts: CatalogPart[] };
+  const part = manifest.parts.find((candidate) => candidate.id === id);
+  expect(part, `missing catalog part ${id}`).toBeDefined();
+  return part!;
+}
+
+describe('universal authored electronics', () => {
+  it('models the A4988 StepStick carrier with real plated-hole interfaces', () => {
+    const a4988 = source(a4988Path);
+
+    expect(a4988).toContain('https://www.pololu.com/product/2128');
+    expect(a4988).toContain('https://www.pololu.com/file/0J1081/a4988-stepper-motor-driver-carrier-black-edition-dimension-diagram.pdf');
+    expect(a4988).toContain('https://www.pololu.com/file/0J1225/a4988-stepper-motor-driver-carrier-black-edition.step');
+    expect(a4988).toContain('const pcbRef = asm.part');
+    expect(a4988).toMatch(/pcbRef\.connector\(\s*'carrier-solder-face'/);
+    expect(a4988).toContain('const padRef = asm.part');
+    expect(a4988).toMatch(/padRef\.connector\(\s*pin\.connector/);
+    expect(a4988).toContain('platedHoles');
+    expect(a4988).toContain('through-hole centerline convention');
+    expect(a4988).toContain('const QFN_X = 3.342;');
+    expect(a4988).toContain('const QFN_Y = 8.803;');
+    expect(a4988).toContain('const TRIMMER_X = 8.727;');
+    expect(a4988).toContain('const TRIMMER_Y = 2.7905;');
+    expect(a4988).toContain('const TRIMMER_RADIUS = 1.5;');
+    expect(a4988).not.toContain('currentLimitAdjuster');
+    for (const contact of a4988ContactNames) expect(a4988).toContain(`'${contact}'`);
+    for (const forbidden of forbiddenInterfaceNames) expect(a4988).not.toContain(forbidden);
+  });
+
+  it('models the SG90 datasheet envelope and canonical plug-contact proxies', () => {
+    const sg90 = source(sg90Path);
+
+    expect(sg90).toContain('https://www.kjell.com/globalassets/mediaassets/701916_87897_datasheet_en.pdf');
+    expect(sg90).toContain('const ENVELOPE_X = 32.0;');
+    expect(sg90).toContain('const ENVELOPE_Y = 12.4;');
+    expect(sg90).toContain('const ENVELOPE_Z = 26.7;');
+    expect(sg90).toContain('const CABLE_LENGTH = 250.0;');
+    expect(sg90).toContain('canonical straightened harness pose');
+    expect(sg90).toContain('const leadRef = asm.part');
+    for (const contact of ['ground', 'vplus', 'pwm']) {
+      expect(sg90).toContain(`name: '${contact}'`);
+    }
+    expect(sg90).toMatch(/leadRef\.connector\(\s*`\$\{lead\.name\}-contact`/);
+    expect(sg90).toContain('value: [CABLE_CONTACT_X, lead.y, CABLE_Z]');
+    expect(sg90).toContain('plug-contact proxy');
+    expect(sg90).toContain('canonical catalog pose');
+    expect(sg90).not.toContain('nominal bare 28-AWG');
+    expect(sg90).not.toContain('output-axis-envelope');
+    expect(sg90).not.toMatch(/type:\s*'axis'/);
+    expect(sg90).not.toContain('OUTPUT_X');
+    expect(sg90).not.toContain('cableStrainRelief');
+    for (const forbidden of forbiddenInterfaceNames) expect(sg90).not.toContain(forbidden);
+  });
+
+  it('registers both components as standalone catalog parts with source attribution', () => {
+    const a4988 = catalogPart('a4988-stepstick-carrier');
+    const sg90 = catalogPart('sg90-micro-servo');
+
+    expect(a4988).toMatchObject({
+      name: 'A4988 StepStick carrier (Pololu #2128 Black Edition)',
+      family: 'stepper-driver',
+      kcad_source: 'scripts/parts/authored/a4988-stepstick-carrier.kcad.ts',
+      license: 'MIT',
+    });
+    expect(a4988.attribution).toContain('pololu.com/product/2128');
+    expect(sg90).toMatchObject({
+      name: 'SG90 micro servo (Luxor Parts 87897)',
+      family: 'micro-servo',
+      kcad_source: 'scripts/parts/authored/sg90-micro-servo.kcad.ts',
+      license: 'MIT',
+    });
+    expect(sg90.attribution).toContain('701916_87897_datasheet_en.pdf');
+  });
+});

--- a/scripts/verifyAuthoredElectronicsCatalog.test.ts
+++ b/scripts/verifyAuthoredElectronicsCatalog.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { runScript } from '../src/modeling/runtime/runScript';
 import {
   AUTHORED_ELECTRONIC_PACKAGE_SPECS,
+  REQUIRED_AUTHORED_CATALOG_COMPONENT_SPECS,
   verifyAuthoredElectronicsCatalog,
 } from './verifyAuthoredElectronicsCatalog';
 
@@ -23,7 +24,7 @@ function makeCatalogFixture(): string {
   mkdirSync(join(catalogDir, 'v1', 'parts'), { recursive: true });
   mkdirSync(join(catalogDir, 'v1', 'catalog'), { recursive: true });
 
-  const records = AUTHORED_ELECTRONIC_PACKAGE_SPECS.map((spec) => {
+  const packageRecords = AUTHORED_ELECTRONIC_PACKAGE_SPECS.map((spec) => {
     const step = Buffer.from(`ISO-10303-21;\nDATA;\n/* ${spec.id} */\nENDSEC;\nEND-ISO-10303-21;\n`);
     const sha256 = createHash('sha256').update(step).digest('hex');
     writeFileSync(join(catalogDir, 'step', `${spec.id}.step`), step);
@@ -53,6 +54,42 @@ function makeCatalogFixture(): string {
     );
     return record;
   });
+  const componentRecords = REQUIRED_AUTHORED_CATALOG_COMPONENT_SPECS.map((spec) => {
+    const step = Buffer.from(`ISO-10303-21;\nDATA;\n/* ${spec.id} */\nENDSEC;\nEND-ISO-10303-21;\n`);
+    const sha256 = createHash('sha256').update(step).digest('hex');
+    writeFileSync(join(catalogDir, 'step', `${spec.id}.step`), step);
+    const record = {
+      id: spec.id,
+      name: spec.id,
+      category: 'Electronics',
+      family: spec.family,
+      tags: ['electronics'],
+      attributes: {},
+      stepUrl: `https://parts.example/step/${spec.id}.step`,
+      sha256,
+      byteSize: step.length,
+      license: 'MIT',
+      connectors: [],
+      connectorManifest: {
+        schemaVersion: 1,
+        partId: spec.id,
+        family: spec.family,
+        geometrySha256: sha256,
+        connectors: spec.connectors.map((connector) => ({
+          name: connector.name,
+          type: connector.type,
+          origin: [0, 0, 0],
+          ...(connector.type === 'axis' ? { axis: [0, 0, 1] } : { normal: [0, 0, 1] }),
+        })),
+      },
+    };
+    writeFileSync(
+      join(catalogDir, 'v1', 'parts', `${spec.id}.json`),
+      JSON.stringify(record, null, 2),
+    );
+    return record;
+  });
+  const records = [...packageRecords, ...componentRecords];
 
   writeFileSync(
     join(catalogDir, 'v1', 'catalog', 'parts.index.json'),
@@ -133,7 +170,12 @@ describe('verifyAuthoredElectronicsCatalog', () => {
 
     await expect(
       verifyAuthoredElectronicsCatalog({ catalogDir, manifestPath }),
-    ).resolves.toEqual({ verifiedIds: AUTHORED_ELECTRONIC_PACKAGE_SPECS.map((spec) => spec.id) });
+    ).resolves.toEqual({
+      verifiedIds: [
+        ...AUTHORED_ELECTRONIC_PACKAGE_SPECS,
+        ...REQUIRED_AUTHORED_CATALOG_COMPONENT_SPECS,
+      ].map((spec) => spec.id),
+    });
   });
 
   it('fails before deploy when one authored package was skipped', async () => {
@@ -144,5 +186,59 @@ describe('verifyAuthoredElectronicsCatalog', () => {
     await expect(
       verifyAuthoredElectronicsCatalog({ catalogDir, manifestPath }),
     ).rejects.toThrow(new RegExp(`${missing.id}.*STEP artifact`, 'i'));
+  });
+
+  it('fails before deploy when a required authored motor-control component was skipped', async () => {
+    const catalogDir = makeCatalogFixture();
+    const missing = REQUIRED_AUTHORED_CATALOG_COMPONENT_SPECS[0];
+    rmSync(join(catalogDir, 'step', `${missing.id}.step`));
+
+    await expect(
+      verifyAuthoredElectronicsCatalog({ catalogDir, manifestPath }),
+    ).rejects.toThrow(new RegExp(`${missing.id}.*STEP artifact`, 'i'));
+  });
+
+  it('fails before deploy when SG90 exports an unsupported output axis', async () => {
+    const catalogDir = makeCatalogFixture();
+    const spec = REQUIRED_AUTHORED_CATALOG_COMPONENT_SPECS.find(
+      (candidate) => candidate.id === 'sg90-micro-servo',
+    )!;
+    const detailPath = join(catalogDir, 'v1', 'parts', `${spec.id}.json`);
+    const detail = JSON.parse(readFileSync(detailPath, 'utf8')) as {
+      connectorManifest: { connectors: Array<Record<string, unknown>> };
+    };
+    detail.connectorManifest.connectors.push({
+      name: 'output-axis-envelope',
+      type: 'axis',
+      origin: [0, 0, 0],
+      axis: [0, 0, 1],
+    });
+    writeFileSync(detailPath, JSON.stringify(detail));
+
+    await expect(
+      verifyAuthoredElectronicsCatalog({ catalogDir, manifestPath }),
+    ).rejects.toThrow(/output-axis-envelope.*unexpected/i);
+  });
+
+  it('fails before deploy when an SG90 electrical contact is not a frame', async () => {
+    const catalogDir = makeCatalogFixture();
+    const spec = REQUIRED_AUTHORED_CATALOG_COMPONENT_SPECS.find(
+      (candidate) => candidate.id === 'sg90-micro-servo',
+    )!;
+    const detailPath = join(catalogDir, 'v1', 'parts', `${spec.id}.json`);
+    const detail = JSON.parse(readFileSync(detailPath, 'utf8')) as {
+      connectorManifest: { connectors: Array<Record<string, unknown>> };
+    };
+    const pwmContact = detail.connectorManifest.connectors.find(
+      (connector) => connector.name === 'pwm-contact',
+    )!;
+    pwmContact.type = 'axis';
+    pwmContact.axis = [0, 0, 1];
+    delete pwmContact.normal;
+    writeFileSync(detailPath, JSON.stringify(detail));
+
+    await expect(
+      verifyAuthoredElectronicsCatalog({ catalogDir, manifestPath }),
+    ).rejects.toThrow(/pwm-contact.*axis.*frame/i);
   });
 });

--- a/scripts/verifyAuthoredElectronicsCatalog.ts
+++ b/scripts/verifyAuthoredElectronicsCatalog.ts
@@ -1,17 +1,21 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 //
-// Deployment gate for the authored electronic IC packages. The electronics
-// ingest is intentionally tolerant of one bad upstream model, but these five
-// package sources are authored in this repository and must never silently
-// disappear from a deployed catalog. Validate both sides of that contract:
-// source-level component/contact semantics and the emitted catalog artifacts.
+// Deployment gate for required authored electronics. The electronics ingest is
+// intentionally tolerant of a bad third-party upstream model, but the five
+// authored IC packages and the A4988/SG90 universal components must never
+// silently disappear from a deployed catalog. Validate both sides of that
+// contract: source-level package semantics and emitted catalog artifacts.
 
 import { createHash } from 'node:crypto';
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { FeatureRecord } from '../src/shared/intent/featureRecord';
+import {
+  validateHashBoundConnectorManifest,
+  type HashBoundConnectorManifest,
+} from '../src/shared/parts/connectorManifestSchema';
 import { runScript } from '../src/modeling/runtime/runScript';
 
 type Axis = 0 | 1 | 2;
@@ -150,17 +154,63 @@ export const AUTHORED_ELECTRONIC_PACKAGE_SPECS: readonly AuthoredElectronicPacka
   },
 ];
 
+/**
+ * These universal components are consumed by projects, rather than being
+ * package-only primitives. Their exported STEP and exact authored interfaces
+ * are therefore required deployment artifacts, not best-effort additions.
+ */
+export interface RequiredAuthoredCatalogComponentSpec {
+  readonly id: string;
+  readonly family: string;
+  readonly source: string;
+  readonly connectors: readonly RequiredAuthoredCatalogConnectorSpec[];
+}
+
+export interface RequiredAuthoredCatalogConnectorSpec {
+  readonly name: string;
+  readonly type: 'frame' | 'axis';
+}
+
+export const REQUIRED_AUTHORED_CATALOG_COMPONENT_SPECS: readonly RequiredAuthoredCatalogComponentSpec[] = [
+  {
+    id: 'a4988-stepstick-carrier',
+    family: 'stepper-driver',
+    source: 'scripts/parts/authored/a4988-stepstick-carrier.kcad.ts',
+    connectors: [
+      'carrier-solder-face',
+      'en-contact', 'ms1-contact', 'ms2-contact', 'ms3-contact',
+      'reset-contact', 'sleep-contact', 'step-contact', 'dir-contact',
+      'vmot-contact', 'gnd-motor-contact', 'motor-2b-contact',
+      'motor-2a-contact', 'motor-1a-contact', 'motor-1b-contact',
+      'gnd-logic-contact', 'vdd-contact',
+    ].map((name) => ({ name, type: 'frame' as const })),
+  },
+  {
+    id: 'sg90-micro-servo',
+    family: 'micro-servo',
+    source: 'scripts/parts/authored/sg90-micro-servo.kcad.ts',
+    connectors: [
+      { name: 'ground-contact', type: 'frame' },
+      { name: 'vplus-contact', type: 'frame' },
+      { name: 'pwm-contact', type: 'frame' },
+    ],
+  },
+];
+
 interface ManifestPart {
   readonly id: string;
+  readonly family?: string;
   readonly kcad_source?: string;
   readonly attributes?: Readonly<Record<string, string | number>>;
 }
 
 interface CatalogRecordLike {
   readonly id?: unknown;
+  readonly family?: unknown;
   readonly attributes?: unknown;
   readonly stepUrl?: unknown;
   readonly sha256?: unknown;
+  readonly connectorManifest?: unknown;
 }
 
 interface CatalogIndexLike {
@@ -219,10 +269,31 @@ export async function verifyAuthoredElectronicsCatalog(
     }
   }
 
+  for (const spec of REQUIRED_AUTHORED_CATALOG_COMPONENT_SPECS) {
+    const manifestPart = manifestParts.find((part) => part.id === spec.id);
+    verifyRequiredComponentManifest(spec, manifestPart, errors);
+
+    const detailPath = join(options.catalogDir, 'v1', 'parts', `${spec.id}.json`);
+    const detail = readJson<CatalogRecordLike>(detailPath, errors, `${spec.id}: detail record`);
+    verifyRequiredComponentRecord(spec, detail, detailPath, options.catalogDir, errors);
+
+    const indexed = indexItems.find((record) => record.id === spec.id);
+    if (indexed === undefined) {
+      errors.push(`${spec.id}: missing from catalog index`);
+    } else if (detail !== undefined && indexed.sha256 !== detail.sha256) {
+      errors.push(`${spec.id}: catalog index SHA-256 does not match its detail record`);
+    }
+  }
+
   if (errors.length > 0) {
     throw new Error(`Authored electronics catalog verification failed:\n- ${errors.join('\n- ')}`);
   }
-  return { verifiedIds: AUTHORED_ELECTRONIC_PACKAGE_SPECS.map((spec) => spec.id) };
+  return {
+    verifiedIds: [
+      ...AUTHORED_ELECTRONIC_PACKAGE_SPECS,
+      ...REQUIRED_AUTHORED_CATALOG_COMPONENT_SPECS,
+    ].map((spec) => spec.id),
+  };
 }
 
 function verifyManifestPart(
@@ -246,6 +317,23 @@ function verifyManifestPart(
   }
   if (spec.pinPitchMm !== undefined && attributes?.pinPitchMm !== spec.pinPitchMm) {
     errors.push(`${spec.id}: manifest pinPitchMm is not ${spec.pinPitchMm}`);
+  }
+}
+
+function verifyRequiredComponentManifest(
+  spec: RequiredAuthoredCatalogComponentSpec,
+  part: ManifestPart | undefined,
+  errors: string[],
+): void {
+  if (!part) {
+    errors.push(`${spec.id}: missing from electronics manifest`);
+    return;
+  }
+  if (part.family !== spec.family) {
+    errors.push(`${spec.id}: manifest family is not '${spec.family}'`);
+  }
+  if (part.kcad_source !== spec.source) {
+    errors.push(`${spec.id}: must declare authored source '${spec.source}'`);
   }
 }
 
@@ -487,6 +575,68 @@ function verifyCatalogRecord(
     errors.push(`${spec.id}: detail record SHA-256 does not match its STEP artifact`);
   }
   if (!existsSync(detailPath)) errors.push(`${spec.id}: missing detail record ${detailPath}`);
+}
+
+function verifyRequiredComponentRecord(
+  spec: RequiredAuthoredCatalogComponentSpec,
+  record: CatalogRecordLike | undefined,
+  detailPath: string,
+  catalogDir: string,
+  errors: string[],
+): void {
+  if (!record) return;
+  if (record.id !== spec.id) errors.push(`${spec.id}: detail record id is incorrect`);
+  if (record.family !== spec.family) {
+    errors.push(`${spec.id}: detail record family is not '${spec.family}'`);
+  }
+
+  const stepPath = join(catalogDir, 'step', `${spec.id}.step`);
+  if (!existsSync(stepPath) || statSync(stepPath).size === 0) {
+    errors.push(`${spec.id}: missing STEP artifact ${stepPath}`);
+    return;
+  }
+  if (record.stepUrl !== undefined && !String(record.stepUrl).endsWith(`/step/${spec.id}.step`)) {
+    errors.push(`${spec.id}: detail record stepUrl does not point at its STEP artifact`);
+  }
+  const stepHash = createHash('sha256').update(readFileSync(stepPath)).digest('hex');
+  if (typeof record.sha256 !== 'string' || record.sha256 !== stepHash) {
+    errors.push(`${spec.id}: detail record SHA-256 does not match its STEP artifact`);
+  }
+  if (!existsSync(detailPath)) errors.push(`${spec.id}: missing detail record ${detailPath}`);
+
+  if (!isRecord(record.connectorManifest)) {
+    errors.push(`${spec.id}: detail record has no authored connector manifest`);
+    return;
+  }
+  const manifest = record.connectorManifest as HashBoundConnectorManifest;
+  try {
+    validateHashBoundConnectorManifest(manifest, {
+      partId: spec.id,
+      family: spec.family,
+      geometrySha256: stepHash,
+    });
+  } catch (error) {
+    errors.push(`${spec.id}: invalid authored connector manifest — ${formatError(error)}`);
+    return;
+  }
+
+  const actualByName = new Map(manifest.connectors.map((connector) => [connector.name, connector]));
+  const expectedNames = new Set(spec.connectors.map((connector) => connector.name));
+  for (const expected of spec.connectors) {
+    const actual = actualByName.get(expected.name);
+    if (actual === undefined) {
+      errors.push(`${spec.id}: authored connector manifest is missing '${expected.name}'`);
+    } else if (actual.type !== expected.type) {
+      errors.push(
+        `${spec.id}: authored connector '${expected.name}' is '${actual.type}', expected '${expected.type}'`,
+      );
+    }
+  }
+  for (const actual of manifest.connectors) {
+    if (!expectedNames.has(actual.name)) {
+      errors.push(`${spec.id}: authored connector '${actual.name}' is unexpected`);
+    }
+  }
 }
 
 function readJson<T>(path: string, errors: string[], label: string): T | undefined {

--- a/src/agent/cli/commands/export.atomic.test.ts
+++ b/src/agent/cli/commands/export.atomic.test.ts
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const publicationRace = vi.hoisted(() => ({
+  attackerOwnedStickyAncestor: undefined as string | undefined,
+  untrustedFinalParent: undefined as string | undefined,
+  untrustedOwnerAncestor: undefined as string | undefined,
+  enabled: false,
+}));
+
+// Deterministically create a final path after the writer's preflight but at
+// its publish syscall. It models a concurrent writer without timing races.
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  async function createLateDestination(destination: string): Promise<void> {
+    if (!publicationRace.enabled) return;
+    await actual.writeFile(destination, 'late manifest from concurrent writer', { flag: 'wx' });
+  }
+  return {
+    ...actual,
+    link: async (existingPath: string, destination: string) => {
+      await createLateDestination(destination);
+      return actual.link(existingPath, destination);
+    },
+    rename: async (existingPath: string, destination: string) => {
+      await createLateDestination(destination);
+      return actual.rename(existingPath, destination);
+    },
+    stat: async (path: string) => {
+      const info = await actual.stat(path);
+      if (
+        path !== publicationRace.attackerOwnedStickyAncestor
+        && path !== publicationRace.untrustedFinalParent
+        && path !== publicationRace.untrustedOwnerAncestor
+      ) return info;
+      return Object.assign(Object.create(info), { uid: info.uid + 1 });
+    },
+  };
+});
+
+import { writeManifestSidecarAtomically } from './export';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  publicationRace.attackerOwnedStickyAncestor = undefined;
+  publicationRace.untrustedFinalParent = undefined;
+  publicationRace.untrustedOwnerAncestor = undefined;
+  publicationRace.enabled = false;
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('writeManifestSidecarAtomically', () => {
+  it('does not replace an existing sidecar destination', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'kcad-manifest-exclusive-sidecar-'));
+    temporaryDirectories.push(directory);
+    const destination = join(directory, 'servo.connector-manifest.json');
+    writeFileSync(destination, 'existing manifest');
+
+    await expect(writeManifestSidecarAtomically(destination, '{"partId":"servo"}\n'))
+      .rejects.toMatchObject({ code: 'EEXIST' });
+
+    expect(readFileSync(destination, 'utf8')).toBe('existing manifest');
+  });
+
+  it('rejects a sidecar directory writable by group or other users', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'kcad-manifest-insecure-parent-'));
+    temporaryDirectories.push(directory);
+    const destination = join(directory, 'servo.connector-manifest.json');
+    chmodSync(directory, 0o777);
+
+    await expect(writeManifestSidecarAtomically(destination, '{"partId":"servo"}\n'))
+      .rejects.toThrow(/must not be writable by group or other users/i);
+
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  it('rejects a safe-looking parent nested below a writable ancestor', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'kcad-manifest-writable-ancestor-'));
+    temporaryDirectories.push(directory);
+    const writableAncestor = join(directory, 'writable-ancestor');
+    const safeParent = join(writableAncestor, 'safe-parent');
+    mkdirSync(safeParent, { recursive: true });
+    chmodSync(writableAncestor, 0o777);
+    chmodSync(safeParent, 0o700);
+    const destination = join(safeParent, 'servo.connector-manifest.json');
+
+    await expect(writeManifestSidecarAtomically(destination, '{"partId":"servo"}\n'))
+      .rejects.toThrow(/ancestry.*writable by group or other users/i);
+
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  it('rejects a current-user child below a sticky ancestor owned by another user', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'kcad-manifest-sticky-ancestor-'));
+    temporaryDirectories.push(directory);
+    const stickyAncestor = join(directory, 'sticky-ancestor');
+    const safeParent = join(stickyAncestor, 'safe-parent');
+    mkdirSync(safeParent, { recursive: true });
+    chmodSync(stickyAncestor, 0o1777);
+    chmodSync(safeParent, 0o700);
+    publicationRace.attackerOwnedStickyAncestor = realpathSync(stickyAncestor);
+    const destination = join(safeParent, 'servo.connector-manifest.json');
+
+    await expect(writeManifestSidecarAtomically(destination, '{"partId":"servo"}\n'))
+      .rejects.toThrow(/ancestry.*sticky.*trusted/i);
+
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  it('rejects a safe-looking parent below a non-sticky ancestor owned by another user', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'kcad-manifest-foreign-ancestor-'));
+    temporaryDirectories.push(directory);
+    const foreignAncestor = join(directory, 'foreign-ancestor');
+    const safeParent = join(foreignAncestor, 'safe-parent');
+    mkdirSync(safeParent, { recursive: true });
+    chmodSync(foreignAncestor, 0o755);
+    chmodSync(safeParent, 0o700);
+    publicationRace.untrustedOwnerAncestor = realpathSync(foreignAncestor);
+    const destination = join(safeParent, 'servo.connector-manifest.json');
+
+    await expect(writeManifestSidecarAtomically(destination, '{"partId":"servo"}\n'))
+      .rejects.toThrow(/ancestry.*owned by the current user or root/i);
+
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  it('rejects a final manifest parent owned by another user', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'kcad-manifest-foreign-parent-'));
+    temporaryDirectories.push(directory);
+    chmodSync(directory, 0o700);
+    publicationRace.untrustedFinalParent = realpathSync(directory);
+    const destination = join(directory, 'servo.connector-manifest.json');
+
+    await expect(writeManifestSidecarAtomically(destination, '{"partId":"servo"}\n'))
+      .rejects.toThrow(/ancestry.*owned by the current user or root/i);
+
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  it('publishes a sidecar without group or other write permission', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'kcad-manifest-private-file-'));
+    temporaryDirectories.push(directory);
+    const destination = join(directory, 'servo.connector-manifest.json');
+    const previousUmask = process.umask(0);
+    try {
+      await writeManifestSidecarAtomically(destination, '{"partId":"servo"}\n');
+    } finally {
+      process.umask(previousUmask);
+    }
+
+    expect(statSync(destination).mode & 0o022).toBe(0);
+  });
+
+  it('does not replace a sidecar that appears at the publication boundary', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'kcad-manifest-publication-race-'));
+    temporaryDirectories.push(directory);
+    const destination = join(directory, 'servo.connector-manifest.json');
+    publicationRace.enabled = true;
+
+    await expect(writeManifestSidecarAtomically(destination, '{"partId":"servo"}\n'))
+      .rejects.toMatchObject({ code: 'EEXIST' });
+
+    expect(readFileSync(destination, 'utf8')).toBe('late manifest from concurrent writer');
+  });
+});

--- a/src/agent/cli/commands/export.ts
+++ b/src/agent/cli/commands/export.ts
@@ -1,8 +1,19 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import { Command } from 'commander';
-import { randomUUID } from 'node:crypto';
-import { writeFile, mkdir, open, realpath, rename, rm, stat } from 'node:fs/promises';
+import type { Stats } from 'node:fs';
+import {
+  chmod,
+  link,
+  lstat,
+  mkdir,
+  mkdtemp,
+  open,
+  realpath,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
 import { resolve, dirname, basename, join } from 'node:path';
 import { initOcct } from '../../../kernel/backends/occt/occtBackend';
 import {
@@ -82,6 +93,13 @@ function isMissingPathError(error: unknown): boolean {
       || (error as { code?: unknown }).code === 'ENOTDIR');
 }
 
+function isExistingPathError(error: unknown): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && (error as { code?: unknown }).code === 'EEXIST';
+}
+
 /** Resolve the deepest existing path segment so sibling paths through a
  * symlinked directory compare as one output target even before either file
  * exists. Fall back to the lexical absolute path on inaccessible paths; the
@@ -114,6 +132,100 @@ async function existingFileIdentity(path: string): Promise<{ dev: number; ino: n
   }
 }
 
+async function outputPathEntryExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Resolve a manifest path through its parent directory and establish the
+ * directory boundary relied on by atomic sidecar publication. Node pathname
+ * APIs cannot hold a directory descriptor across validation and publication,
+ * so every resolved ancestor must be owned by the current user or root, and
+ * must not allow an untrusted user to replace the next child entry.
+ */
+async function trustedManifestPath(destination: string): Promise<string> {
+  const requestedPath = resolve(destination);
+  const requestedParent = dirname(requestedPath);
+  let parent: string;
+  try {
+    parent = await realpath(requestedParent);
+  } catch (error) {
+    throw new Error(
+      `--connector-manifest parent '${requestedParent}' cannot be resolved: ${errorMessage(error)}`,
+    );
+  }
+
+  const ancestry: Array<{ path: string; info: Stats }> = [];
+  for (let directory = parent; ; directory = dirname(directory)) {
+    let info: Stats;
+    try {
+      info = await stat(directory);
+    } catch (error) {
+      throw new Error(
+        `--connector-manifest parent '${directory}' cannot be inspected: ${errorMessage(error)}`,
+      );
+    }
+    if (!info.isDirectory()) {
+      throw new Error(`--connector-manifest parent '${directory}' is not a directory.`);
+    }
+    ancestry.unshift({ path: directory, info });
+    if (dirname(directory) === directory) break;
+  }
+
+  if (process.platform !== 'win32') {
+    const uid = typeof process.getuid === 'function' ? process.getuid() : undefined;
+    if (uid === undefined) {
+      throw new Error('--connector-manifest ancestry cannot determine the current user id.');
+    }
+    const manifestParent = ancestry.at(-1)!;
+    const isTrustedOwner = (info: Stats): boolean => info.uid === uid || info.uid === 0;
+    if (!isTrustedOwner(manifestParent.info)) {
+      throw new Error(
+        `--connector-manifest ancestry is unsafe: '${manifestParent.path}' must be owned by the current user or root.`,
+      );
+    }
+    if ((manifestParent.info.mode & 0o022) !== 0) {
+      throw new Error(
+        `--connector-manifest parent '${manifestParent.path}' must not be writable by group or other users.`,
+      );
+    }
+    for (let index = 0; index < ancestry.length - 1; index++) {
+      const ancestor = ancestry[index];
+      if (!isTrustedOwner(ancestor.info)) {
+        const sticky = (ancestor.info.mode & 0o1000) !== 0;
+        throw new Error(
+          `--connector-manifest ancestry is unsafe: '${ancestor.path}' must be owned by the current user or root.${sticky ? ' A sticky ancestor is trusted only with such an owner.' : ''}`,
+        );
+      }
+      if ((ancestor.info.mode & 0o022) === 0) continue;
+      const child = ancestry[index + 1];
+      const sticky = (ancestor.info.mode & 0o1000) !== 0;
+      if (!sticky || child.info.uid !== uid) {
+        throw new Error(
+          `--connector-manifest ancestry is unsafe: '${ancestor.path}' is writable by group or other users and can replace '${child.path}'. A sticky ancestor must be trusted (owned by the current user or root).`,
+        );
+      }
+    }
+  }
+  return join(parent, basename(requestedPath));
+}
+
+function manifestDestinationExistsError(path: string): Error & { code: 'EEXIST' } {
+  return Object.assign(
+    new Error(`connector manifest destination already exists: ${path}`),
+    { code: 'EEXIST' as const },
+  );
+}
+
 /** Detect lexical, symlink, case-folded, and pre-existing hard-link aliases.
  * Calling this again after writing the STEP also catches case-folded aliases
  * that cannot be observed until the output path exists. */
@@ -134,29 +246,33 @@ async function outputPathsAlias(first: string, second: string): Promise<boolean>
 }
 
 /**
- * Replace a sidecar destination without following a late file or symlink
- * alias. The staging file shares the destination directory, so `rename` is
- * atomic and replaces the destination entry rather than its target.
+ * Publish a fresh sidecar from a private staging directory. The parent
+ * boundary is checked above, then an atomic hard link publishes the complete
+ * staged file only if the destination stays unused, so readers cannot observe
+ * partial JSON or lose a concurrent writer's sidecar.
  *
  * @internal Exported solely for focused filesystem-boundary tests.
  */
 export async function writeManifestSidecarAtomically(destination: string, contents: string): Promise<void> {
-  const path = resolve(destination);
-  const stagedPath = join(dirname(path), `.${basename(path)}.${randomUUID()}.tmp`);
-  let stagedHandle: Awaited<ReturnType<typeof open>> | undefined;
-  let stagedCreated = false;
+  const path = await trustedManifestPath(destination);
+  if (await outputPathEntryExists(path)) throw manifestDestinationExistsError(path);
 
+  const stagingDirectory = await mkdtemp(join(dirname(path), `.${basename(path)}.staging-`));
   try {
-    stagedHandle = await open(stagedPath, 'wx');
-    stagedCreated = true;
-    await stagedHandle.writeFile(contents, 'utf8');
-    await stagedHandle.close();
-    stagedHandle = undefined;
-    await rename(stagedPath, path);
-  } catch (error) {
-    if (stagedHandle !== undefined) await stagedHandle.close().catch(() => undefined);
-    if (stagedCreated) await rm(stagedPath, { force: true }).catch(() => undefined);
-    throw error;
+    // `mkdtemp` is private by default; make that invariant explicit before
+    // placing the manifest bytes in the staging directory.
+    await chmod(stagingDirectory, 0o700);
+    const stagedPath = join(stagingDirectory, 'manifest.json');
+    const handle = await open(stagedPath, 'wx', 0o600);
+    try {
+      await handle.writeFile(contents, 'utf8');
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await link(stagedPath, path);
+  } finally {
+    await rm(stagingDirectory, { recursive: true, force: true }).catch(() => undefined);
   }
 }
 
@@ -177,6 +293,23 @@ function postStepManifestAliasResult(
   };
 }
 
+function postStepManifestDestinationExistsResult(
+  bytes: Uint8Array,
+  diagnostics: readonly CompilerDiagnostic[],
+): ExportCliResult {
+  return {
+    exitCode: 1,
+    bytesWritten: bytes.length,
+    diagnostics: withNextActions([...diagnostics, {
+      target: 'export-occt',
+      code: 'cli.invalid-args',
+      severity: 'error',
+      message: 'The STEP output was written, but --connector-manifest already exists or appeared concurrently; the sidecar was not written.',
+      hint: 'Choose a distinct unused --connector-manifest path and retry; the STEP output remains intact.',
+    }]),
+  };
+}
+
 export async function exportScript(input: ExportInput): Promise<ExportCliResult> {
   const manifestError = manifestOptionError(input);
   if (manifestError !== undefined) return invalidManifestOptionsResult(manifestError);
@@ -184,6 +317,17 @@ export async function exportScript(input: ExportInput): Promise<ExportCliResult>
   const outPath = resolve(input.out);
   if (manifestPath !== undefined && await outputPathsAlias(outPath, manifestPath)) {
     return invalidManifestOptionsResult('--connector-manifest must not overwrite the STEP output path.');
+  }
+  let trustedManifestOutput = manifestPath;
+  if (trustedManifestOutput !== undefined) {
+    try {
+      trustedManifestOutput = await trustedManifestPath(trustedManifestOutput);
+    } catch (error) {
+      return invalidManifestOptionsResult(errorMessage(error));
+    }
+    if (await outputPathEntryExists(trustedManifestOutput)) {
+      return invalidManifestOptionsResult('--connector-manifest must name an unused output path.');
+    }
   }
   await initOcct();
   const read = await readScriptOrDiagnostic(input.file);
@@ -198,7 +342,7 @@ export async function exportScript(input: ExportInput): Promise<ExportCliResult>
       fileName: filePath,
       format: input.format,
       scriptDir: dirname(filePath),
-      ...(input.connectorManifest === undefined
+      ...(trustedManifestOutput === undefined
         ? {}
         : {
             connectorManifest: {
@@ -227,17 +371,24 @@ export async function exportScript(input: ExportInput): Promise<ExportCliResult>
   const meshFiles: string[] = [];
   try {
     await writeFile(outPath, result.bytes);
-    if (manifestPath !== undefined) {
-      if (await outputPathsAlias(outPath, manifestPath)) {
+    if (trustedManifestOutput !== undefined) {
+      if (await outputPathsAlias(outPath, trustedManifestOutput)) {
         return postStepManifestAliasResult(result.bytes, result.diagnostics);
       }
       if (result.connectorManifest === undefined) {
         throw new Error('STEP export completed without the requested connector manifest.');
       }
-      await writeManifestSidecarAtomically(
-        manifestPath,
-        `${JSON.stringify(result.connectorManifest, null, 2)}\n`,
-      );
+      try {
+        await writeManifestSidecarAtomically(
+          trustedManifestOutput,
+          `${JSON.stringify(result.connectorManifest, null, 2)}\n`,
+        );
+      } catch (error) {
+        if (isExistingPathError(error)) {
+          return postStepManifestDestinationExistsResult(result.bytes, result.diagnostics);
+        }
+        throw error;
+      }
     }
     // Robot-description exports (URDF / SDF) reference per-link mesh files
     // by relative path — write them next to the output file so the

--- a/src/agent/cli/commands/export.ts
+++ b/src/agent/cli/commands/export.ts
@@ -310,6 +310,24 @@ function postStepManifestDestinationExistsResult(
   };
 }
 
+function postStepManifestWriteFailureResult(
+  bytes: Uint8Array,
+  diagnostics: readonly CompilerDiagnostic[],
+  error: unknown,
+): ExportCliResult {
+  return {
+    exitCode: 1,
+    bytesWritten: bytes.length,
+    diagnostics: withNextActions([...diagnostics, {
+      target: 'export-occt',
+      code: 'cli.file-write',
+      severity: 'error',
+      message: `The STEP output was written, but --connector-manifest could not be published: ${errorMessage(error)}`,
+      hint: 'Choose a secure, writable, unused connector-manifest path and retry; the STEP output remains intact.',
+    }]),
+  };
+}
+
 export async function exportScript(input: ExportInput): Promise<ExportCliResult> {
   const manifestError = manifestOptionError(input);
   if (manifestError !== undefined) return invalidManifestOptionsResult(manifestError);
@@ -387,7 +405,7 @@ export async function exportScript(input: ExportInput): Promise<ExportCliResult>
         if (isExistingPathError(error)) {
           return postStepManifestDestinationExistsResult(result.bytes, result.diagnostics);
         }
-        throw error;
+        return postStepManifestWriteFailureResult(result.bytes, result.diagnostics, error);
       }
     }
     // Robot-description exports (URDF / SDF) reference per-link mesh files

--- a/src/agent/cli/commands/export.ts
+++ b/src/agent/cli/commands/export.ts
@@ -219,11 +219,10 @@ async function trustedManifestPath(destination: string): Promise<string> {
   return join(parent, basename(requestedPath));
 }
 
-function manifestDestinationExistsError(path: string): Error & { code: 'EEXIST' } {
-  return Object.assign(
-    new Error(`connector manifest destination already exists: ${path}`),
-    { code: 'EEXIST' as const },
-  );
+function manifestDestinationExistsError(path: string): Error & { code?: string } {
+  const error = new Error(`connector manifest destination already exists: ${path}`) as Error & { code?: string };
+  error.code = 'EEXIST';
+  return error;
 }
 
 /** Detect lexical, symlink, case-folded, and pre-existing hard-link aliases.

--- a/src/agent/cli/commands/export.ts
+++ b/src/agent/cli/commands/export.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import { Command } from 'commander';
-import { writeFile, mkdir } from 'node:fs/promises';
-import { resolve, dirname, join } from 'node:path';
+import { writeFile, mkdir, realpath, stat } from 'node:fs/promises';
+import { resolve, dirname, basename, join } from 'node:path';
 import { initOcct } from '../../../kernel/backends/occt/occtBackend';
 import {
   runAndExport,
@@ -31,6 +31,12 @@ export interface ExportInput {
   out: string;
   /** Watertight verify gate for STL; default-on (`--no-verify` to skip). */
   verify?: boolean;
+  /** Output path for a numeric authored connector sidecar. */
+  connectorManifest?: string;
+  /** Catalog identity required for a connector-manifest sidecar. */
+  manifestPartId?: string;
+  /** Catalog family required for a connector-manifest sidecar. */
+  manifestFamily?: string;
 }
 
 export interface ExportCliResult {
@@ -41,7 +47,99 @@ export interface ExportCliResult {
   meshFiles?: string[];
 }
 
+function manifestOptionError(input: Pick<ExportInput, 'format' | 'connectorManifest' | 'manifestPartId' | 'manifestFamily'>): string | undefined {
+  const values = [input.connectorManifest, input.manifestPartId, input.manifestFamily];
+  if (!values.some((value) => value !== undefined)) return undefined;
+  if (values.some((value) => value === undefined)) {
+    return '--connector-manifest, --manifest-part-id, and --manifest-family must be provided together.';
+  }
+  if (input.format !== 'step') {
+    return '--connector-manifest is only supported for STEP exports.';
+  }
+  return undefined;
+}
+
+function invalidManifestOptionsResult(message: string): ExportCliResult {
+  return {
+    exitCode: 2,
+    bytesWritten: 0,
+    diagnostics: withNextActions([{
+      target: 'export-occt',
+      code: 'cli.invalid-args',
+      severity: 'error',
+      message,
+      hint: 'Pass all three connector-manifest options with a STEP export, or omit all three.',
+    }]),
+  };
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && ((error as { code?: unknown }).code === 'ENOENT'
+      || (error as { code?: unknown }).code === 'ENOTDIR');
+}
+
+/** Resolve the deepest existing path segment so sibling paths through a
+ * symlinked directory compare as one output target even before either file
+ * exists. Fall back to the lexical absolute path on inaccessible paths; the
+ * normal write diagnostic remains responsible for reporting that failure. */
+async function canonicalOutputPath(path: string): Promise<string> {
+  const absolute = resolve(path);
+  let probe = absolute;
+  const missingSegments: string[] = [];
+  while (true) {
+    try {
+      return join(await realpath(probe), ...missingSegments);
+    } catch (error) {
+      if (!isMissingPathError(error)) return absolute;
+      const parent = dirname(probe);
+      if (parent === probe) return absolute;
+      missingSegments.unshift(basename(probe));
+      probe = parent;
+    }
+  }
+}
+
+async function existingFileIdentity(path: string): Promise<{ dev: number; ino: number } | undefined> {
+  try {
+    const info = await stat(path);
+    return { dev: info.dev, ino: info.ino };
+  } catch {
+    // The normal output write produces the user-facing diagnostic for paths
+    // that cannot be stat'ed or written. No identity is available to compare.
+    return undefined;
+  }
+}
+
+/** Detect lexical, symlink, case-folded, and pre-existing hard-link aliases.
+ * Calling this again after writing the STEP also catches case-folded aliases
+ * that cannot be observed until the output path exists. */
+async function outputPathsAlias(first: string, second: string): Promise<boolean> {
+  const [firstCanonical, secondCanonical] = await Promise.all([
+    canonicalOutputPath(first),
+    canonicalOutputPath(second),
+  ]);
+  if (firstCanonical === secondCanonical) return true;
+  const [firstIdentity, secondIdentity] = await Promise.all([
+    existingFileIdentity(first),
+    existingFileIdentity(second),
+  ]);
+  return firstIdentity !== undefined
+    && secondIdentity !== undefined
+    && firstIdentity.dev === secondIdentity.dev
+    && firstIdentity.ino === secondIdentity.ino;
+}
+
 export async function exportScript(input: ExportInput): Promise<ExportCliResult> {
+  const manifestError = manifestOptionError(input);
+  if (manifestError !== undefined) return invalidManifestOptionsResult(manifestError);
+  const manifestPath = input.connectorManifest === undefined ? undefined : resolve(input.connectorManifest);
+  const outPath = resolve(input.out);
+  if (manifestPath !== undefined && await outputPathsAlias(outPath, manifestPath)) {
+    return invalidManifestOptionsResult('--connector-manifest must not overwrite the STEP output path.');
+  }
   await initOcct();
   const read = await readScriptOrDiagnostic(input.file);
   if (!read.ok) {
@@ -55,6 +153,14 @@ export async function exportScript(input: ExportInput): Promise<ExportCliResult>
       fileName: filePath,
       format: input.format,
       scriptDir: dirname(filePath),
+      ...(input.connectorManifest === undefined
+        ? {}
+        : {
+            connectorManifest: {
+              partId: input.manifestPartId!,
+              family: input.manifestFamily!,
+            },
+          }),
       ...(input.format === 'stl' && input.verify === false
         ? { options: { format: 'stl' as const, verify: false } }
         : {}),
@@ -73,10 +179,18 @@ export async function exportScript(input: ExportInput): Promise<ExportCliResult>
   // Write-then-fail: a verify-gate failure (export.mesh.not-watertight)
   // still carries the mesh bytes, so the file is written for inspection
   // BEFORE the gate fails the command — same contract as part-mode.
-  const outPath = resolve(input.out);
   const meshFiles: string[] = [];
   try {
     await writeFile(outPath, result.bytes);
+    if (manifestPath !== undefined) {
+      if (await outputPathsAlias(outPath, manifestPath)) {
+        throw new Error('--connector-manifest must not overwrite the STEP output path.');
+      }
+      if (result.connectorManifest === undefined) {
+        throw new Error('STEP export completed without the requested connector manifest.');
+      }
+      await writeFile(manifestPath, `${JSON.stringify(result.connectorManifest, null, 2)}\n`);
+    }
     // Robot-description exports (URDF / SDF) reference per-link mesh files
     // by relative path — write them next to the output file so the
     // document is consumable as-is.
@@ -217,13 +331,27 @@ export function exportCommand(): Command {
     .requiredOption('-o, --out <path>', 'output file path (output directory for --parts all and repeated --part)')
     .option('--part <name>', 'export a single named assembly part (STL only); repeat for a subset (-o is then a directory)', collectParts, [] as string[])
     .option('--parts <all>', "export every assembly part as <out-dir>/<part>.stl (value must be 'all')")
+    .option('--connector-manifest <path>', 'write numeric authored connector manifest beside a STEP export')
+    .option('--manifest-part-id <id>', 'catalog part id for --connector-manifest')
+    .option('--manifest-family <family>', 'catalog family for --connector-manifest')
     .option('--no-verify', 'skip the watertight verify gate after STL export')
     .option('--json', 'emit diagnostics as JSON')
     .action(async (format: string, file: string, opts: {
       out: string; json?: boolean; part?: string[]; parts?: string; verify?: boolean;
+      connectorManifest?: string; manifestPartId?: string; manifestFamily?: string;
     }) => {
       if (!SUPPORTED_FORMATS.has(format as ExportFormat)) {
         console.error(`Unsupported format: ${format}. Use one of ${[...SUPPORTED_FORMATS].join(', ')}.`);
+        process.exitCode = 2; return;
+      }
+      const manifestError = manifestOptionError({
+        format: format as ExportFormat,
+        connectorManifest: opts.connectorManifest,
+        manifestPartId: opts.manifestPartId,
+        manifestFamily: opts.manifestFamily,
+      });
+      if (manifestError !== undefined) {
+        console.error(manifestError);
         process.exitCode = 2; return;
       }
       const partMode = (opts.part?.length ?? 0) > 0 || opts.parts !== undefined;
@@ -260,6 +388,13 @@ export function exportCommand(): Command {
       }
       const r = await exportScript({
         file, format: format as ExportFormat, out: opts.out,
+        ...(opts.connectorManifest === undefined
+          ? {}
+          : {
+              connectorManifest: opts.connectorManifest,
+              manifestPartId: opts.manifestPartId,
+              manifestFamily: opts.manifestFamily,
+            }),
         ...(opts.verify === false ? { verify: false } : {}),
       });
       if (opts.json) {

--- a/src/agent/cli/commands/export.ts
+++ b/src/agent/cli/commands/export.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import { Command } from 'commander';
-import { writeFile, mkdir, realpath, stat } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { writeFile, mkdir, open, realpath, rename, rm, stat } from 'node:fs/promises';
 import { resolve, dirname, basename, join } from 'node:path';
 import { initOcct } from '../../../kernel/backends/occt/occtBackend';
 import {
@@ -132,6 +133,50 @@ async function outputPathsAlias(first: string, second: string): Promise<boolean>
     && firstIdentity.ino === secondIdentity.ino;
 }
 
+/**
+ * Replace a sidecar destination without following a late file or symlink
+ * alias. The staging file shares the destination directory, so `rename` is
+ * atomic and replaces the destination entry rather than its target.
+ *
+ * @internal Exported solely for focused filesystem-boundary tests.
+ */
+export async function writeManifestSidecarAtomically(destination: string, contents: string): Promise<void> {
+  const path = resolve(destination);
+  const stagedPath = join(dirname(path), `.${basename(path)}.${randomUUID()}.tmp`);
+  let stagedHandle: Awaited<ReturnType<typeof open>> | undefined;
+  let stagedCreated = false;
+
+  try {
+    stagedHandle = await open(stagedPath, 'wx');
+    stagedCreated = true;
+    await stagedHandle.writeFile(contents, 'utf8');
+    await stagedHandle.close();
+    stagedHandle = undefined;
+    await rename(stagedPath, path);
+  } catch (error) {
+    if (stagedHandle !== undefined) await stagedHandle.close().catch(() => undefined);
+    if (stagedCreated) await rm(stagedPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+function postStepManifestAliasResult(
+  bytes: Uint8Array,
+  diagnostics: readonly CompilerDiagnostic[],
+): ExportCliResult {
+  return {
+    exitCode: 1,
+    bytesWritten: bytes.length,
+    diagnostics: withNextActions([...diagnostics, {
+      target: 'export-occt',
+      code: 'cli.invalid-args',
+      severity: 'error',
+      message: 'The STEP output was written, but --connector-manifest now aliases it; the sidecar was not written.',
+      hint: 'Choose a distinct --connector-manifest path and retry; the STEP output remains intact.',
+    }]),
+  };
+}
+
 export async function exportScript(input: ExportInput): Promise<ExportCliResult> {
   const manifestError = manifestOptionError(input);
   if (manifestError !== undefined) return invalidManifestOptionsResult(manifestError);
@@ -184,12 +229,15 @@ export async function exportScript(input: ExportInput): Promise<ExportCliResult>
     await writeFile(outPath, result.bytes);
     if (manifestPath !== undefined) {
       if (await outputPathsAlias(outPath, manifestPath)) {
-        throw new Error('--connector-manifest must not overwrite the STEP output path.');
+        return postStepManifestAliasResult(result.bytes, result.diagnostics);
       }
       if (result.connectorManifest === undefined) {
         throw new Error('STEP export completed without the requested connector manifest.');
       }
-      await writeFile(manifestPath, `${JSON.stringify(result.connectorManifest, null, 2)}\n`);
+      await writeManifestSidecarAtomically(
+        manifestPath,
+        `${JSON.stringify(result.connectorManifest, null, 2)}\n`,
+      );
     }
     // Robot-description exports (URDF / SDF) reference per-link mesh files
     // by relative path — write them next to the output file so the

--- a/src/agent/script-runtime/connectorManifestExport.test.ts
+++ b/src/agent/script-runtime/connectorManifestExport.test.ts
@@ -29,7 +29,7 @@ import type { Connector } from '../../modeling/mates/connector';
 import { RecomputeEngine } from '../../modeling/compute/recomputeEngine';
 import { runScript } from '../../modeling/runtime/runScript';
 import { Scene } from '../../modeling/validation/scene';
-import { exportCommand, exportScript } from '../cli/commands/export';
+import { exportCommand, exportScript, writeManifestSidecarAtomically } from '../cli/commands/export';
 import { runAndExport } from './export';
 import { sceneToConnectorManifest } from './connectorManifestExport';
 
@@ -579,4 +579,26 @@ describe('connector manifest runtime and CLI integration', () => {
     expect(hardLinkAliasResult.exitCode).toBe(2);
     expect(readFileSync(hardLinkStepPath, 'utf8')).toBe('existing STEP bytes');
   });
+
+  it.each(['hard link', 'symbolic link'] as const)(
+    'replaces a late %s manifest destination instead of following the STEP inode',
+    async (aliasKind) => {
+      const directory = temporaryDirectory('kcad-manifest-late-alias-');
+      const stepPath = join(directory, 'servo.step');
+      const manifestPath = join(directory, 'servo.connector-manifest.json');
+      const stepBytes = Buffer.from('STEP bytes that must survive');
+      const manifestContents = '{\n  "partId": "servo"\n}\n';
+      writeFileSync(stepPath, stepBytes);
+
+      // Model an alias created after exportScript's post-STEP check but before
+      // the sidecar writer opens its destination.
+      if (aliasKind === 'hard link') linkSync(stepPath, manifestPath);
+      else symlinkSync(stepPath, manifestPath);
+
+      await writeManifestSidecarAtomically(manifestPath, manifestContents);
+
+      expect(readFileSync(stepPath)).toEqual(stepBytes);
+      expect(readFileSync(manifestPath, 'utf8')).toBe(manifestContents);
+    },
+  );
 });

--- a/src/agent/script-runtime/connectorManifestExport.test.ts
+++ b/src/agent/script-runtime/connectorManifestExport.test.ts
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import {
+  chmodSync,
   existsSync,
   linkSync,
   mkdirSync,
@@ -543,6 +544,54 @@ describe('connector manifest runtime and CLI integration', () => {
     });
   });
 
+  it('rejects an existing manifest before it can overwrite the STEP output', async () => {
+    const directory = temporaryDirectory('kcad-manifest-existing-');
+    const file = join(directory, 'servo.kcad.ts');
+    const out = join(directory, 'servo.step');
+    const manifestPath = join(directory, 'servo.connector-manifest.json');
+    writeFileSync(file, RUNTIME_CODE);
+    writeFileSync(manifestPath, 'existing manifest');
+
+    const result = await exportScript({
+      file,
+      format: 'step',
+      out,
+      connectorManifest: manifestPath,
+      manifestPartId: 'servo',
+      manifestFamily: 'micro-servo',
+    });
+
+    expect(result.exitCode).toBe(2);
+    expect(result.bytesWritten).toBe(0);
+    expect(readFileSync(manifestPath, 'utf8')).toBe('existing manifest');
+    expect(existsSync(out)).toBe(false);
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toContain('cli.invalid-args');
+  });
+
+  it('rejects an insecure manifest parent before writing the STEP output', async () => {
+    const directory = temporaryDirectory('kcad-manifest-insecure-parent-');
+    const file = join(directory, 'servo.kcad.ts');
+    const out = join(directory, 'servo.step');
+    const manifestPath = join(directory, 'servo.connector-manifest.json');
+    writeFileSync(file, RUNTIME_CODE);
+    chmodSync(directory, 0o777);
+
+    const result = await exportScript({
+      file,
+      format: 'step',
+      out,
+      connectorManifest: manifestPath,
+      manifestPartId: 'servo',
+      manifestFamily: 'micro-servo',
+    });
+
+    expect(result.exitCode).toBe(2);
+    expect(result.bytesWritten).toBe(0);
+    expect(existsSync(out)).toBe(false);
+    expect(existsSync(manifestPath)).toBe(false);
+    expect(result.diagnostics[0]?.message).toMatch(/must not be writable by group or other users/i);
+  });
+
   it('rejects symlink and hard-link aliases before a manifest can overwrite the STEP output', async () => {
     const directory = temporaryDirectory('kcad-manifest-alias-');
     const realDirectory = join(directory, 'real');
@@ -581,7 +630,7 @@ describe('connector manifest runtime and CLI integration', () => {
   });
 
   it.each(['hard link', 'symbolic link'] as const)(
-    'replaces a late %s manifest destination instead of following the STEP inode',
+    'rejects a late %s manifest destination without following the STEP inode',
     async (aliasKind) => {
       const directory = temporaryDirectory('kcad-manifest-late-alias-');
       const stepPath = join(directory, 'servo.step');
@@ -595,10 +644,11 @@ describe('connector manifest runtime and CLI integration', () => {
       if (aliasKind === 'hard link') linkSync(stepPath, manifestPath);
       else symlinkSync(stepPath, manifestPath);
 
-      await writeManifestSidecarAtomically(manifestPath, manifestContents);
+      await expect(writeManifestSidecarAtomically(manifestPath, manifestContents))
+        .rejects.toMatchObject({ code: 'EEXIST' });
 
       expect(readFileSync(stepPath)).toEqual(stepBytes);
-      expect(readFileSync(manifestPath, 'utf8')).toBe(manifestContents);
+      expect(readFileSync(manifestPath)).toEqual(stepBytes);
     },
   );
 });

--- a/src/agent/script-runtime/connectorManifestExport.test.ts
+++ b/src/agent/script-runtime/connectorManifestExport.test.ts
@@ -592,6 +592,30 @@ describe('connector manifest runtime and CLI integration', () => {
     expect(result.diagnostics[0]?.message).toMatch(/must not be writable by group or other users/i);
   });
 
+  it('reports the written STEP when sidecar publication fails after export', async () => {
+    const directory = temporaryDirectory('kcad-manifest-publication-error-');
+    const file = join(directory, 'servo.kcad.ts');
+    const out = join(directory, 'servo.step');
+    // The parent itself is valid, but this basename exceeds the portable
+    // filesystem component limit when the private staging directory is made.
+    const manifestPath = join(directory, 'm'.repeat(300));
+    writeFileSync(file, RUNTIME_CODE);
+
+    const result = await exportScript({
+      file,
+      format: 'step',
+      out,
+      connectorManifest: manifestPath,
+      manifestPartId: 'servo',
+      manifestFamily: 'micro-servo',
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.bytesWritten).toBeGreaterThan(0);
+    expect(existsSync(out)).toBe(true);
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toContain('cli.file-write');
+  });
+
   it('rejects symlink and hard-link aliases before a manifest can overwrite the STEP output', async () => {
     const directory = temporaryDirectory('kcad-manifest-alias-');
     const realDirectory = join(directory, 'real');

--- a/src/agent/script-runtime/connectorManifestExport.test.ts
+++ b/src/agent/script-runtime/connectorManifestExport.test.ts
@@ -1,0 +1,582 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  existsSync,
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FeatureRecord } from '../../shared/intent/featureRecord';
+import type { Param, Vec3Param } from '../../shared/intent/types';
+import { ParamTable } from '../../shared/runtime/paramTable';
+import { resolveParams } from '../../shared/runtime/resolveParams';
+import { Transform } from '../../shared/runtime/se3';
+import type { ShapeBackend } from '../../kernel/backends/backend';
+import type { SceneBackend } from '../../kernel/backends/sceneBackend';
+import { isSceneBackend } from '../../kernel/backends/sceneBackend';
+import { initOcct } from '../../kernel/backends/occt/occtBackend';
+import { sceneToWorldFrameParts } from '../../kernel/backends/occt/sceneToWorldFrame';
+import { createOcctLowerer } from '../../modeling/backends/occt/occtLowerer';
+import type { Shape } from '../../modeling/capture/proxy';
+import type { Connector } from '../../modeling/mates/connector';
+import { RecomputeEngine } from '../../modeling/compute/recomputeEngine';
+import { runScript } from '../../modeling/runtime/runScript';
+import { Scene } from '../../modeling/validation/scene';
+import { exportCommand, exportScript } from '../cli/commands/export';
+import { runAndExport } from './export';
+import { sceneToConnectorManifest } from './connectorManifestExport';
+
+const SOURCE_ID = 'source-model';
+const temporaryDirectories: string[] = [];
+
+function temporaryDirectory(prefix: string): string {
+  const directory = mkdtempSync(join(tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+interface FixturePart {
+  id: string;
+  name: string;
+  at?: [number, number, number];
+  connectors?: readonly Connector[];
+  worldTransform?: Transform;
+}
+
+interface FixtureOptions {
+  extraRecords?: readonly FeatureRecord[];
+  sourceMates?: boolean;
+  sceneMates?: boolean;
+}
+
+function scalar(value: number, unit: Param['unit'] = 'mm'): Param {
+  return { expression: String(value), unit, evaluated: value };
+}
+
+function vec3Param(values: [number, number, number]): Vec3Param {
+  return { x: scalar(values[0]), y: scalar(values[1]), z: scalar(values[2]) };
+}
+
+function assemblyPartRecord(part: FixturePart): FeatureRecord {
+  return {
+    id: part.id,
+    kind: 'assemblyPart',
+    params: {},
+    inputs: { shape: { kind: 'feature', id: `shape-${part.id}` } },
+    transforms: [],
+    suppressed: false,
+    metadata: {
+      assemblyName: 'target',
+      partName: part.name,
+      at: vec3Param(part.at ?? [0, 0, 0]),
+    },
+  };
+}
+
+function makeFixture(parts: readonly FixturePart[], options: FixtureOptions = {}) {
+  const sourceRecord: FeatureRecord = {
+    id: SOURCE_ID,
+    kind: 'assemblyModel',
+    params: {},
+    inputs: Object.fromEntries(parts.map((part, index) => [
+      `part_${index}`,
+      { kind: 'feature', id: part.id },
+    ])),
+    transforms: [],
+    suppressed: false,
+    metadata: {
+      assemblyName: 'target',
+      partIds: parts.map((part) => part.id),
+      ...(options.sourceMates ? { mates: [{ name: 'mate' }] } : {}),
+    },
+  };
+  const scene = new Scene(
+    'target',
+    parts.map((part) => ({
+      name: part.name,
+      shape: {} as Shape,
+      worldTransform: Transform.identity(),
+      ...(part.connectors === undefined ? {} : { connectors: part.connectors }),
+    })),
+    () => ({ min: [0, 0, 0], max: [0, 0, 0] }),
+    undefined,
+    SOURCE_ID,
+    options.sceneMates ? ([{ name: 'mate' }] as never) : undefined,
+  );
+  const lowered: SceneBackend = {
+    target: 'export-occt',
+    assemblyName: 'target',
+    _kind: 'scene',
+    parts: parts.map((part) => ({
+      name: part.name,
+      shape: {} as ShapeBackend,
+      worldTransform: part.worldTransform ?? Transform.identity(),
+    })),
+  };
+  return {
+    scene,
+    lowered,
+    records: [...parts.map(assemblyPartRecord), sourceRecord, ...(options.extraRecords ?? [])],
+  };
+}
+
+const FRAME: Connector = {
+  name: 'pwm-contact',
+  type: 'frame',
+  origin: { kind: 'vec3', value: [1, 1, 1] },
+  normal: [1, 0, 0],
+};
+
+const AXIS: Connector = {
+  name: 'shaft',
+  type: 'axis',
+  origin: { kind: 'vec3', value: [1, 1, 1] },
+  axis: [0, 1, 0],
+};
+
+const RUNTIME_CODE = `
+  const arm = assembly('target');
+  arm.part('servo', box(1, 1, 1), { at: [10, 20, 30] })
+    .connector('pwm-contact', {
+      type: 'frame',
+      origin: { kind: 'vec3', value: [1, 1, 1] },
+      normal: [1, 0, 0],
+    });
+  return arm.model();
+`;
+
+async function lowerRuntimeScene(code = RUNTIME_CODE) {
+  const run = await runScript({ code, fileName: 'connector-manifest.kcad.ts' });
+  if (!(run.returnValue instanceof Scene)) throw new Error('fixture did not return a Scene');
+  const scene = run.returnValue;
+  const sourceId = scene.__sourceFeatureId();
+  if (sourceId === undefined) throw new Error('fixture Scene has no source id');
+  const engine = new RecomputeEngine(createOcctLowerer(run.session));
+  const recomputed = await engine.run(run.records, { paramTable: run.paramTable });
+  if (recomputed.diagnostics.some((diagnostic) => diagnostic.severity === 'error')) {
+    throw new Error(`fixture lowering failed: ${JSON.stringify(recomputed.diagnostics)}`);
+  }
+  const lowered = recomputed.shapes.get(sourceId);
+  if (!isSceneBackend(lowered)) throw new Error('fixture source did not lower to SceneBackend');
+  return { scene, lowered, run };
+}
+
+describe('sceneToConnectorManifest', () => {
+  beforeAll(async () => { await initOcct(); });
+
+  it('matches the STEP world frame for a real placed assembly part', async () => {
+    const { scene, lowered, run } = await lowerRuntimeScene();
+
+    expect(lowered.parts[0].worldTransform.point([1, 1, 1])).toEqual([1, 1, 1]);
+    expect(sceneToWorldFrameParts(lowered)[0].shape.boundingBox().min).toEqual([10, 20, 30]);
+    expect(sceneToConnectorManifest(
+      scene,
+      lowered,
+      resolveParams(run.records, run.paramTable),
+      { partId: 'servo', family: 'micro-servo' },
+    )).toMatchObject({
+      schemaVersion: 1,
+      partId: 'servo',
+      family: 'micro-servo',
+      connectors: [{
+        name: 'pwm-contact',
+        type: 'frame',
+        origin: [11, 21, 31],
+        normal: [1, 0, 0],
+      }],
+    });
+  });
+
+  it('uses resolved ParamRef placements rather than their stale capture snapshots', () => {
+    const fixture = makeFixture([{ id: 'servo-part', name: 'servo', connectors: [FRAME] }]);
+    const part = fixture.records.find((record) => record.id === 'servo-part')!;
+    const at = (part.metadata as { at: Vec3Param }).at;
+    part.metadata = {
+      ...part.metadata,
+      at: {
+        ...at,
+        x: { expression: 'offset', unit: 'mm', evaluated: 0, paramRef: 'offset' },
+      },
+    };
+    const table = new ParamTable();
+    table.declare('offset', 'number', 40);
+
+    const manifest = sceneToConnectorManifest(
+      fixture.scene,
+      fixture.lowered,
+      resolveParams(fixture.records, table),
+      { partId: 'servo', family: 'micro-servo' },
+    );
+
+    expect(manifest.connectors[0]).toMatchObject({ origin: [41, 1, 1] });
+  });
+
+  it('composes a non-identity SceneBackend world transform after the part placement', () => {
+    const fixture = makeFixture([{
+      id: 'servo-part',
+      name: 'servo',
+      at: [10, 20, 30],
+      connectors: [FRAME, AXIS],
+      worldTransform: Transform.translation(5, 6, 7),
+    }]);
+
+    expect(sceneToConnectorManifest(
+      fixture.scene,
+      fixture.lowered,
+      fixture.records,
+      { partId: 'servo', family: 'micro-servo' },
+    )).toMatchObject({
+      connectors: [
+        { name: 'pwm-contact', type: 'frame', origin: [16, 27, 38], normal: [1, 0, 0] },
+        { name: 'shaft', type: 'axis', origin: [16, 27, 38], axis: [0, 1, 0] },
+      ],
+    });
+  });
+
+  it('defaults omitted frame normals and axis directions to +Z', () => {
+    const fixture = makeFixture([{
+      id: 'servo-part',
+      name: 'servo',
+      connectors: [
+        { name: 'frame-default', type: 'frame', origin: { kind: 'vec3', value: [0, 0, 0] } },
+        { name: 'axis-default', type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] } },
+      ],
+    }]);
+
+    expect(sceneToConnectorManifest(
+      fixture.scene,
+      fixture.lowered,
+      fixture.records,
+      { partId: 'servo', family: 'micro-servo' },
+    ).connectors).toEqual([
+      { name: 'frame-default', type: 'frame', origin: [0, 0, 0], normal: [0, 0, 1] },
+      { name: 'axis-default', type: 'axis', origin: [0, 0, 0], axis: [0, 0, 1] },
+    ]);
+  });
+
+  it('uses source assembly part IDs instead of an unrelated same-named part', () => {
+    const unrelatedPart = assemblyPartRecord({
+      id: 'other-servo-part',
+      name: 'servo',
+      at: [900, 0, 0],
+    });
+    unrelatedPart.metadata = {
+      ...unrelatedPart.metadata,
+      assemblyName: 'unrelated',
+    };
+    const unrelatedModel: FeatureRecord = {
+      id: 'other-model',
+      kind: 'assemblyModel',
+      params: {},
+      inputs: { part_0: { kind: 'feature', id: 'other-servo-part' } },
+      transforms: [],
+      suppressed: false,
+      metadata: { assemblyName: 'unrelated', partIds: ['other-servo-part'] },
+    };
+    const fixture = makeFixture([{
+      id: 'source-servo-part',
+      name: 'servo',
+      at: [10, 0, 0],
+      connectors: [FRAME],
+    }], { extraRecords: [unrelatedPart, unrelatedModel] });
+
+    const manifest = sceneToConnectorManifest(
+      fixture.scene,
+      fixture.lowered,
+      fixture.records,
+      { partId: 'servo', family: 'micro-servo' },
+    );
+
+    expect(manifest.connectors).toEqual([{
+      name: 'pwm-contact', type: 'frame', origin: [11, 1, 1], normal: [1, 0, 0],
+    }]);
+  });
+
+  it.each([
+    ['duplicate connector names', () => makeFixture([
+      { id: 'a', name: 'a', connectors: [{ ...FRAME, name: 'duplicate' }] },
+      { id: 'b', name: 'b', connectors: [{ ...AXIS, name: 'duplicate' }] },
+    ]), /duplicate connector/i],
+    ['a topology connector origin', () => makeFixture([{
+      id: 'servo-part', name: 'servo', connectors: [{
+        ...FRAME,
+        origin: { kind: 'topology', query: { kind: 'face-center', name: 'top' } },
+      }],
+    }]), /numeric Vec3/i],
+    ['a planar connector', () => makeFixture([{
+      id: 'servo-part', name: 'servo', connectors: [{
+        name: 'plane', type: 'planar', origin: { kind: 'vec3', value: [0, 0, 0] }, normal: [0, 0, 1],
+      }],
+    }]), /frame or axis/i],
+    ['a ball connector', () => makeFixture([{
+      id: 'servo-part', name: 'servo', connectors: [{
+        name: 'ball', type: 'ball', origin: { kind: 'vec3', value: [0, 0, 0] },
+      }],
+    }]), /frame or axis/i],
+    ['source assembly mates', () => makeFixture([{
+      id: 'servo-part', name: 'servo', connectors: [FRAME],
+    }], { sourceMates: true, sceneMates: true }), /mate-free/i],
+    ['a joint connected to source assembly parts', () => makeFixture([
+      { id: 'a', name: 'a', connectors: [FRAME] },
+      { id: 'b', name: 'b', connectors: [AXIS] },
+    ], {
+      extraRecords: [{
+        id: 'joint', kind: 'assemblyJoint', params: {}, transforms: [], suppressed: false,
+        inputs: { a: { kind: 'feature', id: 'a' }, b: { kind: 'feature', id: 'b' } },
+        metadata: { assemblyName: 'target', jointName: 'hinge' },
+      }],
+    }), /joint-free/i],
+  ] as const)('rejects %s', (_label, build, expected) => {
+    const fixture = build();
+    expect(() => sceneToConnectorManifest(
+      fixture.scene,
+      fixture.lowered,
+      fixture.records,
+      { partId: 'servo', family: 'micro-servo' },
+    )).toThrow(expected);
+  });
+
+  it('does not confuse an unrelated assembly joint with a source-owned joint', () => {
+    const unrelatedJoint: FeatureRecord = {
+      id: 'unrelated-joint', kind: 'assemblyJoint', params: {}, transforms: [], suppressed: false,
+      inputs: {
+        a: { kind: 'feature', id: 'source-a' },
+        b: { kind: 'feature', id: 'source-b' },
+      },
+      metadata: { assemblyName: 'unrelated', jointName: 'foreign-hinge' },
+    };
+    const fixture = makeFixture([
+      { id: 'source-a', name: 'a', connectors: [FRAME] },
+      { id: 'source-b', name: 'b', connectors: [AXIS] },
+    ], { extraRecords: [unrelatedJoint] });
+
+    expect(sceneToConnectorManifest(
+      fixture.scene,
+      fixture.lowered,
+      fixture.records,
+      { partId: 'servo', family: 'micro-servo' },
+    ).connectors).toHaveLength(2);
+  });
+
+  it('rejects a source-owned joint even when only one endpoint is a source part', () => {
+    const fixture = makeFixture([{
+      id: 'source-part', name: 'servo', connectors: [FRAME],
+    }], {
+      extraRecords: [{
+        id: 'source-joint', kind: 'assemblyJoint', params: {}, transforms: [], suppressed: false,
+        inputs: {
+          a: { kind: 'feature', id: 'source-part' },
+          b: { kind: 'feature', id: 'outside-part' },
+        },
+        metadata: { assemblyName: 'target', jointName: 'cross-boundary' },
+      }],
+    });
+
+    expect(() => sceneToConnectorManifest(
+      fixture.scene,
+      fixture.lowered,
+      fixture.records,
+      { partId: 'servo', family: 'micro-servo' },
+    )).toThrow(/joint-free/i);
+  });
+
+  it('fails closed on a malformed resolved part placement', () => {
+    const fixture = makeFixture([{ id: 'servo-part', name: 'servo', connectors: [FRAME] }]);
+    const part = fixture.records.find((record) => record.id === 'servo-part')!;
+    part.metadata = {
+      ...part.metadata,
+      at: { x: scalar(0), y: null, z: scalar(0) },
+    };
+
+    expect(() => sceneToConnectorManifest(
+      fixture.scene,
+      fixture.lowered,
+      fixture.records,
+      { partId: 'servo', family: 'micro-servo' },
+    )).toThrow(/invalid resolved at placement/i);
+  });
+
+  it('fails closed when the source is solved, parts are ambiguous, or names disagree', () => {
+    const fixture = makeFixture([{ id: 'servo-part', name: 'servo', connectors: [FRAME] }]);
+    const source = fixture.records.find((record) => record.id === SOURCE_ID)!;
+    const sourceAsSolved = fixture.records.map((record) => (
+      record.id === SOURCE_ID ? { ...record, kind: 'solvedAssembly' as const } : record
+    ));
+    expect(() => sceneToConnectorManifest(
+      fixture.scene, fixture.lowered, sourceAsSolved, { partId: 'servo', family: 'micro-servo' },
+    )).toThrow(/assemblyModel/i);
+
+    const part = fixture.records.find((record) => record.id === 'servo-part')!;
+    expect(() => sceneToConnectorManifest(
+      fixture.scene,
+      fixture.lowered,
+      [...fixture.records, { ...part }],
+      { partId: 'servo', family: 'micro-servo' },
+    )).toThrow(/ambiguous/i);
+
+    const mismatchedBackend: SceneBackend = {
+      ...fixture.lowered,
+      parts: [{ ...fixture.lowered.parts[0], name: 'wrong-name' }],
+    };
+    expect(() => sceneToConnectorManifest(
+      fixture.scene, mismatchedBackend, fixture.records, { partId: 'servo', family: 'micro-servo' },
+    )).toThrow(/name agreement/i);
+    expect(source.kind).toBe('assemblyModel');
+  });
+});
+
+describe('connector manifest runtime and CLI integration', () => {
+  beforeAll(async () => { await initOcct(); });
+  afterEach(() => {
+    process.exitCode = undefined;
+    for (const directory of temporaryDirectories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('returns a manifest from the exact SceneBackend used for STEP export', async () => {
+    const result = await runAndExport({
+      code: RUNTIME_CODE,
+      fileName: 'runtime-manifest.kcad.ts',
+      format: 'step',
+      connectorManifest: { partId: 'servo', family: 'micro-servo' },
+    });
+
+    expect(result.diagnostics.filter((diagnostic) => diagnostic.severity === 'error')).toEqual([]);
+    expect(result.connectorManifest).toMatchObject({
+      partId: 'servo', family: 'micro-servo',
+      connectors: [{ name: 'pwm-contact', origin: [11, 21, 31] }],
+    });
+  });
+
+  it('rejects manifest requests outside STEP Scene exports and mismatched feature ids', async () => {
+    await expect(runAndExport({
+      code: RUNTIME_CODE,
+      fileName: 'runtime-manifest.kcad.ts',
+      format: 'stl',
+      connectorManifest: { partId: 'servo', family: 'micro-servo' },
+    })).rejects.toThrow(/STEP/i);
+
+    const run = await runScript({ code: RUNTIME_CODE, fileName: 'runtime-manifest.kcad.ts' });
+    const boxId = run.records.find((record) => record.kind === 'box')!.id;
+    await expect(runAndExport({
+      code: RUNTIME_CODE,
+      fileName: 'runtime-manifest.kcad.ts',
+      format: 'step',
+      feature_id: boxId,
+      connectorManifest: { partId: 'servo', family: 'micro-servo' },
+    })).rejects.toThrow(/source feature/i);
+  });
+
+  it('requires the three CLI manifest options as a STEP-only group', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await exportCommand().parseAsync(
+        ['step', '/tmp/unused.kcad.ts', '-o', '/tmp/out.step', '--connector-manifest', '/tmp/out.json', '--manifest-part-id', 'servo'],
+        { from: 'user' },
+      );
+      expect(process.exitCode).toBe(2);
+      expect(err.mock.calls.flat().join('\n')).toMatch(/must be provided together/i);
+      err.mockClear();
+      process.exitCode = undefined;
+
+      await exportCommand().parseAsync(
+        ['stl', '/tmp/unused.kcad.ts', '-o', '/tmp/out.stl', '--connector-manifest', '/tmp/out.json', '--manifest-part-id', 'servo', '--manifest-family', 'micro-servo'],
+        { from: 'user' },
+      );
+      expect(process.exitCode).toBe(2);
+      expect(err.mock.calls.flat().join('\n')).toMatch(/STEP/i);
+    } finally {
+      err.mockRestore();
+    }
+  });
+
+  it('validates the connector-manifest option group for direct exportScript callers', async () => {
+    const incomplete = await exportScript({
+      file: '/tmp/unused.kcad.ts',
+      format: 'step',
+      out: '/tmp/out.step',
+      connectorManifest: '/tmp/out.json',
+    });
+    expect(incomplete.exitCode).toBe(2);
+    expect(incomplete.diagnostics[0]?.message).toMatch(/must be provided together/i);
+
+    const nonStep = await exportScript({
+      file: '/tmp/unused.kcad.ts',
+      format: 'stl',
+      out: '/tmp/out.stl',
+      connectorManifest: '/tmp/out.json',
+      manifestPartId: 'servo',
+      manifestFamily: 'micro-servo',
+    });
+    expect(nonStep.exitCode).toBe(2);
+    expect(nonStep.diagnostics[0]?.message).toMatch(/STEP/i);
+  });
+
+  it('writes the requested manifest beside the STEP output through exportScript', async () => {
+    const directory = temporaryDirectory('kcad-manifest-export-');
+    const file = join(directory, 'servo.kcad.ts');
+    const out = join(directory, 'servo.step');
+    const manifestPath = join(directory, 'servo.connector-manifest.json');
+    writeFileSync(file, RUNTIME_CODE);
+
+    const result = await exportScript({
+      file,
+      format: 'step',
+      out,
+      connectorManifest: manifestPath,
+      manifestPartId: 'servo',
+      manifestFamily: 'micro-servo',
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(readFileSync(manifestPath, 'utf8'))).toMatchObject({
+      partId: 'servo', family: 'micro-servo',
+      connectors: [{ name: 'pwm-contact', origin: [11, 21, 31] }],
+    });
+  });
+
+  it('rejects symlink and hard-link aliases before a manifest can overwrite the STEP output', async () => {
+    const directory = temporaryDirectory('kcad-manifest-alias-');
+    const realDirectory = join(directory, 'real');
+    const aliasDirectory = join(directory, 'alias');
+    const scriptPath = join(directory, 'servo.kcad.ts');
+    mkdirSync(realDirectory);
+    symlinkSync(realDirectory, aliasDirectory);
+    writeFileSync(scriptPath, RUNTIME_CODE);
+
+    const stepPath = join(realDirectory, 'servo.step');
+    const symlinkAliasResult = await exportScript({
+      file: scriptPath,
+      format: 'step',
+      out: stepPath,
+      connectorManifest: join(aliasDirectory, 'servo.step'),
+      manifestPartId: 'servo',
+      manifestFamily: 'micro-servo',
+    });
+    expect(symlinkAliasResult.exitCode).toBe(2);
+    expect(existsSync(stepPath)).toBe(false);
+
+    const hardLinkStepPath = join(directory, 'hard-link.step');
+    const hardLinkManifestPath = join(directory, 'hard-link.json');
+    writeFileSync(hardLinkStepPath, 'existing STEP bytes');
+    linkSync(hardLinkStepPath, hardLinkManifestPath);
+    const hardLinkAliasResult = await exportScript({
+      file: scriptPath,
+      format: 'step',
+      out: hardLinkStepPath,
+      connectorManifest: hardLinkManifestPath,
+      manifestPartId: 'servo',
+      manifestFamily: 'micro-servo',
+    });
+    expect(hardLinkAliasResult.exitCode).toBe(2);
+    expect(readFileSync(hardLinkStepPath, 'utf8')).toBe('existing STEP bytes');
+  });
+});

--- a/src/agent/script-runtime/connectorManifestExport.ts
+++ b/src/agent/script-runtime/connectorManifestExport.ts
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import type { Scene } from '../../modeling/validation/scene';
+import type { Connector } from '../../modeling/mates/connector';
+import type { SceneBackend } from '../../kernel/backends/sceneBackend';
+import type { FeatureRecord } from '../../shared/intent/featureRecord';
+import type { Param, Vec3 } from '../../shared/intent/types';
+import {
+  validateConnectorManifest,
+  type ConnectorEntry,
+  type ConnectorManifest,
+} from '../../shared/parts/connectorManifestSchema';
+import { Transform } from '../../shared/runtime/se3';
+
+interface AssemblyModelMetadata {
+  assemblyName: string;
+  partIds: readonly string[];
+  mates: readonly unknown[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isResolvedParam(value: unknown): value is Param {
+  return isRecord(value)
+    && typeof value.expression === 'string'
+    && typeof value.unit === 'string'
+    && typeof value.evaluated === 'number'
+    && Number.isFinite(value.evaluated);
+}
+
+function mutableVec3(vector: readonly [number, number, number]): Vec3 {
+  return [vector[0], vector[1], vector[2]];
+}
+
+function onlyRecordById(
+  records: readonly FeatureRecord[],
+  id: string,
+  label: string,
+): FeatureRecord {
+  const matches = records.filter((record) => record.id === id);
+  if (matches.length !== 1) {
+    throw new Error(
+      `connector-manifest export found an ambiguous or missing ${label} record '${id}' (found ${matches.length}).`,
+    );
+  }
+  return matches[0];
+}
+
+function readAssemblyModelMetadata(record: FeatureRecord): AssemblyModelMetadata {
+  if (!isRecord(record.metadata)) {
+    throw new Error('connector-manifest export assemblyModel source is missing metadata.');
+  }
+  const assemblyName = record.metadata.assemblyName;
+  if (typeof assemblyName !== 'string' || assemblyName.length === 0) {
+    throw new Error('connector-manifest export assemblyModel source is missing assemblyName.');
+  }
+  const partIds = record.metadata.partIds;
+  if (!Array.isArray(partIds) || partIds.length === 0 || partIds.some((id) => typeof id !== 'string')) {
+    throw new Error('connector-manifest export assemblyModel source has invalid partIds.');
+  }
+  if (new Set(partIds).size !== partIds.length) {
+    throw new Error('connector-manifest export assemblyModel source has ambiguous partIds.');
+  }
+  const mates = record.metadata.mates;
+  if (mates !== undefined && !Array.isArray(mates)) {
+    throw new Error('connector-manifest export assemblyModel source has invalid mates metadata.');
+  }
+  return { assemblyName, partIds, mates: mates ?? [] };
+}
+
+function assertAssemblyPartInputs(
+  source: FeatureRecord,
+  partIds: readonly string[],
+): void {
+  const partInputKeys = Object.keys(source.inputs).filter((key) => /^part_\d+$/.test(key));
+  if (partInputKeys.length !== partIds.length) {
+    throw new Error(
+      'connector-manifest export assemblyModel input count does not agree with metadata.partIds.',
+    );
+  }
+  for (const [index, partId] of partIds.entries()) {
+    const input = source.inputs[`part_${index}`];
+    if (input?.kind !== 'feature' || input.id !== partId) {
+      throw new Error(
+        `connector-manifest export assemblyModel input part_${index} does not agree with metadata.partIds.`,
+      );
+    }
+  }
+}
+
+function readAssemblyPartName(
+  record: FeatureRecord,
+  expectedAssemblyName: string,
+): string {
+  if (record.kind !== 'assemblyPart' || !isRecord(record.metadata)) {
+    throw new Error(`connector-manifest export expected an assemblyPart record '${record.id}'.`);
+  }
+  if (record.metadata.assemblyName !== expectedAssemblyName) {
+    throw new Error(
+      `connector-manifest export assemblyPart '${record.id}' does not belong to source assembly '${expectedAssemblyName}'.`,
+    );
+  }
+  const partName = record.metadata.partName;
+  if (typeof partName !== 'string' || partName.length === 0) {
+    throw new Error(`connector-manifest export assemblyPart '${record.id}' is missing partName.`);
+  }
+  return partName;
+}
+
+function readAssemblyPartAt(record: FeatureRecord): Vec3 {
+  if (!isRecord(record.metadata) || !isRecord(record.metadata.at)) {
+    throw new Error(`connector-manifest export assemblyPart '${record.id}' is missing resolved at placement.`);
+  }
+  const { x, y, z } = record.metadata.at;
+  if (!isResolvedParam(x) || !isResolvedParam(y) || !isResolvedParam(z)) {
+    throw new Error(`connector-manifest export assemblyPart '${record.id}' has invalid resolved at placement.`);
+  }
+  return [x.evaluated, y.evaluated, z.evaluated];
+}
+
+function sourceAssemblyHasJoints(
+  sourceAssemblyName: string,
+  sourcePartIds: ReadonlySet<string>,
+  records: readonly FeatureRecord[],
+): boolean {
+  return records.some((record) => {
+    if (record.kind !== 'assemblyJoint') return false;
+    if (!isRecord(record.metadata) || record.metadata.assemblyName !== sourceAssemblyName) {
+      return false;
+    }
+    const a = record.inputs.a;
+    const b = record.inputs.b;
+    return (a?.kind === 'feature' && sourcePartIds.has(a.id))
+      || (b?.kind === 'feature' && sourcePartIds.has(b.id));
+  });
+}
+
+function assertUniquePartNames(names: readonly string[], label: string): void {
+  if (new Set(names).size !== names.length) {
+    throw new Error(`connector-manifest export ${label} has ambiguous duplicate part names.`);
+  }
+}
+
+function connectorToManifestEntry(
+  connector: Connector,
+  transform: Transform,
+): ConnectorEntry {
+  if (connector.type !== 'frame' && connector.type !== 'axis') {
+    throw new Error(
+      `connector-manifest export supports only frame or axis connectors; '${connector.name}' is '${connector.type}'.`,
+    );
+  }
+  if (connector.origin.kind !== 'vec3') {
+    throw new Error(
+      `connector-manifest export requires a numeric Vec3 origin for connector '${connector.name}'.`,
+    );
+  }
+  const origin = mutableVec3(transform.point(connector.origin.value));
+  if (connector.type === 'frame') {
+    return {
+      name: connector.name,
+      type: 'frame',
+      origin,
+      normal: mutableVec3(transform.axisDir(connector.normal ?? [0, 0, 1])),
+    };
+  }
+  return {
+    name: connector.name,
+    type: 'axis',
+    origin,
+    axis: mutableVec3(transform.axisDir(connector.axis ?? [0, 0, 1])),
+  };
+}
+
+/**
+ * Convert the numeric, source-scoped connectors of a mate-free static
+ * assembly Scene into a portable manifest. The assembly part's `at` placement
+ * is baked into the lowered part shape, while SceneBackend.worldTransform is
+ * applied later by STEP export, so the manifest uses their exact composition.
+ */
+export function sceneToConnectorManifest(
+  scene: Scene,
+  lowered: SceneBackend,
+  resolvedRecords: readonly FeatureRecord[],
+  identity: { partId: string; family: string },
+): ConnectorManifest {
+  const sourceId = scene.__sourceFeatureId();
+  if (sourceId === undefined) {
+    throw new Error('connector-manifest export requires a Scene with an assemblyModel source feature.');
+  }
+  const source = onlyRecordById(resolvedRecords, sourceId, 'source feature');
+  if (source.kind !== 'assemblyModel') {
+    throw new Error(
+      `connector-manifest export requires an assemblyModel source feature; received '${source.kind}'.`,
+    );
+  }
+  const metadata = readAssemblyModelMetadata(source);
+  if ((scene.mates?.length ?? 0) > 0 || metadata.mates.length > 0) {
+    throw new Error('connector-manifest export requires a mate-free, joint-free assembly.');
+  }
+  const sourcePartIds = new Set(metadata.partIds);
+  if (sourceAssemblyHasJoints(metadata.assemblyName, sourcePartIds, resolvedRecords)) {
+    throw new Error('connector-manifest export requires a mate-free, joint-free assembly.');
+  }
+  assertAssemblyPartInputs(source, metadata.partIds);
+
+  if (
+    scene.parts.length !== metadata.partIds.length ||
+    lowered.parts.length !== metadata.partIds.length
+  ) {
+    throw new Error('connector-manifest export requires source, Scene, and lowered part counts to agree.');
+  }
+  if (scene.assemblyName !== metadata.assemblyName || lowered.assemblyName !== metadata.assemblyName) {
+    throw new Error('connector-manifest export source, Scene, and lowered assembly names must agree.');
+  }
+  assertUniquePartNames(scene.parts.map((part) => part.name), 'Scene');
+  assertUniquePartNames(lowered.parts.map((part) => part.name), 'lowered SceneBackend');
+
+  const connectors: ConnectorEntry[] = [];
+  const connectorNames = new Set<string>();
+  for (const [index, partId] of metadata.partIds.entries()) {
+    const scenePart = scene.parts[index];
+    const backendPart = lowered.parts[index];
+    const assemblyPart = onlyRecordById(resolvedRecords, partId, 'assemblyPart');
+    const partName = readAssemblyPartName(assemblyPart, metadata.assemblyName);
+    if (scenePart.name !== partName || backendPart.name !== partName) {
+      throw new Error(
+        `connector-manifest export Scene and lowered part name agreement failed at index ${index}.`,
+      );
+    }
+    const at = readAssemblyPartAt(assemblyPart);
+    const transform = backendPart.worldTransform.compose(
+      Transform.translation(at[0], at[1], at[2]),
+    );
+    for (const connector of scenePart.connectors ?? []) {
+      if (connectorNames.has(connector.name)) {
+        throw new Error(`connector-manifest export has duplicate connector name '${connector.name}'.`);
+      }
+      connectorNames.add(connector.name);
+      connectors.push(connectorToManifestEntry(connector, transform));
+    }
+  }
+
+  const manifest: ConnectorManifest = {
+    schemaVersion: 1,
+    partId: identity.partId,
+    family: identity.family,
+    connectors,
+  };
+  validateConnectorManifest(manifest);
+  return manifest;
+}

--- a/src/agent/script-runtime/export.ts
+++ b/src/agent/script-runtime/export.ts
@@ -21,6 +21,9 @@ import { NEXT_ACTIONS, HINT_TEMPLATES } from '../../shared/diagnostics/registry'
 import { Shape } from '../../modeling/capture/proxy';
 import { Scene } from '../../modeling/validation/scene';
 import { isRegion } from '../../shared/intent/region';
+import { resolveParams } from '../../shared/runtime/resolveParams';
+import type { ConnectorManifest } from '../../shared/parts/connectorManifestSchema';
+import { sceneToConnectorManifest } from './connectorManifestExport';
 
 export type ExportFormat =
   | 'stl' | 'step' | 'dxf' | '3mf' | 'glb' | 'svg-drawing'
@@ -64,6 +67,8 @@ export interface ExportInput {
   scriptDir?: string;
   /** Per-format options. Discriminator `options.format` must equal top-level `format`. */
   options?: ExportOptions;
+  /** Request a numeric authored connector sidecar for a static assembly STEP export. */
+  connectorManifest?: { partId: string; family: string };
 }
 
 /** Companion mesh file for robot-description exports (URDF / SDF). The
@@ -82,10 +87,12 @@ export interface ExportResult {
   diagnostics: CompilerDiagnostic[];
   /** Per-link mesh files referenced by the primary output (URDF / SDF). */
   meshes?: CompanionMeshFile[];
+  /** Numeric authored connector sidecar, present only when requested for a STEP Scene export. */
+  connectorManifest?: ConnectorManifest;
 }
 
 export async function runAndExport(input: ExportInput): Promise<ExportResult> {
-  const { code, fileName, format, feature_id, scriptDir } = input;
+  const { code, fileName, format, feature_id, scriptDir, connectorManifest: manifestRequest } = input;
 
   if (input.options && input.options.format !== input.format) {
     return {
@@ -102,6 +109,10 @@ export async function runAndExport(input: ExportInput): Promise<ExportResult> {
     };
   }
 
+  if (manifestRequest !== undefined && format !== 'step') {
+    throw new Error('connector-manifest export requires STEP format.');
+  }
+
   const run = await runScript({ code, fileName, scriptDir });
   const engine = new RecomputeEngine(createOcctLowerer(run.session));
   const r = await engine.run(run.records, { paramTable: run.paramTable });
@@ -112,6 +123,22 @@ export async function runAndExport(input: ExportInput): Promise<ExportResult> {
   if (fatal.length > 0) {
     return { bytes: new Uint8Array(), featureCount, diagnostics: r.diagnostics };
   }
+
+  const manifestScene = manifestRequest === undefined ? undefined : (() => {
+    if (!(run.returnValue instanceof Scene)) {
+      throw new Error('connector-manifest export requires the script to return an assembly Scene.');
+    }
+    const sourceId = run.returnValue.__sourceFeatureId();
+    if (sourceId === undefined) {
+      throw new Error('connector-manifest export requires a Scene with a source feature.');
+    }
+    if (feature_id !== undefined && feature_id !== sourceId) {
+      throw new Error(
+        `connector-manifest export feature_id '${feature_id}' must match Scene source feature '${sourceId}'.`,
+      );
+    }
+    return run.returnValue;
+  })();
 
   // DXF entry path: a script that returns a `Region` (typically from
   // `Shape.flattenPattern()`) bypasses target-shape lowering — the Region's
@@ -257,6 +284,10 @@ export async function runAndExport(input: ExportInput): Promise<ExportResult> {
     };
   }
 
+  if (manifestScene !== undefined && !isSceneBackend(lowered)) {
+    throw new Error('connector-manifest export requires the Scene source to lower to a SceneBackend.');
+  }
+
   // svg-drawing entry path: the engineering-drawing sheet accepts both a
   // single body and a multi-body Scene — Scene parts ship in world frame so
   // the hidden-line pass sees inter-part occlusion. Dispatched before the
@@ -282,8 +313,21 @@ export async function runAndExport(input: ExportInput): Promise<ExportResult> {
   // so fall back to the boolean union via assemblyExport(union).
   if (isSceneBackend(lowered)) {
     if (format === 'step') {
+      const connectorManifest = manifestRequest === undefined
+        ? undefined
+        : sceneToConnectorManifest(
+            manifestScene!,
+            lowered,
+            resolveParams(run.records, run.paramTable),
+            manifestRequest,
+          );
       const bytes = await exportSceneToSTEPAsync(lowered);
-      return { bytes, featureCount, diagnostics: r.diagnostics };
+      return {
+        bytes,
+        featureCount,
+        diagnostics: r.diagnostics,
+        ...(connectorManifest === undefined ? {} : { connectorManifest }),
+      };
     }
     if (format === 'dxf') {
       // DXF needs a single planar wire source; a multi-body Scene cannot

--- a/src/modeling/capture/assembly.catalogConnectors.test.ts
+++ b/src/modeling/capture/assembly.catalogConnectors.test.ts
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { describe, expect, it } from 'vitest';
+import type { ConnectorEntry } from '../../shared/parts/connectorManifestSchema';
+import { createApi } from '../api';
+import { CaptureSession } from './captureSession';
+
+const authoredConnectors = (): ConnectorEntry[] => [
+  {
+    name: 'mount',
+    type: 'frame',
+    origin: [1, 2, 3],
+    normal: [0, 0, 1],
+  },
+  {
+    name: 'shaft',
+    type: 'axis',
+    origin: [4, 5, 6],
+    axis: [0, 1, 0],
+  },
+];
+
+describe('Assembly catalog connector promotion', () => {
+  it('promotes authored frame and axis entries to both connector APIs and mates', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('arm');
+    const catalogShape = kcad.box(10, 10, 10);
+    session.attachCatalogConnectors(catalogShape.id, authoredConnectors());
+
+    const catalog = arm.part('catalog', catalogShape);
+    const mount = catalog.connector('mount');
+    const shaft = catalog.connector('shaft');
+
+    expect(mount.origin.x.evaluated).toBe(1);
+    expect(mount.origin.y.evaluated).toBe(2);
+    expect(mount.axis?.z.evaluated).toBe(1);
+    expect(shaft.origin.z.evaluated).toBe(6);
+    expect(shaft.axis?.y.evaluated).toBe(1);
+    expect(catalog.mateConnectors).toMatchObject([
+      {
+        name: 'mount',
+        type: 'frame',
+        origin: { kind: 'vec3', value: [1, 2, 3] },
+        normal: [0, 0, 1],
+      },
+      {
+        name: 'shaft',
+        type: 'axis',
+        origin: { kind: 'vec3', value: [4, 5, 6] },
+        axis: [0, 1, 0],
+      },
+    ]);
+
+    const fixture = arm.part('fixture', kcad.box(10, 10, 10));
+    fixture
+      .connector('mount', {
+        type: 'frame',
+        origin: { kind: 'vec3', value: [0, 0, 0] },
+        normal: [0, 0, 1],
+      })
+      .connector('shaft', {
+        type: 'axis',
+        origin: { kind: 'vec3', value: [0, 0, 0] },
+        axis: [0, 1, 0],
+      });
+
+    expect(() => arm.mate('fasten', 'catalog.mount', 'fixture.mount', 'fastened')).not.toThrow();
+    expect(() => arm.mate('turn', 'catalog.shaft', 'fixture.shaft', 'revolute')).not.toThrow();
+    expect(arm.__mates().map((mate) => [mate.name, mate.type])).toEqual([
+      ['fasten', 'fastened'],
+      ['turn', 'revolute'],
+    ]);
+  });
+
+  it('uses a promoted catalog connector for legacy opts.connect placement', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('arm');
+    const base = arm.part('base', kcad.box(10, 10, 10), {
+      at: [10, 0, 0],
+      connectors: { socket: { origin: [0, 0, 0], axis: [1, 0, 0] } },
+    });
+    const catalogShape = kcad.box(10, 10, 10);
+    session.attachCatalogConnectors(catalogShape.id, authoredConnectors());
+
+    const connected = arm.part('catalog', catalogShape, {
+      connect: { connector: 'mount', to: base.connector('socket') },
+    });
+
+    expect(connected.at.x.evaluated).toBe(9);
+    expect(connected.at.y.evaluated).toBe(-2);
+    expect(connected.at.z.evaluated).toBe(-3);
+  });
+
+  it('does not promote generic auto connectors', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('arm');
+    const genericShape = kcad.box(10, 10, 10);
+    session.attachAutoConnectors(genericShape.id, [
+      { name: 'heuristic-only', origin: [0, 0, 0], axis: [0, 0, 1] },
+    ]);
+
+    const part = arm.part('generic', genericShape);
+
+    expect(part.connectors).toEqual({});
+    expect(part.mateConnectors).toEqual([]);
+    expect(() => part.connector('heuristic-only')).toThrow(/not defined on part 'generic'/);
+  });
+
+  it('rejects a collision between catalog and user-declared legacy connectors', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('arm');
+    const catalogShape = kcad.box(10, 10, 10);
+    session.attachCatalogConnectors(catalogShape.id, authoredConnectors());
+
+    expect(() => arm.part('catalog', catalogShape, {
+      connectors: { mount: { origin: [0, 0, 0] } },
+    })).toThrow(/declared both by the catalog part and assembly\.part options/);
+  });
+
+  it('applies declared literal translate and rotate transforms to catalog frames in order', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('arm');
+    const catalogShape = kcad.box(10, 10, 10)
+      .translate(10, 0, 0)
+      .rotate([0, 0, 1], 90);
+    session.attachCatalogConnectors(catalogShape.id, [
+      {
+        name: 'mount',
+        type: 'frame',
+        origin: [1, 0, 0],
+        normal: [1, 0, 0],
+      },
+      {
+        name: 'shaft',
+        type: 'axis',
+        origin: [1, 0, 0],
+        axis: [1, 0, 0],
+      },
+    ]);
+
+    const part = arm.part('catalog', catalogShape);
+    const mount = part.mateConnectors.find((connector) => connector.name === 'mount');
+    const shaft = part.mateConnectors.find((connector) => connector.name === 'shaft');
+
+    expect(mount).toMatchObject({ name: 'mount', type: 'frame', origin: { kind: 'vec3' } });
+    if (mount?.origin.kind !== 'vec3') throw new Error('catalog mount must have a Vec3 origin');
+    expect(mount.origin.value[0]).toBeCloseTo(0, 10);
+    expect(mount.origin.value[1]).toBeCloseTo(11, 10);
+    expect(mount.normal?.[0]).toBeCloseTo(0, 10);
+    expect(mount.normal?.[1]).toBeCloseTo(1, 10);
+    expect(shaft).toMatchObject({
+      name: 'shaft',
+      type: 'axis',
+      origin: { kind: 'vec3' },
+    });
+    if (shaft?.origin.kind !== 'vec3') throw new Error('catalog shaft must have a Vec3 origin');
+    expect(shaft.origin.value[0]).toBeCloseTo(0, 10);
+    expect(shaft.origin.value[1]).toBeCloseTo(11, 10);
+    expect(shaft.origin.value[2]).toBeCloseTo(0, 10);
+    expect(shaft.axis?.[0]).toBeCloseTo(0, 10);
+    expect(shaft.axis?.[1]).toBeCloseTo(1, 10);
+    expect(shaft.axis?.[2]).toBeCloseTo(0, 10);
+    expect(part.connector('shaft').origin.x.evaluated).toBeCloseTo(0, 10);
+    expect(part.connector('shaft').origin.y.evaluated).toBeCloseTo(11, 10);
+    expect(part.connector('shaft').axis?.x.evaluated).toBeCloseTo(0, 10);
+    expect(part.connector('shaft').axis?.y.evaluated).toBeCloseTo(1, 10);
+  });
+
+  it('rejects catalog connector promotion through scale', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('arm');
+    const catalogShape = kcad.box(10, 10, 10).scale(2);
+    session.attachCatalogConnectors(catalogShape.id, authoredConnectors());
+
+    expect(() => arm.part('catalog', catalogShape)).toThrow(/catalog connector.*scale/i);
+  });
+
+  it('rejects catalog connector promotion through reflection', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('arm');
+    const catalogShape = kcad.box(10, 10, 10).reflect('xy');
+    session.attachCatalogConnectors(catalogShape.id, authoredConnectors());
+
+    expect(() => arm.part('catalog', catalogShape)).toThrow(/catalog connector.*reflect/i);
+  });
+
+  it('rejects catalog connector promotion through a ParamRef translate transform', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('arm');
+    const offset = kcad.param('offset', 10);
+    const catalogShape = kcad.box(10, 10, 10).translate(offset, 0, 0);
+    session.attachCatalogConnectors(catalogShape.id, authoredConnectors());
+
+    expect(() => arm.part('catalog', catalogShape)).toThrow(/catalog connector.*ParamRef/i);
+  });
+
+  it('rejects catalog connector promotion through a ParamRef rotate transform', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const arm = kcad.assembly('arm');
+    const degrees = kcad.param('degrees', 90);
+    const catalogShape = kcad.box(10, 10, 10).rotate([0, 0, 1], degrees);
+    session.attachCatalogConnectors(catalogShape.id, authoredConnectors());
+
+    expect(() => arm.part('catalog', catalogShape)).toThrow(/catalog connector.*ParamRef/i);
+  });
+
+  it('does not re-promote catalog connectors while flattening a subassembly', () => {
+    const session = new CaptureSession();
+    const kcad = createApi({ session });
+    const source = kcad.assembly('source');
+    const target = kcad.assembly('target');
+    const catalogShape = kcad.box(10, 10, 10);
+    session.attachCatalogConnectors(catalogShape.id, authoredConnectors());
+    source.part('catalog', catalogShape);
+
+    const imported = target.subAssembly('nested', source).part('catalog');
+
+    expect(imported.connectors).toHaveProperty('mount');
+    expect(imported.connectors).toHaveProperty('shaft');
+    expect(imported.mateConnectors.map((connector) => connector.name)).toEqual(['mount', 'shaft']);
+  });
+});

--- a/src/modeling/capture/assembly.ts
+++ b/src/modeling/capture/assembly.ts
@@ -748,6 +748,17 @@ export class Assembly {
   }
 
   part(name: string, shape: Shape, opts: AssemblyPartOpts = {}): AssemblyPartRef {
+    return this.partInternal(name, shape, opts, true);
+  }
+
+  /** Internal part route used by subAssembly() to copy already-promoted
+   * catalog interfaces without registering them a second time. */
+  private partInternal(
+    name: string,
+    shape: Shape,
+    opts: AssemblyPartOpts,
+    promoteCatalogConnectors: boolean,
+  ): AssemblyPartRef {
     assertTopoRefSafeName(name, 'part-name', shape.id);
     if (opts.at !== undefined && !isValidEditableVec3(opts.at)) {
       throw new KernelError(
@@ -807,6 +818,26 @@ export class Assembly {
       );
     }
     const connectors = normalizeConnectors(name, shape.id, opts.connectors);
+    const transformedCatalogConnectors = promoteCatalogConnectors
+      ? transformCatalogConnectors(this.session, shape)
+      : [];
+    for (const connector of transformedCatalogConnectors) {
+      if (Object.hasOwn(connectors, connector.name)) {
+        throw new KernelError(
+          'feature.invalid-args',
+          `assembly connector '${connector.name}' is declared both by the catalog part and assembly.part options.`,
+          shape.id,
+          'Rename the user-declared connector or use the catalog connector as-is.',
+        );
+      }
+      connectors[connector.name] = {
+        origin: toVec3Param(connector.origin, 'mm'),
+        axis: toVec3Param(
+          connector.type === 'frame' ? connector.normal : connector.axis,
+          'unitless',
+        ),
+      };
+    }
     const at = resolvePartPlacement(this.name, name, shape.id, opts.at, connectors, opts.connect);
     const record = this.session.assemblyPart(this.name, name, shape, { at, connectors, placedBy: opts.connect });
     // Q1.5: write the part-lineage entry now that the capture-session has
@@ -834,6 +865,15 @@ export class Assembly {
       (chainName, chainShape, chainOpts) => this.part(chainName, chainShape, chainOpts),
       this,
     );
+    for (const connector of transformedCatalogConnectors) {
+      part.connector(connector.name, {
+        type: connector.type,
+        origin: { kind: 'vec3', value: connector.origin },
+        ...(connector.type === 'frame'
+          ? { normal: connector.normal }
+          : { axis: connector.axis }),
+      });
+    }
     const stored: AssemblyPartStored = {
       ...part,
       originalShape: shape,
@@ -908,9 +948,9 @@ export class Assembly {
     const importedByOriginalName = new Map<string, AssemblyPartRef>();
     for (const op of other.__parts()) {
       const newName = `${prefix}${op.name}`;
-      const newRef = this.part(newName, op.originalShape, {
+      const newRef = this.partInternal(newName, op.originalShape, {
         ...(op.connectors !== undefined ? { connectors: op.connectors } : {}),
-      });
+      }, false);
       // Copy v0.6 mateConnectors (the .connector(name, opts) chain output)
       // by shallow-copying the array contents. The new part already owns an
       // empty mateConnectors array per `part()`; populate it now so post-
@@ -3074,6 +3114,113 @@ function normalizeConnectors(
       : { origin: toVec3Param(frame.origin, 'mm'), axis: toVec3Param(frame.axis, 'unitless') };
   }
   return normalized;
+}
+
+type TransformedCatalogConnector =
+  | {
+      name: string;
+      type: 'frame';
+      origin: Vec3;
+      normal: Vec3;
+    }
+  | {
+      name: string;
+      type: 'axis';
+      origin: Vec3;
+      axis: Vec3;
+    };
+
+function mutableVec3(vector: readonly [number, number, number]): Vec3 {
+  return [vector[0], vector[1], vector[2]];
+}
+
+function literalCatalogTransformParam(
+  value: Param,
+  shapeId: FeatureId,
+  transformLabel: string,
+): number {
+  if (value.paramRef !== undefined) {
+    throw new KernelError(
+      'feature.invalid-args',
+      `assembly.part cannot promote catalog connectors for shape '${shapeId}' because its ${transformLabel} uses a ParamRef.`,
+      shapeId,
+      'Use only literal translate and rotate transforms on catalog-backed shapes before adding them to an assembly.',
+    );
+  }
+  return value.evaluated;
+}
+
+function literalCatalogTransformVec3(
+  value: Vec3Param,
+  shapeId: FeatureId,
+  transformLabel: string,
+): Vec3 {
+  return [
+    literalCatalogTransformParam(value.x, shapeId, `${transformLabel}.x`),
+    literalCatalogTransformParam(value.y, shapeId, `${transformLabel}.y`),
+    literalCatalogTransformParam(value.z, shapeId, `${transformLabel}.z`),
+  ];
+}
+
+/**
+ * Catalog connector manifests describe a shape's untransformed local frame.
+ * Preserve that exact authored meaning through rigid, literal Shape transforms
+ * so the legacy connector-placement and mate connector APIs agree. Generic
+ * autoConnectors deliberately never enter this path.
+ */
+function transformCatalogConnectors(
+  session: CaptureSession,
+  shape: Shape,
+): TransformedCatalogConnector[] {
+  const catalogConnectors = session.catalogConnectors.get(shape.id);
+  if (catalogConnectors === undefined) return [];
+
+  const transforms = session.getRecords().find((record) => record.id === shape.id)?.transforms ?? [];
+  let total = Transform.identity();
+  for (const transform of transforms) {
+    let next: Transform;
+    if (transform.op === 'translate') {
+      const vector = literalCatalogTransformVec3(transform.vec, shape.id, 'translate');
+      next = Transform.translation(vector[0], vector[1], vector[2]);
+    } else if (transform.op === 'rotateAxis') {
+      const axis = literalCatalogTransformVec3(transform.axis, shape.id, 'rotate.axis');
+      const degrees = literalCatalogTransformParam(transform.degrees, shape.id, 'rotate.degrees');
+      const pivot = transform.pivot === undefined
+        ? [0, 0, 0] as Vec3
+        : literalCatalogTransformVec3(transform.pivot, shape.id, 'rotate.pivot');
+      next = Transform.rotationAroundPivot(axis, degrees, pivot);
+    } else {
+      const label = transform.op === 'scale' ? 'scale' : 'reflect';
+      throw new KernelError(
+        'feature.invalid-args',
+        `assembly.part cannot promote catalog connectors for shape '${shape.id}' through ${label}: catalog interfaces require rigid transforms.`,
+        shape.id,
+        'Use only literal translate and rotate transforms on catalog-backed shapes before adding them to an assembly.',
+      );
+    }
+    // Shape transforms execute in declaration order. Transform.compose reads
+    // "apply other, then this", so each new transform pre-multiplies the
+    // accumulated local-frame transform.
+    total = next.compose(total);
+  }
+
+  return catalogConnectors.map((connector): TransformedCatalogConnector => {
+    const origin = mutableVec3(total.point(connector.origin));
+    if (connector.type === 'frame') {
+      return {
+        name: connector.name,
+        type: 'frame',
+        origin,
+        normal: mutableVec3(total.axisDir(connector.normal)),
+      };
+    }
+    return {
+      name: connector.name,
+      type: 'axis',
+      origin,
+      axis: mutableVec3(total.axisDir(connector.axis)),
+    };
+  });
 }
 
 /** Sanity-check every numeric field on an authored cross-section. Lengths

--- a/src/modeling/capture/captureSession.ts
+++ b/src/modeling/capture/captureSession.ts
@@ -75,6 +75,11 @@ import {
   type ShapeOperationEdgeSelector,
   type ShapeOperationFaceSelector,
 } from './shapeOperationFeatureRecords';
+import {
+  validateConnectorManifest,
+  type ConnectorEntry,
+} from '../../shared/parts/connectorManifestSchema';
+import type { CatalogConnectorEntry } from '../../shared/parts/types';
 
 export type { EncodedMateRecord, SolvedAssemblyMateMetadata } from './assemblyFeatureRecords';
 
@@ -119,6 +124,35 @@ export interface SerializedSession {
   schemaVersion?: number;
   params?: SerializedParamTable;
   records: readonly FeatureRecord[];
+}
+
+function snapshotCatalogVector(
+  vector: [number, number, number],
+): readonly [number, number, number] {
+  const snapshot: [number, number, number] = [...vector];
+  Object.freeze(snapshot);
+  return snapshot;
+}
+
+function snapshotCatalogConnector(entry: ConnectorEntry): CatalogConnectorEntry {
+  if (entry.type === 'frame') {
+    const snapshot: CatalogConnectorEntry = {
+      name: entry.name,
+      type: 'frame',
+      origin: snapshotCatalogVector(entry.origin),
+      normal: snapshotCatalogVector(entry.normal),
+    };
+    Object.freeze(snapshot);
+    return snapshot;
+  }
+  const snapshot: CatalogConnectorEntry = {
+    name: entry.name,
+    type: 'axis',
+    origin: snapshotCatalogVector(entry.origin),
+    axis: snapshotCatalogVector(entry.axis),
+  };
+  Object.freeze(snapshot);
+  return snapshot;
 }
 
 export class CaptureSession {
@@ -191,6 +225,12 @@ export class CaptureSession {
    *  importedStep record. Untyped to avoid a cycle with modeling/parts. */
   readonly autoConnectors: Map<string, ReadonlyArray<unknown>> = new Map();
 
+  /** Factual, authored catalog interfaces. Unlike `autoConnectors`, this
+   *  store preserves frame-vs-axis semantics and only exposes frozen snapshots. */
+  private readonly catalogConnectorStore: Map<string, readonly CatalogConnectorEntry[]> = new Map();
+  readonly catalogConnectors: ReadonlyMap<string, readonly CatalogConnectorEntry[]> =
+    this.catalogConnectorStore;
+
   /** Attach a set of auto-connectors to a feature/shape id. Subsequent calls
    *  on the same id replace any previous entry. */
   attachAutoConnectors(
@@ -198,6 +238,29 @@ export class CaptureSession {
     connectors: ReadonlyArray<unknown>,
   ): void {
     this.autoConnectors.set(shapeId, connectors);
+  }
+
+  /**
+   * Attach exact catalog interfaces without retaining caller-owned objects.
+   * The synthetic manifest validates the public entry array at runtime, then
+   * every nested vector, entry, and array is detached and frozen.
+   */
+  attachCatalogConnectors(
+    shapeId: string,
+    connectors: readonly ConnectorEntry[],
+  ): void {
+    if (!Array.isArray(connectors)) {
+      throw new Error('catalog connectors: entries must be an array');
+    }
+    validateConnectorManifest({
+      schemaVersion: 1,
+      partId: 'catalog-session',
+      family: 'catalog-session',
+      connectors: Array.from(connectors),
+    });
+    const snapshots = Array.from(connectors, snapshotCatalogConnector);
+    Object.freeze(snapshots);
+    this.catalogConnectorStore.set(shapeId, snapshots);
   }
   /** v0.6: absolute directory of the calling `.kcad.ts` script. Used by the
    *  OCCT text lowerer to resolve relative `fontPath(...)` arguments at

--- a/src/modeling/parts/fetchPart.test.ts
+++ b/src/modeling/parts/fetchPart.test.ts
@@ -25,6 +25,34 @@ describe('fetchPart orchestrator', () => {
     expect(r.record.source).toBe('local-catalog');
   });
 
+  it('retains a bundled sidecar as exact catalog connectors and a discovery projection', async () => {
+    const session = new CaptureSession();
+    const r = await fetchPartHost({ session }, 'spur-gear-m2-z20', {});
+
+    expect(session.catalogConnectors.get(r.shape.id)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'bore',
+          type: 'axis',
+          origin: [0, 0, 0],
+          axis: [0, 0, 1],
+        }),
+        expect.objectContaining({
+          name: 'front-face',
+          type: 'frame',
+          origin: [0, 0, 0],
+          normal: [0, 0, -1],
+        }),
+      ]),
+    );
+    expect(session.autoConnectors.get(r.shape.id)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'bore', axis: [0, 0, 1], type: 'frame' }),
+        expect.objectContaining({ name: 'front-face', axis: [0, 0, -1], type: 'frame' }),
+      ]),
+    );
+  });
+
   it('returns parts.fetch.remote-disabled when id is unknown and the tier is disabled (off)', async () => {
     const session = new CaptureSession();
     try {

--- a/src/modeling/parts/fetchPart.ts
+++ b/src/modeling/parts/fetchPart.ts
@@ -26,6 +26,7 @@ import {
   loadConnectorManifest,
   validateHashBoundConnectorManifest,
   type ConnectorManifest,
+  type HashBoundConnectorManifest,
 } from '../../shared/parts/connectorManifest';
 import { formatTopoRef } from '../../kernel/naming';
 import { inspectStepFile } from '../../agent/inspect/inspectStep';
@@ -143,6 +144,19 @@ const MESH_EXT_RE = /\.(stl|dae|obj)(\?.*)?$/i;
 
 function sha256Hex(bytes: Buffer): string {
   return createHash('sha256').update(bytes).digest('hex');
+}
+
+/** Bind a remote manifest to the exact STEP bytes that passed cache integrity. */
+export function validateManifestAgainstStepBytes(
+  manifest: HashBoundConnectorManifest,
+  identity: Pick<PartRecord, 'id' | 'family'>,
+  bytes: Buffer,
+): void {
+  validateHashBoundConnectorManifest(manifest, {
+    partId: identity.id,
+    family: identity.family,
+    geometrySha256: sha256Hex(bytes),
+  });
 }
 
 /**
@@ -394,11 +408,7 @@ export async function fetchPartHost(
     const bytes = readFileSync(path);
     const manifest = meta.connectorManifest;
     if (manifest !== undefined) {
-      validateHashBoundConnectorManifest(manifest, {
-        partId: meta.id,
-        family: meta.family,
-        geometrySha256: sha256Hex(bytes),
-      });
+      validateManifestAgainstStepBytes(manifest, meta, bytes);
     }
     const shape = await fromStepBytes(ctx, bytes, meta.stepUrl);
     let record: PartRecord = { ...meta, source: 'remote' };

--- a/src/modeling/parts/fetchPart.ts
+++ b/src/modeling/parts/fetchPart.ts
@@ -22,7 +22,11 @@ import {
 } from './remoteClient';
 import { KernelError } from '../../shared/intent/kernelError';
 import { snapshotCatalogPart, type PartRecord } from '../../shared/parts/types';
-import { loadConnectorManifest } from '../../shared/parts/connectorManifest';
+import {
+  loadConnectorManifest,
+  validateHashBoundConnectorManifest,
+  type ConnectorManifest,
+} from '../../shared/parts/connectorManifest';
 import { formatTopoRef } from '../../kernel/naming';
 import { inspectStepFile } from '../../agent/inspect/inspectStep';
 import { synthesizeConnectorsFromReport } from './synthesizeConnectors';
@@ -388,22 +392,32 @@ export async function fetchPartHost(
       fetcher: (u) => remoteFetchPartBytes(u),
     });
     const bytes = readFileSync(path);
+    const manifest = meta.connectorManifest;
+    if (manifest !== undefined) {
+      validateHashBoundConnectorManifest(manifest, {
+        partId: meta.id,
+        family: meta.family,
+        geometrySha256: sha256Hex(bytes),
+      });
+    }
     const shape = await fromStepBytes(ctx, bytes, meta.stepUrl);
-    // Catalog STEP ships no connector frames, so a *found* part would arrive as
-    // a dead solid that cannot mate. Recover the bundled-tier auto-connector
-    // convention from the geometry itself (bbox faces + detected hole axes).
-    // Defensive: a STEP that resists inspection still imports, just without
-    // synthesized connectors.
     let record: PartRecord = { ...meta, source: 'remote' };
-    try {
-      const report = await inspectStepFile(path);
-      const conns = synthesizeConnectorsFromReport(report, shape.id);
-      if (conns.length > 0) {
-        ctx.session.attachAutoConnectors(shape.id, conns);
-        record = { ...record, connectors: conns.map((c) => c.name) };
+    if (manifest !== undefined) {
+      const connectors = attachManifestConnectors(ctx, shape, manifest);
+      record = { ...record, connectors };
+    } else {
+      // Records without authored interfaces retain geometry-derived discovery
+      // connectors. A STEP that resists inspection still imports normally.
+      try {
+        const report = await inspectStepFile(path);
+        const conns = synthesizeConnectorsFromReport(report, shape.id);
+        if (conns.length > 0) {
+          ctx.session.attachAutoConnectors(shape.id, conns);
+          record = { ...record, connectors: conns.map((c) => c.name) };
+        }
+      } catch {
+        // fall through to the unenriched record
       }
-    } catch {
-      // fall through to the unenriched record
     }
     attachCatalogPartMetadata(ctx, shape, record);
     return { shape, record };
@@ -414,11 +428,32 @@ export async function fetchPartHost(
 }
 
 /**
- * Load the per-part `<id>.json` connector manifest sidecar (when present) and
- * attach the manifest's connectors to the captured shape via the session's
- * autoConnectors map. The Slice C bracket-side auto-connector consumers use
- * the same map, so the assembly resolver can mix authored + bundled parts
- * without distinguishing the source.
+ * Attach exact manifest data and retain the legacy discovery projection.
+ */
+function attachManifestConnectors(
+  ctx: FetchPartCtx,
+  shape: Shape,
+  manifest: ConnectorManifest,
+): string[] {
+  ctx.session.attachCatalogConnectors(shape.id, manifest.connectors);
+  const conns = manifest.connectors.map((c) => ({
+    name: c.name,
+    ref: formatTopoRef({
+      owner: shape.id,
+      kind: 'connector',
+      segments: [c.name],
+    }),
+    origin: c.origin,
+    axis: c.type === 'axis' ? c.axis : c.normal,
+    type: 'frame' as const,
+  }));
+  ctx.session.attachAutoConnectors(shape.id, conns);
+  return conns.map((connector) => connector.name);
+}
+
+/**
+ * Load the per-part `<id>.json` connector manifest sidecar (when present).
+ * Local sidecars remain best-effort: a malformed one must not block import.
  */
 function attachManifestConnectorsFromSidecar(
   ctx: FetchPartCtx,
@@ -429,18 +464,7 @@ function attachManifestConnectorsFromSidecar(
   if (!existsSync(manifestPath)) return;
   try {
     const manifest = loadConnectorManifest(manifestPath);
-    const conns = manifest.connectors.map((c) => ({
-      name: c.name,
-      ref: formatTopoRef({
-        owner: shape.id,
-        kind: 'connector',
-        segments: [c.name],
-      }),
-      origin: c.origin,
-      axis: c.type === 'axis' ? c.axis : c.normal,
-      type: 'frame' as const,
-    }));
-    ctx.session.attachAutoConnectors(shape.id, conns);
+    attachManifestConnectors(ctx, shape, manifest);
   } catch {
     // A malformed manifest must not break the import; the lowerer survives
     // without the manifest's named connectors.

--- a/src/modeling/parts/fetchPartMetadata.test.ts
+++ b/src/modeling/parts/fetchPartMetadata.test.ts
@@ -40,22 +40,87 @@ import { listFeaturesTool } from '../../agent/mcp/tools/listFeatures';
 import { createApi } from '../api';
 import { CaptureSession } from '../capture/captureSession';
 import { __resetUserCacheForTests } from '../../shared/cache/userCache';
+import type { ConnectorEntry } from '../../shared/parts/connectorManifestSchema';
+import { inspectStepFile } from '../../agent/inspect/inspectStep';
+import { synthesizeConnectorsFromReport } from './synthesizeConnectors';
+import { fetchPartHost } from './fetchPart';
 
 const PART_ID = 'max30102-optical';
+const PART_FAMILY = 'Sensor';
 const BASE_URL = 'https://parts.example';
 const STEP_URL = `${BASE_URL}/step/${PART_ID}.step`;
 const STEP_BYTES = Buffer.from('ISO-10303-21;\nDATA;\nENDSEC;\nEND-ISO-10303-21;\n');
 const STEP_SHA256 = createHash('sha256').update(STEP_BYTES).digest('hex');
+const AUTHORED_CONNECTORS: ConnectorEntry[] = [
+  {
+    name: 'pwm-contact',
+    type: 'frame',
+    origin: [1, 2, 3],
+    normal: [1, 0, 0],
+  },
+  {
+    name: 'shaft-axis',
+    type: 'axis',
+    origin: [4, 5, 6],
+    axis: [0, 1, 0],
+  },
+];
+const AUTHORED_MANIFEST = {
+  schemaVersion: 1 as const,
+  partId: PART_ID,
+  family: PART_FAMILY,
+  geometrySha256: STEP_SHA256,
+  connectors: AUTHORED_CONNECTORS,
+};
+const SYNTHESIZED_CONNECTOR = {
+  name: 'mating-face',
+  ref: '@kc[shape:synthetic]/connector:mating-face',
+  origin: [0, 0, 0] as [number, number, number],
+  axis: [0, 0, 1] as [number, number, number],
+  type: 'frame' as const,
+};
+
+function remoteRecord(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: PART_ID,
+    name: 'Analog Devices MAX30102 optical biosensor module',
+    category: 'Electronics',
+    family: PART_FAMILY,
+    tags: ['sensor', 'optical'],
+    attributes: { package: 'optical module' },
+    stepUrl: STEP_URL,
+    sha256: STEP_SHA256,
+    ...overrides,
+  };
+}
+
+function mockRemotePart(body: unknown, stepBytes: Buffer = STEP_BYTES): void {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    const url = String(input);
+    if (url === `${BASE_URL}/v1/parts/${PART_ID}`) {
+      return new Response(JSON.stringify(body), { status: 200 });
+    }
+    if (url === STEP_URL) return new Response(stepBytes, { status: 200 });
+    return new Response('not found', { status: 404 });
+  });
+}
 
 describe('lib.fetchPart catalog semantic identity', () => {
   let cacheDir: string;
   let previousCacheDir: string | undefined;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     previousCacheDir = process.env.KERNELCAD_CACHE_DIR;
     cacheDir = mkdtempSync(join(tmpdir(), 'kc-fetch-part-metadata-'));
     process.env.KERNELCAD_CACHE_DIR = cacheDir;
     __resetUserCacheForTests();
+    vi.mocked(inspectStepFile).mockImplementation(async (path: string) => ({
+      file: path,
+      solidCount: 1,
+      solids: [],
+    }));
+    vi.mocked(synthesizeConnectorsFromReport).mockReturnValue([]);
   });
 
   afterEach(() => {
@@ -75,7 +140,7 @@ describe('lib.fetchPart catalog semantic identity', () => {
             id: PART_ID,
             name: 'Analog Devices MAX30102 optical biosensor module',
             category: 'Electronics',
-            family: 'Sensor',
+            family: PART_FAMILY,
             tags: ['sensor', 'optical'],
             attributes: {
               package: 'optical module',
@@ -132,5 +197,119 @@ describe('lib.fetchPart catalog semantic identity', () => {
       id: PART_ID,
       attributes: { package: 'optical module', pinCount: 14, pinPitchMm: 0.8 },
     });
+  });
+
+  it('stores exact catalog connector entries as detached frozen data', () => {
+    const session = new CaptureSession();
+    const connectors: ConnectorEntry[] = [
+      {
+        name: 'mount-face',
+        type: 'frame',
+        origin: [1, 2, 3],
+        normal: [0, 0, 1],
+      },
+    ];
+
+    session.attachCatalogConnectors('imported_1', connectors);
+    connectors[0].origin[0] = 99;
+
+    const stored = session.catalogConnectors.get('imported_1');
+    expect(stored).toEqual([
+      {
+        name: 'mount-face',
+        type: 'frame',
+        origin: [1, 2, 3],
+        normal: [0, 0, 1],
+      },
+    ]);
+    expect(Object.isFrozen(stored)).toBe(true);
+    expect(Object.isFrozen(stored?.[0])).toBe(true);
+    expect(Object.isFrozen(stored?.[0]?.origin)).toBe(true);
+  });
+
+  it('attaches a verified remote manifest exactly and skips generic synthesis', async () => {
+    mockRemotePart(remoteRecord({ connectorManifest: AUTHORED_MANIFEST }));
+    const session = new CaptureSession();
+
+    const { shape, record } = await fetchPartHost(
+      { session },
+      PART_ID,
+      { partsBaseUrl: BASE_URL },
+    );
+
+    expect(inspectStepFile).not.toHaveBeenCalled();
+    expect(synthesizeConnectorsFromReport).not.toHaveBeenCalled();
+    expect(record.connectors).toEqual(['pwm-contact', 'shaft-axis']);
+    const exact = session.catalogConnectors.get(shape.id);
+    expect(exact).toEqual(AUTHORED_CONNECTORS);
+    expect(Object.isFrozen(exact)).toBe(true);
+    expect(Object.isFrozen(exact?.[0])).toBe(true);
+    expect(Object.isFrozen(exact?.[0]?.origin)).toBe(true);
+    expect(session.autoConnectors.get(shape.id)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'pwm-contact',
+          origin: [1, 2, 3],
+          axis: [1, 0, 0],
+          type: 'frame',
+        }),
+        expect.objectContaining({
+          name: 'shaft-axis',
+          origin: [4, 5, 6],
+          axis: [0, 1, 0],
+          type: 'frame',
+        }),
+      ]),
+    );
+  });
+
+  it('keeps generic synthesis for remote records without an authored manifest', async () => {
+    mockRemotePart(remoteRecord());
+    vi.mocked(synthesizeConnectorsFromReport).mockReturnValue([SYNTHESIZED_CONNECTOR]);
+    const session = new CaptureSession();
+
+    const { shape, record } = await fetchPartHost(
+      { session },
+      PART_ID,
+      { partsBaseUrl: BASE_URL },
+    );
+
+    expect(inspectStepFile).toHaveBeenCalledTimes(1);
+    expect(synthesizeConnectorsFromReport).toHaveBeenCalledTimes(1);
+    expect(record.connectors).toEqual(['mating-face']);
+    expect(session.autoConnectors.get(shape.id)).toEqual([SYNTHESIZED_CONNECTOR]);
+    expect(session.catalogConnectors.get(shape.id)).toBeUndefined();
+  });
+
+  it.each([
+    [
+      'malformed',
+      {
+        ...AUTHORED_MANIFEST,
+        connectors: [
+          {
+            name: 'pwm-contact',
+            type: 'frame',
+            origin: [1, 2, 3],
+            normal: [0, 0, 0],
+          },
+        ],
+      },
+      /normal/,
+    ],
+    [
+      'hash-mismatched',
+      { ...AUTHORED_MANIFEST, geometrySha256: 'f'.repeat(64) },
+      /geometrySha256/,
+    ],
+  ])('rejects a %s remote manifest without synthesis', async (_, connectorManifest, error) => {
+    mockRemotePart(remoteRecord({ connectorManifest }));
+    const session = new CaptureSession();
+
+    await expect(
+      fetchPartHost({ session }, PART_ID, { partsBaseUrl: BASE_URL }),
+    ).rejects.toThrow(error);
+    expect(inspectStepFile).not.toHaveBeenCalled();
+    expect(synthesizeConnectorsFromReport).not.toHaveBeenCalled();
   });
 });

--- a/src/modeling/parts/fetchPartMetadata.test.ts
+++ b/src/modeling/parts/fetchPartMetadata.test.ts
@@ -40,10 +40,14 @@ import { listFeaturesTool } from '../../agent/mcp/tools/listFeatures';
 import { createApi } from '../api';
 import { CaptureSession } from '../capture/captureSession';
 import { __resetUserCacheForTests } from '../../shared/cache/userCache';
-import type { ConnectorEntry } from '../../shared/parts/connectorManifestSchema';
+import {
+  validateHashBoundConnectorManifest,
+  type ConnectorEntry,
+} from '../../shared/parts/connectorManifestSchema';
 import { inspectStepFile } from '../../agent/inspect/inspectStep';
 import { synthesizeConnectorsFromReport } from './synthesizeConnectors';
-import { fetchPartHost } from './fetchPart';
+import { fromStepBytes } from './fromSTEP';
+import { fetchPartHost, validateManifestAgainstStepBytes } from './fetchPart';
 
 const PART_ID = 'max30102-optical';
 const PART_FAMILY = 'Sensor';
@@ -261,6 +265,24 @@ describe('lib.fetchPart catalog semantic identity', () => {
         }),
       ]),
     );
+  });
+
+  it('rejects bytes that disagree with an otherwise valid manifest before import or synthesis', () => {
+    validateHashBoundConnectorManifest(AUTHORED_MANIFEST, {
+      partId: PART_ID,
+      family: PART_FAMILY,
+      geometrySha256: STEP_SHA256,
+    });
+    expect(() =>
+      validateManifestAgainstStepBytes(
+        AUTHORED_MANIFEST,
+        { id: PART_ID, family: PART_FAMILY },
+        Buffer.from('different STEP bytes'),
+      ),
+    ).toThrow(/geometrySha256/);
+    expect(fromStepBytes).not.toHaveBeenCalled();
+    expect(inspectStepFile).not.toHaveBeenCalled();
+    expect(synthesizeConnectorsFromReport).not.toHaveBeenCalled();
   });
 
   it('keeps generic synthesis for remote records without an authored manifest', async () => {

--- a/src/modeling/parts/remoteClient.ts
+++ b/src/modeling/parts/remoteClient.ts
@@ -101,10 +101,10 @@ export async function remoteFindParts(
   if (opts.tag) qs.set('tag', opts.tag);
   if (opts.limit) qs.set('pageSize', String(opts.limit));
   const res = await callRemote(`${base}/v1/parts?${qs.toString()}`, 5000);
-  // step.parts search returns `{ items, total, ... }` where each item is the
-  // same per-part shape as the detail endpoint (stepUrl + sha256 included).
-  // Map each onto a PartRecord; geometry/connectors are resolved later by
-  // fetch_part, so discovery records carry empty connectors.
+  // The catalog search response returns `{ items, total, ... }` where each item
+  // is the same per-part shape as the detail endpoint (stepUrl + sha256 included).
+  // Map each onto a PartRecord. Authored hash-bound manifests preserve their
+  // connector names; records without one leave connectors for fetch-time synthesis.
   const raw = (await res.json()) as {
     items?: StepPartsRecord[];
     total?: number;
@@ -121,9 +121,9 @@ export async function remoteFetchPartMeta(
     `${base}/v1/parts/${encodeURIComponent(opts.id)}`,
     5000,
   );
-  // step.parts (the default source) returns its own schema, not a kernelCAD
-  // PartRecord — map it. `connectors` come back empty; fetchPartHost synthesizes
-  // them from the downloaded STEP.
+  // Remote catalog records use their own schema rather than a kernelCAD
+  // PartRecord — map them. Authored hash-bound manifests carry their connector
+  // names; fetchPartHost synthesizes connectors only when no manifest is present.
   const raw = (await res.json()) as StepPartsRecord;
   return mapStepPartsRecord(raw);
 }

--- a/src/modeling/parts/remoteClient.ts
+++ b/src/modeling/parts/remoteClient.ts
@@ -122,8 +122,8 @@ export async function remoteFetchPartMeta(
     5000,
   );
   // Remote catalog records use their own schema rather than a kernelCAD
-  // PartRecord — map them. Authored hash-bound manifests carry their connector
-  // names; fetchPartHost synthesizes connectors only when no manifest is present.
+  // PartRecord — map them. Mapping preserves authored hash-bound manifest names;
+  // fetch-time connector enrichment is handled separately.
   const raw = (await res.json()) as StepPartsRecord;
   return mapStepPartsRecord(raw);
 }

--- a/src/modeling/parts/stepPartsAdapter.test.ts
+++ b/src/modeling/parts/stepPartsAdapter.test.ts
@@ -9,7 +9,8 @@ import {
   STEP_PARTS_LICENSE,
   type StepPartsRecord,
 } from './stepPartsAdapter';
-import { isPartRecord } from '../../shared/parts/types';
+import { isPartRecord, snapshotCatalogPart } from '../../shared/parts/types';
+import type { HashBoundConnectorManifest } from '../../shared/parts/connectorManifestSchema';
 
 const REAL: StepPartsRecord = {
   id: 'din913_set_screw_m3x3',
@@ -42,6 +43,29 @@ const GLB_ONLY_BOARD: StepPartsRecord = {
   glbUrl: 'https://kernelcad-parts.pages.dev/glb/nucleo-h563zi-board.glb',
 };
 
+function testConnectorManifest(geometrySha256: string): HashBoundConnectorManifest {
+  return {
+    schemaVersion: 1,
+    partId: REAL.id,
+    family: REAL.family,
+    geometrySha256,
+    connectors: [
+      {
+        name: 'mount-face',
+        type: 'frame',
+        origin: [0, 0, 0],
+        normal: [0, 0, 1],
+      },
+      {
+        name: 'shaft-axis',
+        type: 'axis',
+        origin: [0, 0, -3],
+        axis: [0, 0, 1],
+      },
+    ],
+  };
+}
+
 describe('mapStepPartsRecord', () => {
   it('produces a valid PartRecord from a real step.parts detail record', () => {
     const r = mapStepPartsRecord(REAL);
@@ -73,6 +97,82 @@ describe('mapStepPartsRecord', () => {
 
   it('emits no connectors — those are synthesized at fetch time', () => {
     expect(mapStepPartsRecord(REAL).connectors).toEqual([]);
+  });
+
+  it('preserves a hash-bound connector manifest and exposes its connector names', () => {
+    const connectorManifest = testConnectorManifest(REAL.sha256!);
+    const r = mapStepPartsRecord({ ...REAL, connectorManifest });
+
+    expect(r.connectorManifest).toEqual(connectorManifest);
+    expect(r.connectors).toEqual(['mount-face', 'shaft-axis']);
+    expect(isPartRecord(r)).toBe(true);
+  });
+
+  it('takes a detached, frozen nested connector-manifest snapshot', () => {
+    const connectorManifest = testConnectorManifest(REAL.sha256!);
+    const raw: StepPartsRecord = { ...REAL, connectorManifest };
+    const snapshot = snapshotCatalogPart(mapStepPartsRecord(raw));
+
+    connectorManifest.connectors[0].origin[0] = 42;
+
+    expect(snapshot.connectorManifest!.connectors[0].origin).toEqual([0, 0, 0]);
+    expect(Object.isFrozen(snapshot.connectorManifest)).toBe(true);
+    expect(Object.isFrozen(snapshot.connectorManifest!.connectors)).toBe(true);
+    expect(Object.isFrozen(snapshot.connectorManifest!.connectors[0])).toBe(true);
+    expect(Object.isFrozen(snapshot.connectorManifest!.connectors[0].origin)).toBe(true);
+  });
+
+  it('rejects a remote connector manifest when the raw record has no SHA-256', () => {
+    expect(() =>
+      mapStepPartsRecord({
+        ...REAL,
+        sha256: undefined,
+        connectorManifest: testConnectorManifest('a'.repeat(64)),
+      }),
+    ).toThrow(/record sha256/i);
+  });
+
+  it('rejects malformed unknown connector data from the remote record', () => {
+    expect(() =>
+      mapStepPartsRecord({
+        ...REAL,
+        connectorManifest: {
+          schemaVersion: 1,
+          partId: REAL.id,
+          family: REAL.family,
+          geometrySha256: REAL.sha256,
+          connectors: [
+            {
+              name: 'mount-face',
+              type: 'frame',
+              origin: [0, 0, 0],
+              axis: [0, 0, 1],
+            },
+          ],
+        },
+      }),
+    ).toThrow(/normal|unexpected field/i);
+  });
+
+  it('rejects records whose connector names contradict the manifest', () => {
+    const record = mapStepPartsRecord({
+      ...REAL,
+      connectorManifest: testConnectorManifest(REAL.sha256!),
+    });
+    record.connectors = ['different-connector'];
+
+    expect(isPartRecord(record)).toBe(false);
+  });
+
+  it('returns false rather than throwing for an invalid connector manifest', () => {
+    const record = mapStepPartsRecord({
+      ...REAL,
+      connectorManifest: testConnectorManifest(REAL.sha256!),
+    });
+    record.connectorManifest!.geometrySha256 = 'a'.repeat(64);
+
+    expect(() => isPartRecord(record)).not.toThrow();
+    expect(isPartRecord(record)).toBe(false);
   });
 
   it('tolerates a legacy string standard and missing optional fields', () => {

--- a/src/modeling/parts/stepPartsAdapter.test.ts
+++ b/src/modeling/parts/stepPartsAdapter.test.ts
@@ -164,6 +164,46 @@ describe('mapStepPartsRecord', () => {
     expect(isPartRecord(record)).toBe(false);
   });
 
+  it('rejects sparse connector-name arrays that only match a manifest by length', () => {
+    const record = mapStepPartsRecord({
+      ...REAL,
+      connectorManifest: testConnectorManifest(REAL.sha256!),
+    });
+    record.connectors = new Array<string>(record.connectorManifest!.connectors.length);
+
+    expect(isPartRecord(record)).toBe(false);
+  });
+
+  it('rejects contradictory connector names before snapshotting catalog metadata', () => {
+    const record = mapStepPartsRecord({
+      ...REAL,
+      connectorManifest: testConnectorManifest(REAL.sha256!),
+    });
+    record.connectors = ['different-connector'];
+
+    expect(() => snapshotCatalogPart(record)).toThrow(/connector/i);
+  });
+
+  it('rejects malformed manifests before snapshotting catalog metadata', () => {
+    const record = mapStepPartsRecord({
+      ...REAL,
+      connectorManifest: testConnectorManifest(REAL.sha256!),
+    });
+    record.connectorManifest = {
+      ...record.connectorManifest!,
+      connectors: [
+        {
+          name: 'mount-face',
+          type: 'frame',
+          origin: [0, 0, 0],
+          normal: 'not-a-vector',
+        },
+      ],
+    } as unknown as HashBoundConnectorManifest;
+
+    expect(() => snapshotCatalogPart(record)).toThrow(/finite three-vector/i);
+  });
+
   it('returns false rather than throwing for an invalid connector manifest', () => {
     const record = mapStepPartsRecord({
       ...REAL,

--- a/src/modeling/parts/stepPartsAdapter.ts
+++ b/src/modeling/parts/stepPartsAdapter.ts
@@ -8,9 +8,9 @@
 // step.parts record onto kernelCAD's canonical `PartRecord`.
 //
 // Two schema gaps are filled here, not at the API:
-//   - `connectors` — step.parts ships none; they are synthesized at fetch time
-//     from the downloaded STEP (see synthesizeConnectors.ts). The mapper emits
-//     an empty list; fetchPartHost fills it.
+//   - `connectors` — records without an authored, hash-bound connector manifest
+//     synthesize them at fetch time from downloaded STEP (see
+//     synthesizeConnectors.ts). The mapper otherwise exposes the authored names.
 //   - `license`    — step.parts exposes no per-part license field, but the
 //     catalog repo (earthtojake/step.parts) is MIT, which covers the geometry.
 //     We stamp `STEP_PARTS_LICENSE` ('MIT') plus `attribution = pageUrl` to
@@ -21,6 +21,7 @@
 // integrity verification (getOrFetchAsync) works unchanged.
 
 import type { PartRecord } from '../../shared/parts/types';
+import { validateHashBoundConnectorManifest } from '../../shared/parts/connectorManifestSchema';
 
 export const STEP_PARTS_BASE_URL = 'https://api.step.parts';
 
@@ -51,6 +52,8 @@ export interface StepPartsRecord {
   byteSize?: number;
   sha256?: string;
   pageUrl?: string;
+  /** Optional authored connector data, bound to this exact geometry digest. */
+  connectorManifest?: unknown;
 }
 
 /** step.parts `standard` is an object `{body, number, designation}`; kernelCAD's
@@ -82,12 +85,25 @@ function coerceAttributes(
 /**
  * Map a step.parts detail record onto a kernelCAD PartRecord.
  *
- * `connectors` is intentionally empty — fetchPartHost synthesizes them from the
- * downloaded STEP. Aliases are folded into `tags` so fuzzy discovery can match
- * the names humans actually type ("M3 set screw").
+ * Authored connector manifests are validated against the raw record and
+ * transported intact; otherwise `connectors` remains empty for fetch-time
+ * synthesis. Aliases are folded into `tags` so fuzzy discovery can match the
+ * names humans actually type ("M3 set screw").
  */
 export function mapStepPartsRecord(raw: StepPartsRecord): PartRecord {
   const tags = [...(raw.tags ?? []), ...(raw.aliases ?? [])];
+  const sha256 = raw.sha256 ?? '';
+  const connectorManifest = raw.connectorManifest;
+  if (connectorManifest !== undefined) {
+    if (typeof raw.sha256 !== 'string' || !/^[a-f0-9]{64}$/.test(raw.sha256)) {
+      throw new Error('step.parts: connectorManifest requires a lowercase record sha256');
+    }
+    validateHashBoundConnectorManifest(connectorManifest, {
+      partId: raw.id,
+      family: raw.family,
+      geometrySha256: sha256,
+    });
+  }
   const record: PartRecord = {
     id: raw.id,
     name: raw.name,
@@ -95,10 +111,11 @@ export function mapStepPartsRecord(raw: StepPartsRecord): PartRecord {
     family: raw.family,
     tags,
     attributes: coerceAttributes(raw.attributes),
-    sha256: raw.sha256 ?? '',
+    sha256,
     source: 'remote',
     license: STEP_PARTS_LICENSE,
-    connectors: [],
+    connectors: connectorManifest?.connectors.map((connector) => connector.name) ?? [],
+    ...(connectorManifest === undefined ? {} : { connectorManifest }),
   };
   const standard = flattenStandard(raw.standard);
   if (standard !== undefined) record.standard = standard;

--- a/src/shared/parts/connectorManifest.test.ts
+++ b/src/shared/parts/connectorManifest.test.ts
@@ -2,9 +2,10 @@
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import { describe, it, expect } from 'vitest';
 import {
+  validateHashBoundConnectorManifest,
   validateConnectorManifest,
   type ConnectorManifest,
-} from './connectorManifest';
+} from './connectorManifestSchema';
 
 describe('ConnectorManifest validator', () => {
   it('accepts a v1 manifest with required fields', () => {
@@ -40,6 +41,20 @@ describe('ConnectorManifest validator', () => {
     ).toThrow(/schemaVersion/);
   });
 
+  it('rejects mutable optional manifest metadata', () => {
+    expect(() =>
+      validateConnectorManifest({
+        schemaVersion: 1,
+        partId: 'iso-4762-m3x12',
+        family: 'socket-head-cap-screw',
+        connectors: [],
+        license: { mutable: true },
+        attribution: ['not', 'a', 'string'],
+        generatedAt: 42,
+      }),
+    ).toThrow(/license/i);
+  });
+
   it('rejects schemaVersion !== 1', () => {
     expect(() =>
       validateConnectorManifest({
@@ -67,5 +82,186 @@ describe('ConnectorManifest validator', () => {
         ],
       } as unknown as ConnectorManifest),
     ).toThrow();
+  });
+
+  it('rejects duplicate connector names', () => {
+    expect(() =>
+      validateConnectorManifest({
+        schemaVersion: 1,
+        partId: 'iso-4762-m3x12',
+        family: 'socket-head-cap-screw',
+        connectors: [
+          {
+            name: 'mount',
+            type: 'frame',
+            origin: [0, 0, 0],
+            normal: [0, 0, 1],
+          },
+          {
+            name: 'mount',
+            type: 'axis',
+            origin: [0, 0, 0],
+            axis: [0, 0, 1],
+          },
+        ],
+      } as unknown as ConnectorManifest),
+    ).toThrow(/duplicate/i);
+  });
+
+  it('rejects a non-object connector entry', () => {
+    expect(() =>
+      validateConnectorManifest({
+        schemaVersion: 1,
+        partId: 'iso-4762-m3x12',
+        family: 'socket-head-cap-screw',
+        connectors: [null],
+      }),
+    ).toThrow(/connector must be an object/i);
+  });
+
+  it('rejects connector fields inherited from a non-plain object', () => {
+    const connector = Object.assign(Object.create({ normal: [0, 0, 1] }), {
+      name: 'mount',
+      type: 'frame',
+      origin: [0, 0, 0],
+    });
+
+    expect(() =>
+      validateConnectorManifest({
+        schemaVersion: 1,
+        partId: 'iso-4762-m3x12',
+        family: 'socket-head-cap-screw',
+        connectors: [connector],
+      }),
+    ).toThrow(/connector must be an object/i);
+  });
+
+  it('rejects non-finite connector vectors', () => {
+    expect(() =>
+      validateConnectorManifest({
+        schemaVersion: 1,
+        partId: 'iso-4762-m3x12',
+        family: 'socket-head-cap-screw',
+        connectors: [
+          {
+            name: 'mount',
+            type: 'frame',
+            origin: [0, 0, 0],
+            normal: [0, Number.NaN, 1],
+          },
+        ],
+      } as unknown as ConnectorManifest),
+    ).toThrow(/finite/i);
+  });
+
+  it('rejects connector vectors that are not exactly three values', () => {
+    expect(() =>
+      validateConnectorManifest({
+        schemaVersion: 1,
+        partId: 'iso-4762-m3x12',
+        family: 'socket-head-cap-screw',
+        connectors: [
+          {
+            name: 'mount',
+            type: 'frame',
+            origin: [0, 0],
+            normal: [0, 0, 1],
+          },
+        ],
+      } as unknown as ConnectorManifest),
+    ).toThrow(/three-vector/i);
+  });
+
+  it('rejects a zero frame normal', () => {
+    expect(() =>
+      validateConnectorManifest({
+        schemaVersion: 1,
+        partId: 'iso-4762-m3x12',
+        family: 'socket-head-cap-screw',
+        connectors: [
+          {
+            name: 'mount',
+            type: 'frame',
+            origin: [0, 0, 0],
+            normal: [0, 0, 0],
+          },
+        ],
+      } as unknown as ConnectorManifest),
+    ).toThrow(/normal/i);
+  });
+
+  it('rejects a zero axis direction', () => {
+    expect(() =>
+      validateConnectorManifest({
+        schemaVersion: 1,
+        partId: 'iso-4762-m3x12',
+        family: 'socket-head-cap-screw',
+        connectors: [
+          {
+            name: 'mount-axis',
+            type: 'axis',
+            origin: [0, 0, 0],
+            axis: [0, 0, 0],
+          },
+        ],
+      } as unknown as ConnectorManifest),
+    ).toThrow(/axis/i);
+  });
+
+  it('rejects connector fields that do not match the declared type', () => {
+    expect(() =>
+      validateConnectorManifest({
+        schemaVersion: 1,
+        partId: 'iso-4762-m3x12',
+        family: 'socket-head-cap-screw',
+        connectors: [
+          {
+            name: 'mount',
+            type: 'frame',
+            origin: [0, 0, 0],
+            normal: [0, 0, 1],
+            axis: [0, 0, 1],
+          },
+        ],
+      } as unknown as ConnectorManifest),
+    ).toThrow(/axis|unexpected/i);
+  });
+
+  it('rejects a manifest whose hash is not bound to the expected geometry', () => {
+    expect(() =>
+      validateHashBoundConnectorManifest(
+        {
+          schemaVersion: 1,
+          partId: 'iso-4762-m3x12',
+          family: 'socket-head-cap-screw',
+          geometrySha256: 'a'.repeat(64),
+          connectors: [],
+        },
+        {
+          partId: 'iso-4762-m3x12',
+          family: 'socket-head-cap-screw',
+          geometrySha256: 'b'.repeat(64),
+        },
+      ),
+    ).toThrow(/geometrySha256/);
+  });
+
+  it('rejects a non-lowercase hash-bound geometry digest', () => {
+    expect(() =>
+      validateHashBoundConnectorManifest(
+        {
+          schemaVersion: 1,
+          partId: 'iso-4762-m3x12',
+          family: 'socket-head-cap-screw',
+          geometrySha256: 'A'.repeat(64),
+          connectors: [],
+        },
+        {
+          partId: 'iso-4762-m3x12',
+          family: 'socket-head-cap-screw',
+          geometrySha256: 'a'.repeat(64),
+        },
+      ),
+    ).toThrow(/geometrySha256/);
   });
 });

--- a/src/shared/parts/connectorManifest.test.ts
+++ b/src/shared/parts/connectorManifest.test.ts
@@ -172,6 +172,50 @@ describe('ConnectorManifest validator', () => {
     ).toThrow(/three-vector/i);
   });
 
+  it('rejects a sparse origin vector despite its nominal length', () => {
+    const origin = new Array<number>(3);
+    origin[0] = 0;
+    origin[2] = 0;
+
+    expect(() =>
+      validateConnectorManifest({
+        schemaVersion: 1,
+        partId: 'iso-4762-m3x12',
+        family: 'socket-head-cap-screw',
+        connectors: [
+          {
+            name: 'mount',
+            type: 'frame',
+            origin: origin as unknown as [number, number, number],
+            normal: [0, 0, 1],
+          },
+        ],
+      }),
+    ).toThrow(/finite three-vector/i);
+  });
+
+  it('rejects a sparse direction vector despite its nominal length', () => {
+    const normal = new Array<number>(3);
+    normal[0] = 0;
+    normal[2] = 1;
+
+    expect(() =>
+      validateConnectorManifest({
+        schemaVersion: 1,
+        partId: 'iso-4762-m3x12',
+        family: 'socket-head-cap-screw',
+        connectors: [
+          {
+            name: 'mount',
+            type: 'frame',
+            origin: [0, 0, 0],
+            normal: normal as unknown as [number, number, number],
+          },
+        ],
+      }),
+    ).toThrow(/finite three-vector/i);
+  });
+
   it('rejects a zero frame normal', () => {
     expect(() =>
       validateConnectorManifest({

--- a/src/shared/parts/connectorManifest.ts
+++ b/src/shared/parts/connectorManifest.ts
@@ -2,69 +2,26 @@
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // src/shared/parts/connectorManifest.ts
 //
-// Sidecar JSON loaded next to each bundled STEP file. The loader rejects a
-// file without `schemaVersion: 1`; the validator runs every connector
-// `name` through assertTopoRefSafeName so a manifest that would later
-// collide with the @kc[...] grammar fails AT BUILD TIME, not at runtime.
+// Node-only sidecar JSON loader for bundled STEP files. Browser-safe manifest
+// types and validation live in connectorManifestSchema.ts.
 
 import { readFileSync } from 'node:fs';
-import { assertTopoRefSafeName } from '../naming/topoRefName';
+import {
+  validateConnectorManifest,
+  type ConnectorManifest,
+} from './connectorManifestSchema';
 
-export type ConnectorType = 'frame' | 'axis';
-
-export interface ConnectorFrameEntry {
-  name: string;
-  type: 'frame';
-  origin: [number, number, number];
-  normal: [number, number, number];
-}
-
-export interface ConnectorAxisEntry {
-  name: string;
-  type: 'axis';
-  origin: [number, number, number];
-  axis: [number, number, number];
-}
-
-export type ConnectorEntry = ConnectorFrameEntry | ConnectorAxisEntry;
-
-export interface ConnectorManifest {
-  schemaVersion: 1;
-  partId: string;
-  family: string;
-  connectors: ConnectorEntry[];
-  license?: string;
-  attribution?: string | null;
-  generatedAt?: string;
-}
-
-export function validateConnectorManifest(m: ConnectorManifest): void {
-  if (!m || typeof m !== 'object') throw new Error('manifest: not an object');
-  if (m.schemaVersion !== 1) {
-    throw new Error(
-      `manifest: schemaVersion must be 1, got ${String(m.schemaVersion)}`,
-    );
-  }
-  if (typeof m.partId !== 'string' || m.partId.length === 0) {
-    throw new Error('manifest: partId required');
-  }
-  if (typeof m.family !== 'string' || m.family.length === 0) {
-    throw new Error('manifest: family required');
-  }
-  if (!Array.isArray(m.connectors)) {
-    throw new Error('manifest: connectors must be an array');
-  }
-  for (const c of m.connectors) {
-    const entry = c as { name: string; type: unknown };
-    // Throws KernelError if the name would conflict with the @kc[...] grammar.
-    assertTopoRefSafeName(entry.name, 'connector-name', m.partId);
-    if (entry.type !== 'frame' && entry.type !== 'axis') {
-      throw new Error(
-        `manifest: connector ${entry.name} type must be 'frame' or 'axis'`,
-      );
-    }
-  }
-}
+export {
+  validateConnectorManifest,
+  validateHashBoundConnectorManifest,
+  type ConnectorAxisEntry,
+  type ConnectorEntry,
+  type ConnectorFrameEntry,
+  type ConnectorManifest,
+  type ConnectorManifestBinding,
+  type ConnectorType,
+  type HashBoundConnectorManifest,
+} from './connectorManifestSchema';
 
 export function loadConnectorManifest(path: string): ConnectorManifest {
   const raw = readFileSync(path, 'utf8');

--- a/src/shared/parts/connectorManifestSchema.ts
+++ b/src/shared/parts/connectorManifestSchema.ts
@@ -55,12 +55,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function validateVector3(value: unknown, label: string): asserts value is [number, number, number] {
-  if (
-    !Array.isArray(value) ||
-    value.length !== 3 ||
-    !value.every((component) => typeof component === 'number' && Number.isFinite(component))
-  ) {
+  if (!Array.isArray(value) || value.length !== 3) {
     throw new Error(`manifest: ${label} must be a finite three-vector`);
+  }
+  for (let index = 0; index < 3; index += 1) {
+    const component = value[index];
+    if (typeof component !== 'number' || !Number.isFinite(component)) {
+      throw new Error(`manifest: ${label} must be a finite three-vector`);
+    }
   }
 }
 

--- a/src/shared/parts/connectorManifestSchema.ts
+++ b/src/shared/parts/connectorManifestSchema.ts
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// Browser-safe connector-manifest schema and validation. Keep Node file I/O in
+// connectorManifest.ts so catalog metadata may validate manifests at runtime.
+
+import { assertTopoRefSafeName } from '../naming/topoRefName';
+
+export type ConnectorType = 'frame' | 'axis';
+
+export interface ConnectorFrameEntry {
+  name: string;
+  type: 'frame';
+  origin: [number, number, number];
+  normal: [number, number, number];
+}
+
+export interface ConnectorAxisEntry {
+  name: string;
+  type: 'axis';
+  origin: [number, number, number];
+  axis: [number, number, number];
+}
+
+export type ConnectorEntry = ConnectorFrameEntry | ConnectorAxisEntry;
+
+export interface ConnectorManifest {
+  schemaVersion: 1;
+  partId: string;
+  family: string;
+  connectors: ConnectorEntry[];
+  license?: string;
+  attribution?: string | null;
+  generatedAt?: string;
+}
+
+/** A connector manifest explicitly bound to the geometry it describes. */
+export interface HashBoundConnectorManifest extends ConnectorManifest {
+  geometrySha256: string;
+}
+
+/** The catalog identity a hash-bound connector manifest must agree with. */
+export interface ConnectorManifestBinding {
+  partId: string;
+  family: string;
+  geometrySha256: string;
+}
+
+const SHA256_HEX = /^[a-f0-9]{64}$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function validateVector3(value: unknown, label: string): asserts value is [number, number, number] {
+  if (
+    !Array.isArray(value) ||
+    value.length !== 3 ||
+    !value.every((component) => typeof component === 'number' && Number.isFinite(component))
+  ) {
+    throw new Error(`manifest: ${label} must be a finite three-vector`);
+  }
+}
+
+function validateNonZeroVector(value: [number, number, number], label: string): void {
+  if (value[0] === 0 && value[1] === 0 && value[2] === 0) {
+    throw new Error(`manifest: ${label} must not be a zero vector`);
+  }
+}
+
+function validateExactConnectorFields(
+  entry: Record<string, unknown>,
+  allowedFields: readonly string[],
+  label: string,
+): void {
+  for (const field of allowedFields) {
+    if (!Object.hasOwn(entry, field)) {
+      throw new Error(`manifest: ${label} requires field '${field}'`);
+    }
+  }
+  for (const field of Reflect.ownKeys(entry)) {
+    if (typeof field !== 'string' || !allowedFields.includes(field)) {
+      throw new Error(`manifest: ${label} has unexpected field '${String(field)}'`);
+    }
+  }
+}
+
+/** Validate local v1 connector data independently of any geometry binding. */
+export function validateConnectorManifest(value: unknown): asserts value is ConnectorManifest {
+  if (!isRecord(value)) throw new Error('manifest: not an object');
+  if (value.schemaVersion !== 1) {
+    throw new Error(
+      `manifest: schemaVersion must be 1, got ${String(value.schemaVersion)}`,
+    );
+  }
+  if (typeof value.partId !== 'string' || value.partId.length === 0) {
+    throw new Error('manifest: partId required');
+  }
+  if (typeof value.family !== 'string' || value.family.length === 0) {
+    throw new Error('manifest: family required');
+  }
+  if (value.license !== undefined && typeof value.license !== 'string') {
+    throw new Error('manifest: license must be a string when provided');
+  }
+  if (
+    value.attribution !== undefined &&
+    value.attribution !== null &&
+    typeof value.attribution !== 'string'
+  ) {
+    throw new Error('manifest: attribution must be a string or null when provided');
+  }
+  if (value.generatedAt !== undefined && typeof value.generatedAt !== 'string') {
+    throw new Error('manifest: generatedAt must be a string when provided');
+  }
+  if (!Array.isArray(value.connectors)) {
+    throw new Error('manifest: connectors must be an array');
+  }
+
+  const names = new Set<string>();
+  for (const connector of value.connectors) {
+    if (!isRecord(connector)) {
+      throw new Error('manifest: connector must be an object');
+    }
+    if (!Object.hasOwn(connector, 'name') || typeof connector.name !== 'string') {
+      throw new Error('manifest: connector name required');
+    }
+    // Throws KernelError if the name would conflict with the @kc[...] grammar.
+    assertTopoRefSafeName(connector.name, 'connector-name', value.partId);
+    if (names.has(connector.name)) {
+      throw new Error(`manifest: duplicate connector name '${connector.name}'`);
+    }
+    names.add(connector.name);
+
+    if (!Object.hasOwn(connector, 'type')) {
+      throw new Error(`manifest: connector ${connector.name} type required`);
+    }
+    if (connector.type === 'frame') {
+      validateExactConnectorFields(
+        connector,
+        ['name', 'type', 'origin', 'normal'],
+        `frame connector ${connector.name}`,
+      );
+      validateVector3(connector.origin, `connector ${connector.name} origin`);
+      validateVector3(connector.normal, `connector ${connector.name} normal`);
+      validateNonZeroVector(connector.normal, `connector ${connector.name} normal`);
+      continue;
+    }
+    if (connector.type === 'axis') {
+      validateExactConnectorFields(
+        connector,
+        ['name', 'type', 'origin', 'axis'],
+        `axis connector ${connector.name}`,
+      );
+      validateVector3(connector.origin, `connector ${connector.name} origin`);
+      validateVector3(connector.axis, `connector ${connector.name} axis`);
+      validateNonZeroVector(connector.axis, `connector ${connector.name} axis`);
+      continue;
+    }
+    throw new Error(
+      `manifest: connector ${connector.name} type must be 'frame' or 'axis'`,
+    );
+  }
+}
+
+/**
+ * Validate an authored connector manifest before it crosses a catalog boundary.
+ * The binding prevents connector data from one geometry revision being applied
+ * silently to another part or family.
+ */
+export function validateHashBoundConnectorManifest(
+  manifest: unknown,
+  expected: ConnectorManifestBinding,
+): asserts manifest is HashBoundConnectorManifest {
+  validateConnectorManifest(manifest);
+  const candidate = manifest as unknown as Record<string, unknown>;
+  if (
+    typeof candidate.geometrySha256 !== 'string' ||
+    !SHA256_HEX.test(candidate.geometrySha256)
+  ) {
+    throw new Error('manifest: geometrySha256 must be a lowercase SHA-256 hex digest');
+  }
+  if (!isRecord(expected)) {
+    throw new Error('manifest: expected catalog identity must be an object');
+  }
+  if (typeof expected.partId !== 'string' || expected.partId.length === 0) {
+    throw new Error('manifest: expected partId required');
+  }
+  if (typeof expected.family !== 'string' || expected.family.length === 0) {
+    throw new Error('manifest: expected family required');
+  }
+  if (
+    typeof expected.geometrySha256 !== 'string' ||
+    !SHA256_HEX.test(expected.geometrySha256)
+  ) {
+    throw new Error('manifest: expected geometrySha256 must be a lowercase SHA-256 hex digest');
+  }
+  if (manifest.partId !== expected.partId) {
+    throw new Error('manifest: partId does not match the expected catalog record');
+  }
+  if (manifest.family !== expected.family) {
+    throw new Error('manifest: family does not match the expected catalog record');
+  }
+  if (candidate.geometrySha256 !== expected.geometrySha256) {
+    throw new Error('manifest: geometrySha256 does not match the expected geometry');
+  }
+}

--- a/src/shared/parts/types.ts
+++ b/src/shared/parts/types.ts
@@ -6,6 +6,14 @@
 // entry (bundled or remote). Geometry lives separately (in the cache);
 // PartRecord is the discovery + provenance handle.
 
+import {
+  validateHashBoundConnectorManifest,
+  type ConnectorAxisEntry,
+  type ConnectorEntry,
+  type ConnectorFrameEntry,
+  type HashBoundConnectorManifest,
+} from './connectorManifestSchema';
+
 export type PartSource = 'local-catalog' | 'remote';
 
 /**
@@ -27,6 +35,25 @@ export interface UpstreamProvenance {
   path: string;
 }
 
+type ReadonlyVector3 = readonly [number, number, number];
+
+/** Deeply immutable connector entry retained on catalog-backed runtime metadata. */
+export type CatalogConnectorEntry =
+  | (Readonly<Omit<ConnectorFrameEntry, 'origin' | 'normal'>> & {
+      readonly origin: ReadonlyVector3;
+      readonly normal: ReadonlyVector3;
+    })
+  | (Readonly<Omit<ConnectorAxisEntry, 'origin' | 'axis'>> & {
+      readonly origin: ReadonlyVector3;
+      readonly axis: ReadonlyVector3;
+    });
+
+/** Deeply immutable manifest snapshot retained on catalog-backed runtime metadata. */
+export type CatalogConnectorManifest =
+  Readonly<Omit<HashBoundConnectorManifest, 'connectors'>> & {
+    readonly connectors: readonly CatalogConnectorEntry[];
+  };
+
 export interface PartRecord {
   id: string;
   name: string;
@@ -40,6 +67,8 @@ export interface PartRecord {
   license: string;
   attribution?: string;
   connectors: string[];
+  /** Authored connector frames, bound to this record's exact geometry digest. */
+  connectorManifest?: HashBoundConnectorManifest;
   stepUrl?: string;
   /**
    * Display-mesh URL (GLB), when the catalog serves this part as a mesh instead
@@ -86,11 +115,59 @@ export interface CatalogPartMetadata {
   readonly license: string;
   readonly attribution?: string;
   readonly connectors: readonly string[];
+  readonly connectorManifest?: CatalogConnectorManifest;
   readonly stepUrl?: string;
   readonly glbUrl?: string;
   readonly licenseClass?: LicenseClass;
   readonly redistribution?: RedistributionMode;
   readonly upstream?: Readonly<UpstreamProvenance>;
+}
+
+function snapshotVector3(vector: [number, number, number]): ReadonlyVector3 {
+  const snapshot: [number, number, number] = [...vector];
+  Object.freeze(snapshot);
+  return snapshot;
+}
+
+function snapshotConnectorEntry(entry: ConnectorEntry): CatalogConnectorEntry {
+  if (entry.type === 'frame') {
+    const snapshot: CatalogConnectorEntry = {
+      name: entry.name,
+      type: 'frame',
+      origin: snapshotVector3(entry.origin),
+      normal: snapshotVector3(entry.normal),
+    };
+    Object.freeze(snapshot);
+    return snapshot;
+  }
+  const snapshot: CatalogConnectorEntry = {
+    name: entry.name,
+    type: 'axis',
+    origin: snapshotVector3(entry.origin),
+    axis: snapshotVector3(entry.axis),
+  };
+  Object.freeze(snapshot);
+  return snapshot;
+}
+
+/** Deep-copy nested connector data so runtime metadata cannot retain raw catalog references. */
+function snapshotConnectorManifest(
+  manifest: HashBoundConnectorManifest,
+): CatalogConnectorManifest {
+  const connectors: CatalogConnectorEntry[] = manifest.connectors.map(snapshotConnectorEntry);
+  Object.freeze(connectors);
+  const snapshot: CatalogConnectorManifest = {
+    schemaVersion: manifest.schemaVersion,
+    partId: manifest.partId,
+    family: manifest.family,
+    geometrySha256: manifest.geometrySha256,
+    connectors,
+    ...(manifest.license === undefined ? {} : { license: manifest.license }),
+    ...(manifest.attribution === undefined ? {} : { attribution: manifest.attribution }),
+    ...(manifest.generatedAt === undefined ? {} : { generatedAt: manifest.generatedAt }),
+  };
+  Object.freeze(snapshot);
+  return snapshot;
 }
 
 /** Create a detached, frozen copy of a catalog record for runtime metadata. */
@@ -108,6 +185,9 @@ export function snapshotCatalogPart(record: PartRecord): CatalogPartMetadata {
     license: record.license,
     ...(record.attribution === undefined ? {} : { attribution: record.attribution }),
     connectors: Object.freeze([...record.connectors]),
+    ...(record.connectorManifest === undefined
+      ? {}
+      : { connectorManifest: snapshotConnectorManifest(record.connectorManifest) }),
     ...(record.stepUrl === undefined ? {} : { stepUrl: record.stepUrl }),
     ...(record.glbUrl === undefined ? {} : { glbUrl: record.glbUrl }),
     ...(record.licenseClass === undefined ? {} : { licenseClass: record.licenseClass }),
@@ -135,7 +215,34 @@ export function isPartRecord(v: unknown): v is PartRecord {
   if (typeof r.sha256 !== 'string') return false;
   if (r.source !== 'local-catalog' && r.source !== 'remote') return false;
   if (typeof r.license !== 'string') return false;
-  if (!Array.isArray(r.connectors)) return false;
+  if (
+    !Array.isArray(r.connectors) ||
+    !r.connectors.every((connector) => typeof connector === 'string')
+  ) {
+    return false;
+  }
+  if (r.connectorManifest !== undefined) {
+    try {
+      const manifest = r.connectorManifest;
+      validateHashBoundConnectorManifest(
+        manifest,
+        {
+          partId: r.id,
+          family: r.family,
+          geometrySha256: r.sha256,
+        },
+      );
+      const manifestConnectorNames = manifest.connectors.map((connector) => connector.name);
+      if (
+        r.connectors.length !== manifestConnectorNames.length ||
+        r.connectors.some((connector, index) => connector !== manifestConnectorNames[index])
+      ) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+  }
   if (r.licenseClass !== undefined && !isLicenseClass(r.licenseClass)) return false;
   if (
     r.redistribution !== undefined &&

--- a/src/shared/parts/types.ts
+++ b/src/shared/parts/types.ts
@@ -54,6 +54,18 @@ export type CatalogConnectorManifest =
     readonly connectors: readonly CatalogConnectorEntry[];
   };
 
+declare const validatedConnectorEntry: unique symbol;
+
+/** An entry admitted only after its containing hash-bound manifest is validated. */
+type ValidatedConnectorEntry = ConnectorEntry & {
+  readonly [validatedConnectorEntry]: true;
+};
+
+type ValidatedHashBoundConnectorManifest =
+  Omit<HashBoundConnectorManifest, 'connectors'> & {
+    connectors: ValidatedConnectorEntry[];
+  };
+
 export interface PartRecord {
   id: string;
   name: string;
@@ -129,7 +141,7 @@ function snapshotVector3(vector: [number, number, number]): ReadonlyVector3 {
   return snapshot;
 }
 
-function snapshotConnectorEntry(entry: ConnectorEntry): CatalogConnectorEntry {
+function snapshotConnectorEntry(entry: ValidatedConnectorEntry): CatalogConnectorEntry {
   if (entry.type === 'frame') {
     const snapshot: CatalogConnectorEntry = {
       name: entry.name,
@@ -152,9 +164,12 @@ function snapshotConnectorEntry(entry: ConnectorEntry): CatalogConnectorEntry {
 
 /** Deep-copy nested connector data so runtime metadata cannot retain raw catalog references. */
 function snapshotConnectorManifest(
-  manifest: HashBoundConnectorManifest,
+  manifest: ValidatedHashBoundConnectorManifest,
 ): CatalogConnectorManifest {
-  const connectors: CatalogConnectorEntry[] = manifest.connectors.map(snapshotConnectorEntry);
+  const connectors: CatalogConnectorEntry[] = Array.from(
+    manifest.connectors,
+    snapshotConnectorEntry,
+  );
   Object.freeze(connectors);
   const snapshot: CatalogConnectorManifest = {
     schemaVersion: manifest.schemaVersion,
@@ -170,8 +185,48 @@ function snapshotConnectorManifest(
   return snapshot;
 }
 
+function hasExactManifestConnectorNames(
+  connectors: unknown,
+  manifest: HashBoundConnectorManifest,
+): boolean {
+  if (!Array.isArray(connectors)) return false;
+  const recordConnectorNames = Array.from(connectors);
+  if (!recordConnectorNames.every((connector) => typeof connector === 'string')) {
+    return false;
+  }
+  const manifestConnectorNames = Array.from(
+    manifest.connectors,
+    (connector) => connector.name,
+  );
+  return (
+    recordConnectorNames.length === manifestConnectorNames.length &&
+    recordConnectorNames.every(
+      (connector, index) => connector === manifestConnectorNames[index],
+    )
+  );
+}
+
+function validateSnapshotConnectorManifest(
+  record: PartRecord,
+): ValidatedHashBoundConnectorManifest | undefined {
+  const manifest = record.connectorManifest;
+  if (manifest === undefined) return undefined;
+  validateHashBoundConnectorManifest(manifest, {
+    partId: record.id,
+    family: record.family,
+    geometrySha256: record.sha256,
+  });
+  if (!hasExactManifestConnectorNames(record.connectors, manifest)) {
+    throw new Error(
+      'catalog snapshot: connectors must exactly match the validated connector manifest',
+    );
+  }
+  return manifest as ValidatedHashBoundConnectorManifest;
+}
+
 /** Create a detached, frozen copy of a catalog record for runtime metadata. */
 export function snapshotCatalogPart(record: PartRecord): CatalogPartMetadata {
+  const connectorManifest = validateSnapshotConnectorManifest(record);
   const snapshot: CatalogPartMetadata = {
     id: record.id,
     name: record.name,
@@ -185,9 +240,9 @@ export function snapshotCatalogPart(record: PartRecord): CatalogPartMetadata {
     license: record.license,
     ...(record.attribution === undefined ? {} : { attribution: record.attribution }),
     connectors: Object.freeze([...record.connectors]),
-    ...(record.connectorManifest === undefined
+    ...(connectorManifest === undefined
       ? {}
-      : { connectorManifest: snapshotConnectorManifest(record.connectorManifest) }),
+      : { connectorManifest: snapshotConnectorManifest(connectorManifest) }),
     ...(record.stepUrl === undefined ? {} : { stepUrl: record.stepUrl }),
     ...(record.glbUrl === undefined ? {} : { glbUrl: record.glbUrl }),
     ...(record.licenseClass === undefined ? {} : { licenseClass: record.licenseClass }),
@@ -215,12 +270,6 @@ export function isPartRecord(v: unknown): v is PartRecord {
   if (typeof r.sha256 !== 'string') return false;
   if (r.source !== 'local-catalog' && r.source !== 'remote') return false;
   if (typeof r.license !== 'string') return false;
-  if (
-    !Array.isArray(r.connectors) ||
-    !r.connectors.every((connector) => typeof connector === 'string')
-  ) {
-    return false;
-  }
   if (r.connectorManifest !== undefined) {
     try {
       const manifest = r.connectorManifest;
@@ -232,16 +281,17 @@ export function isPartRecord(v: unknown): v is PartRecord {
           geometrySha256: r.sha256,
         },
       );
-      const manifestConnectorNames = manifest.connectors.map((connector) => connector.name);
-      if (
-        r.connectors.length !== manifestConnectorNames.length ||
-        r.connectors.some((connector, index) => connector !== manifestConnectorNames[index])
-      ) {
+      if (!hasExactManifestConnectorNames(r.connectors, manifest)) {
         return false;
       }
     } catch {
       return false;
     }
+  } else if (
+    !Array.isArray(r.connectors) ||
+    !Array.from(r.connectors).every((connector) => typeof connector === 'string')
+  ) {
+    return false;
   }
   if (r.licenseClass !== undefined && !isLicenseClass(r.licenseClass)) return false;
   if (


### PR DESCRIPTION
## Summary
- Add universal `A4988` stepstick carrier and `SG90` micro-servo authored parts to the parts catalog pipeline.
- Model these parts with real connector interfaces (via connector manifests) and enforce exact connector/frame requirements with verification gates.
- Tighten catalog/part manifest ingest validation so authored connector metadata is consistently preserved and verified.
- Add regression coverage for authored component manifests and verification invariants.

## Why
These changes make component-aware published parts reusable and safer to consume in LabWired workflows.

## Checks
- `npx vitest run` across the relevant catalog/model/connector test set (110 tests)
- `npx eslint` on edited scripts and manifest helpers
- `npx tsc --noEmit -p tsconfig.cli.json`
- `git diff origin/develop...HEAD --check`
