### PR TITLE
Render pinned kernelCAD revisions in studio embed

### DIFF
--- a/src/funnel/lib/apiClient.test.ts
+++ b/src/funnel/lib/apiClient.test.ts
@@ -11,6 +11,7 @@ import {
   setProjectPrivacy,
   postProjectRender,
   PRIVATE_REQUIRES_PAID,
+  fetchProjectRevisionBySlug,
   listProjectRevisions,
   restoreProjectRevision,
 } from './apiClient';
@@ -162,6 +163,45 @@ describe('listProjectRevisions', () => {
     fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ revisions: [] }) });
     await listProjectRevisions('a/b');
     expect(fetchMock.mock.calls[0]![0]).toBe('https://api.kernelcad.com/api/v1/projects/a%2Fb/revisions');
+  });
+});
+
+describe('fetchProjectRevisionBySlug', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    getSessionMock.mockReset();
+    getSupabaseMock.mockReturnValue({ auth: { getSession: getSessionMock } });
+    getSessionMock.mockResolvedValue({ data: { session: { access_token: 'tok-1' } } });
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.kernelcad.com');
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('GETs the exact saved revision through the public project API', async () => {
+    const revision = { slug: 'slug-1', version: 7, code: 'cube(7);', parameters: [] };
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => revision });
+
+    await expect(fetchProjectRevisionBySlug('slug-1', 7)).resolves.toEqual(revision);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.kernelcad.com/api/v1/projects/slug-1/revisions/7');
+    expect(init.method).toBe('GET');
+    expect(init.headers.Authorization).toBe('Bearer tok-1');
+  });
+
+  it('url-encodes the slug before requesting the revision', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ slug: 'a/b', version: 1, code: 'cube();', parameters: [] }) });
+
+    await fetchProjectRevisionBySlug('a/b', 1);
+
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://api.kernelcad.com/api/v1/projects/a%2Fb/revisions/1');
   });
 });
 

--- a/src/funnel/lib/apiClient.ts
+++ b/src/funnel/lib/apiClient.ts
@@ -157,6 +157,28 @@ export interface ProjectRevision {
   created_at: string;
 }
 
+/** Saved source captured for one project version. */
+export interface ProjectRevisionBody {
+  slug: string;
+  version: number;
+  code: string;
+  parameters: Artifact['parameters'];
+}
+
+/**
+ * Fetch an exact saved revision. Consumers that request a pinned revision must
+ * treat a failed read as unavailable rather than use the live project row.
+ */
+export async function fetchProjectRevisionBySlug(
+  slug: string,
+  version: number,
+): Promise<ProjectRevisionBody> {
+  return authedFetch<ProjectRevisionBody>(
+    'GET',
+    `/api/v1/projects/${encodeURIComponent(slug)}/revisions/${version}`,
+  );
+}
+
 /** Newest-first list of saved server revisions for a slug-backed project.
  *  Unwraps the `{ revisions: [...] }` envelope; returns `[]` when missing. */
 export async function listProjectRevisions(slug: string): Promise<ProjectRevision[]> {

--- a/src/studio/routes/-embedConfig.ts
+++ b/src/studio/routes/-embedConfig.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+
+export type EmbedPresentation = 'viewer' | 'studio';
+
+/** The plain embed stays the compatibility default; Studio is opt-in per host. */
+export function embedPresentationMode(value: unknown): EmbedPresentation {
+  return value === 'studio' ? 'studio' : 'viewer';
+}
+
+/**
+ * `undefined` means no requested revision (the compatible live model). `null`
+ * means a malformed requested revision, which the embed must fail closed.
+ */
+export function embedRevision(value: unknown): number | null | undefined {
+  if (value === undefined) return undefined;
+  const raw = typeof value === 'number' ? String(value) : value;
+  if (typeof raw !== 'string' || !/^[1-9][0-9]*$/.test(raw)) return null;
+  const revision = Number(raw);
+  return Number.isSafeInteger(revision) ? revision : null;
+}
+
+export interface EmbedCodeLoaders {
+  loadCurrent: () => Promise<string | null>;
+  loadRevision: (revision: number) => Promise<string>;
+}
+
+/**
+ * Resolves the source code an embed is allowed to render. Explicit revisions
+ * never fall back to the mutable current project after a failed read.
+ */
+export async function loadEmbedCode(
+  revision: number | null | undefined,
+  loaders: EmbedCodeLoaders,
+): Promise<string | null> {
+  if (revision === null) return null;
+  if (revision === undefined) return loaders.loadCurrent();
+  try {
+    return await loaders.loadRevision(revision);
+  } catch {
+    return null;
+  }
+}

--- a/src/studio/routes/embed.$slug.test.ts
+++ b/src/studio/routes/embed.$slug.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
-import { describe, expect, it } from 'vitest';
-import { embedPresentationMode } from '../embedPresentation';
+import { describe, expect, it, vi } from 'vitest';
+import { embedPresentationMode, embedRevision, loadEmbedCode } from './-embedConfig';
 
 describe('embedPresentationMode', () => {
   it('keeps the default embed model-only', () => {
@@ -11,5 +11,45 @@ describe('embedPresentationMode', () => {
 
   it('selects the read-only Studio shell only when requested', () => {
     expect(embedPresentationMode('studio')).toBe('studio');
+  });
+
+  it('distinguishes an absent revision from an invalid or pinned revision', () => {
+    expect(embedRevision(undefined)).toBeUndefined();
+    expect(embedRevision('7')).toBe(7);
+    expect(embedRevision('07')).toBeNull();
+    expect(embedRevision('0')).toBeNull();
+    expect(embedRevision('7.5')).toBeNull();
+    expect(embedRevision('latest')).toBeNull();
+  });
+
+  it('keeps an absent revision on the compatible live-project loader', async () => {
+    const loadCurrent = vi.fn().mockResolvedValue('live-code');
+    const loadRevision = vi.fn();
+
+    await expect(loadEmbedCode(undefined, { loadCurrent, loadRevision })).resolves.toBe('live-code');
+    expect(loadCurrent).toHaveBeenCalledOnce();
+    expect(loadRevision).not.toHaveBeenCalled();
+  });
+
+  it('loads an explicit revision without consulting the live project', async () => {
+    const loadCurrent = vi.fn();
+    const loadRevision = vi.fn().mockResolvedValue('pinned-code');
+
+    await expect(loadEmbedCode(7, { loadCurrent, loadRevision })).resolves.toBe('pinned-code');
+    expect(loadRevision).toHaveBeenCalledWith(7);
+    expect(loadCurrent).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when an explicit revision is malformed or unavailable', async () => {
+    const loadCurrent = vi.fn().mockResolvedValue('live-code');
+    const loadRevision = vi.fn().mockRejectedValue(new Error('not_found'));
+
+    await expect(loadEmbedCode(null, { loadCurrent, loadRevision })).resolves.toBeNull();
+    expect(loadCurrent).not.toHaveBeenCalled();
+    expect(loadRevision).not.toHaveBeenCalled();
+
+    await expect(loadEmbedCode(7, { loadCurrent, loadRevision })).resolves.toBeNull();
+    expect(loadCurrent).not.toHaveBeenCalled();
+    expect(loadRevision).toHaveBeenCalledWith(7);
   });
 });

--- a/src/studio/routes/embed.$slug.tsx
+++ b/src/studio/routes/embed.$slug.tsx
@@ -19,22 +19,25 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 import { FunnelViewer } from '../../funnel/components/FunnelViewer';
-import { fetchProjectBySlug, type ProjectRow } from '../../funnel/lib/apiClient';
+import { fetchProjectBySlug, fetchProjectRevisionBySlug } from '../../funnel/lib/apiClient';
 import StudioApp from '../App';
 import { StudioConfigProvider } from '../config/StudioConfigContext';
-import { embedPresentationMode } from '../embedPresentation';
+import { embedPresentationMode, embedRevision, loadEmbedCode } from './-embedConfig';
 
 export const Route = createFileRoute('/embed/$slug')({
   validateSearch: (search: Record<string, unknown>) => ({
     mode: embedPresentationMode(search.mode),
+    revision: embedRevision(search.revision),
   }),
   component: EmbedPage,
 });
 
 function EmbedPage() {
   const { slug } = Route.useParams();
-  const { mode } = Route.useSearch();
-  const [project, setProject] = useState<ProjectRow | null>(null);
+  const { mode, revision } = Route.useSearch();
+  const sourceKey = `${slug}\u0000${revision === undefined ? 'current' : revision === null ? 'invalid' : revision}`;
+  const [code, setCode] = useState<string | null>(null);
+  const [loadedSourceKey, setLoadedSourceKey] = useState<string | null>(null);
   const [state, setState] = useState<'loading' | 'ready' | 'missing' | 'error'>('loading');
   const [err, setErr] = useState<string | null>(null);
 
@@ -42,34 +45,49 @@ function EmbedPage() {
     // `state` starts at 'loading' (initial useState); the fetch resolves it to
     // ready/missing/error. No synchronous setState in the effect body.
     let disposed = false;
-    fetchProjectBySlug(slug)
-      .then((p) => {
+    const source = loadEmbedCode(revision, {
+      loadCurrent: () => fetchProjectBySlug(slug).then((project) => project?.current_code ?? null),
+      loadRevision: (version) => fetchProjectRevisionBySlug(slug, version).then((saved) => saved.code),
+    });
+    source
+      .then((sourceCode) => {
         if (disposed) return;
-        if (p) { setProject(p); setState('ready'); }
-        else { setState('missing'); }
+        if (sourceCode) { setCode(sourceCode); setLoadedSourceKey(sourceKey); setState('ready'); }
+        else { setLoadedSourceKey(sourceKey); setState('missing'); }
       })
-      .catch((e) => { if (!disposed) { setErr(String(e)); setState('error'); } });
+      .catch((e) => {
+        if (disposed) return;
+        // Requested release revisions fail closed: never substitute the live model
+        // when the revision endpoint is unavailable or refuses access.
+        if (revision !== undefined) { setLoadedSourceKey(sourceKey); setState('missing'); return; }
+        setLoadedSourceKey(sourceKey);
+        setErr(String(e));
+        setState('error');
+      });
     return () => { disposed = true; };
-  }, [slug]);
+  }, [slug, revision, sourceKey]);
 
-  if (state === 'ready' && project) {
+  const sourceSettled = loadedSourceKey === sourceKey;
+
+  if (revision !== null && sourceSettled && state === 'ready' && code) {
     if (mode === 'studio') {
       return (
         <StudioConfigProvider value={{ showHeader: false, enableAgentRail: false, enableConnect: false }}>
-          <StudioApp initialCode={project.current_code} viewerMode />
+          <StudioApp initialCode={code} viewerMode />
         </StudioConfigProvider>
       );
     }
     return (
       <div className="fixed inset-0">
-        <FunnelViewer code={project.current_code} />
+        <FunnelViewer code={code} />
       </div>
     );
   }
 
   const message =
-    state === 'error' ? `Failed to load: ${err}`
-    : state === 'missing' ? 'Model not available.'
+    revision === null || (sourceSettled && state === 'missing') ? 'Model not available.'
+    : !sourceSettled ? 'Loading…'
+    : state === 'error' ? `Failed to load: ${err}`
     : 'Loading…';
   return (
     <main className="fixed inset-0 bg-vellum font-sans grid place-items-center p-8">


### PR DESCRIPTION
## What changed
- Add optional  pinning to studio embed URL/config path.
- Thread revision through API client and embed route params.
- Keep existing embed behavior backward compatible while supporting immutable revision playback.

## Validation
- Added/updated embed route tests and API client tests