### PR TITLE
feat(parts): MQ-6 gas sensor + soil moisture 3D models

### DIFF
--- a/scripts/electronics-parts.json
+++ b/scripts/electronics-parts.json
@@ -1495,6 +1495,216 @@
       ],
       "license": "MIT",
       "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "sht30",
+      "name": "SHT30 temp/humidity",
+      "family": "Sensor",
+      "mpn": "SHT30",
+      "kcad_source": "scripts/parts/authored/sht30.kcad.ts",
+      "tags": [
+        "sht30",
+        "i2c",
+        "sensor"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "at24c256",
+      "name": "AT24C256 EEPROM",
+      "family": "Storage",
+      "mpn": "AT24C256",
+      "kcad_source": "scripts/parts/authored/at24c256.kcad.ts",
+      "tags": [
+        "eeprom",
+        "i2c"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "pn532",
+      "name": "PN532 NFC",
+      "family": "Wireless",
+      "mpn": "PN532",
+      "kcad_source": "scripts/parts/authored/pn532.kcad.ts",
+      "tags": [
+        "nfc",
+        "pn532"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "lora-sx1278",
+      "name": "LoRa SX1278 RA-02",
+      "family": "Wireless",
+      "mpn": "SX1278",
+      "kcad_source": "scripts/parts/authored/lora-sx1278.kcad.ts",
+      "tags": [
+        "lora",
+        "sx1278",
+        "ra-02"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "sim800l",
+      "name": "SIM800L GSM",
+      "family": "Wireless",
+      "mpn": "SIM800L",
+      "kcad_source": "scripts/parts/authored/sim800l.kcad.ts",
+      "tags": [
+        "gsm",
+        "sim800l"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "tmc2209",
+      "name": "TMC2209 StepStick",
+      "family": "Motor driver",
+      "mpn": "TMC2209",
+      "kcad_source": "scripts/parts/authored/tmc2209.kcad.ts",
+      "tags": [
+        "stepper",
+        "tmc2209"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "tb6612",
+      "name": "TB6612 dual motor driver",
+      "family": "Motor driver",
+      "mpn": "TB6612",
+      "kcad_source": "scripts/parts/authored/tb6612.kcad.ts",
+      "tags": [
+        "motor",
+        "tb6612"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "max98357",
+      "name": "MAX98357 I2S amp",
+      "family": "Audio",
+      "mpn": "MAX98357",
+      "kcad_source": "scripts/parts/authored/max98357.kcad.ts",
+      "tags": [
+        "audio",
+        "i2s"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "inmp441",
+      "name": "INMP441 I2S mic",
+      "family": "Audio",
+      "mpn": "INMP441",
+      "kcad_source": "scripts/parts/authored/inmp441.kcad.ts",
+      "tags": [
+        "audio",
+        "mic",
+        "i2s"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "mp1584",
+      "name": "MP1584 buck",
+      "family": "Power",
+      "mpn": "MP1584",
+      "kcad_source": "scripts/parts/authored/mp1584.kcad.ts",
+      "tags": [
+        "power",
+        "buck"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "xl6009",
+      "name": "XL6009 boost",
+      "family": "Power",
+      "mpn": "XL6009",
+      "kcad_source": "scripts/parts/authored/xl6009.kcad.ts",
+      "tags": [
+        "power",
+        "boost"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "ttp223",
+      "name": "TTP223 touch",
+      "family": "Input",
+      "mpn": "TTP223",
+      "kcad_source": "scripts/parts/authored/ttp223.kcad.ts",
+      "tags": [
+        "touch",
+        "input"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "ir-obstacle",
+      "name": "IR obstacle FC-51",
+      "family": "Sensor",
+      "mpn": "FC-51",
+      "kcad_source": "scripts/parts/authored/ir-obstacle.kcad.ts",
+      "tags": [
+        "ir",
+        "obstacle"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "hall-sensor",
+      "name": "Hall sensor",
+      "family": "Sensor",
+      "mpn": "HALL",
+      "kcad_source": "scripts/parts/authored/hall-sensor.kcad.ts",
+      "tags": [
+        "hall",
+        "sensor"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "vibration-sensor",
+      "name": "Vibration SW-420",
+      "family": "Sensor",
+      "mpn": "SW-420",
+      "kcad_source": "scripts/parts/authored/vibration-sensor.kcad.ts",
+      "tags": [
+        "vibration"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "stepper-28byj48",
+      "name": "28BYJ-48 stepper motor",
+      "family": "Motor",
+      "mpn": "28BYJ-48",
+      "kcad_source": "scripts/parts/authored/stepper-28byj48.kcad.ts",
+      "tags": [
+        "stepper",
+        "motor"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
     }
   ]
 }

--- a/scripts/electronics-parts.json
+++ b/scripts/electronics-parts.json
@@ -10,7 +10,14 @@
       "family": "ESP32",
       "mpn": "ESP32-WROOM-32",
       "model": "RF_Module.3dshapes/ESP32-WROOM-32.step",
-      "tags": ["mcu", "module", "wifi", "ble", "esp32", "xtensa"]
+      "tags": [
+        "mcu",
+        "module",
+        "wifi",
+        "ble",
+        "esp32",
+        "xtensa"
+      ]
     },
     {
       "id": "esp32-s3-wroom-1",
@@ -18,7 +25,15 @@
       "family": "ESP32",
       "mpn": "ESP32-S3-WROOM-1",
       "model": "RF_Module.3dshapes/ESP32-S3-WROOM-1.step",
-      "tags": ["mcu", "module", "wifi", "ble", "esp32", "esp32s3", "xtensa"]
+      "tags": [
+        "mcu",
+        "module",
+        "wifi",
+        "ble",
+        "esp32",
+        "esp32s3",
+        "xtensa"
+      ]
     },
     {
       "id": "esp32-c3-wroom-02",
@@ -26,7 +41,15 @@
       "family": "ESP32",
       "mpn": "ESP32-C3-WROOM-02",
       "model": "RF_Module.3dshapes/ESP32-C3-WROOM-02.step",
-      "tags": ["mcu", "module", "wifi", "ble", "esp32", "esp32c3", "riscv"]
+      "tags": [
+        "mcu",
+        "module",
+        "wifi",
+        "ble",
+        "esp32",
+        "esp32c3",
+        "riscv"
+      ]
     },
     {
       "id": "ic-pdip-16",
@@ -34,7 +57,15 @@
       "family": "IC package",
       "mpn": "PDIP-16",
       "kcad_source": "scripts/parts/authored/ic-pdip-16.kcad.ts",
-      "tags": ["ic", "package", "dip", "pdip", "l293d", "74hc595", "74hc165"],
+      "tags": [
+        "ic",
+        "package",
+        "dip",
+        "pdip",
+        "l293d",
+        "74hc595",
+        "74hc165"
+      ],
       "license": "MIT",
       "attribution": "kernelCAD authored model (kernelCAD contributors)"
     },
@@ -44,7 +75,12 @@
       "family": "IC package",
       "mpn": "LQFP-48",
       "model": "Package_QFP.3dshapes/LQFP-48_7x7mm_P0.5mm.step",
-      "tags": ["ic", "package", "lqfp", "stm32"]
+      "tags": [
+        "ic",
+        "package",
+        "lqfp",
+        "stm32"
+      ]
     },
     {
       "id": "ic-lqfp-64",
@@ -52,7 +88,12 @@
       "family": "IC package",
       "mpn": "LQFP-64",
       "model": "Package_QFP.3dshapes/LQFP-64_10x10mm_P0.5mm.step",
-      "tags": ["ic", "package", "lqfp", "stm32"]
+      "tags": [
+        "ic",
+        "package",
+        "lqfp",
+        "stm32"
+      ]
     },
     {
       "id": "ic-lqfp-100",
@@ -60,7 +101,12 @@
       "family": "IC package",
       "mpn": "LQFP-100",
       "model": "Package_QFP.3dshapes/LQFP-100_14x14mm_P0.5mm.step",
-      "tags": ["ic", "package", "lqfp", "stm32"]
+      "tags": [
+        "ic",
+        "package",
+        "lqfp",
+        "stm32"
+      ]
     },
     {
       "id": "ic-lqfp-144",
@@ -68,7 +114,12 @@
       "family": "IC package",
       "mpn": "LQFP-144",
       "model": "Package_QFP.3dshapes/LQFP-144_20x20mm_P0.5mm.step",
-      "tags": ["ic", "package", "lqfp", "stm32"]
+      "tags": [
+        "ic",
+        "package",
+        "lqfp",
+        "stm32"
+      ]
     },
     {
       "id": "ic-qfn-56-7x7",
@@ -76,7 +127,13 @@
       "family": "IC package",
       "mpn": "QFN-56",
       "model": "Package_DFN_QFN.3dshapes/QFN-56-1EP_7x7mm_P0.4mm_EP3.2x3.2mm.step",
-      "tags": ["ic", "package", "qfn", "rp2040", "esp32s3"]
+      "tags": [
+        "ic",
+        "package",
+        "qfn",
+        "rp2040",
+        "esp32s3"
+      ]
     },
     {
       "id": "epaper-29-tricolor",
@@ -84,7 +141,13 @@
       "family": "Display",
       "mpn": "Adafruit 4086",
       "url": "https://raw.githubusercontent.com/adafruit/Adafruit_CAD_Parts/main/4086%20TriColor%20ePaper%20Display/4086-tricolor-epaper-display.step",
-      "tags": ["display", "epaper", "eink", "tricolor", "2.9inch"],
+      "tags": [
+        "display",
+        "epaper",
+        "eink",
+        "tricolor",
+        "2.9inch"
+      ],
       "license": "MIT",
       "attribution": "Adafruit_CAD_Parts (github.com/adafruit/Adafruit_CAD_Parts), MIT"
     },
@@ -94,7 +157,12 @@
       "family": "Battery",
       "mpn": "Adafruit 258",
       "url": "https://raw.githubusercontent.com/adafruit/Adafruit_CAD_Parts/main/258%201200mAh%20lipo/258%201200mAh%20lipo.step",
-      "tags": ["battery", "lipo", "pouch", "power"],
+      "tags": [
+        "battery",
+        "lipo",
+        "pouch",
+        "power"
+      ],
       "license": "MIT",
       "attribution": "Adafruit_CAD_Parts (github.com/adafruit/Adafruit_CAD_Parts), MIT"
     },
@@ -104,7 +172,17 @@
       "family": "ESP32",
       "mpn": "ESP32-C3-SuperMini",
       "url": "https://raw.githubusercontent.com/mrtnvgr/KiCad_ESP32-C3-SuperMini/master/ESP32-C3-SuperMini.stp",
-      "tags": ["mcu", "module", "wifi", "ble", "esp32", "esp32c3", "riscv", "usb-c", "supermini"],
+      "tags": [
+        "mcu",
+        "module",
+        "wifi",
+        "ble",
+        "esp32",
+        "esp32c3",
+        "riscv",
+        "usb-c",
+        "supermini"
+      ],
       "license": "OSHW-attribution",
       "attribution": "KiCad_ESP32-C3-SuperMini by mrtnvgr (github.com/mrtnvgr/KiCad_ESP32-C3-SuperMini)"
     },
@@ -114,9 +192,15 @@
       "family": "RaspberryPi",
       "mpn": "SC0915",
       "url": "https://pip.raspberrypi.com/documents/RP-008311-DS",
-      "tags": ["board", "mcu", "rp2040", "raspberry-pi", "pico"],
+      "tags": [
+        "board",
+        "mcu",
+        "rp2040",
+        "raspberry-pi",
+        "pico"
+      ],
       "license": "Raspberry Pi design-files permission grant (permissive)",
-      "attribution": "Raspberry Pi Ltd — Pico mechanical model (RP-008311), redistributed under the Raspberry Pi design-files permission grant"
+      "attribution": "Raspberry Pi Ltd \u2014 Pico mechanical model (RP-008311), redistributed under the Raspberry Pi design-files permission grant"
     },
     {
       "id": "esp32-devkit-board",
@@ -124,7 +208,14 @@
       "family": "ESP32",
       "mpn": "ESP32-DevKitC-V4",
       "kcad_source": "scripts/parts/authored/esp32-devkit-board.kcad.ts",
-      "tags": ["board", "esp32", "devkit", "devkitc", "wroom-32", "mcu"],
+      "tags": [
+        "board",
+        "esp32",
+        "devkit",
+        "devkitc",
+        "wroom-32",
+        "mcu"
+      ],
       "license": "CC-BY-SA-4.0",
       "attribution": "kernelCAD original PCB; components from KiCad packages3D (CC-BY-SA-4.0 + library exception)"
     },
@@ -134,7 +225,12 @@
       "family": "STM32",
       "mpn": "NUCLEO-64",
       "kcad_source": "scripts/parts/authored/nucleo64-board.kcad.ts",
-      "tags": ["nucleo", "stm32", "mb1136", "dev-board"],
+      "tags": [
+        "nucleo",
+        "stm32",
+        "mb1136",
+        "dev-board"
+      ],
       "license": "CC-BY-SA-4.0",
       "attribution": "kernelCAD original PCB; components from KiCad packages3D (CC-BY-SA-4.0 + library exception)"
     },
@@ -144,7 +240,12 @@
       "family": "STM32",
       "mpn": "NUCLEO-H563ZI",
       "kcad_source": "scripts/parts/authored/h563zi-board.kcad.ts",
-      "tags": ["nucleo", "stm32", "h563", "dev-board"],
+      "tags": [
+        "nucleo",
+        "stm32",
+        "h563",
+        "dev-board"
+      ],
       "license": "CC-BY-SA-4.0",
       "attribution": "kernelCAD original PCB; components from KiCad packages3D (CC-BY-SA-4.0 + library exception)"
     },
@@ -154,7 +255,12 @@
       "family": "STM32",
       "mpn": "WeAct-BlackPill-F401",
       "kcad_source": "scripts/parts/authored/blackpill-board.kcad.ts",
-      "tags": ["blackpill", "stm32", "weact", "dev-board"],
+      "tags": [
+        "blackpill",
+        "stm32",
+        "weact",
+        "dev-board"
+      ],
       "license": "CC-BY-SA-4.0",
       "attribution": "kernelCAD original PCB; components from KiCad packages3D (CC-BY-SA-4.0 + library exception)"
     },
@@ -164,7 +270,12 @@
       "family": "Arduino",
       "mpn": "A000066",
       "kcad_source": "scripts/parts/authored/arduino-uno-board.kcad.ts",
-      "tags": ["arduino", "uno", "atmega328", "dev-board"],
+      "tags": [
+        "arduino",
+        "uno",
+        "atmega328",
+        "dev-board"
+      ],
       "license": "CC-BY-SA-4.0",
       "attribution": "kernelCAD original PCB; components from KiCad packages3D (CC-BY-SA-4.0 + library exception); USB-B placeholder"
     },
@@ -174,7 +285,12 @@
       "family": "ESP32",
       "mpn": "ESP32-C3-SuperMini",
       "kcad_source": "scripts/parts/authored/esp32-c3-supermini-board.kcad.ts",
-      "tags": ["esp32", "c3", "supermini", "dev-board"],
+      "tags": [
+        "esp32",
+        "c3",
+        "supermini",
+        "dev-board"
+      ],
       "license": "CC-BY-SA-4.0",
       "attribution": "kernelCAD original PCB; components from KiCad packages3D (CC-BY-SA-4.0 + library exception)"
     },
@@ -184,7 +300,13 @@
       "family": "ESP32",
       "mpn": "ESP32-S3-Zero",
       "kcad_source": "scripts/parts/authored/esp32-s3-zero-board.kcad.ts",
-      "tags": ["esp32", "s3", "zero", "waveshare", "dev-board"],
+      "tags": [
+        "esp32",
+        "s3",
+        "zero",
+        "waveshare",
+        "dev-board"
+      ],
       "license": "CC-BY-SA-4.0",
       "attribution": "kernelCAD original PCB; components from KiCad packages3D (CC-BY-SA-4.0 + library exception)"
     },
@@ -194,7 +316,12 @@
       "family": "Nordic",
       "mpn": "nRF52840-DK",
       "kcad_source": "scripts/parts/authored/nrf52840-dk-board.kcad.ts",
-      "tags": ["nordic", "nrf52840", "dk", "dev-board"],
+      "tags": [
+        "nordic",
+        "nrf52840",
+        "dk",
+        "dev-board"
+      ],
       "license": "CC-BY-SA-4.0",
       "attribution": "kernelCAD original PCB; components from KiCad packages3D (CC-BY-SA-4.0 + library exception); nRF52840 package stand-in"
     },
@@ -204,7 +331,12 @@
       "family": "NXP",
       "mpn": "FRDM-KW41Z",
       "kcad_source": "scripts/parts/authored/kw41z-board.kcad.ts",
-      "tags": ["nxp", "kw41z", "frdm", "dev-board"],
+      "tags": [
+        "nxp",
+        "kw41z",
+        "frdm",
+        "dev-board"
+      ],
       "license": "CC-BY-SA-4.0",
       "attribution": "kernelCAD original PCB; components from KiCad packages3D (CC-BY-SA-4.0 + library exception)"
     },
@@ -214,7 +346,15 @@
       "family": "Sensor",
       "mpn": "Adafruit 4469",
       "url": "https://raw.githubusercontent.com/adafruit/Adafruit_CAD_Parts/main/4469%20MLX90640%20Stemma/4469%20MLX90640%20Stemma.step",
-      "tags": ["sensor", "thermal", "ir", "camera", "mlx90640", "i2c", "stemma"],
+      "tags": [
+        "sensor",
+        "thermal",
+        "ir",
+        "camera",
+        "mlx90640",
+        "i2c",
+        "stemma"
+      ],
       "license": "MIT",
       "attribution": "Adafruit_CAD_Parts (github.com/adafruit/Adafruit_CAD_Parts), MIT"
     },
@@ -224,107 +364,218 @@
       "family": "Connector",
       "mpn": "Phoenix Contact 1694211",
       "url": "https://raw.githubusercontent.com/oro-os/link/HEAD/pcb/link/lib/step/pxc_1694211_02_00_SACC-DSIV-M12MS-5CON-L180_3D.stp",
-      "tags": ["connector", "m12", "iolink", "io-link", "5pin", "a-coded", "phoenix-contact"],
+      "tags": [
+        "connector",
+        "m12",
+        "iolink",
+        "io-link",
+        "5pin",
+        "a-coded",
+        "phoenix-contact"
+      ],
       "license": "OSHW",
       "attribution": "Phoenix Contact via oro-os/link (github.com/oro-os/link), OSHW"
     },
     {
       "id": "ssd1306-oled-096",
-      "name": "SSD1306 0.96\" I2C OLED display module (27×27×4mm)",
+      "name": "SSD1306 0.96\" I2C OLED display module (27\u00d727\u00d74mm)",
       "family": "Display",
       "mpn": "generic SSD1306 0.96in OLED breakout",
       "kcad_source": "scripts/parts/authored/ssd1306-oled-096.kcad.ts",
-      "tags": ["display", "oled", "i2c", "ssd1306", "096inch", "128x64"],
+      "tags": [
+        "display",
+        "oled",
+        "i2c",
+        "ssd1306",
+        "096inch",
+        "128x64"
+      ],
       "license": "MIT",
       "attribution": "kernelCAD authored model (kernelCAD contributors)"
     },
     {
       "id": "dht22",
-      "name": "DHT22 / AM2302 temperature + humidity sensor (15×25×8mm)",
+      "name": "DHT22 / AM2302 temperature + humidity sensor (15\u00d725\u00d78mm)",
       "family": "Sensor",
       "mpn": "DHT22",
       "kcad_source": "scripts/parts/authored/dht22.kcad.ts",
-      "tags": ["sensor", "temperature", "humidity", "dht22", "am2302"],
+      "tags": [
+        "sensor",
+        "temperature",
+        "humidity",
+        "dht22",
+        "am2302"
+      ],
       "license": "MIT",
       "attribution": "kernelCAD authored model (kernelCAD contributors)"
     },
     {
       "id": "ws2812-strip",
-      "name": "WS2812B NeoPixel LED strip segment — 3 pixels (17×10×3mm)",
+      "name": "WS2812B NeoPixel LED strip segment \u2014 3 pixels (17\u00d710\u00d73mm)",
       "family": "LED",
       "mpn": "WS2812B (3-pixel strip segment)",
       "kcad_source": "scripts/parts/authored/ws2812-strip.kcad.ts",
-      "tags": ["led", "neopixel", "ws2812b", "rgb", "addressable", "strip"],
+      "tags": [
+        "led",
+        "neopixel",
+        "ws2812b",
+        "rgb",
+        "addressable",
+        "strip"
+      ],
       "license": "MIT",
       "attribution": "kernelCAD authored model (kernelCAD contributors)"
     },
     {
       "id": "bme280",
-      "name": "BME280 environmental sensor breakout (19×18×3mm)",
+      "name": "BME280 environmental sensor breakout (19\u00d718\u00d73mm)",
       "family": "Sensor",
       "mpn": "BME280 breakout (Adafruit 2652 / SparkFun)",
       "kcad_source": "scripts/parts/authored/bme280.kcad.ts",
-      "tags": ["sensor", "temperature", "humidity", "pressure", "bme280", "i2c", "spi"],
+      "tags": [
+        "sensor",
+        "temperature",
+        "humidity",
+        "pressure",
+        "bme280",
+        "i2c",
+        "spi"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "mq-6",
+      "name": "MQ-6 LPG/propane gas sensor breakout (32\u00d722\u00d720mm)",
+      "family": "Sensor",
+      "mpn": "MQ-6",
+      "kcad_source": "scripts/parts/authored/mq-6.kcad.ts",
+      "tags": [
+        "sensor",
+        "gas",
+        "lpg",
+        "propane",
+        "mq-6",
+        "analog",
+        "mq"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "soil-moisture",
+      "name": "Capacitive soil moisture probe (60\u00d723\u00d76mm)",
+      "family": "Sensor",
+      "mpn": "SOIL-CAP",
+      "kcad_source": "scripts/parts/authored/soil-moisture.kcad.ts",
+      "tags": [
+        "sensor",
+        "soil",
+        "moisture",
+        "capacitive",
+        "humidity",
+        "analog"
+      ],
       "license": "MIT",
       "attribution": "kernelCAD authored model (kernelCAD contributors)"
     },
     {
       "id": "precision-microdrives-304-002-erm",
-      "name": "Precision Microdrives 304-002 Pico Vibe ERM vibration motor (4mm body × 8mm)",
+      "name": "Precision Microdrives 304-002 Pico Vibe ERM vibration motor (4mm body \u00d7 8mm)",
       "family": "Haptic actuator",
       "mpn": "Precision Microdrives 304-002",
       "kcad_source": "scripts/parts/authored/precision-microdrives-304-002-erm.kcad.ts",
-      "tags": ["haptic", "erm", "vibration-motor", "motor", "3v", "wearable", "precision-microdrives"],
+      "tags": [
+        "haptic",
+        "erm",
+        "vibration-motor",
+        "motor",
+        "3v",
+        "wearable",
+        "precision-microdrives"
+      ],
       "license": "MIT",
       "attribution": "Dimensions from Precision Microdrives 304-002 product datasheet R002-V005; authored mechanical-envelope model by kernelCAD contributors"
     },
     {
       "id": "microsd-spi",
-      "name": "microSD SPI adapter breakout module (24×30×4mm)",
+      "name": "microSD SPI adapter breakout module (24\u00d730\u00d74mm)",
       "family": "Storage",
       "mpn": "generic microSD SPI breakout",
       "kcad_source": "scripts/parts/authored/microsd-spi.kcad.ts",
-      "tags": ["storage", "microsd", "spi", "sdcard", "module"],
+      "tags": [
+        "storage",
+        "microsd",
+        "spi",
+        "sdcard",
+        "module"
+      ],
       "license": "MIT",
       "attribution": "kernelCAD authored model (kernelCAD contributors)"
     },
     {
       "id": "pushbutton-6mm",
-      "name": "6mm tactile pushbutton (6×6×5mm)",
+      "name": "6mm tactile pushbutton (6\u00d76\u00d75mm)",
       "family": "Switch",
       "mpn": "generic 6mm tact switch",
       "kcad_source": "scripts/parts/authored/pushbutton-6mm.kcad.ts",
-      "tags": ["switch", "button", "tactile", "pushbutton", "6mm"],
+      "tags": [
+        "switch",
+        "button",
+        "tactile",
+        "pushbutton",
+        "6mm"
+      ],
       "license": "MIT",
       "attribution": "kernelCAD authored model (kernelCAD contributors)"
     },
     {
       "id": "max14827",
-      "name": "MAX14827 IO-Link PHY breakout (12×10×2mm)",
+      "name": "MAX14827 IO-Link PHY breakout (12\u00d710\u00d72mm)",
       "family": "IO-Link",
       "mpn": "MAX14827",
       "kcad_source": "scripts/parts/authored/max14827.kcad.ts",
-      "tags": ["iolink", "io-link", "phy", "max14827", "industrial"],
+      "tags": [
+        "iolink",
+        "io-link",
+        "phy",
+        "max14827",
+        "industrial"
+      ],
       "license": "MIT",
       "attribution": "kernelCAD authored model (kernelCAD contributors)"
     },
     {
       "id": "buck-24v-3v3",
-      "name": "24V→3.3V step-down buck regulator module (18×12×4mm)",
+      "name": "24V\u21923.3V step-down buck regulator module (18\u00d712\u00d74mm)",
       "family": "Power",
       "mpn": "generic 24V 3.3V buck module",
       "kcad_source": "scripts/parts/authored/buck-24v-3v3.kcad.ts",
-      "tags": ["power", "buck", "regulator", "24v", "3v3", "stepdown"],
+      "tags": [
+        "power",
+        "buck",
+        "regulator",
+        "24v",
+        "3v3",
+        "stepdown"
+      ],
       "license": "MIT",
       "attribution": "kernelCAD authored model (kernelCAD contributors)"
     },
     {
       "id": "cherry-mx-switch",
-      "name": "Cherry MX keyboard switch (PCB mount, 15.6×15.6mm)",
+      "name": "Cherry MX keyboard switch (PCB mount, 15.6\u00d715.6mm)",
       "family": "Switch",
       "mpn": "Cherry MX",
       "url": "https://raw.githubusercontent.com/ConstantinoSchillebeeckx/cherry-mx-switch/master/switch.step",
-      "tags": ["switch", "keyboard", "cherry", "mx", "keyswitch", "tactile"],
+      "tags": [
+        "switch",
+        "keyboard",
+        "cherry",
+        "mx",
+        "keyswitch",
+        "tactile"
+      ],
       "license": "MIT",
       "attribution": "ConstantinoSchillebeeckx/cherry-mx-switch (github.com/ConstantinoSchillebeeckx/cherry-mx-switch), MIT"
     },
@@ -334,7 +585,22 @@
       "family": "Encoder",
       "mpn": "PEC11R / EC11E",
       "kcad_source": "scripts/parts/authored/rotary-encoder-ec11.kcad.ts",
-      "tags": ["encoder", "rotary", "rotary encoder", "ec11", "incremental", "quadrature", "knob", "shaft", "d-shaft", "switch", "pushbutton", "panel", "input", "maker"],
+      "tags": [
+        "encoder",
+        "rotary",
+        "rotary encoder",
+        "ec11",
+        "incremental",
+        "quadrature",
+        "knob",
+        "shaft",
+        "d-shaft",
+        "switch",
+        "pushbutton",
+        "panel",
+        "input",
+        "maker"
+      ],
       "license": "MIT",
       "attribution": "kernelCAD authored model (kernelCAD contributors)"
     },
@@ -344,7 +610,22 @@
       "family": "Switch",
       "mpn": "MX1A",
       "kcad_source": "scripts/parts/authored/keyswitch-mx.kcad.ts",
-      "tags": ["keyswitch", "key switch", "cherry", "mx", "cherry mx", "mechanical", "keyboard", "keycap", "switch", "button", "cross stem", "plate", "input", "maker"],
+      "tags": [
+        "keyswitch",
+        "key switch",
+        "cherry",
+        "mx",
+        "cherry mx",
+        "mechanical",
+        "keyboard",
+        "keycap",
+        "switch",
+        "button",
+        "cross stem",
+        "plate",
+        "input",
+        "maker"
+      ],
       "license": "MIT",
       "attribution": "kernelCAD authored model (kernelCAD contributors)"
     },
@@ -402,7 +683,19 @@
       "family": "Switch",
       "mpn": "Omron B3F-4050 + B32-16x0",
       "kcad_source": "scripts/parts/authored/tactile-12mm.kcad.ts",
-      "tags": ["switch", "button", "tactile", "pushbutton", "12mm", "keycap", "cap", "b3f", "panel", "input", "maker"],
+      "tags": [
+        "switch",
+        "button",
+        "tactile",
+        "pushbutton",
+        "12mm",
+        "keycap",
+        "cap",
+        "b3f",
+        "panel",
+        "input",
+        "maker"
+      ],
       "license": "MIT",
       "attribution": "kernelCAD authored model (kernelCAD contributors)"
     },
@@ -412,7 +705,14 @@
       "family": "stepper-driver",
       "mpn": "Pololu #2128",
       "kcad_source": "scripts/parts/authored/a4988-stepstick-carrier.kcad.ts",
-      "tags": ["stepper-driver", "a4988", "stepstick", "carrier", "motor-control", "pololu"],
+      "tags": [
+        "stepper-driver",
+        "a4988",
+        "stepstick",
+        "carrier",
+        "motor-control",
+        "pololu"
+      ],
       "license": "MIT",
       "attribution": "kernelCAD authored mechanical model; dimensions and pinout from Pololu #2128: https://www.pololu.com/product/2128, https://www.pololu.com/file/0J1081/a4988-stepper-motor-driver-carrier-black-edition-dimension-diagram.pdf, and https://www.pololu.com/file/0J1225/a4988-stepper-motor-driver-carrier-black-edition.step"
     },
@@ -422,7 +722,13 @@
       "family": "micro-servo",
       "mpn": "Luxor Parts 87897 (SG90)",
       "kcad_source": "scripts/parts/authored/sg90-micro-servo.kcad.ts",
-      "tags": ["servo", "micro-servo", "sg90", "pwm", "actuator"],
+      "tags": [
+        "servo",
+        "micro-servo",
+        "sg90",
+        "pwm",
+        "actuator"
+      ],
       "license": "MIT",
       "attribution": "kernelCAD authored conservative mechanical envelope and canonical harness-contact proxies; dimensions and cable convention from Luxor Parts 87897 data sheet (which does not establish a shaft or mounting datum): https://www.kjell.com/globalassets/mediaassets/701916_87897_datasheet_en.pdf"
     },
@@ -432,7 +738,15 @@
       "family": "MCU",
       "mpn": "nRF54L15-QFAA",
       "kcad_source": "scripts/parts/authored/nrf54l15-qfn48.kcad.ts",
-      "tags": ["mcu", "nordic", "nrf54l15", "qfn", "qfn48", "bluetooth", "802.15.4"],
+      "tags": [
+        "mcu",
+        "nordic",
+        "nrf54l15",
+        "qfn",
+        "qfn48",
+        "bluetooth",
+        "802.15.4"
+      ],
       "attributes": {
         "package": "QFN48 (QFAA)",
         "packageLengthMm": 6,
@@ -452,7 +766,15 @@
       "family": "Sensor",
       "mpn": "BMI270",
       "kcad_source": "scripts/parts/authored/bmi270-lga14.kcad.ts",
-      "tags": ["sensor", "imu", "accelerometer", "gyroscope", "bmi270", "lga", "lga14"],
+      "tags": [
+        "sensor",
+        "imu",
+        "accelerometer",
+        "gyroscope",
+        "bmi270",
+        "lga",
+        "lga14"
+      ],
       "attributes": {
         "package": "LGA-14",
         "packageLengthMm": 3,
@@ -472,7 +794,15 @@
       "family": "Sensor",
       "mpn": "MAX30102",
       "kcad_source": "scripts/parts/authored/max30102-optical.kcad.ts",
-      "tags": ["sensor", "biosensor", "heart-rate", "pulse-oximeter", "max30102", "optical", "i2c"],
+      "tags": [
+        "sensor",
+        "biosensor",
+        "heart-rate",
+        "pulse-oximeter",
+        "max30102",
+        "optical",
+        "i2c"
+      ],
       "attributes": {
         "package": "optical module",
         "packageLengthMm": 5.6,
@@ -492,7 +822,14 @@
       "family": "Sensor",
       "mpn": "TMP117NAIYBGR",
       "kcad_source": "scripts/parts/authored/tmp117-dsbga.kcad.ts",
-      "tags": ["sensor", "temperature", "tmp117", "i2c", "dsbga", "ybg"],
+      "tags": [
+        "sensor",
+        "temperature",
+        "tmp117",
+        "i2c",
+        "dsbga",
+        "ybg"
+      ],
       "attributes": {
         "package": "DSBGA-6 (YBG)",
         "packageLengthMm": 1.488,
@@ -512,7 +849,15 @@
       "family": "Haptic driver",
       "mpn": "DRV2605YZF",
       "kcad_source": "scripts/parts/authored/drv2605-yzf.kcad.ts",
-      "tags": ["haptic", "haptic-driver", "drv2605", "lra", "erm", "dsbga", "yzf"],
+      "tags": [
+        "haptic",
+        "haptic-driver",
+        "drv2605",
+        "lra",
+        "erm",
+        "dsbga",
+        "yzf"
+      ],
       "attributes": {
         "package": "DSBGA-9 (YZF)",
         "packageLengthMm": 1.44,

--- a/scripts/electronics-parts.json
+++ b/scripts/electronics-parts.json
@@ -204,10 +204,10 @@
     },
     {
       "id": "esp32-devkit-board",
-      "name": "ESP32 DevKitC",
+      "name": "ESP32 DevKitC / DevKit V1",
       "family": "ESP32",
       "mpn": "ESP32-DevKitC-V4",
-      "kcad_source": "scripts/parts/authored/esp32-devkit-board.kcad.ts",
+      "url": "https://tfvg9prl3arlawj9.public.blob.vercel-storage.com/parts/cad/grabcad/board-esp32-devkit-v1/board-esp32-devkit-v1-source.step",
       "tags": [
         "board",
         "esp32",
@@ -216,8 +216,8 @@
         "wroom-32",
         "mcu"
       ],
-      "license": "CC-BY-SA-4.0",
-      "attribution": "kernelCAD original PCB; components from KiCad packages3D (CC-BY-SA-4.0 + library exception)"
+      "license": "GrabCAD per-model / community FreeCAD export",
+      "attribution": "GrabCAD ESP32 DevKit v1 FreeCAD STEP (community). Authored fallback: scripts/parts/authored/esp32-devkit-board.kcad.ts"
     },
     {
       "id": "nucleo64-board",
@@ -254,52 +254,68 @@
       "name": "WeAct STM32 BlackPill F4x1",
       "family": "STM32",
       "mpn": "WeAct-BlackPill-F401",
-      "kcad_source": "scripts/parts/authored/blackpill-board.kcad.ts",
+      "url": "https://cdn.jsdelivr.net/gh/piit79/Kicad-STM32@master/Packages3d/YAAJ_BlackPill_PinHeaders_V_SWD.zip",
       "tags": [
         "blackpill",
         "stm32",
         "weact",
         "dev-board"
       ],
-      "license": "CC-BY-SA-4.0",
-      "attribution": "kernelCAD original PCB; components from KiCad packages3D (CC-BY-SA-4.0 + library exception)"
+      "license": "upstream-unspecified (community KiCad library; no SPDX on piit79/Kicad-STM32 \u2014 retain attribution; re-review for commercial redistrib)",
+      "attribution": "KiCad-STM32 BlackPill 3D by piit79 / yet-another-average-joe (github.com/piit79/Kicad-STM32), PinHeaders_V_SWD variant. Authored fallback: scripts/parts/authored/blackpill-board.kcad.ts"
+    },
+    {
+      "id": "bluepill-board",
+      "name": "STM32F103 BluePill",
+      "family": "STM32",
+      "mpn": "STM32F103C8T6-BluePill",
+      "url": "https://cdn.jsdelivr.net/gh/piit79/Kicad-STM32@master/Packages3d/YAAJ_BluePill_PinHeaders_V_SWD.zip",
+      "tags": [
+        "bluepill",
+        "stm32",
+        "f103",
+        "dev-board"
+      ],
+      "license": "upstream-unspecified (community KiCad library; no SPDX on piit79/Kicad-STM32 \u2014 retain attribution; re-review for commercial redistrib)",
+      "attribution": "KiCad-STM32 BluePill 3D by piit79 / yet-another-average-joe (github.com/piit79/Kicad-STM32), PinHeaders_V_SWD variant"
     },
     {
       "id": "arduino-uno-board",
-      "name": "Arduino Uno R3",
+      "name": "Arduino Uno R3 (Freeduino-compatible form factor)",
       "family": "Arduino",
       "mpn": "A000066",
-      "kcad_source": "scripts/parts/authored/arduino-uno-board.kcad.ts",
+      "url": "https://raw.githubusercontent.com/FreeCAD/FreeCAD-library/master/Electronics%20Parts/Boards/Arduino/freaduino-uno.step",
       "tags": [
         "arduino",
         "uno",
         "atmega328",
-        "dev-board"
+        "dev-board",
+        "freeduino"
       ],
-      "license": "CC-BY-SA-4.0",
-      "attribution": "kernelCAD original PCB; components from KiCad packages3D (CC-BY-SA-4.0 + library exception); USB-B placeholder"
+      "license": "CC-BY-3.0",
+      "attribution": "FreeCAD parts library \u2014 freaduino-uno.step (CC-BY-3.0). Authored fallback: scripts/parts/authored/arduino-uno-board.kcad.ts"
     },
     {
       "id": "esp32-c3-supermini-board",
       "name": "ESP32-C3 SuperMini",
       "family": "ESP32",
       "mpn": "ESP32-C3-SuperMini",
-      "kcad_source": "scripts/parts/authored/esp32-c3-supermini-board.kcad.ts",
+      "url": "https://raw.githubusercontent.com/mrtnvgr/KiCad_ESP32-C3-SuperMini/master/ESP32-C3-SuperMini.stp",
       "tags": [
         "esp32",
         "c3",
         "supermini",
         "dev-board"
       ],
-      "license": "CC-BY-SA-4.0",
-      "attribution": "kernelCAD original PCB; components from KiCad packages3D (CC-BY-SA-4.0 + library exception)"
+      "license": "OSHW-attribution",
+      "attribution": "KiCad_ESP32-C3-SuperMini by mrtnvgr (github.com/mrtnvgr/KiCad_ESP32-C3-SuperMini). Authored fallback: scripts/parts/authored/esp32-c3-supermini-board.kcad.ts"
     },
     {
       "id": "esp32-s3-zero-board",
       "name": "Waveshare ESP32-S3-Zero",
       "family": "ESP32",
       "mpn": "ESP32-S3-Zero",
-      "kcad_source": "scripts/parts/authored/esp32-s3-zero-board.kcad.ts",
+      "url": "https://files.waveshare.com/wiki/ESP32-S3-Zero/manual/ESP32-S3-Zero%20V2.step",
       "tags": [
         "esp32",
         "s3",
@@ -307,8 +323,23 @@
         "waveshare",
         "dev-board"
       ],
-      "license": "CC-BY-SA-4.0",
-      "attribution": "kernelCAD original PCB; components from KiCad packages3D (CC-BY-SA-4.0 + library exception)"
+      "license": "Waveshare product CAD (vendor resource download)",
+      "attribution": "Waveshare official ESP32-S3-Zero V2 STEP (files.waveshare.com). Authored fallback: scripts/parts/authored/esp32-s3-zero-board.kcad.ts"
+    },
+    {
+      "id": "nrf52840-mdk-board",
+      "name": "makerdiary nRF52840-MDK",
+      "family": "Nordic",
+      "mpn": "nRF52840-MDK",
+      "url": "https://cdn.jsdelivr.net/gh/makerdiary/nrf52840-mdk@master/docs/hardware/nrf52840-mdk-3d-step-v1_0.step",
+      "tags": [
+        "nordic",
+        "nrf52840",
+        "mdk",
+        "dev-board"
+      ],
+      "license": "community open hardware (makerdiary nrf52840-mdk)",
+      "attribution": "makerdiary nRF52840-MDK 3D STEP (github.com/makerdiary/nrf52840-mdk). Note: form factor differs from Nordic nRF52840-DK."
     },
     {
       "id": "nrf52840-dk-board",
@@ -870,6 +901,413 @@
       },
       "license": "MIT",
       "attribution": "kernelCAD authored package model; dimensions from Texas Instruments DRV2605 YZF package drawing"
+    },
+    {
+      "id": "adxl343",
+      "name": "Adafruit ADXL343 accelerometer (stand-in for ADXL345)",
+      "family": "Sensor",
+      "mpn": "ADXL343",
+      "url": "https://raw.githubusercontent.com/adafruit/Adafruit_CAD_Parts/main/4097%20ADXL343%20Accelerometer/4097%20ADXL343%20STEMMA%20QT.step",
+      "tags": [
+        "sensor",
+        "accel",
+        "adxl",
+        "i2c"
+      ],
+      "license": "MIT",
+      "attribution": "Adafruit_CAD_Parts #4097 (MIT)"
+    },
+    {
+      "id": "vl53l4cd",
+      "name": "Adafruit VL53L4CD ToF (stand-in for VL53L1X)",
+      "family": "Sensor",
+      "mpn": "VL53L4CD",
+      "url": "https://raw.githubusercontent.com/adafruit/Adafruit_CAD_Parts/main/5396%20VL53L4CD%20Sensor/5396%20Adafruit%20VL53L4CD.step",
+      "tags": [
+        "sensor",
+        "tof",
+        "vl53",
+        "i2c"
+      ],
+      "license": "MIT",
+      "attribution": "Adafruit_CAD_Parts #5396 (MIT)"
+    },
+    {
+      "id": "veml7700",
+      "name": "Adafruit VEML7700 lux sensor",
+      "family": "Sensor",
+      "mpn": "VEML7700",
+      "url": "https://raw.githubusercontent.com/adafruit/Adafruit_CAD_Parts/main/5378%20VEML7700%20Lux%20Sensor/5378%20VEML7700%20Lux%20Sensor.step",
+      "tags": [
+        "sensor",
+        "light",
+        "veml7700",
+        "i2c"
+      ],
+      "license": "MIT",
+      "attribution": "Adafruit_CAD_Parts #5378 (MIT)"
+    },
+    {
+      "id": "scd40",
+      "name": "Adafruit SCD-40 CO2 sensor (stand-in for SCD41)",
+      "family": "Sensor",
+      "mpn": "SCD40",
+      "url": "https://raw.githubusercontent.com/adafruit/Adafruit_CAD_Parts/main/5187%20SCD-40%20C02%20Sensor/5187%20SCD-40%20C02%20Sensor.step",
+      "tags": [
+        "sensor",
+        "co2",
+        "scd40",
+        "scd41",
+        "i2c"
+      ],
+      "license": "MIT",
+      "attribution": "Adafruit_CAD_Parts #5187 (MIT)"
+    },
+    {
+      "id": "sgp40",
+      "name": "Adafruit SGP40 VOC sensor (stand-in for SGP41)",
+      "family": "Sensor",
+      "mpn": "SGP40",
+      "url": "https://raw.githubusercontent.com/adafruit/Adafruit_CAD_Parts/main/4829%20SGP40%20Sensor/4829%20SGP40%20Sensor.step",
+      "tags": [
+        "sensor",
+        "voc",
+        "sgp40",
+        "sgp41",
+        "i2c"
+      ],
+      "license": "MIT",
+      "attribution": "Adafruit_CAD_Parts #4829 (MIT)"
+    },
+    {
+      "id": "servo-micro-mg",
+      "name": "Adafruit micro servo metal gear (SG90-class)",
+      "family": "Actuator",
+      "mpn": "ADA1143",
+      "url": "https://raw.githubusercontent.com/adafruit/Adafruit_CAD_Parts/main/1143%20Micro%20Servo%20-%20High%20Torque%20Metal%20Gear/1143%20Micro%20Servo%20High%20Torque%20Metal%20Gear.step",
+      "tags": [
+        "servo",
+        "actuator",
+        "sg90"
+      ],
+      "license": "MIT",
+      "attribution": "Adafruit_CAD_Parts #1143 (MIT)"
+    },
+    {
+      "id": "rotary-encoder-qt",
+      "name": "Adafruit QT rotary encoder",
+      "family": "Input",
+      "mpn": "ADA4991",
+      "url": "https://raw.githubusercontent.com/adafruit/Adafruit_CAD_Parts/main/4991%20QT%20Rotary%20Encoder/4991%20QT%20Rotary%20Encoder.step",
+      "tags": [
+        "encoder",
+        "rotary",
+        "input"
+      ],
+      "license": "MIT",
+      "attribution": "Adafruit_CAD_Parts #4991 (MIT)"
+    },
+    {
+      "id": "gps-pa1010d",
+      "name": "Adafruit Mini GPS PA1010D (stand-in for NEO-6M class)",
+      "family": "Sensor",
+      "mpn": "PA1010D",
+      "url": "https://raw.githubusercontent.com/adafruit/Adafruit_CAD_Parts/main/4415%20Mini%20GPS%20PA1010D/4415%20Mini%20GPS%20PA1010D.step",
+      "tags": [
+        "gps",
+        "sensor",
+        "uart"
+      ],
+      "license": "MIT",
+      "attribution": "Adafruit_CAD_Parts #4415 (MIT)"
+    },
+    {
+      "id": "oled-091-i2c",
+      "name": "Adafruit 0.91in OLED I2C",
+      "family": "Display",
+      "mpn": "ADA4440",
+      "url": "https://raw.githubusercontent.com/adafruit/Adafruit_CAD_Parts/main/4440%200.91%20OLED%20I2C%20Display/4440%200.91%20OLED%20I2C%20Display.step",
+      "tags": [
+        "oled",
+        "display",
+        "ssd1306",
+        "i2c"
+      ],
+      "license": "MIT",
+      "attribution": "Adafruit_CAD_Parts #4440 (MIT)"
+    },
+    {
+      "id": "ina219",
+      "name": "INA219 current/power monitor breakout (25\u00d720\u00d75mm)",
+      "family": "Sensor",
+      "mpn": "INA219 breakout",
+      "kcad_source": "scripts/parts/authored/ina219.kcad.ts",
+      "tags": [
+        "sensor",
+        "current",
+        "power",
+        "ina219",
+        "i2c",
+        "shunt"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "ads1115",
+      "name": "ADS1115 16-bit ADC breakout (25\u00d718\u00d74mm)",
+      "family": "Sensor",
+      "mpn": "ADS1115 breakout",
+      "kcad_source": "scripts/parts/authored/ads1115.kcad.ts",
+      "tags": [
+        "sensor",
+        "adc",
+        "ads1115",
+        "i2c"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "ds3231",
+      "name": "DS3231 RTC + CR2032 module (38\u00d722\u00d76mm)",
+      "family": "Sensor",
+      "mpn": "DS3231 ZS-042",
+      "kcad_source": "scripts/parts/authored/ds3231.kcad.ts",
+      "tags": [
+        "sensor",
+        "rtc",
+        "ds3231",
+        "i2c",
+        "clock"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "hx711",
+      "name": "HX711 load-cell amplifier (33\u00d720\u00d74mm)",
+      "family": "Sensor",
+      "mpn": "HX711",
+      "kcad_source": "scripts/parts/authored/hx711.kcad.ts",
+      "tags": [
+        "sensor",
+        "load-cell",
+        "hx711",
+        "weight"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "as5600",
+      "name": "AS5600 magnetic rotary encoder (22\u00d718\u00d74mm)",
+      "family": "Sensor",
+      "mpn": "AS5600",
+      "kcad_source": "scripts/parts/authored/as5600.kcad.ts",
+      "tags": [
+        "sensor",
+        "encoder",
+        "as5600",
+        "magnetic",
+        "angle"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "bno055",
+      "name": "BNO055 9-DOF IMU breakout (20\u00d727\u00d74mm)",
+      "family": "Sensor",
+      "mpn": "BNO055",
+      "kcad_source": "scripts/parts/authored/bno055.kcad.ts",
+      "tags": [
+        "sensor",
+        "imu",
+        "bno055",
+        "orientation",
+        "i2c"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "vl53l0x",
+      "name": "VL53L0X ToF laser ranging breakout (12\u00d718\u00d74mm)",
+      "family": "Sensor",
+      "mpn": "VL53L0X",
+      "kcad_source": "scripts/parts/authored/vl53l0x.kcad.ts",
+      "tags": [
+        "sensor",
+        "tof",
+        "vl53l0x",
+        "distance",
+        "i2c"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "hc-05",
+      "name": "HC-05 Bluetooth SPP module (37\u00d716\u00d76mm)",
+      "family": "Wireless",
+      "mpn": "HC-05",
+      "kcad_source": "scripts/parts/authored/hc-05.kcad.ts",
+      "tags": [
+        "bluetooth",
+        "hc-05",
+        "uart",
+        "wireless"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "nrf24l01",
+      "name": "nRF24L01+ 2.4GHz transceiver (15\u00d729\u00d74mm)",
+      "family": "Wireless",
+      "mpn": "nRF24L01+",
+      "kcad_source": "scripts/parts/authored/nrf24l01.kcad.ts",
+      "tags": [
+        "nrf24",
+        "2.4ghz",
+        "spi",
+        "wireless"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "mcp2515",
+      "name": "MCP2515 CAN bus module (40\u00d728\u00d712mm)",
+      "family": "Interface",
+      "mpn": "MCP2515",
+      "kcad_source": "scripts/parts/authored/mcp2515.kcad.ts",
+      "tags": [
+        "can",
+        "mcp2515",
+        "spi",
+        "tja1050"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "l298n",
+      "name": "L298N dual H-bridge motor driver (43\u00d743\u00d718mm)",
+      "family": "Motor driver",
+      "mpn": "L298N",
+      "kcad_source": "scripts/parts/authored/l298n.kcad.ts",
+      "tags": [
+        "motor",
+        "h-bridge",
+        "l298n"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "relay-4ch",
+      "name": "4-channel 5V relay module (75\u00d755\u00d718mm)",
+      "family": "Actuator",
+      "mpn": "4CH-RELAY",
+      "kcad_source": "scripts/parts/authored/relay-4ch.kcad.ts",
+      "tags": [
+        "relay",
+        "4ch",
+        "opto"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "irf520",
+      "name": "IRF520 MOSFET driver module (33\u00d724\u00d714mm)",
+      "family": "Power",
+      "mpn": "IRF520 module",
+      "kcad_source": "scripts/parts/authored/irf520.kcad.ts",
+      "tags": [
+        "mosfet",
+        "irf520",
+        "driver"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "acs712",
+      "name": "ACS712 Hall current sensor module (31\u00d713\u00d711mm)",
+      "family": "Sensor",
+      "mpn": "ACS712",
+      "kcad_source": "scripts/parts/authored/acs712.kcad.ts",
+      "tags": [
+        "sensor",
+        "current",
+        "acs712",
+        "hall"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "tp4056",
+      "name": "TP4056 Li-ion charger with micro-USB (25\u00d717\u00d74mm)",
+      "family": "Power",
+      "mpn": "TP4056",
+      "kcad_source": "scripts/parts/authored/tp4056.kcad.ts",
+      "tags": [
+        "charger",
+        "lipo",
+        "tp4056",
+        "usb"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "max485",
+      "name": "MAX485 RS-485 transceiver breakout (44\u00d714\u00d712mm)",
+      "family": "Interface",
+      "mpn": "MAX485",
+      "kcad_source": "scripts/parts/authored/max485.kcad.ts",
+      "tags": [
+        "rs485",
+        "max485",
+        "uart"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "mq-2",
+      "name": "MQ-2 smoke/gas sensor breakout (32\u00d720\u00d720mm)",
+      "family": "Sensor",
+      "mpn": "MQ-2",
+      "kcad_source": "scripts/parts/authored/mq-2.kcad.ts",
+      "tags": [
+        "sensor",
+        "gas",
+        "smoke",
+        "mq-2",
+        "analog"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "lm2596",
+      "name": "LM2596 adjustable buck converter (43\u00d721\u00d712mm)",
+      "family": "Power",
+      "mpn": "LM2596 module",
+      "kcad_source": "scripts/parts/authored/lm2596.kcad.ts",
+      "tags": [
+        "power",
+        "buck",
+        "lm2596",
+        "regulator"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
     }
   ]
 }

--- a/scripts/electronics-parts.json
+++ b/scripts/electronics-parts.json
@@ -1308,6 +1308,193 @@
       ],
       "license": "MIT",
       "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "aht20",
+      "name": "AHT20 temp/humidity breakout",
+      "family": "Sensor",
+      "mpn": "AHT20",
+      "kcad_source": "scripts/parts/authored/aht20.kcad.ts",
+      "tags": [
+        "sensor",
+        "aht20",
+        "i2c",
+        "humidity",
+        "temperature"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "bh1750",
+      "name": "BH1750 ambient light sensor",
+      "family": "Sensor",
+      "mpn": "BH1750",
+      "kcad_source": "scripts/parts/authored/bh1750.kcad.ts",
+      "tags": [
+        "sensor",
+        "bh1750",
+        "i2c",
+        "lux",
+        "light"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "pcf8574",
+      "name": "PCF8574 I2C I/O expander",
+      "family": "Interface",
+      "mpn": "PCF8574",
+      "kcad_source": "scripts/parts/authored/pcf8574.kcad.ts",
+      "tags": [
+        "i2c",
+        "expander",
+        "pcf8574"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "ds18b20",
+      "name": "DS18B20 temperature sensor",
+      "family": "Sensor",
+      "mpn": "DS18B20",
+      "kcad_source": "scripts/parts/authored/ds18b20.kcad.ts",
+      "tags": [
+        "sensor",
+        "ds18b20",
+        "1wire",
+        "temperature"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "joystick",
+      "name": "Analog joystick module",
+      "family": "Input",
+      "mpn": "KY-023",
+      "kcad_source": "scripts/parts/authored/joystick.kcad.ts",
+      "tags": [
+        "input",
+        "joystick",
+        "analog"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "uln2003",
+      "name": "ULN2003 stepper driver board",
+      "family": "Motor driver",
+      "mpn": "ULN2003",
+      "kcad_source": "scripts/parts/authored/uln2003.kcad.ts",
+      "tags": [
+        "stepper",
+        "uln2003",
+        "motor"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "mt3608",
+      "name": "MT3608 boost converter",
+      "family": "Power",
+      "mpn": "MT3608",
+      "kcad_source": "scripts/parts/authored/mt3608.kcad.ts",
+      "tags": [
+        "power",
+        "boost",
+        "mt3608"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "ams1117",
+      "name": "AMS1117 LDO module",
+      "family": "Power",
+      "mpn": "AMS1117",
+      "kcad_source": "scripts/parts/authored/ams1117.kcad.ts",
+      "tags": [
+        "power",
+        "ldo",
+        "ams1117"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "flame-sensor",
+      "name": "IR flame sensor module",
+      "family": "Sensor",
+      "mpn": "FLAME",
+      "kcad_source": "scripts/parts/authored/flame-sensor.kcad.ts",
+      "tags": [
+        "sensor",
+        "flame",
+        "ir"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "sound-sensor",
+      "name": "Sound / microphone sensor",
+      "family": "Sensor",
+      "mpn": "KY-037",
+      "kcad_source": "scripts/parts/authored/sound-sensor.kcad.ts",
+      "tags": [
+        "sensor",
+        "sound",
+        "mic"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "water-level",
+      "name": "Water level probe",
+      "family": "Sensor",
+      "mpn": "WATER-LVL",
+      "kcad_source": "scripts/parts/authored/water-level.kcad.ts",
+      "tags": [
+        "sensor",
+        "water",
+        "level"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "rain-sensor",
+      "name": "Rain drop sensor board",
+      "family": "Sensor",
+      "mpn": "RAIN",
+      "kcad_source": "scripts/parts/authored/rain-sensor.kcad.ts",
+      "tags": [
+        "sensor",
+        "rain"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
+      "id": "rc522",
+      "name": "RC522 RFID reader",
+      "family": "Wireless",
+      "mpn": "MFRC522",
+      "kcad_source": "scripts/parts/authored/rc522.kcad.ts",
+      "tags": [
+        "rfid",
+        "rc522",
+        "spi",
+        "nfc"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
     }
   ]
 }

--- a/scripts/parts/authored/acs712.kcad.ts
+++ b/scripts/parts/authored/acs712.kcad.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/acs712.kcad.ts
+//
+// ACS712 Hall-effect current sensor module (green, screw terminals for IP+/IP−).
+// 31 × 13 mm class; SOIC ACS712; VCC/OUT/GND header.
+
+const PCB_L = 31.0;
+const PCB_W = 13.0;
+const PCB_T = 1.6;
+const HOLE_R = 1.0;
+
+const PCB = '#1a6b3a';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const HDR = '#1a1a28';
+const TERM = '#2a2a32';
+const PASS = '#8a6a40';
+
+const holes = [
+  [2.0, PCB_W / 2],
+  [PCB_L - 2.0, PCB_W / 2],
+].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 20).translate(x, y, -1));
+const pcb = box(PCB_L, PCB_W, PCB_T).subtract(...holes).color(PCB);
+
+// 3-pin analog header
+const n = 3;
+const pitch = 2.54;
+const hdrW = (n - 1) * pitch + 2.4;
+const hdrX = (PCB_L - hdrW) / 2;
+const headerBody = box(hdrW, 2.4, 2.5).color(HDR).translate(hdrX, -2.4, PCB_T);
+const pins: Shape[] = [];
+for (let i = 0; i < n; i++) {
+  const px = hdrX + 1.2 + i * pitch;
+  pins.push(box(0.64, 7.0, 0.64).color(CU).translate(px, -7.0, PCB_T + 0.95));
+}
+
+// ACS712 SOIC-8
+const soic = box(5.0, 4.0, 1.55).color(IC).translate(13.0, 4.5, PCB_T);
+const pin1 = cylinder(0.18, 0.25, 12).color('#f0f0f8').translate(13.5, 5.0, PCB_T + 1.55);
+
+// High-current screw terminals (IP+ / IP−) on board ends
+const termL = box(7.0, 8.0, 9.0).color(TERM).translate(3.0, 2.5, PCB_T);
+const termR = box(7.0, 8.0, 9.0).color(TERM).translate(21.0, 2.5, PCB_T);
+const screwL = box(2.0, 2.0, 1.0).color(CU).translate(5.5, 5.0, PCB_T + 9.0);
+const screwR = box(2.0, 2.0, 1.0).color(CU).translate(23.5, 5.0, PCB_T + 9.0);
+
+// Thick current path copper pours (visual)
+const pourL = box(4.0, 3.0, 0.2).color(CU).translate(9.5, 5.0, PCB_T);
+const pourR = box(4.0, 3.0, 0.2).color(CU).translate(17.5, 5.0, PCB_T);
+
+const caps: Shape[] = [
+  box(1.6, 0.8, 0.5).color(PASS).translate(11.0, 9.5, PCB_T),
+  box(1.6, 0.8, 0.5).color(PASS).translate(14.5, 9.5, PCB_T),
+];
+
+const asm = assembly('acs712');
+asm.part('pcb', pcb);
+asm.part('header-body', headerBody);
+pins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('acs712-soic', soic);
+asm.part('pin1-dot', pin1);
+asm.part('term-ip-plus', termL);
+asm.part('term-ip-minus', termR);
+asm.part('screw-plus', screwL);
+asm.part('screw-minus', screwR);
+asm.part('pour-plus', pourL);
+asm.part('pour-minus', pourR);
+caps.forEach((c, i) => asm.part(`passive-${i}`, c));
+return asm.model();

--- a/scripts/parts/authored/ads1115.kcad.ts
+++ b/scripts/parts/authored/ads1115.kcad.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/ads1115.kcad.ts
+//
+// ADS1115 16-bit I²C ADC breakout (Adafruit #1085 class).
+// 25.4 × 17.8 mm blue FR4, 10-pin header, MSOP-style ADC package, ADDR pads.
+
+const PCB_L = 25.4;
+const PCB_W = 17.8;
+const PCB_T = 1.6;
+const HOLE_R = 1.0;
+
+const PCB = '#1a3a6e';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const HDR = '#1a1a28';
+const PASS = '#8a6a40';
+const LED = '#38bdf8';
+
+const holes = [
+  [2.0, 2.0],
+  [PCB_L - 2.0, 2.0],
+  [2.0, PCB_W - 2.0],
+  [PCB_L - 2.0, PCB_W - 2.0],
+].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 24).translate(x, y, -1));
+const pcb = box(PCB_L, PCB_W, PCB_T).subtract(...holes).color(PCB);
+
+const n = 10;
+const pitch = 2.54;
+const hdrW = (n - 1) * pitch + 2.4;
+const hdrX = (PCB_L - hdrW) / 2;
+const headerBody = box(hdrW, 2.4, 2.5).color(HDR).translate(hdrX, -2.4, PCB_T);
+const pins: Shape[] = [];
+for (let i = 0; i < n; i++) {
+  const px = hdrX + 1.2 + i * pitch;
+  pins.push(box(0.64, 7.5, 0.64).color(CU).translate(px, -7.5, PCB_T + 0.95));
+}
+
+// ADS1115 MSOP-10 body
+const ic = box(3.0, 4.9, 1.1).color(IC).translate(11.2, 6.8, PCB_T);
+const pin1 = cylinder(0.18, 0.22, 12).color('#f0f0f8').translate(11.45, 7.05, PCB_T + 1.1);
+const leads: Shape[] = [];
+for (let i = 0; i < 5; i++) {
+  const ly = 6.95 + i * 0.9;
+  leads.push(box(0.7, 0.28, 0.15).color(CU).translate(10.5, ly, PCB_T + 0.15));
+  leads.push(box(0.7, 0.28, 0.15).color(CU).translate(14.2, ly, PCB_T + 0.15));
+}
+
+// ADDR / ALERT solder-bridge pads
+const addr = box(2.8, 1.4, 0.2).color(CU).translate(4.0, 12.5, PCB_T);
+const alert = box(2.8, 1.4, 0.2).color(CU).translate(18.5, 12.5, PCB_T);
+
+const led = box(1.6, 0.8, 0.5).color(LED).translate(4.0, 7.0, PCB_T);
+const caps: Shape[] = [
+  box(1.0, 0.5, 0.45).color(PASS).translate(4.0, 9.5, PCB_T),
+  box(1.0, 0.5, 0.45).color(PASS).translate(6.0, 9.5, PCB_T),
+  box(1.6, 0.8, 0.5).color(PASS).translate(18.5, 7.0, PCB_T),
+  box(1.6, 0.8, 0.5).color(PASS).translate(18.5, 9.5, PCB_T),
+];
+
+const asm = assembly('ads1115');
+asm.part('pcb', pcb);
+asm.part('header-body', headerBody);
+pins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('ads1115-ic', ic);
+asm.part('pin1-dot', pin1);
+leads.forEach((l, i) => asm.part(`lead-${i}`, l));
+asm.part('addr-pads', addr);
+asm.part('alert-pads', alert);
+asm.part('pwr-led', led);
+caps.forEach((c, i) => asm.part(`passive-${i}`, c));
+return asm.model();

--- a/scripts/parts/authored/aht20.kcad.ts
+++ b/scripts/parts/authored/aht20.kcad.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/aht20.kcad.ts
+//
+// AHT20 temp/humidity breakout (15×15 mm).
+
+const PCB_L = 15;
+const PCB_W = 15;
+const PCB_T = 1.6;
+const HOLE_R = 1.0;
+const PCB = '#1a3a4a';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const HDR = '#1a1a28';
+const PASS = '#8a6a40';
+
+const holes = [
+  [2.0, 2.0], [PCB_L - 2.0, 2.0], [2.0, PCB_W - 2.0], [PCB_L - 2.0, PCB_W - 2.0],
+].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 20).translate(x, y, -1));
+const pcb = box(PCB_L, PCB_W, PCB_T).subtract(...holes).color(PCB);
+
+const n = 4;
+const pitch = 2.54;
+const hdrH = (n - 1) * pitch + 2.4;
+const hdrY = (PCB_W - hdrH) / 2;
+const headerBody = box(2.4, hdrH, 2.5).color(HDR).translate(-2.4, hdrY, PCB_T);
+const headerPins: Shape[] = [];
+for (let i = 0; i < n; i++) {
+  const py = hdrY + 1.2 + i * pitch;
+  headerPins.push(box(7.0, 0.64, 0.64).color(CU).translate(-7.0, py, PCB_T + 0.95));
+}
+
+const ic = box(3.0, 3.0, 0.9).color(IC).translate(6.0, 6.0, PCB_T);
+const caps: Shape[] = [box(1.0,0.5,0.45).color(PASS).translate(3.0,4.0,PCB_T), box(1.0,0.5,0.45).color(PASS).translate(11.0,4.0,PCB_T)];
+
+const asm = assembly('aht20');
+asm.part('pcb', pcb);
+asm.part('header-body', headerBody);
+headerPins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('aht20-ic', ic);
+caps.forEach((c,i)=>asm.part(`cap-${i}`,c));
+return asm.model();

--- a/scripts/parts/authored/ams1117.kcad.ts
+++ b/scripts/parts/authored/ams1117.kcad.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+// AMS1117 LDO module 25×11 mm.
+const PCB_L=25.0, PCB_W=11.0, PCB_T=1.2;
+const PCB='#1a1a22', IC='#1a1a22', CU='#c8a040', TAB='#9ca3af';
+const pcb=box(PCB_L,PCB_W,PCB_T).color(PCB);
+const pads:Shape[]=[];
+for (const [x,y] of [[1,2],[1,7],[21,2],[21,7]] as [number,number][]) {
+  pads.push(box(3,2.5,0.25).color(CU).translate(x,y,PCB_T));
+}
+const body=box(6.5,6.5,1.8).color(IC).translate(9,2.2,PCB_T);
+const tab=box(6.5,1.2,4.5).color(TAB).translate(9,8.7,PCB_T);
+const asm=assembly('ams1117');
+asm.part('pcb',pcb); pads.forEach((p,i)=>asm.part(`pad-${i}`,p));
+asm.part('sot223',body); asm.part('tab',tab);
+return asm.model();

--- a/scripts/parts/authored/as5600.kcad.ts
+++ b/scripts/parts/authored/as5600.kcad.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/as5600.kcad.ts
+//
+// AS5600 12-bit magnetic rotary position sensor breakout.
+// 22 × 18 mm; SOIC-8 above diametric magnet well; 5-pin header; DIR pad.
+
+const PCB_L = 22.0;
+const PCB_W = 18.0;
+const PCB_T = 1.6;
+const HOLE_R = 1.0;
+
+const PCB = '#1a3a6e';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const HDR = '#1a1a28';
+const PASS = '#8a6a40';
+const MAG = '#5c1010';
+const WELL = '#0c0c14';
+
+const holes = [
+  [2.0, 2.0],
+  [PCB_L - 2.0, 2.0],
+  [2.0, PCB_W - 2.0],
+  [PCB_L - 2.0, PCB_W - 2.0],
+].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 24).translate(x, y, -1));
+const pcb = box(PCB_L, PCB_W, PCB_T).subtract(...holes).color(PCB);
+
+const n = 5;
+const pitch = 2.54;
+const hdrW = (n - 1) * pitch + 2.4;
+const hdrX = (PCB_L - hdrW) / 2;
+const headerBody = box(hdrW, 2.4, 2.5).color(HDR).translate(hdrX, -2.4, PCB_T);
+const pins: Shape[] = [];
+for (let i = 0; i < n; i++) {
+  const px = hdrX + 1.2 + i * pitch;
+  pins.push(box(0.64, 7.5, 0.64).color(CU).translate(px, -7.5, PCB_T + 0.95));
+}
+
+const mx = 11.0;
+const my = 11.5;
+// Magnet well ring + diametric magnet disk
+const well = cylinder(0.5, 4.2, 40).color(WELL).translate(mx, my, PCB_T);
+const magnet = cylinder(1.6, 3.0, 40).color(MAG).translate(mx, my, PCB_T + 0.4);
+const magN = box(1.2, 2.4, 0.15).color('#8b2020').translate(mx - 0.6, my - 1.2, PCB_T + 2.0);
+
+// AS5600 SOIC slightly offset so magnet remains visible
+const soic = box(4.9, 3.9, 1.55).color(IC).translate(3.5, 8.5, PCB_T);
+const pin1 = cylinder(0.18, 0.25, 12).color('#f0f0f8').translate(4.0, 9.0, PCB_T + 1.55);
+
+const dirPad = box(2.6, 1.4, 0.2).color(CU).translate(16.5, 5.0, PCB_T);
+const caps: Shape[] = [
+  box(1.0, 0.5, 0.45).color(PASS).translate(4.0, 5.0, PCB_T),
+  box(1.0, 0.5, 0.45).color(PASS).translate(6.0, 5.0, PCB_T),
+  box(1.6, 0.8, 0.5).color(PASS).translate(16.5, 14.5, PCB_T),
+];
+
+const asm = assembly('as5600');
+asm.part('pcb', pcb);
+asm.part('header-body', headerBody);
+pins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('magnet-well', well);
+asm.part('magnet', magnet);
+asm.part('magnet-n-mark', magN);
+asm.part('as5600-soic', soic);
+asm.part('pin1-dot', pin1);
+asm.part('dir-pad', dirPad);
+caps.forEach((c, i) => asm.part(`passive-${i}`, c));
+return asm.model();

--- a/scripts/parts/authored/at24c256.kcad.ts
+++ b/scripts/parts/authored/at24c256.kcad.ts
@@ -3,7 +3,7 @@
 // scripts/parts/authored/at24c256.kcad.ts
 // AT24C256 EEPROM
 const PCB_L=18, PCB_W=12, PCB_T=1.6, HOLE_R=1.0;
-const PCB='#2a1a3a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28', PASS='#8a6a40';
+const PCB='#2a1a3a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28';
 const holes=[[2,2],[PCB_L-2,2],[2,PCB_W-2],[PCB_L-2,PCB_W-2]].map(([x,y])=>cylinder(PCB_T+2,HOLE_R,20).translate(x,y,-1));
 const pcb=box(PCB_L,PCB_W,PCB_T).subtract(...holes).color(PCB);
 const n=5, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;

--- a/scripts/parts/authored/at24c256.kcad.ts
+++ b/scripts/parts/authored/at24c256.kcad.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/at24c256.kcad.ts
+// AT24C256 EEPROM
+const PCB_L=18, PCB_W=12, PCB_T=1.6, HOLE_R=1.0;
+const PCB='#2a1a3a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28', PASS='#8a6a40';
+const holes=[[2,2],[PCB_L-2,2],[2,PCB_W-2],[PCB_L-2,PCB_W-2]].map(([x,y])=>cylinder(PCB_T+2,HOLE_R,20).translate(x,y,-1));
+const pcb=box(PCB_L,PCB_W,PCB_T).subtract(...holes).color(PCB);
+const n=5, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;
+const headerBody=box(2.4,hdrH,2.5).color(HDR).translate(-2.4,hdrY,PCB_T);
+const headerPins:Shape[]=[];
+for(let i=0;i<n;i++){const py=hdrY+1.2+i*pitch; headerPins.push(box(7,0.64,0.64).color(CU).translate(-7,py,PCB_T+0.95));}
+const ic=box(10,6,1.5).color(IC).translate(4,3,PCB_T);
+const asm=assembly('at24c256');
+asm.part('pcb',pcb); asm.part('header',headerBody); headerPins.forEach((p,i)=>asm.part(`pin-${i}`,p));
+asm.part('eeprom',ic);
+return asm.model();

--- a/scripts/parts/authored/bh1750.kcad.ts
+++ b/scripts/parts/authored/bh1750.kcad.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/bh1750.kcad.ts
+//
+// BH1750 ambient light sensor (18×14 mm).
+
+const PCB_L = 18;
+const PCB_W = 14;
+const PCB_T = 1.6;
+const HOLE_R = 1.0;
+const PCB = '#2a3a1a';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const HDR = '#1a1a28';
+const PASS = '#8a6a40';
+
+const holes = [
+  [2.0, 2.0], [PCB_L - 2.0, 2.0], [2.0, PCB_W - 2.0], [PCB_L - 2.0, PCB_W - 2.0],
+].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 20).translate(x, y, -1));
+const pcb = box(PCB_L, PCB_W, PCB_T).subtract(...holes).color(PCB);
+
+const n = 5;
+const pitch = 2.54;
+const hdrH = (n - 1) * pitch + 2.4;
+const hdrY = (PCB_W - hdrH) / 2;
+const headerBody = box(2.4, hdrH, 2.5).color(HDR).translate(-2.4, hdrY, PCB_T);
+const headerPins: Shape[] = [];
+for (let i = 0; i < n; i++) {
+  const py = hdrY + 1.2 + i * pitch;
+  headerPins.push(box(7.0, 0.64, 0.64).color(CU).translate(-7.0, py, PCB_T + 0.95));
+}
+
+const ic = box(4.5, 2.5, 0.9).color(IC).translate(7.0, 5.5, PCB_T);
+const window = box(2.0, 1.5, 0.3).color('#c8d060').translate(8.25, 6.0, PCB_T+0.9);
+
+const asm = assembly('bh1750');
+asm.part('pcb', pcb);
+asm.part('header-body', headerBody);
+headerPins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('bh1750-ic', ic);
+asm.part('light-window', window);
+return asm.model();

--- a/scripts/parts/authored/bh1750.kcad.ts
+++ b/scripts/parts/authored/bh1750.kcad.ts
@@ -12,8 +12,6 @@ const PCB = '#2a3a1a';
 const IC = '#1a1a22';
 const CU = '#c8a040';
 const HDR = '#1a1a28';
-const PASS = '#8a6a40';
-
 const holes = [
   [2.0, 2.0], [PCB_L - 2.0, 2.0], [2.0, PCB_W - 2.0], [PCB_L - 2.0, PCB_W - 2.0],
 ].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 20).translate(x, y, -1));

--- a/scripts/parts/authored/bno055.kcad.ts
+++ b/scripts/parts/authored/bno055.kcad.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/bno055.kcad.ts
+//
+// BNO055 9-DOF absolute orientation IMU breakout (Adafruit #2472 class).
+// 20.3 × 27 mm; LGA package with pin-1; 9-pin header; PS0/PS1 + ADDR pads.
+
+const PCB_L = 20.3;
+const PCB_W = 27.0;
+const PCB_T = 1.6;
+const HOLE_R = 1.0;
+
+const PCB = '#1a3a6e';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const HDR = '#1a1a28';
+const PASS = '#8a6a40';
+const LED = '#a78bfa';
+
+const holes = [
+  [2.0, 2.0],
+  [PCB_L - 2.0, 2.0],
+  [2.0, PCB_W - 2.0],
+  [PCB_L - 2.0, PCB_W - 2.0],
+].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 24).translate(x, y, -1));
+const pcb = box(PCB_L, PCB_W, PCB_T).subtract(...holes).color(PCB);
+
+const n = 9;
+const pitch = 2.54;
+const hdrW = (n - 1) * pitch + 2.4;
+const hdrX = (PCB_L - hdrW) / 2;
+const headerBody = box(hdrW, 2.4, 2.5).color(HDR).translate(hdrX, -2.4, PCB_T);
+const pins: Shape[] = [];
+for (let i = 0; i < n; i++) {
+  const px = hdrX + 1.2 + i * pitch;
+  pins.push(box(0.64, 7.5, 0.64).color(CU).translate(px, -7.5, PCB_T + 0.95));
+}
+
+// BNO055 LGA ~3.8×5.2×1.1
+const lga = box(3.8, 5.2, 1.15).color(IC).translate(8.25, 11.5, PCB_T);
+const pin1 = cylinder(0.18, 0.25, 12).color('#f0f0f8').translate(8.5, 11.75, PCB_T + 1.15);
+// Contact pad ring under package (visual underside balls as flat grid)
+const balls: Shape[] = [];
+for (let r = 0; r < 3; r++) {
+  for (let c = 0; c < 4; c++) {
+    balls.push(
+      cylinder(0.12, 0.2, 10)
+        .color(CU)
+        .translate(8.6 + c * 0.85, 12.0 + r * 1.2, PCB_T - 0.05),
+    );
+  }
+}
+
+const addr = box(2.4, 1.3, 0.2).color(CU).translate(14.5, 20.5, PCB_T);
+const ps0 = box(1.8, 1.2, 0.2).color(CU).translate(3.0, 20.5, PCB_T);
+const ps1 = box(1.8, 1.2, 0.2).color(CU).translate(5.5, 20.5, PCB_T);
+const led = box(1.6, 0.8, 0.5).color(LED).translate(14.5, 6.0, PCB_T);
+
+const caps: Shape[] = [
+  box(1.0, 0.5, 0.45).color(PASS).translate(3.5, 8.0, PCB_T),
+  box(1.0, 0.5, 0.45).color(PASS).translate(3.5, 10.0, PCB_T),
+  box(1.6, 0.8, 0.5).color(PASS).translate(14.5, 9.0, PCB_T),
+  box(1.6, 0.8, 0.5).color(PASS).translate(14.5, 12.0, PCB_T),
+  box(1.0, 0.5, 0.45).color(PASS).translate(8.5, 20.0, PCB_T),
+];
+
+const asm = assembly('bno055');
+asm.part('pcb', pcb);
+asm.part('header-body', headerBody);
+pins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('bno055-lga', lga);
+asm.part('pin1-dot', pin1);
+balls.forEach((b, i) => asm.part(`lga-ball-${i}`, b));
+asm.part('addr-pad', addr);
+asm.part('ps0-pad', ps0);
+asm.part('ps1-pad', ps1);
+asm.part('pwr-led', led);
+caps.forEach((c, i) => asm.part(`passive-${i}`, c));
+return asm.model();

--- a/scripts/parts/authored/ds18b20.kcad.ts
+++ b/scripts/parts/authored/ds18b20.kcad.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/ds18b20.kcad.ts
+// DS18B20 TO-92 temperature probe + module board (15×15 mm) or bare TO-92.
+const PCB_L=15.0, PCB_W=15.0, PCB_T=1.6;
+const PCB='#1a6b3a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28';
+const pcb=box(PCB_L,PCB_W,PCB_T).color(PCB);
+const n=3, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;
+const headerBody=box(2.4,hdrH,2.5).color(HDR).translate(-2.4,hdrY,PCB_T);
+const pins:Shape[]=[];
+for(let i=0;i<n;i++){const py=hdrY+1.2+i*pitch; pins.push(box(7,0.64,0.64).color(CU).translate(-7,py,PCB_T+0.95));}
+// TO-92 package
+const body=box(4.0,4.0,4.5).color(IC).translate(5.5,5.5,PCB_T);
+const curve=cylinder(4.5,2.0,24).color(IC).translate(7.5,7.5,PCB_T);
+const asm=assembly('ds18b20');
+asm.part('pcb',pcb); asm.part('header',headerBody); pins.forEach((p,i)=>asm.part(`pin-${i}`,p));
+asm.part('to92-flat',body); asm.part('to92-curve',curve);
+return asm.model();

--- a/scripts/parts/authored/ds3231.kcad.ts
+++ b/scripts/parts/authored/ds3231.kcad.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/ds3231.kcad.ts
+//
+// DS3231 precision RTC module with CR2032 backup (ZS-042 / AT24C32 class).
+// 38 × 22 mm blue FR4; SOIC RTC; 32.768 kHz can crystal; coin-cell holder;
+// optional EEPROM SOIC; 6-pin I²C header.
+
+const PCB_L = 38.0;
+const PCB_W = 22.0;
+const PCB_T = 1.6;
+const HOLE_R = 1.1;
+
+const PCB = '#1a3a6e';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const HDR = '#1a1a28';
+const PASS = '#8a6a40';
+const STEEL = '#b8bcc4';
+const CELL = '#d8dce0';
+const XTAL = '#a8aab0';
+
+const holes = [
+  [2.2, 2.2],
+  [PCB_L - 2.2, 2.2],
+  [2.2, PCB_W - 2.2],
+  [PCB_L - 2.2, PCB_W - 2.2],
+].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 24).translate(x, y, -1));
+const pcb = box(PCB_L, PCB_W, PCB_T).subtract(...holes).color(PCB);
+
+const n = 6;
+const pitch = 2.54;
+const hdrH = (n - 1) * pitch + 2.4;
+const hdrY = (PCB_W - hdrH) / 2;
+const headerBody = box(2.4, hdrH, 2.5).color(HDR).translate(-2.4, hdrY, PCB_T);
+const pins: Shape[] = [];
+for (let i = 0; i < n; i++) {
+  const py = hdrY + 1.2 + i * pitch;
+  pins.push(box(7.5, 0.64, 0.64).color(CU).translate(-7.5, py, PCB_T + 0.95));
+}
+
+// DS3231 SOIC-16
+const rtc = box(10.3, 7.5, 1.75).color(IC).translate(3.5, 7.2, PCB_T);
+const pin1 = cylinder(0.2, 0.3, 16).color('#f0f0f8').translate(4.0, 7.7, PCB_T + 1.75);
+
+// AT24C32 EEPROM SOIC-8
+const eeprom = box(5.0, 4.0, 1.5).color(IC).translate(3.5, 2.5, PCB_T);
+
+// HC-49/US crystal can
+const xtal = box(10.5, 4.2, 3.5).color(XTAL).translate(15.0, 2.0, PCB_T);
+const xtalTop = box(9.5, 3.4, 0.3).color('#909098').translate(15.5, 2.4, PCB_T + 3.5);
+
+// CR2032 holder + cell (cylinder height, radius)
+const hx = 28.5;
+const hy = PCB_W / 2;
+const holderBase = cylinder(0.6, 10.5, 48).color(STEEL).translate(hx, hy, PCB_T);
+const holderWall = cylinder(3.2, 10.2, 48)
+  .subtract(cylinder(3.4, 9.3, 48).translate(0, 0, -0.1))
+  .color(STEEL)
+  .translate(hx, hy, PCB_T + 0.5);
+const cell = cylinder(2.8, 9.0, 48).color(CELL).translate(hx, hy, PCB_T + 0.7);
+const clip = box(5.0, 2.2, 1.2).color(STEEL).translate(hx + 7.5, hy - 1.1, PCB_T + 2.8);
+
+const caps: Shape[] = [
+  box(1.6, 0.8, 0.5).color(PASS).translate(14.5, 12.0, PCB_T),
+  box(1.6, 0.8, 0.5).color(PASS).translate(14.5, 15.0, PCB_T),
+  box(1.0, 0.5, 0.45).color(PASS).translate(9.0, 16.5, PCB_T),
+];
+const led = box(1.6, 0.8, 0.5).color('#fbbf24').translate(9.0, 18.5, PCB_T);
+
+const asm = assembly('ds3231');
+asm.part('pcb', pcb);
+asm.part('header-body', headerBody);
+pins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('ds3231-soic', rtc);
+asm.part('pin1-dot', pin1);
+asm.part('eeprom-soic', eeprom);
+asm.part('crystal', xtal);
+asm.part('crystal-lid', xtalTop);
+asm.part('holder-base', holderBase);
+asm.part('holder-wall', holderWall);
+asm.part('cr2032', cell);
+asm.part('holder-clip', clip);
+caps.forEach((c, i) => asm.part(`passive-${i}`, c));
+asm.part('pwr-led', led);
+return asm.model();

--- a/scripts/parts/authored/flame-sensor.kcad.ts
+++ b/scripts/parts/authored/flame-sensor.kcad.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/flame-sensor.kcad.ts
+//
+// IR flame sensor module (32×14 mm).
+
+const PCB_L = 32;
+const PCB_W = 14;
+const PCB_T = 1.6;
+const HOLE_R = 1.0;
+const PCB = '#1a6b3a';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const HDR = '#1a1a28';
+const PASS = '#8a6a40';
+
+const holes = [
+  [2.0, 2.0], [PCB_L - 2.0, 2.0], [2.0, PCB_W - 2.0], [PCB_L - 2.0, PCB_W - 2.0],
+].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 20).translate(x, y, -1));
+const pcb = box(PCB_L, PCB_W, PCB_T).subtract(...holes).color(PCB);
+
+const n = 4;
+const pitch = 2.54;
+const hdrH = (n - 1) * pitch + 2.4;
+const hdrY = (PCB_W - hdrH) / 2;
+const headerBody = box(2.4, hdrH, 2.5).color(HDR).translate(-2.4, hdrY, PCB_T);
+const headerPins: Shape[] = [];
+for (let i = 0; i < n; i++) {
+  const py = hdrY + 1.2 + i * pitch;
+  headerPins.push(box(7.0, 0.64, 0.64).color(CU).translate(-7.0, py, PCB_T + 0.95));
+}
+
+const photodiode=cylinder(2.5,2.5,20).color('#1a1a22').translate(22,7,PCB_T);
+const lens=cylinder(1.0,2.0,16).color('#334155').translate(22,7,PCB_T+2.5);
+const pot=cylinder(2.0,2.0,16).color('#2a2a32').translate(10,7,PCB_T);
+
+const asm = assembly('flame-sensor');
+asm.part('pcb', pcb);
+asm.part('header-body', headerBody);
+headerPins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('photo',photodiode);
+asm.part('lens',lens);
+asm.part('trim',pot);
+return asm.model();

--- a/scripts/parts/authored/flame-sensor.kcad.ts
+++ b/scripts/parts/authored/flame-sensor.kcad.ts
@@ -9,10 +9,8 @@ const PCB_W = 14;
 const PCB_T = 1.6;
 const HOLE_R = 1.0;
 const PCB = '#1a6b3a';
-const IC = '#1a1a22';
 const CU = '#c8a040';
 const HDR = '#1a1a28';
-const PASS = '#8a6a40';
 
 const holes = [
   [2.0, 2.0], [PCB_L - 2.0, 2.0], [2.0, PCB_W - 2.0], [PCB_L - 2.0, PCB_W - 2.0],

--- a/scripts/parts/authored/hall-sensor.kcad.ts
+++ b/scripts/parts/authored/hall-sensor.kcad.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/hall-sensor.kcad.ts
+// Hall effect sensor
+const PCB_L=32, PCB_W=14, PCB_T=1.6, HOLE_R=1.0;
+const PCB='#1a6b3a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28', PASS='#8a6a40';
+const holes=[[2,2],[PCB_L-2,2],[2,PCB_W-2],[PCB_L-2,PCB_W-2]].map(([x,y])=>cylinder(PCB_T+2,HOLE_R,20).translate(x,y,-1));
+const pcb=box(PCB_L,PCB_W,PCB_T).subtract(...holes).color(PCB);
+const n=4, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;
+const headerBody=box(2.4,hdrH,2.5).color(HDR).translate(-2.4,hdrY,PCB_T);
+const headerPins:Shape[]=[];
+for(let i=0;i<n;i++){const py=hdrY+1.2+i*pitch; headerPins.push(box(7,0.64,0.64).color(CU).translate(-7,py,PCB_T+0.95));}
+const sensor=box(4,3,1.2).color(IC).translate(20,5.5,PCB_T); const pot=cylinder(2,2,16).color("#2a2a32").translate(10,7,PCB_T);
+const asm=assembly('hall-sensor');
+asm.part('pcb',pcb); asm.part('header',headerBody); headerPins.forEach((p,i)=>asm.part(`pin-${i}`,p));
+asm.part('hall-ic',sensor);
+asm.part('trim',pot);
+return asm.model();

--- a/scripts/parts/authored/hall-sensor.kcad.ts
+++ b/scripts/parts/authored/hall-sensor.kcad.ts
@@ -3,7 +3,7 @@
 // scripts/parts/authored/hall-sensor.kcad.ts
 // Hall effect sensor
 const PCB_L=32, PCB_W=14, PCB_T=1.6, HOLE_R=1.0;
-const PCB='#1a6b3a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28', PASS='#8a6a40';
+const PCB='#1a6b3a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28';
 const holes=[[2,2],[PCB_L-2,2],[2,PCB_W-2],[PCB_L-2,PCB_W-2]].map(([x,y])=>cylinder(PCB_T+2,HOLE_R,20).translate(x,y,-1));
 const pcb=box(PCB_L,PCB_W,PCB_T).subtract(...holes).color(PCB);
 const n=4, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;

--- a/scripts/parts/authored/hc-05.kcad.ts
+++ b/scripts/parts/authored/hc-05.kcad.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/hc-05.kcad.ts
+//
+// HC-05 Bluetooth SPP module (classic blue breadboard breakout).
+// 37 × 16 mm carrier + 27 × 13 mm radio daughterboard with meander antenna.
+
+const PCB_L = 37.0;
+const PCB_W = 15.5;
+const PCB_T = 1.6;
+
+const CARRIER = '#1565c0';
+const RADIO = '#0d1b2a';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const HDR = '#1a1a28';
+const LED_R = '#ef4444';
+const LED_B = '#3b82f6';
+const ANT = '#94a3b8';
+
+const carrier = box(PCB_L, PCB_W, PCB_T).color(CARRIER);
+
+// 6-pin header (STATE RX TX GND KEY VCC)
+const n = 6;
+const pitch = 2.54;
+const hdrH = (n - 1) * pitch + 2.4;
+const hdrY = (PCB_W - hdrH) / 2;
+const headerBody = box(2.4, hdrH, 2.5).color(HDR).translate(-2.4, hdrY, PCB_T);
+const pins: Shape[] = [];
+for (let i = 0; i < n; i++) {
+  const py = hdrY + 1.2 + i * pitch;
+  pins.push(box(7.5, 0.64, 0.64).color(CU).translate(-7.5, py, PCB_T + 0.95));
+}
+
+// Radio daughter PCB (soldered on top)
+const radio = box(27.0, 13.0, 0.9).color(RADIO).translate(8.0, 1.25, PCB_T);
+// Shield can over RFIC
+const can = box(10.0, 9.0, 1.8).color('#64748b').translate(10.0, 3.0, PCB_T + 0.9);
+const canLid = box(9.4, 8.4, 0.25).color('#475569').translate(10.3, 3.3, PCB_T + 2.7);
+// Crystal
+const xtal = box(3.2, 2.5, 0.8).color('#a8aab0').translate(21.0, 4.0, PCB_T + 0.9);
+// Meander / chip antenna pad area
+const antPad = box(6.0, 10.0, 0.15).color(ANT).translate(28.5, 2.5, PCB_T + 0.9);
+const antTrace = box(0.4, 8.0, 0.12).color(CU).translate(31.0, 3.5, PCB_T + 1.05);
+
+// Button (EN/KEY)
+const btn = box(3.0, 2.5, 1.2).color('#334155').translate(3.5, 6.0, PCB_T);
+const btnTop = cylinder(0.4, 0.9, 16).color('#94a3b8').translate(5.0, 7.25, PCB_T + 1.2);
+
+const ledState = box(1.6, 0.8, 0.5).color(LED_B).translate(3.5, 11.5, PCB_T);
+const ledLink = box(1.6, 0.8, 0.5).color(LED_R).translate(5.5, 11.5, PCB_T);
+
+const asm = assembly('hc-05');
+asm.part('carrier-pcb', carrier);
+asm.part('header-body', headerBody);
+pins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('radio-pcb', radio);
+asm.part('shield-can', can);
+asm.part('shield-lid', canLid);
+asm.part('crystal', xtal);
+asm.part('antenna-pad', antPad);
+asm.part('antenna-trace', antTrace);
+asm.part('key-button', btn);
+asm.part('key-cap', btnTop);
+asm.part('led-state', ledState);
+asm.part('led-link', ledLink);
+return asm.model();

--- a/scripts/parts/authored/hc-05.kcad.ts
+++ b/scripts/parts/authored/hc-05.kcad.ts
@@ -11,7 +11,6 @@ const PCB_T = 1.6;
 
 const CARRIER = '#1565c0';
 const RADIO = '#0d1b2a';
-const IC = '#1a1a22';
 const CU = '#c8a040';
 const HDR = '#1a1a28';
 const LED_R = '#ef4444';

--- a/scripts/parts/authored/hx711.kcad.ts
+++ b/scripts/parts/authored/hx711.kcad.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/hx711.kcad.ts
+//
+// HX711 24-bit load-cell amplifier breakout (common green dual-header module).
+// 33 × 20 mm; MCU 4-pin + load-cell 4-pin; SOIC-16 HX711; rate jumper.
+
+const PCB_L = 33.0;
+const PCB_W = 20.0;
+const PCB_T = 1.6;
+const HOLE_R = 1.05;
+
+const PCB = '#1a6b3a';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const HDR = '#1a1a28';
+const PASS = '#8a6a40';
+
+const holes = [
+  [2.0, 2.0],
+  [PCB_L - 2.0, 2.0],
+  [2.0, PCB_W - 2.0],
+  [PCB_L - 2.0, PCB_W - 2.0],
+].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 24).translate(x, y, -1));
+const pcb = box(PCB_L, PCB_W, PCB_T).subtract(...holes).color(PCB);
+
+function sideHeader(x0: number, outward: number): { body: Shape; pins: Shape[] } {
+  const n = 4;
+  const pitch = 2.54;
+  const h = (n - 1) * pitch + 2.4;
+  const y0 = (PCB_W - h) / 2;
+  const body = box(2.4, h, 2.5).color(HDR).translate(x0, y0, PCB_T);
+  const pins: Shape[] = [];
+  for (let i = 0; i < n; i++) {
+    const py = y0 + 1.2 + i * pitch;
+    const px = outward < 0 ? x0 - 7.0 : x0 + 2.4;
+    pins.push(box(7.0, 0.64, 0.64).color(CU).translate(px, py, PCB_T + 0.95));
+  }
+  return { body, pins };
+}
+
+const mcu = sideHeader(-2.4, -1);
+const lc = sideHeader(PCB_L, 1);
+
+const soic = box(10.3, 7.5, 1.75).color(IC).translate(11.3, 6.2, PCB_T);
+const pin1 = cylinder(0.2, 0.3, 16).color('#f0f0f8').translate(11.8, 6.7, PCB_T + 1.75);
+const leads: Shape[] = [];
+for (let i = 0; i < 8; i++) {
+  const ly = 6.5 + i * 0.85;
+  if (ly > 13.0) break;
+  leads.push(box(0.85, 0.3, 0.15).color(CU).translate(10.45, ly, PCB_T + 0.15));
+  leads.push(box(0.85, 0.3, 0.15).color(CU).translate(21.6, ly, PCB_T + 0.15));
+}
+
+const ratePads = box(3.0, 2.2, 0.22).color(CU).translate(5.0, 14.5, PCB_T);
+const rateBridge = box(1.2, 0.6, 0.35).color('#333340').translate(5.9, 15.3, PCB_T + 0.22);
+
+const caps: Shape[] = [
+  box(2.0, 1.2, 0.6).color(PASS).translate(7.0, 3.5, PCB_T),
+  box(2.0, 1.2, 0.6).color(PASS).translate(12.0, 3.5, PCB_T),
+  box(2.0, 1.2, 0.6).color(PASS).translate(17.0, 3.5, PCB_T),
+  box(1.6, 0.8, 0.5).color(PASS).translate(24.0, 14.5, PCB_T),
+  box(1.6, 0.8, 0.5).color(PASS).translate(24.0, 16.5, PCB_T),
+];
+
+const asm = assembly('hx711');
+asm.part('pcb', pcb);
+asm.part('mcu-header', mcu.body);
+mcu.pins.forEach((p, i) => asm.part(`mcu-pin-${i}`, p));
+asm.part('lc-header', lc.body);
+lc.pins.forEach((p, i) => asm.part(`lc-pin-${i}`, p));
+asm.part('hx711-soic', soic);
+asm.part('pin1-dot', pin1);
+leads.forEach((l, i) => asm.part(`lead-${i}`, l));
+asm.part('rate-pads', ratePads);
+asm.part('rate-jumper', rateBridge);
+caps.forEach((c, i) => asm.part(`passive-${i}`, c));
+return asm.model();

--- a/scripts/parts/authored/ina219.kcad.ts
+++ b/scripts/parts/authored/ina219.kcad.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/ina219.kcad.ts
+//
+// INA219 high-side DC current sensor breakout (Adafruit #904 / generic class).
+// Form factor: 25.4 × 20.3 × ~5 mm with 6-pin 2.54 mm header.
+// Distinctive: blue FR4, SOIC-8 INA219, 0.1 Ω sense shunt bar, VIN+/− pads.
+
+// cylinder(height, radius) — kernelCAD convention.
+
+const PCB_L = 25.4;
+const PCB_W = 20.3;
+const PCB_T = 1.6;
+const HOLE_R = 1.05; // M2.5 mounting
+
+const PCB = '#1a3a6e';
+const SILK = '#e8eef8';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const SHUNT = '#2c2c34';
+const HDR = '#1a1a28';
+const PASS = '#8a6a40';
+const LED_G = '#22c55e';
+
+// Corner mounting holes
+const holes = [
+  [2.0, 2.0],
+  [PCB_L - 2.0, 2.0],
+  [2.0, PCB_W - 2.0],
+  [PCB_L - 2.0, PCB_W - 2.0],
+].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 28).translate(x, y, -1));
+
+const pcb = box(PCB_L, PCB_W, PCB_T).subtract(...holes).color(PCB);
+
+// 6-pin right-angle style header on -X (pins stick out for breadboard)
+const n = 6;
+const pitch = 2.54;
+const hdrH = (n - 1) * pitch + 2.4;
+const hdrY = (PCB_W - hdrH) / 2;
+const headerBody = box(2.4, hdrH, 2.5).color(HDR).translate(-2.4, hdrY, PCB_T);
+const pins: Shape[] = [];
+const pinBoxes: Shape[] = [];
+for (let i = 0; i < n; i++) {
+  const py = hdrY + 1.2 + i * pitch;
+  pins.push(box(7.5, 0.64, 0.64).color(CU).translate(-7.5, py, PCB_T + 0.95));
+  // solder fillet stubs on board
+  pinBoxes.push(box(1.2, 1.2, 0.15).color(CU).translate(0.2, py - 0.3, PCB_T));
+}
+
+// INA219 SOIC-8 with lead stubs
+const icX = 9.0;
+const icY = 8.2;
+const soic = box(4.9, 3.9, 1.55).color(IC).translate(icX, icY, PCB_T);
+const pin1 = cylinder(0.2, 0.28, 16).color('#f0f0f8').translate(icX + 0.55, icY + 0.55, PCB_T + 1.55);
+const leads: Shape[] = [];
+for (let i = 0; i < 4; i++) {
+  const ly = icY + 0.45 + i * 1.0;
+  leads.push(box(0.9, 0.35, 0.2).color(CU).translate(icX - 0.9, ly, PCB_T + 0.2));
+  leads.push(box(0.9, 0.35, 0.2).color(CU).translate(icX + 4.9, ly, PCB_T + 0.2));
+}
+
+// 0.1 Ω shunt (thick current path)
+const shunt = box(3.4, 1.8, 0.85).color(SHUNT).translate(17.5, 9.2, PCB_T);
+const shuntMark = box(3.0, 0.25, 0.1).color('#666670').translate(17.7, 9.95, PCB_T + 0.85);
+
+// High-current terminal pads
+const padPlus = box(3.2, 3.2, 0.25).color(CU).translate(19.5, 2.5, PCB_T);
+const padMinus = box(3.2, 3.2, 0.25).color(CU).translate(19.5, 14.6, PCB_T);
+
+// Power LED + 0402s
+const led = box(1.6, 0.8, 0.55).color(LED_G).translate(5.5, 16.5, PCB_T);
+const caps: Shape[] = [
+  box(1.0, 0.5, 0.45).color(PASS).translate(5.5, 4.0, PCB_T),
+  box(1.0, 0.5, 0.45).color(PASS).translate(7.0, 4.0, PCB_T),
+  box(1.6, 0.8, 0.5).color(PASS).translate(14.0, 4.5, PCB_T),
+  box(1.6, 0.8, 0.5).color(PASS).translate(14.0, 15.0, PCB_T),
+];
+
+// Silkscreen bar (visual brand strip)
+const silk = box(PCB_L - 4, 0.4, 0.05).color(SILK).translate(2.0, PCB_W - 1.2, PCB_T);
+
+const asm = assembly('ina219');
+asm.part('pcb', pcb);
+asm.part('header-body', headerBody);
+pins.forEach((p, i) => asm.part(`header-pin-${i}`, p));
+pinBoxes.forEach((p, i) => asm.part(`solder-pad-${i}`, p));
+asm.part('ina219-soic', soic);
+asm.part('pin1-dot', pin1);
+leads.forEach((l, i) => asm.part(`soic-lead-${i}`, l));
+asm.part('shunt', shunt);
+asm.part('shunt-mark', shuntMark);
+asm.part('pad-vin-plus', padPlus);
+asm.part('pad-vin-minus', padMinus);
+asm.part('pwr-led', led);
+caps.forEach((c, i) => asm.part(`passive-${i}`, c));
+asm.part('silk-bar', silk);
+
+return asm.model();

--- a/scripts/parts/authored/inmp441.kcad.ts
+++ b/scripts/parts/authored/inmp441.kcad.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/inmp441.kcad.ts
+// INMP441 I2S mic
+const PCB_L=14, PCB_W=12, PCB_T=1.6, HOLE_R=1.0;
+const PCB='#1a1a22', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28', PASS='#8a6a40';
+const holes=[[2,2],[PCB_L-2,2],[2,PCB_W-2],[PCB_L-2,PCB_W-2]].map(([x,y])=>cylinder(PCB_T+2,HOLE_R,20).translate(x,y,-1));
+const pcb=box(PCB_L,PCB_W,PCB_T).subtract(...holes).color(PCB);
+const n=6, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;
+const headerBody=box(2.4,hdrH,2.5).color(HDR).translate(-2.4,hdrY,PCB_T);
+const headerPins:Shape[]=[];
+for(let i=0;i<n;i++){const py=hdrY+1.2+i*pitch; headerPins.push(box(7,0.64,0.64).color(CU).translate(-7,py,PCB_T+0.95));}
+const mic=cylinder(2.5,3.5,24).color("#2a2a32").translate(7,6,PCB_T); const mesh=cylinder(0.4,3,16).color("#6a6a78").translate(7,6,PCB_T+2.5);
+const asm=assembly('inmp441');
+asm.part('pcb',pcb); asm.part('header',headerBody); headerPins.forEach((p,i)=>asm.part(`pin-${i}`,p));
+asm.part('mic',mic);
+asm.part('mesh',mesh);
+return asm.model();

--- a/scripts/parts/authored/inmp441.kcad.ts
+++ b/scripts/parts/authored/inmp441.kcad.ts
@@ -3,7 +3,7 @@
 // scripts/parts/authored/inmp441.kcad.ts
 // INMP441 I2S mic
 const PCB_L=14, PCB_W=12, PCB_T=1.6, HOLE_R=1.0;
-const PCB='#1a1a22', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28', PASS='#8a6a40';
+const PCB='#1a1a22', CU='#c8a040', HDR='#1a1a28';
 const holes=[[2,2],[PCB_L-2,2],[2,PCB_W-2],[PCB_L-2,PCB_W-2]].map(([x,y])=>cylinder(PCB_T+2,HOLE_R,20).translate(x,y,-1));
 const pcb=box(PCB_L,PCB_W,PCB_T).subtract(...holes).color(PCB);
 const n=6, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;

--- a/scripts/parts/authored/ir-obstacle.kcad.ts
+++ b/scripts/parts/authored/ir-obstacle.kcad.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/ir-obstacle.kcad.ts
+// FC-51 IR obstacle
+const PCB_L=32, PCB_W=14, PCB_T=1.6, HOLE_R=1.0;
+const PCB='#1a6b3a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28', PASS='#8a6a40';
+const holes=[[2,2],[PCB_L-2,2],[2,PCB_W-2],[PCB_L-2,PCB_W-2]].map(([x,y])=>cylinder(PCB_T+2,HOLE_R,20).translate(x,y,-1));
+const pcb=box(PCB_L,PCB_W,PCB_T).subtract(...holes).color(PCB);
+const n=3, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;
+const headerBody=box(2.4,hdrH,2.5).color(HDR).translate(-2.4,hdrY,PCB_T);
+const headerPins:Shape[]=[];
+for(let i=0;i<n;i++){const py=hdrY+1.2+i*pitch; headerPins.push(box(7,0.64,0.64).color(CU).translate(-7,py,PCB_T+0.95));}
+const tx=cylinder(4,3,20).color("#1a1a22").translate(20,7,PCB_T); const rx=cylinder(4,3,20).color("#334155").translate(26,7,PCB_T); const pot=cylinder(2,2,16).color("#2a2a32").translate(10,7,PCB_T);
+const asm=assembly('ir-obstacle');
+asm.part('pcb',pcb); asm.part('header',headerBody); headerPins.forEach((p,i)=>asm.part(`pin-${i}`,p));
+asm.part('ir-tx',tx);
+asm.part('ir-rx',rx);
+asm.part('trim',pot);
+return asm.model();

--- a/scripts/parts/authored/ir-obstacle.kcad.ts
+++ b/scripts/parts/authored/ir-obstacle.kcad.ts
@@ -3,7 +3,7 @@
 // scripts/parts/authored/ir-obstacle.kcad.ts
 // FC-51 IR obstacle
 const PCB_L=32, PCB_W=14, PCB_T=1.6, HOLE_R=1.0;
-const PCB='#1a6b3a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28', PASS='#8a6a40';
+const PCB='#1a6b3a', CU='#c8a040', HDR='#1a1a28';
 const holes=[[2,2],[PCB_L-2,2],[2,PCB_W-2],[PCB_L-2,PCB_W-2]].map(([x,y])=>cylinder(PCB_T+2,HOLE_R,20).translate(x,y,-1));
 const pcb=box(PCB_L,PCB_W,PCB_T).subtract(...holes).color(PCB);
 const n=3, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;

--- a/scripts/parts/authored/irf520.kcad.ts
+++ b/scripts/parts/authored/irf520.kcad.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/irf520.kcad.ts
+//
+// IRF520 MOSFET driver module (green breakout, TO-220 FET, screw terminals).
+// 33 × 24 mm; SIG/VCC/GND header; load screw terminals; TO-220 tab.
+
+const PCB_L = 33.0;
+const PCB_W = 24.0;
+const PCB_T = 1.6;
+const HOLE_R = 1.1;
+
+const PCB = '#1a6b3a';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const HDR = '#1a1a28';
+const TERM = '#2a2a32';
+const TAB = '#9ca3af';
+const PASS = '#8a6a40';
+const LED = '#22c55e';
+
+const holes = [
+  [2.5, 2.5],
+  [PCB_L - 2.5, 2.5],
+  [2.5, PCB_W - 2.5],
+  [PCB_L - 2.5, PCB_W - 2.5],
+].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 24).translate(x, y, -1));
+const pcb = box(PCB_L, PCB_W, PCB_T).subtract(...holes).color(PCB);
+
+// 3-pin logic header
+const n = 3;
+const pitch = 2.54;
+const hdrW = (n - 1) * pitch + 2.4;
+const hdrX = (PCB_L - hdrW) / 2;
+const headerBody = box(hdrW, 2.4, 2.5).color(HDR).translate(hdrX, -2.4, PCB_T);
+const pins: Shape[] = [];
+for (let i = 0; i < n; i++) {
+  const px = hdrX + 1.2 + i * pitch;
+  pins.push(box(0.64, 7.0, 0.64).color(CU).translate(px, -7.0, PCB_T + 0.95));
+}
+
+// TO-220 body + metal tab
+const to220 = box(10.0, 4.5, 8.5).color(IC).translate(11.5, 8.0, PCB_T);
+const tab = box(10.0, 1.2, 12.0).color(TAB).translate(11.5, 12.5, PCB_T);
+const tabHole = cylinder(1.5, 1.6, 20).color(TAB).translate(16.5, 13.1, PCB_T + 8.0);
+// TO-220 leads
+const leads: Shape[] = [];
+for (let i = 0; i < 3; i++) {
+  leads.push(box(0.7, 4.0, 0.5).color(CU).translate(12.5 + i * 2.8, 4.0, PCB_T + 0.5));
+}
+
+// Dual screw terminal (VIN / load)
+const term = box(14.0, 8.0, 10.0).color(TERM).translate(9.5, 15.0, PCB_T);
+const screw1 = box(2.2, 2.2, 1.0).color(CU).translate(12.0, 17.0, PCB_T + 10.0);
+const screw2 = box(2.2, 2.2, 1.0).color(CU).translate(18.5, 17.0, PCB_T + 10.0);
+
+const led = box(1.6, 0.8, 0.5).color(LED).translate(3.0, 10.0, PCB_T);
+const r1 = box(2.0, 1.2, 0.6).color(PASS).translate(3.0, 6.0, PCB_T);
+
+const asm = assembly('irf520');
+asm.part('pcb', pcb);
+asm.part('header-body', headerBody);
+pins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('to220-body', to220);
+asm.part('to220-tab', tab);
+asm.part('tab-hole-boss', tabHole);
+leads.forEach((l, i) => asm.part(`to220-lead-${i}`, l));
+asm.part('load-terminal', term);
+asm.part('screw-a', screw1);
+asm.part('screw-b', screw2);
+asm.part('status-led', led);
+asm.part('gate-resistor', r1);
+return asm.model();

--- a/scripts/parts/authored/joystick.kcad.ts
+++ b/scripts/parts/authored/joystick.kcad.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// KY-023 style dual-axis joystick module 34×26 mm.
+const PCB_L=34.0, PCB_W=26.0, PCB_T=1.6;
+const PCB='#1a1a22', CU='#c8a040', HDR='#1a1a28', BASE='#2a2a32', CAP='#3a3a48';
+const pcb=box(PCB_L,PCB_W,PCB_T).color(PCB);
+const n=5, pitch=2.54, hdrW=(n-1)*pitch+2.4, hdrX=(PCB_L-hdrW)/2;
+const headerBody=box(hdrW,2.4,2.5).color(HDR).translate(hdrX,-2.4,PCB_T);
+const pins:Shape[]=[];
+for(let i=0;i<n;i++){const px=hdrX+1.2+i*pitch; pins.push(box(0.64,7,0.64).color(CU).translate(px,-7,PCB_T+0.95));}
+const base=box(18,18,6).color(BASE).translate(8,4,PCB_T);
+const stick=cylinder(10,3.5,24).color(CAP).translate(17,13,PCB_T+6);
+const cap=cylinder(2,6,24).color('#4a4a58').translate(17,13,PCB_T+16);
+const asm=assembly('joystick');
+asm.part('pcb',pcb); asm.part('header',headerBody); pins.forEach((p,i)=>asm.part(`p-${i}`,p));
+asm.part('pot-base',base); asm.part('stick',stick); asm.part('cap',cap);
+return asm.model();

--- a/scripts/parts/authored/l298n.kcad.ts
+++ b/scripts/parts/authored/l298n.kcad.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/l298n.kcad.ts
+//
+// L298N dual H-bridge motor driver module (classic red board + heatsink).
+// 43 × 43 mm; large aluminum heatsink; screw terminals; enable jumpers.
+
+const PCB_L = 43.0;
+const PCB_W = 43.0;
+const PCB_T = 1.6;
+const HOLE_R = 1.5;
+
+const PCB = '#b91c1c';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const HDR = '#1a1a28';
+const HS = '#9ca3af';
+const TERM = '#2a2a32';
+const JUMP = '#1e3a5f';
+
+const holes = [
+  [3.5, 3.5],
+  [PCB_L - 3.5, 3.5],
+  [3.5, PCB_W - 3.5],
+  [PCB_L - 3.5, PCB_W - 3.5],
+].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 24).translate(x, y, -1));
+const pcb = box(PCB_L, PCB_W, PCB_T).subtract(...holes).color(PCB);
+
+// L298N Multiwatt package under heatsink
+const l298 = box(20.0, 10.0, 4.5).color(IC).translate(11.5, 16.0, PCB_T);
+
+// Aluminum heatsink with fins
+const hsBase = box(25.0, 16.0, 2.0).color(HS).translate(9.0, 13.5, PCB_T + 4.5);
+const fins: Shape[] = [];
+for (let i = 0; i < 8; i++) {
+  fins.push(box(25.0, 1.0, 10.0).color(HS).translate(9.0, 13.8 + i * 1.85, PCB_T + 6.5));
+}
+
+// Power screw terminals (VS, GND, VSS) — 3-pos
+const pwrTerm = box(15.0, 8.0, 10.0).color(TERM).translate(2.0, 32.0, PCB_T);
+// Motor A screw terminal 2-pos
+const motA = box(10.0, 8.0, 10.0).color(TERM).translate(2.0, 2.0, PCB_T);
+// Motor B screw terminal 2-pos
+const motB = box(10.0, 8.0, 10.0).color(TERM).translate(31.0, 2.0, PCB_T);
+
+// Logic header (IN1-4, ENA, ENB) on +X
+const n = 6;
+const pitch = 2.54;
+const hdrH = (n - 1) * pitch + 2.4;
+const hdrY = (PCB_W - hdrH) / 2;
+const headerBody = box(2.4, hdrH, 2.5).color(HDR).translate(PCB_L, hdrY, PCB_T);
+const pins: Shape[] = [];
+for (let i = 0; i < n; i++) {
+  const py = hdrY + 1.2 + i * pitch;
+  pins.push(box(7.0, 0.64, 0.64).color(CU).translate(PCB_L + 0.5, py, PCB_T + 0.95));
+}
+
+// ENA/ENB jumper blocks
+const j1 = box(5.0, 2.5, 2.0).color(JUMP).translate(20.0, 33.0, PCB_T);
+const j2 = box(5.0, 2.5, 2.0).color(JUMP).translate(27.0, 33.0, PCB_T);
+
+// Electrolytic caps
+const cap1 = cylinder(8.0, 4.0, 28).color('#1e293b').translate(34.0, 28.0, PCB_T);
+const cap2 = cylinder(6.0, 3.0, 24).color('#1e293b').translate(34.0, 18.0, PCB_T);
+
+const led = box(1.6, 0.8, 0.5).color('#22c55e').translate(20.0, 38.0, PCB_T);
+
+const asm = assembly('l298n');
+asm.part('pcb', pcb);
+asm.part('l298n-ic', l298);
+asm.part('heatsink-base', hsBase);
+fins.forEach((f, i) => asm.part(`fin-${i}`, f));
+asm.part('power-terminal', pwrTerm);
+asm.part('motor-a-terminal', motA);
+asm.part('motor-b-terminal', motB);
+asm.part('logic-header', headerBody);
+pins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('ena-jumper', j1);
+asm.part('enb-jumper', j2);
+asm.part('cap-large', cap1);
+asm.part('cap-mid', cap2);
+asm.part('pwr-led', led);
+return asm.model();

--- a/scripts/parts/authored/lm2596.kcad.ts
+++ b/scripts/parts/authored/lm2596.kcad.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/lm2596.kcad.ts
+//
+// LM2596 adjustable buck converter module (blue board, classic layout).
+// 43 × 21 mm; large inductor; multi-turn pot; two electrolytics; IN/OUT pads.
+
+const PCB_L = 43.0;
+const PCB_W = 21.0;
+const PCB_T = 1.6;
+const HOLE_R = 1.1;
+
+const PCB = '#1e3a8a';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const IND = '#1a1a22';
+const IND_TOP = '#334155';
+const CAP = '#1e293b';
+const CAP_TOP = '#94a3b8';
+const POT = '#0f172a';
+const DIODE = '#1a1a22';
+
+const holes = [
+  [2.5, 2.5],
+  [PCB_L - 2.5, 2.5],
+  [2.5, PCB_W - 2.5],
+  [PCB_L - 2.5, PCB_W - 2.5],
+].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 24).translate(x, y, -1));
+const pcb = box(PCB_L, PCB_W, PCB_T).subtract(...holes).color(PCB);
+
+// LM2596 TO-263 / TO-220 style package
+const reg = box(10.0, 9.0, 4.5).color(IC).translate(8.0, 6.0, PCB_T);
+const tab = box(10.0, 1.5, 8.0).color('#9ca3af').translate(8.0, 15.0, PCB_T);
+
+// Power inductor (shielded drum)
+const ind = cylinder(7.0, 5.5, 36).color(IND).translate(26.0, 10.5, PCB_T);
+const indTop = cylinder(0.8, 5.0, 36).color(IND_TOP).translate(26.0, 10.5, PCB_T + 7.0);
+
+// Multi-turn trim pot for Vout
+const pot = box(5.0, 5.0, 4.5).color(POT).translate(18.0, 3.0, PCB_T);
+const potScrew = cylinder(0.8, 1.2, 16).color('#c0c4cc').translate(20.5, 5.5, PCB_T + 4.5);
+
+// Input / output electrolytics
+const cin = cylinder(10.0, 4.0, 28).color(CAP).translate(5.0, 10.5, PCB_T);
+const cinTop = cylinder(0.4, 3.5, 24).color(CAP_TOP).translate(5.0, 10.5, PCB_T + 10.0);
+const cout = cylinder(10.0, 4.0, 28).color(CAP).translate(35.0, 10.5, PCB_T);
+const coutTop = cylinder(0.4, 3.5, 24).color(CAP_TOP).translate(35.0, 10.5, PCB_T + 10.0);
+
+// Schottky diode
+const diode = box(5.0, 2.5, 2.2).color(DIODE).translate(18.0, 12.0, PCB_T);
+const diodeBand = box(0.6, 2.5, 2.2).color('#c8a040').translate(22.0, 12.0, PCB_T);
+
+// IN+/IN− OUT+/OUT− pads
+const pads: Shape[] = [
+  box(3.0, 3.0, 0.25).color(CU).translate(1.5, 1.5, PCB_T),
+  box(3.0, 3.0, 0.25).color(CU).translate(1.5, 16.5, PCB_T),
+  box(3.0, 3.0, 0.25).color(CU).translate(38.5, 1.5, PCB_T),
+  box(3.0, 3.0, 0.25).color(CU).translate(38.5, 16.5, PCB_T),
+];
+
+const led = box(1.6, 0.8, 0.5).color('#22c55e').translate(14.0, 17.5, PCB_T);
+
+const asm = assembly('lm2596');
+asm.part('pcb', pcb);
+asm.part('lm2596-reg', reg);
+asm.part('reg-tab', tab);
+asm.part('inductor', ind);
+asm.part('inductor-top', indTop);
+asm.part('trim-pot', pot);
+asm.part('pot-screw', potScrew);
+asm.part('cap-in', cin);
+asm.part('cap-in-top', cinTop);
+asm.part('cap-out', cout);
+asm.part('cap-out-top', coutTop);
+asm.part('schottky', diode);
+asm.part('diode-band', diodeBand);
+pads.forEach((p, i) => asm.part(`pad-${i}`, p));
+asm.part('pwr-led', led);
+return asm.model();

--- a/scripts/parts/authored/lora-sx1278.kcad.ts
+++ b/scripts/parts/authored/lora-sx1278.kcad.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+// RA-02 LoRa SX1278 module 17x16 mm on carrier 25x35
+const PCB_L=25, PCB_W=35, PCB_T=1.6;
+const PCB='#1a1a22', MOD='#0f172a', CU='#c8a040', HDR='#1a1a28', ANT='#94a3b8';
+const pcb=box(PCB_L,PCB_W,PCB_T).color(PCB);
+const n=8, pitch=2.54, hdrW=(n-1)*pitch+2.4, hdrX=(PCB_L-hdrW)/2;
+const headerBody=box(hdrW,2.4,2.5).color(HDR).translate(hdrX,-2.4,PCB_T);
+const pins:Shape[]=[];
+for(let i=0;i<n;i++){const px=hdrX+1.2+i*pitch; pins.push(box(0.64,7,0.64).color(CU).translate(px,-7,PCB_T+0.95));}
+const mod=box(17,16,2.5).color(MOD).translate(4,6,PCB_T);
+const can=box(12,10,1.5).color('#64748b').translate(6.5,8,PCB_T+2.5);
+const ant=box(2,12,0.8).color(ANT).translate(11.5,22,PCB_T);
+const asm=assembly('lora-sx1278');
+asm.part('pcb',pcb); asm.part('header',headerBody); pins.forEach((p,i)=>asm.part(`p-${i}`,p));
+asm.part('ra02',mod); asm.part('shield',can); asm.part('antenna',ant);
+return asm.model();

--- a/scripts/parts/authored/max485.kcad.ts
+++ b/scripts/parts/authored/max485.kcad.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/max485.kcad.ts
+//
+// MAX485 TTL↔RS-485 transceiver breakout.
+// 44 × 14 mm; DIP/SOIC MAX485; A/B screw terminal; RO DI DE RE headers.
+
+const PCB_L = 44.0;
+const PCB_W = 14.0;
+const PCB_T = 1.6;
+const HOLE_R = 1.0;
+
+const PCB = '#1a6b3a';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const HDR = '#1a1a28';
+const TERM = '#2a2a32';
+const PASS = '#8a6a40';
+
+const holes = [
+  [2.0, 2.0],
+  [PCB_L - 2.0, 2.0],
+  [2.0, PCB_W - 2.0],
+  [PCB_L - 2.0, PCB_W - 2.0],
+].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 20).translate(x, y, -1));
+const pcb = box(PCB_L, PCB_W, PCB_T).subtract(...holes).color(PCB);
+
+// Left 4-pin (VCC RO RE DE) + right 4-pin style — single 8-pin common clone
+const n = 4;
+const pitch = 2.54;
+const hdrH = (n - 1) * pitch + 2.4;
+const hdrY = (PCB_W - hdrH) / 2;
+const leftHdr = box(2.4, hdrH, 2.5).color(HDR).translate(-2.4, hdrY, PCB_T);
+const rightHdr = box(2.4, hdrH, 2.5).color(HDR).translate(PCB_L, hdrY, PCB_T);
+const pins: Shape[] = [];
+for (let i = 0; i < n; i++) {
+  const py = hdrY + 1.2 + i * pitch;
+  pins.push(box(7.0, 0.64, 0.64).color(CU).translate(-7.0, py, PCB_T + 0.95));
+  pins.push(box(7.0, 0.64, 0.64).color(CU).translate(PCB_L + 0.5, py, PCB_T + 0.95));
+}
+
+// MAX485 DIP-8
+const dip = box(9.5, 6.5, 3.3).color(IC).translate(17.0, 3.75, PCB_T);
+const notch = cylinder(0.5, 0.9, 16).color(IC).translate(17.0, 7.0, PCB_T + 3.3);
+const pin1 = cylinder(0.2, 0.25, 12).color('#f0f0f8').translate(17.5, 4.2, PCB_T + 3.3);
+// DIP legs
+const legs: Shape[] = [];
+for (let i = 0; i < 4; i++) {
+  const ly = 4.3 + i * 1.5;
+  legs.push(box(1.2, 0.45, 0.3).color(CU).translate(15.8, ly, PCB_T + 0.2));
+  legs.push(box(1.2, 0.45, 0.3).color(CU).translate(26.5, ly, PCB_T + 0.2));
+}
+
+// A/B screw terminal
+const term = box(10.0, 8.0, 9.5).color(TERM).translate(30.0, 3.0, PCB_T);
+const sa = box(2.0, 2.0, 1.0).color(CU).translate(32.0, 5.0, PCB_T + 9.5);
+const sb = box(2.0, 2.0, 1.0).color(CU).translate(36.0, 5.0, PCB_T + 9.5);
+
+const caps: Shape[] = [
+  box(1.6, 0.8, 0.5).color(PASS).translate(10.0, 5.0, PCB_T),
+  box(1.6, 0.8, 0.5).color(PASS).translate(12.5, 5.0, PCB_T),
+];
+const led = box(1.6, 0.8, 0.5).color('#22c55e').translate(10.0, 9.5, PCB_T);
+
+const asm = assembly('max485');
+asm.part('pcb', pcb);
+asm.part('left-header', leftHdr);
+asm.part('right-header', rightHdr);
+pins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('max485-dip', dip);
+asm.part('dip-notch', notch);
+asm.part('pin1-dot', pin1);
+legs.forEach((l, i) => asm.part(`dip-leg-${i}`, l));
+asm.part('ab-terminal', term);
+asm.part('screw-a', sa);
+asm.part('screw-b', sb);
+caps.forEach((c, i) => asm.part(`passive-${i}`, c));
+asm.part('pwr-led', led);
+return asm.model();

--- a/scripts/parts/authored/max98357.kcad.ts
+++ b/scripts/parts/authored/max98357.kcad.ts
@@ -3,7 +3,7 @@
 // scripts/parts/authored/max98357.kcad.ts
 // MAX98357 I2S amp
 const PCB_L=18, PCB_W=18, PCB_T=1.6, HOLE_R=1.0;
-const PCB='#1a1a22', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28', PASS='#8a6a40';
+const PCB='#1a1a22', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28';
 const holes=[[2,2],[PCB_L-2,2],[2,PCB_W-2],[PCB_L-2,PCB_W-2]].map(([x,y])=>cylinder(PCB_T+2,HOLE_R,20).translate(x,y,-1));
 const pcb=box(PCB_L,PCB_W,PCB_T).subtract(...holes).color(PCB);
 const n=6, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;

--- a/scripts/parts/authored/max98357.kcad.ts
+++ b/scripts/parts/authored/max98357.kcad.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/max98357.kcad.ts
+// MAX98357 I2S amp
+const PCB_L=18, PCB_W=18, PCB_T=1.6, HOLE_R=1.0;
+const PCB='#1a1a22', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28', PASS='#8a6a40';
+const holes=[[2,2],[PCB_L-2,2],[2,PCB_W-2],[PCB_L-2,PCB_W-2]].map(([x,y])=>cylinder(PCB_T+2,HOLE_R,20).translate(x,y,-1));
+const pcb=box(PCB_L,PCB_W,PCB_T).subtract(...holes).color(PCB);
+const n=6, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;
+const headerBody=box(2.4,hdrH,2.5).color(HDR).translate(-2.4,hdrY,PCB_T);
+const headerPins:Shape[]=[];
+for(let i=0;i<n;i++){const py=hdrY+1.2+i*pitch; headerPins.push(box(7,0.64,0.64).color(CU).translate(-7,py,PCB_T+0.95));}
+const ic=box(3,3,0.9).color(IC).translate(7.5,7.5,PCB_T); const pads=[box(3,3,0.25).color(CU).translate(12,2,PCB_T), box(3,3,0.25).color(CU).translate(12,13,PCB_T)];
+const asm=assembly('max98357');
+asm.part('pcb',pcb); asm.part('header',headerBody); headerPins.forEach((p,i)=>asm.part(`pin-${i}`,p));
+asm.part('max98357-ic',ic);
+pads.forEach((p,i)=>asm.part(`spk-${i}`,p));
+return asm.model();

--- a/scripts/parts/authored/mcp2515.kcad.ts
+++ b/scripts/parts/authored/mcp2515.kcad.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/mcp2515.kcad.ts
+//
+// MCP2515 + TJA1050 CAN bus module (common green SPI breakout).
+// 40 × 28 mm; crystal; SPI header; CAN H/L screw-style pads; 120 Ω jumper.
+
+const PCB_L = 40.0;
+const PCB_W = 28.0;
+const PCB_T = 1.6;
+const HOLE_R = 1.1;
+
+const PCB = '#1a6b3a';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const HDR = '#1a1a28';
+const PASS = '#8a6a40';
+const TERM = '#2a2a32';
+const XTAL = '#a8aab0';
+
+const holes = [
+  [2.5, 2.5],
+  [PCB_L - 2.5, 2.5],
+  [2.5, PCB_W - 2.5],
+  [PCB_L - 2.5, PCB_W - 2.5],
+].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 24).translate(x, y, -1));
+const pcb = box(PCB_L, PCB_W, PCB_T).subtract(...holes).color(PCB);
+
+// SPI + power 8-pin header on -Y
+const n = 8;
+const pitch = 2.54;
+const hdrW = (n - 1) * pitch + 2.4;
+const hdrX = (PCB_L - hdrW) / 2;
+const headerBody = box(hdrW, 2.4, 2.5).color(HDR).translate(hdrX, -2.4, PCB_T);
+const pins: Shape[] = [];
+for (let i = 0; i < n; i++) {
+  const px = hdrX + 1.2 + i * pitch;
+  pins.push(box(0.64, 7.5, 0.64).color(CU).translate(px, -7.5, PCB_T + 0.95));
+}
+
+// MCP2515 SOIC-18-ish
+const mcp = box(11.5, 7.5, 1.75).color(IC).translate(5.0, 8.0, PCB_T);
+const pin1 = cylinder(0.2, 0.28, 14).color('#f0f0f8').translate(5.5, 8.5, PCB_T + 1.75);
+
+// TJA1050 SOIC-8
+const tja = box(5.0, 4.0, 1.5).color(IC).translate(20.0, 9.0, PCB_T);
+
+// Crystal
+const xtal = box(10.5, 4.2, 3.2).color(XTAL).translate(5.0, 17.5, PCB_T);
+
+// Screw terminal block for CANH / CANL (2-pos)
+const termBody = box(10.0, 7.5, 8.5).color(TERM).translate(26.0, 18.0, PCB_T);
+const termMetal1 = box(2.2, 2.2, 1.0).color(CU).translate(27.5, 19.5, PCB_T + 8.5);
+const termMetal2 = box(2.2, 2.2, 1.0).color(CU).translate(32.5, 19.5, PCB_T + 8.5);
+
+// 120 Ω terminator jumper
+const jmp = box(3.0, 2.2, 0.25).color(CU).translate(26.0, 8.0, PCB_T);
+const jmpCap = box(1.4, 0.7, 0.4).color('#334155').translate(26.8, 8.7, PCB_T + 0.25);
+
+const caps: Shape[] = [
+  box(2.0, 1.2, 0.6).color(PASS).translate(18.0, 18.0, PCB_T),
+  box(2.0, 1.2, 0.6).color(PASS).translate(18.0, 21.0, PCB_T),
+  box(1.6, 0.8, 0.5).color(PASS).translate(28.0, 5.0, PCB_T),
+];
+const led = box(1.6, 0.8, 0.5).color('#22c55e').translate(32.0, 5.0, PCB_T);
+
+const asm = assembly('mcp2515');
+asm.part('pcb', pcb);
+asm.part('header-body', headerBody);
+pins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('mcp2515-soic', mcp);
+asm.part('pin1-dot', pin1);
+asm.part('tja1050-soic', tja);
+asm.part('crystal', xtal);
+asm.part('can-terminal', termBody);
+asm.part('canh-screw', termMetal1);
+asm.part('canl-screw', termMetal2);
+asm.part('term-jumper-pads', jmp);
+asm.part('term-jumper', jmpCap);
+caps.forEach((c, i) => asm.part(`passive-${i}`, c));
+asm.part('pwr-led', led);
+return asm.model();

--- a/scripts/parts/authored/mp1584.kcad.ts
+++ b/scripts/parts/authored/mp1584.kcad.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // MP1584 buck 22x17
 const PCB_L=22, PCB_W=17, PCB_T=1.6;
-const PCB='#1a1a22', CU='#c8a040', IND='#2a2a32', IC='#1a1a22';
+const PCB='#1a1a22', CU='#c8a040', IND='#2a2a32';
 const pcb=box(PCB_L,PCB_W,PCB_T).color(PCB);
 const pads:Shape[]=[];
 for(const [x,y] of [[1,2],[1,12],[18,2],[18,12]] as [number,number][]){pads.push(box(3,3,0.25).color(CU).translate(x,y,PCB_T));}

--- a/scripts/parts/authored/mp1584.kcad.ts
+++ b/scripts/parts/authored/mp1584.kcad.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+// MP1584 buck 22x17
+const PCB_L=22, PCB_W=17, PCB_T=1.6;
+const PCB='#1a1a22', CU='#c8a040', IND='#2a2a32', IC='#1a1a22';
+const pcb=box(PCB_L,PCB_W,PCB_T).color(PCB);
+const pads:Shape[]=[];
+for(const [x,y] of [[1,2],[1,12],[18,2],[18,12]] as [number,number][]){pads.push(box(3,3,0.25).color(CU).translate(x,y,PCB_T));}
+const ind=cylinder(5,3.5,24).color(IND).translate(11,8.5,PCB_T);
+const pot=box(3.5,3.5,3).color('#0f172a').translate(5,6.5,PCB_T);
+const asm=assembly('mp1584');
+asm.part('pcb',pcb); pads.forEach((p,i)=>asm.part(`pad-${i}`,p));
+asm.part('inductor',ind); asm.part('trim',pot);
+return asm.model();

--- a/scripts/parts/authored/mq-2.kcad.ts
+++ b/scripts/parts/authored/mq-2.kcad.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/mq-2.kcad.ts
+//
+// Hanwei MQ-2 smoke / LPG / CO gas sensor breakout.
+// Same MQ family silhouette as MQ-6 with distinct board silk and pinout.
+
+// cylinder(height, radius)
+
+const PCB_L = 32.0;
+const PCB_W = 20.0;
+const PCB_T = 1.6;
+
+const PCB = '#1f6b3a';
+const CAN = '#b0b6c0';
+const MESH = '#5a6068';
+const CU = '#c8a040';
+const IC = '#1a1a22';
+const PASS = '#8a6a40';
+const POT = '#2a2a32';
+const HDR = '#1a1a28';
+
+const pcb = box(PCB_L, PCB_W, PCB_T).color(PCB);
+
+const n = 4;
+const pitch = 2.54;
+const hdrH = (n - 1) * pitch + 2.4;
+const hdrY = (PCB_W - hdrH) / 2;
+const headerBody = box(2.4, hdrH, 2.5).color(HDR).translate(-2.4, hdrY, PCB_T);
+const pins: Shape[] = [];
+for (let i = 0; i < n; i++) {
+  const py = hdrY + 1.2 + i * pitch;
+  pins.push(box(7.0, 0.64, 0.64).color(CU).translate(-7.0, py, PCB_T + 0.95));
+}
+
+// Heater can ∅16 × 17 tall
+const canR = 8.0;
+const canH = 17.0;
+const cx = 20.0;
+const cy = PCB_W / 2;
+const can = cylinder(canH, canR, 48).color(CAN).translate(cx, cy, PCB_T);
+const bands: Shape[] = [];
+for (let i = 0; i < 6; i++) {
+  bands.push(cylinder(0.55, canR + 0.2, 48).color(MESH).translate(cx, cy, PCB_T + 2.0 + i * 2.4));
+}
+const top = cylinder(0.9, canR - 0.5, 48).color(MESH).translate(cx, cy, PCB_T + canH);
+
+const soic = box(5.0, 4.0, 1.5).color(IC).translate(3.5, 3.0, PCB_T);
+const pot = cylinder(2.4, 2.2, 24).color(POT).translate(6.0, 13.0, PCB_T);
+const potKnob = cylinder(0.5, 1.0, 16).color('#888890').translate(6.0, 13.0, PCB_T + 2.4);
+
+const caps: Shape[] = [
+  box(2.0, 1.2, 0.6).color(PASS).translate(9.5, 3.5, PCB_T),
+  box(2.0, 1.2, 0.6).color(PASS).translate(9.5, 6.5, PCB_T),
+  box(1.6, 0.8, 0.5).color(PASS).translate(12.5, 3.5, PCB_T),
+];
+
+// Silk label bar (distinguish MQ-2)
+const silk = box(8.0, 1.2, 0.08).color('#e8f5e9').translate(3.0, 17.5, PCB_T);
+
+const asm = assembly('mq-2');
+asm.part('pcb', pcb);
+asm.part('header-body', headerBody);
+pins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('heater-can', can);
+bands.forEach((b, i) => asm.part(`mesh-${i}`, b));
+asm.part('can-top', top);
+asm.part('soic', soic);
+asm.part('trim-pot', pot);
+asm.part('trim-knob', potKnob);
+caps.forEach((c, i) => asm.part(`passive-${i}`, c));
+asm.part('silk-label', silk);
+return asm.model();

--- a/scripts/parts/authored/mq-6.kcad.ts
+++ b/scripts/parts/authored/mq-6.kcad.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/mq-6.kcad.ts
+//
+// Hanwei MQ-6 LPG / propane gas sensor breakout module.
+// Overall footprint: 32 x 22 x 20 mm (heater can dominates Z).
+// Layout: green FR4 slab; 4-pin 2.54mm header on the long edge; large
+// metal mesh heater can (the iconic MQ family silhouette) centered;
+// small dual-op-amp SOIC and trim pot on the free half of the board.
+
+const PCB_L = 32.0; // X
+const PCB_W = 22.0; // Y
+const PCB_T = 1.6;
+
+const PCB_GREEN = '#1f6b3a';
+const CAN_METAL = '#a8aeb8';
+const CAN_MESH  = '#6a7078';
+const GOLD      = '#c8a040';
+const IC_DARK   = '#222228';
+const PASSIVE   = '#7a6040';
+const POT_BODY  = '#2a2a32';
+
+// PCB slab
+const pcb = box(PCB_L, PCB_W, PCB_T).color(PCB_GREEN);
+
+// 4-pin header (VCC GND AOUT DOUT) on the -X short edge
+const pinCount = 4;
+const pinPitch = 2.54;
+const headerH = (pinCount - 1) * pinPitch + 2.5;
+const headerY = (PCB_W - headerH) / 2;
+const headerBody = box(2.5, headerH, 2.5).color('#1a1a28').translate(-2.5, headerY, PCB_T);
+const headerPins: Shape[] = [];
+for (let i = 0; i < pinCount; i++) {
+  const py = headerY + 1.25 + i * pinPitch;
+  headerPins.push(
+    box(6.0, 0.6, 0.6).color(GOLD).translate(-6.0, py, PCB_T + 0.9),
+  );
+}
+
+// Heater can — the MQ family's signature look (approx ∅16 × 16 mm tall)
+const canR = 8.0;
+const canH = 16.0;
+const canX = 20.0;
+const canY = PCB_W / 2;
+const can = cylinder(canR, canH, 48)
+  .color(CAN_METAL)
+  .translate(canX, canY, PCB_T);
+// Mesh bands around the can (stacked rings as thin discs on the side look)
+const meshBands: Shape[] = [];
+for (let i = 0; i < 5; i++) {
+  const z = PCB_T + 2.0 + i * 2.6;
+  meshBands.push(
+    cylinder(canR + 0.15, 0.6, 48).color(CAN_MESH).translate(canX, canY, z),
+  );
+}
+// Can top cap
+const canTop = cylinder(canR - 0.4, 0.8, 48)
+  .color(CAN_MESH)
+  .translate(canX, canY, PCB_T + canH);
+
+// Dual op-amp SOIC-8 near the header side
+const soic = box(5.0, 4.0, 1.5).color(IC_DARK).translate(4.0, 3.0, PCB_T);
+// Pin-1 mark
+const pin1 = cylinder(0.3, 0.2, 16).color('#e0e0e8').translate(4.6, 3.6, PCB_T + 1.5);
+
+// Trim pot for DOUT threshold
+const pot = cylinder(2.2, 2.5, 24).color(POT_BODY).translate(6.0, 14.0, PCB_T);
+const potKnob = cylinder(1.0, 0.6, 16).color('#888890').translate(6.0, 14.0, PCB_T + 2.5);
+
+// A few 0805 passives
+const caps: Shape[] = [];
+for (const [cx, cy] of [[10.0, 4.0], [10.0, 6.5], [12.5, 4.0]] as [number, number][]) {
+  caps.push(box(2.0, 1.2, 0.6).color(PASSIVE).translate(cx, cy, PCB_T));
+}
+
+const asm = assembly('mq-6');
+asm.part('pcb', pcb);
+asm.part('header-body', headerBody);
+headerPins.forEach((p, i) => asm.part(`header-pin-${i}`, p));
+asm.part('heater-can', can);
+meshBands.forEach((b, i) => asm.part(`mesh-band-${i}`, b));
+asm.part('can-top', canTop);
+asm.part('soic', soic);
+asm.part('pin1', pin1);
+asm.part('trim-pot', pot);
+asm.part('trim-knob', potKnob);
+caps.forEach((c, i) => asm.part(`cap-${i}`, c));
+
+return asm.model();

--- a/scripts/parts/authored/mq-6.kcad.ts
+++ b/scripts/parts/authored/mq-6.kcad.ts
@@ -42,7 +42,7 @@ const canR = 8.0;
 const canH = 16.0;
 const canX = 20.0;
 const canY = PCB_W / 2;
-const can = cylinder(canR, canH, 48)
+const can = cylinder(canH, canR, 48)
   .color(CAN_METAL)
   .translate(canX, canY, PCB_T);
 // Mesh bands around the can (stacked rings as thin discs on the side look)
@@ -50,22 +50,22 @@ const meshBands: Shape[] = [];
 for (let i = 0; i < 5; i++) {
   const z = PCB_T + 2.0 + i * 2.6;
   meshBands.push(
-    cylinder(canR + 0.15, 0.6, 48).color(CAN_MESH).translate(canX, canY, z),
+    cylinder(0.6, canR + 0.15, 48).color(CAN_MESH).translate(canX, canY, z),
   );
 }
 // Can top cap
-const canTop = cylinder(canR - 0.4, 0.8, 48)
+const canTop = cylinder(0.8, canR - 0.4, 48)
   .color(CAN_MESH)
   .translate(canX, canY, PCB_T + canH);
 
 // Dual op-amp SOIC-8 near the header side
 const soic = box(5.0, 4.0, 1.5).color(IC_DARK).translate(4.0, 3.0, PCB_T);
 // Pin-1 mark
-const pin1 = cylinder(0.3, 0.2, 16).color('#e0e0e8').translate(4.6, 3.6, PCB_T + 1.5);
+const pin1 = cylinder(0.2, 0.3, 16).color('#e0e0e8').translate(4.6, 3.6, PCB_T + 1.5);
 
 // Trim pot for DOUT threshold
-const pot = cylinder(2.2, 2.5, 24).color(POT_BODY).translate(6.0, 14.0, PCB_T);
-const potKnob = cylinder(1.0, 0.6, 16).color('#888890').translate(6.0, 14.0, PCB_T + 2.5);
+const pot = cylinder(2.5, 2.2, 24).color(POT_BODY).translate(6.0, 14.0, PCB_T);
+const potKnob = cylinder(0.6, 1.0, 16).color('#888890').translate(6.0, 14.0, PCB_T + 2.5);
 
 // A few 0805 passives
 const caps: Shape[] = [];

--- a/scripts/parts/authored/mt3608.kcad.ts
+++ b/scripts/parts/authored/mt3608.kcad.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // MT3608 boost converter module 36×17 mm.
 const PCB_L=36.0, PCB_W=17.0, PCB_T=1.6;
-const PCB='#1a1a22', IC='#1a1a22', CU='#c8a040', IND='#2a2a32', CAP='#1e293b';
+const PCB='#1a1a22', IC='#1a1a22', CU='#c8a040', IND='#2a2a32';
 const pcb=box(PCB_L,PCB_W,PCB_T).color(PCB);
 const pads:Shape[]=[];
 for (const [x,y] of [[1.5,2],[1.5,12],[31.5,2],[31.5,12]] as [number,number][]) {

--- a/scripts/parts/authored/mt3608.kcad.ts
+++ b/scripts/parts/authored/mt3608.kcad.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+// MT3608 boost converter module 36×17 mm.
+const PCB_L=36.0, PCB_W=17.0, PCB_T=1.6;
+const PCB='#1a1a22', IC='#1a1a22', CU='#c8a040', IND='#2a2a32', CAP='#1e293b';
+const pcb=box(PCB_L,PCB_W,PCB_T).color(PCB);
+const pads:Shape[]=[];
+for (const [x,y] of [[1.5,2],[1.5,12],[31.5,2],[31.5,12]] as [number,number][]) {
+  pads.push(box(3,3,0.25).color(CU).translate(x,y,PCB_T));
+}
+const ind=cylinder(6,4,28).color(IND).translate(18,8.5,PCB_T);
+const pot=box(4,4,3.5).color('#0f172a').translate(10,6.5,PCB_T);
+const ic=box(3,3,1.2).color(IC).translate(24,7,PCB_T);
+const asm=assembly('mt3608');
+asm.part('pcb',pcb); pads.forEach((p,i)=>asm.part(`pad-${i}`,p));
+asm.part('inductor',ind); asm.part('trim-pot',pot); asm.part('mt3608-ic',ic);
+return asm.model();

--- a/scripts/parts/authored/nrf24l01.kcad.ts
+++ b/scripts/parts/authored/nrf24l01.kcad.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/nrf24l01.kcad.ts
+//
+// nRF24L01+ 2.4 GHz transceiver breakout (8-pin SPI, PCB antenna).
+// 15 × 29 mm black/green module with crystal + meander antenna.
+
+const PCB_L = 15.0;
+const PCB_W = 29.0;
+const PCB_T = 1.0;
+
+const PCB = '#0f172a';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const HDR = '#1a1a28';
+const PASS = '#8a6a40';
+const ANT = '#94a3b8';
+
+const pcb = box(PCB_L, PCB_W, PCB_T).color(PCB);
+
+// 8-pin 2×4 header footprint on -Y (single row of 8 common clone)
+const n = 8;
+const pitch = 2.54;
+const hdrW = (n - 1) * pitch + 2.4;
+const hdrX = (PCB_L - hdrW) / 2;
+const headerBody = box(hdrW, 2.4, 2.5).color(HDR).translate(hdrX, -2.4, PCB_T);
+const pins: Shape[] = [];
+for (let i = 0; i < n; i++) {
+  const px = hdrX + 1.2 + i * pitch;
+  pins.push(box(0.64, 7.0, 0.64).color(CU).translate(px, -7.0, PCB_T + 0.95));
+}
+
+// nRF24L01 QFN package
+const qfn = box(4.0, 4.0, 0.9).color(IC).translate(5.5, 8.0, PCB_T);
+const pin1 = cylinder(0.15, 0.2, 10).color('#f0f0f8').translate(5.75, 8.25, PCB_T + 0.9);
+
+// 16 MHz crystal
+const xtal = box(3.2, 2.5, 0.8).color('#a8aab0').translate(5.9, 13.5, PCB_T);
+
+// PCB meander antenna on +Y end
+const antBase = box(PCB_L - 2, 8.0, 0.12).color(ANT).translate(1.0, 19.5, PCB_T);
+const meander: Shape[] = [];
+for (let i = 0; i < 5; i++) {
+  meander.push(box(0.35, 6.0, 0.15).color(CU).translate(2.5 + i * 2.2, 20.5, PCB_T + 0.12));
+  if (i < 4) {
+    meander.push(box(2.2, 0.35, 0.15).color(CU).translate(2.5 + i * 2.2, 20.5 + (i % 2 === 0 ? 5.65 : 0), PCB_T + 0.12));
+  }
+}
+
+const caps: Shape[] = [
+  box(1.0, 0.5, 0.4).color(PASS).translate(2.0, 6.0, PCB_T),
+  box(1.0, 0.5, 0.4).color(PASS).translate(2.0, 8.0, PCB_T),
+  box(1.6, 0.8, 0.5).color(PASS).translate(11.0, 8.0, PCB_T),
+  box(1.6, 0.8, 0.5).color(PASS).translate(11.0, 11.0, PCB_T),
+];
+
+const asm = assembly('nrf24l01');
+asm.part('pcb', pcb);
+asm.part('header-body', headerBody);
+pins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('nrf24-qfn', qfn);
+asm.part('pin1-dot', pin1);
+asm.part('crystal', xtal);
+asm.part('antenna-ground', antBase);
+meander.forEach((m, i) => asm.part(`meander-${i}`, m));
+caps.forEach((c, i) => asm.part(`passive-${i}`, c));
+return asm.model();

--- a/scripts/parts/authored/pcf8574.kcad.ts
+++ b/scripts/parts/authored/pcf8574.kcad.ts
@@ -12,8 +12,6 @@ const PCB = '#2a1a3a';
 const IC = '#1a1a22';
 const CU = '#c8a040';
 const HDR = '#1a1a28';
-const PASS = '#8a6a40';
-
 const holes = [
   [2.0, 2.0], [PCB_L - 2.0, 2.0], [2.0, PCB_W - 2.0], [PCB_L - 2.0, PCB_W - 2.0],
 ].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 20).translate(x, y, -1));

--- a/scripts/parts/authored/pcf8574.kcad.ts
+++ b/scripts/parts/authored/pcf8574.kcad.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/pcf8574.kcad.ts
+//
+// PCF8574 I2C I/O expander (21×16 mm).
+
+const PCB_L = 21;
+const PCB_W = 16;
+const PCB_T = 1.6;
+const HOLE_R = 1.0;
+const PCB = '#2a1a3a';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const HDR = '#1a1a28';
+const PASS = '#8a6a40';
+
+const holes = [
+  [2.0, 2.0], [PCB_L - 2.0, 2.0], [2.0, PCB_W - 2.0], [PCB_L - 2.0, PCB_W - 2.0],
+].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 20).translate(x, y, -1));
+const pcb = box(PCB_L, PCB_W, PCB_T).subtract(...holes).color(PCB);
+
+const n = 4;
+const pitch = 2.54;
+const hdrH = (n - 1) * pitch + 2.4;
+const hdrY = (PCB_W - hdrH) / 2;
+const headerBody = box(2.4, hdrH, 2.5).color(HDR).translate(-2.4, hdrY, PCB_T);
+const headerPins: Shape[] = [];
+for (let i = 0; i < n; i++) {
+  const py = hdrY + 1.2 + i * pitch;
+  headerPins.push(box(7.0, 0.64, 0.64).color(CU).translate(-7.0, py, PCB_T + 0.95));
+}
+
+const ic = box(10.0, 6.0, 1.6).color(IC).translate(5.5, 5.0, PCB_T);
+const pin1 = cylinder(0.2, 0.28, 12).color('#f0f0f8').translate(6.0, 5.5, PCB_T+1.6);
+
+const asm = assembly('pcf8574');
+asm.part('pcb', pcb);
+asm.part('header-body', headerBody);
+headerPins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('pcf8574-soic', ic);
+asm.part('pin1', pin1);
+return asm.model();

--- a/scripts/parts/authored/pn532.kcad.ts
+++ b/scripts/parts/authored/pn532.kcad.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+// PN532 NFC module ~43x40 mm with antenna area
+const PCB_L=43, PCB_W=40, PCB_T=1.6;
+const PCB='#1a2a4a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28';
+const pcb=box(PCB_L,PCB_W,PCB_T).color(PCB);
+const n=6, pitch=2.54, hdrW=(n-1)*pitch+2.4, hdrX=(PCB_L-hdrW)/2;
+const headerBody=box(hdrW,2.4,2.5).color(HDR).translate(hdrX,-2.4,PCB_T);
+const pins:Shape[]=[];
+for(let i=0;i<n;i++){const px=hdrX+1.2+i*pitch; pins.push(box(0.64,7,0.64).color(CU).translate(px,-7,PCB_T+0.95));}
+const ic=box(6,6,1.2).color(IC).translate(18.5,6,PCB_T);
+const coils:Shape[]=[];
+for(let i=0;i<3;i++){const m=4+i*3; coils.push(box(PCB_L-2*m,0.5,0.15).color(CU).translate(m,14+m,PCB_T)); coils.push(box(PCB_L-2*m,0.5,0.15).color(CU).translate(m,PCB_W-m-0.5,PCB_T));}
+const asm=assembly('pn532');
+asm.part('pcb',pcb); asm.part('header',headerBody); pins.forEach((p,i)=>asm.part(`p-${i}`,p));
+asm.part('pn532-ic',ic); coils.forEach((c,i)=>asm.part(`coil-${i}`,c));
+return asm.model();

--- a/scripts/parts/authored/rain-sensor.kcad.ts
+++ b/scripts/parts/authored/rain-sensor.kcad.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+// Rain drop sensor board + comparator module.
+const PCB_L=40.0, PCB_W=28.0, PCB_T=1.2;
+const PCB='#1a1a22', CU='#c8a040', HDR='#1a1a28', TRACE='#6a90b0';
+const board=box(PCB_L,PCB_W,PCB_T).color(PCB);
+const traces:Shape[]=[];
+for(let i=0;i<12;i++){traces.push(box(PCB_L-4,0.8,0.12).color(TRACE).translate(2,3+i*2.0,PCB_T));}
+const mod=box(22,16,1.6).color('#1a6b3a').translate(9,PCB_W+2,0);
+const n=4, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=2;
+const headerBody=box(2.4,hdrH,2.5).color(HDR).translate(PCB_L+2,hdrY+PCB_W,PCB_T);
+const pins:Shape[]=[];
+for(let i=0;i<n;i++){const py=hdrY+1.2+i*pitch+PCB_W; pins.push(box(7,0.64,0.64).color(CU).translate(PCB_L+2.5,py,PCB_T+0.95));}
+const asm=assembly('rain-sensor');
+asm.part('sense-board',board); traces.forEach((t,i)=>asm.part(`t-${i}`,t));
+asm.part('comparator',mod); asm.part('header',headerBody); pins.forEach((p,i)=>asm.part(`p-${i}`,p));
+return asm.model();

--- a/scripts/parts/authored/rc522.kcad.ts
+++ b/scripts/parts/authored/rc522.kcad.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+// RC522 RFID reader 40×60 mm with coil outline.
+const PCB_L=40.0, PCB_W=60.0, PCB_T=1.6;
+const PCB='#1a1a22', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28', COIL='#c8a040';
+const pcb=box(PCB_L,PCB_W,PCB_T).color(PCB);
+const n=8, pitch=2.54, hdrW=(n-1)*pitch+2.4, hdrX=(PCB_L-hdrW)/2;
+const headerBody=box(hdrW,2.4,2.5).color(HDR).translate(hdrX,-2.4,PCB_T);
+const pins:Shape[]=[];
+for(let i=0;i<n;i++){const px=hdrX+1.2+i*pitch; pins.push(box(0.64,7,0.64).color(CU).translate(px,-7,PCB_T+0.95));}
+const ic=box(5,5,1.0).color(IC).translate(17.5,8,PCB_T);
+// Antenna coil as concentric frames (visual)
+const coils:Shape[]=[];
+for(let i=0;i<4;i++){
+  const m=4+i*3;
+  coils.push(box(PCB_L-2*m,0.6,0.2).color(COIL).translate(m,12+m,PCB_T));
+  coils.push(box(PCB_L-2*m,0.6,0.2).color(COIL).translate(m,PCB_W-m-0.6,PCB_T));
+  coils.push(box(0.6,PCB_W-12-2*m,0.2).color(COIL).translate(m,12+m,PCB_T));
+  coils.push(box(0.6,PCB_W-12-2*m,0.2).color(COIL).translate(PCB_L-m-0.6,12+m,PCB_T));
+}
+const asm=assembly('rc522');
+asm.part('pcb',pcb); asm.part('header',headerBody); pins.forEach((p,i)=>asm.part(`p-${i}`,p));
+asm.part('mfrc522',ic); coils.forEach((c,i)=>asm.part(`coil-${i}`,c));
+return asm.model();

--- a/scripts/parts/authored/relay-4ch.kcad.ts
+++ b/scripts/parts/authored/relay-4ch.kcad.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/relay-4ch.kcad.ts
+//
+// 4-channel 5V relay module with optoisolation (blue Songle-class relays).
+// 75 × 55 mm; IN1–4 header; VCC/GND/JD-VCC; 3-pos screw terminals per channel.
+
+const PCB_L = 75.0;
+const PCB_W = 55.0;
+const PCB_T = 1.6;
+const HOLE_R = 1.5;
+
+const PCB = '#1a1a22';
+const RELAY_BLUE = '#1d4ed8';
+const RELAY_TOP = '#2563eb';
+const CU = '#c8a040';
+const HDR = '#1a1a28';
+const TERM = '#2a2a32';
+const OPTO = '#1a1a22';
+const LED = '#ef4444';
+
+const holes = [
+  [3.5, 3.5],
+  [PCB_L - 3.5, 3.5],
+  [3.5, PCB_W - 3.5],
+  [PCB_L - 3.5, PCB_W - 3.5],
+].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 24).translate(x, y, -1));
+const pcb = box(PCB_L, PCB_W, PCB_T).subtract(...holes).color(PCB);
+
+// Control header IN1-4 + GND/VCC (6-pin)
+const n = 6;
+const pitch = 2.54;
+const hdrW = (n - 1) * pitch + 2.4;
+const hdrX = 4.0;
+const headerBody = box(hdrW, 2.4, 2.5).color(HDR).translate(hdrX, -2.4, PCB_T);
+const pins: Shape[] = [];
+for (let i = 0; i < n; i++) {
+  const px = hdrX + 1.2 + i * pitch;
+  pins.push(box(0.64, 7.0, 0.64).color(CU).translate(px, -7.0, PCB_T + 0.95));
+}
+
+// JD-VCC jumper block
+const jd = box(5.0, 2.5, 2.0).color('#1e3a5f').translate(25.0, 2.0, PCB_T);
+
+const relays: Shape[] = [];
+const tops: Shape[] = [];
+const terms: Shape[] = [];
+const optos: Shape[] = [];
+const leds: Shape[] = [];
+for (let ch = 0; ch < 4; ch++) {
+  const x = 4.0 + ch * 18.0;
+  // Songle SRD-class envelope ~19×15×15
+  relays.push(box(15.5, 19.0, 15.0).color(RELAY_BLUE).translate(x, 18.0, PCB_T));
+  tops.push(box(14.5, 18.0, 0.8).color(RELAY_TOP).translate(x + 0.5, 18.5, PCB_T + 15.0));
+  // 3-pos screw terminal (NO COM NC)
+  terms.push(box(15.0, 10.0, 10.0).color(TERM).translate(x, 40.0, PCB_T));
+  // Optocoupler SOIC-ish
+  optos.push(box(5.0, 4.0, 1.5).color(OPTO).translate(x + 5.0, 8.0, PCB_T));
+  leds.push(box(1.6, 0.8, 0.5).color(LED).translate(x + 2.0, 13.0, PCB_T));
+}
+
+const asm = assembly('relay-4ch');
+asm.part('pcb', pcb);
+asm.part('header-body', headerBody);
+pins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('jd-vcc-jumper', jd);
+relays.forEach((r, i) => asm.part(`relay-${i}`, r));
+tops.forEach((t, i) => asm.part(`relay-top-${i}`, t));
+terms.forEach((t, i) => asm.part(`terminal-${i}`, t));
+optos.forEach((o, i) => asm.part(`opto-${i}`, o));
+leds.forEach((l, i) => asm.part(`ch-led-${i}`, l));
+return asm.model();

--- a/scripts/parts/authored/sht30.kcad.ts
+++ b/scripts/parts/authored/sht30.kcad.ts
@@ -3,7 +3,7 @@
 // scripts/parts/authored/sht30.kcad.ts
 // SHT30 temp/humidity
 const PCB_L=16, PCB_W=16, PCB_T=1.6, HOLE_R=1.0;
-const PCB='#1a3a2a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28', PASS='#8a6a40';
+const PCB='#1a3a2a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28';
 const holes=[[2,2],[PCB_L-2,2],[2,PCB_W-2],[PCB_L-2,PCB_W-2]].map(([x,y])=>cylinder(PCB_T+2,HOLE_R,20).translate(x,y,-1));
 const pcb=box(PCB_L,PCB_W,PCB_T).subtract(...holes).color(PCB);
 const n=4, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;

--- a/scripts/parts/authored/sht30.kcad.ts
+++ b/scripts/parts/authored/sht30.kcad.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/sht30.kcad.ts
+// SHT30 temp/humidity
+const PCB_L=16, PCB_W=16, PCB_T=1.6, HOLE_R=1.0;
+const PCB='#1a3a2a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28', PASS='#8a6a40';
+const holes=[[2,2],[PCB_L-2,2],[2,PCB_W-2],[PCB_L-2,PCB_W-2]].map(([x,y])=>cylinder(PCB_T+2,HOLE_R,20).translate(x,y,-1));
+const pcb=box(PCB_L,PCB_W,PCB_T).subtract(...holes).color(PCB);
+const n=4, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;
+const headerBody=box(2.4,hdrH,2.5).color(HDR).translate(-2.4,hdrY,PCB_T);
+const headerPins:Shape[]=[];
+for(let i=0;i<n;i++){const py=hdrY+1.2+i*pitch; headerPins.push(box(7,0.64,0.64).color(CU).translate(-7,py,PCB_T+0.95));}
+const ic=box(2.5,2.5,0.9).color(IC).translate(6.5,6.5,PCB_T);
+const asm=assembly('sht30');
+asm.part('pcb',pcb); asm.part('header',headerBody); headerPins.forEach((p,i)=>asm.part(`pin-${i}`,p));
+asm.part('sht30-ic',ic);
+return asm.model();

--- a/scripts/parts/authored/sim800l.kcad.ts
+++ b/scripts/parts/authored/sim800l.kcad.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+// SIM800L GSM mini board 25x23 mm
+const PCB_L=25, PCB_W=23, PCB_T=1.0;
+const PCB='#1a1a22', MOD='#0f172a', CU='#c8a040', HDR='#1a1a28';
+const pcb=box(PCB_L,PCB_W,PCB_T).color(PCB);
+const n=6, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;
+const headerBody=box(2.4,hdrH,2.5).color(HDR).translate(-2.4,hdrY,PCB_T);
+const pins:Shape[]=[];
+for(let i=0;i<n;i++){const py=hdrY+1.2+i*pitch; pins.push(box(7,0.64,0.64).color(CU).translate(-7,py,PCB_T+0.95));}
+const mod=box(18,16,2.2).color(MOD).translate(4,3.5,PCB_T);
+const can=box(12,10,1.2).color('#64748b').translate(6,5,PCB_T+2.2);
+const sim=box(14,10,0.8).color('#334155').translate(5,PCB_W-11,0);
+const asm=assembly('sim800l');
+asm.part('pcb',pcb); asm.part('header',headerBody); pins.forEach((p,i)=>asm.part(`p-${i}`,p));
+asm.part('module',mod); asm.part('shield',can); asm.part('sim-slot',sim);
+return asm.model();

--- a/scripts/parts/authored/soil-moisture.kcad.ts
+++ b/scripts/parts/authored/soil-moisture.kcad.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/soil-moisture.kcad.ts
+//
+// Capacitive soil moisture probe (corrosion-resistant PCB fork style).
+// Overall footprint: 60 x 23 x 6 mm including the probe forks.
+// Layout: small green header board (23×15×1.6) with 4-pin header, SOIC
+// comparator, and trim pot; two long capacitive fork prongs extending
+// downward (the "soil" half, typically a different FR4 mask tone).
+
+const HEAD_L = 23.0; // X width of the electronics head
+const HEAD_W = 15.0; // Y depth of the head
+const PCB_T = 1.6;
+
+const FORK_L = 8.0;   // each prong width
+const FORK_W = 45.0;  // prong length (into the soil, +Y)
+const FORK_GAP = 4.0; // gap between prongs
+
+const PCB_GREEN = '#2d6a4f';
+const FORK_GREEN = '#95d5b2';
+const GOLD = '#c8a040';
+const IC_DARK = '#222228';
+const PASSIVE = '#7a6040';
+const POT_BODY = '#2a2a32';
+
+// Head PCB
+const head = box(HEAD_L, HEAD_W, PCB_T).color(PCB_GREEN);
+
+// Full-extent footprint plate (0.2mm) so catalog bbox measures the whole probe,
+// not a single fork solid. Sits under the PCB plane.
+const FOOT_L = HEAD_L;
+const FOOT_W = HEAD_W + FORK_W;
+const footprint = box(FOOT_L, FOOT_W, 0.2).color(FORK_GREEN).translate(0, 0, -0.2);
+
+// Two capacitive forks extending in +Y from the head
+const totalForkSpan = FORK_L * 2 + FORK_GAP;
+const forkStartX = (HEAD_L - totalForkSpan) / 2;
+const forkLeft = box(FORK_L, FORK_W, PCB_T)
+  .color(FORK_GREEN)
+  .translate(forkStartX, HEAD_W, 0);
+const forkRight = box(FORK_L, FORK_W, PCB_T)
+  .color(FORK_GREEN)
+  .translate(forkStartX + FORK_L + FORK_GAP, HEAD_W, 0);
+
+// Capacitive traces (gold-ish strips on each fork face)
+const traceL = box(FORK_L - 2.0, FORK_W - 4.0, 0.15)
+  .color(GOLD)
+  .translate(forkStartX + 1.0, HEAD_W + 2.0, PCB_T);
+const traceR = box(FORK_L - 2.0, FORK_W - 4.0, 0.15)
+  .color(GOLD)
+  .translate(forkStartX + FORK_L + FORK_GAP + 1.0, HEAD_W + 2.0, PCB_T);
+
+// 4-pin header on -Y edge of the head
+const pinCount = 4;
+const pinPitch = 2.54;
+const headerW = (pinCount - 1) * pinPitch + 2.5;
+const headerX = (HEAD_L - headerW) / 2;
+const headerBody = box(headerW, 2.5, 2.5).color('#1a1a28').translate(headerX, -2.5, PCB_T);
+const pins: Shape[] = [];
+for (let i = 0; i < pinCount; i++) {
+  const px = headerX + 1.25 + i * pinPitch;
+  pins.push(box(0.6, 6.0, 0.6).color(GOLD).translate(px, -6.0, PCB_T + 0.9));
+}
+
+// SOIC comparator / oscillator
+const soic = box(5.0, 4.0, 1.5).color(IC_DARK).translate(3.0, 5.0, PCB_T);
+
+// Threshold trim pot
+const pot = cylinder(2.0, 2.2, 24).color(POT_BODY).translate(16.0, 6.0, PCB_T);
+const potKnob = cylinder(0.9, 0.5, 16).color('#888890').translate(16.0, 6.0, PCB_T + 2.2);
+
+// Passives
+const caps: Shape[] = [];
+for (const [cx, cy] of [[9.0, 4.0], [9.0, 6.5], [11.5, 4.0]] as [number, number][]) {
+  caps.push(box(1.6, 0.8, 0.5).color(PASSIVE).translate(cx, cy, PCB_T));
+}
+
+const asm = assembly('soil-moisture');
+asm.part('footprint-plate', footprint);
+asm.part('head-pcb', head);
+asm.part('fork-left', forkLeft);
+asm.part('fork-right', forkRight);
+asm.part('trace-left', traceL);
+asm.part('trace-right', traceR);
+asm.part('header-body', headerBody);
+pins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('soic', soic);
+asm.part('trim-pot', pot);
+asm.part('trim-knob', potKnob);
+caps.forEach((c, i) => asm.part(`cap-${i}`, c));
+
+return asm.model();

--- a/scripts/parts/authored/sound-sensor.kcad.ts
+++ b/scripts/parts/authored/sound-sensor.kcad.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/sound-sensor.kcad.ts
+//
+// KY-037 sound sensor (32×17 mm).
+
+const PCB_L = 32;
+const PCB_W = 17;
+const PCB_T = 1.6;
+const HOLE_R = 1.0;
+const PCB = '#1a6b3a';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const HDR = '#1a1a28';
+const PASS = '#8a6a40';
+
+const holes = [
+  [2.0, 2.0], [PCB_L - 2.0, 2.0], [2.0, PCB_W - 2.0], [PCB_L - 2.0, PCB_W - 2.0],
+].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 20).translate(x, y, -1));
+const pcb = box(PCB_L, PCB_W, PCB_T).subtract(...holes).color(PCB);
+
+const n = 4;
+const pitch = 2.54;
+const hdrH = (n - 1) * pitch + 2.4;
+const hdrY = (PCB_W - hdrH) / 2;
+const headerBody = box(2.4, hdrH, 2.5).color(HDR).translate(-2.4, hdrY, PCB_T);
+const headerPins: Shape[] = [];
+for (let i = 0; i < n; i++) {
+  const py = hdrY + 1.2 + i * pitch;
+  headerPins.push(box(7.0, 0.64, 0.64).color(CU).translate(-7.0, py, PCB_T + 0.95));
+}
+
+const mic=cylinder(3.5,4.5,24).color('#2a2a32').translate(22,8.5,PCB_T);
+const mesh=cylinder(0.4,4.0,20).color('#6a6a78').translate(22,8.5,PCB_T+3.5);
+const pot=cylinder(2.0,2.0,16).color('#2a2a32').translate(10,8.5,PCB_T);
+
+const asm = assembly('sound-sensor');
+asm.part('pcb', pcb);
+asm.part('header-body', headerBody);
+headerPins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('mic',mic);
+asm.part('mesh',mesh);
+asm.part('trim',pot);
+return asm.model();

--- a/scripts/parts/authored/sound-sensor.kcad.ts
+++ b/scripts/parts/authored/sound-sensor.kcad.ts
@@ -9,10 +9,8 @@ const PCB_W = 17;
 const PCB_T = 1.6;
 const HOLE_R = 1.0;
 const PCB = '#1a6b3a';
-const IC = '#1a1a22';
 const CU = '#c8a040';
 const HDR = '#1a1a28';
-const PASS = '#8a6a40';
 
 const holes = [
   [2.0, 2.0], [PCB_L - 2.0, 2.0], [2.0, PCB_W - 2.0], [PCB_L - 2.0, PCB_W - 2.0],

--- a/scripts/parts/authored/stepper-28byj48.kcad.ts
+++ b/scripts/parts/authored/stepper-28byj48.kcad.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+// 28BYJ-48 geared stepper motor envelope
+const body=cylinder(19,14,40).color('#c8ccd0');
+const gear=cylinder(8,10,32).color('#94a3b8').translate(0,0,19);
+const shaft=cylinder(8,2.5,20).color('#64748b').translate(0,0,27);
+const flange=box(18,18,1.5).color('#a8aeb8').translate(-9,-9,0);
+const wires=box(6,2,12).color('#1a1a22').translate(-3,12,4);
+const asm=assembly('stepper-28byj48');
+asm.part('flange',flange); asm.part('body',body); asm.part('gearbox',gear);
+asm.part('shaft',shaft); asm.part('cable',wires);
+return asm.model();

--- a/scripts/parts/authored/tb6612.kcad.ts
+++ b/scripts/parts/authored/tb6612.kcad.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/tb6612.kcad.ts
+// TB6612 dual motor driver
+const PCB_L=25, PCB_W=20, PCB_T=1.6, HOLE_R=1.0;
+const PCB='#1a6b3a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28', PASS='#8a6a40';
+const holes=[[2,2],[PCB_L-2,2],[2,PCB_W-2],[PCB_L-2,PCB_W-2]].map(([x,y])=>cylinder(PCB_T+2,HOLE_R,20).translate(x,y,-1));
+const pcb=box(PCB_L,PCB_W,PCB_T).subtract(...holes).color(PCB);
+const n=8, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;
+const headerBody=box(2.4,hdrH,2.5).color(HDR).translate(-2.4,hdrY,PCB_T);
+const headerPins:Shape[]=[];
+for(let i=0;i<n;i++){const py=hdrY+1.2+i*pitch; headerPins.push(box(7,0.64,0.64).color(CU).translate(-7,py,PCB_T+0.95));}
+const ic=box(8,6,1.5).color(IC).translate(8.5,7,PCB_T); const term=box(10,6,6).color("#2a2a32").translate(13,12,PCB_T);
+const asm=assembly('tb6612');
+asm.part('pcb',pcb); asm.part('header',headerBody); headerPins.forEach((p,i)=>asm.part(`pin-${i}`,p));
+asm.part('tb6612-ic',ic);
+asm.part('motor-term',term);
+return asm.model();

--- a/scripts/parts/authored/tb6612.kcad.ts
+++ b/scripts/parts/authored/tb6612.kcad.ts
@@ -3,7 +3,7 @@
 // scripts/parts/authored/tb6612.kcad.ts
 // TB6612 dual motor driver
 const PCB_L=25, PCB_W=20, PCB_T=1.6, HOLE_R=1.0;
-const PCB='#1a6b3a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28', PASS='#8a6a40';
+const PCB='#1a6b3a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28';
 const holes=[[2,2],[PCB_L-2,2],[2,PCB_W-2],[PCB_L-2,PCB_W-2]].map(([x,y])=>cylinder(PCB_T+2,HOLE_R,20).translate(x,y,-1));
 const pcb=box(PCB_L,PCB_W,PCB_T).subtract(...holes).color(PCB);
 const n=8, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;

--- a/scripts/parts/authored/tmc2209.kcad.ts
+++ b/scripts/parts/authored/tmc2209.kcad.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// TMC2209 silent StepStick 15.2x20.3 mm
+const PCB_L=15.24, PCB_W=20.32, PCB_T=1.57;
+const PCB='#17191d', IC='#17171c', CU='#c8a040';
+const pcb=box(PCB_L,PCB_W,PCB_T).color(PCB);
+const pads:Shape[]=[];
+for(let row=0;row<8;row++){
+  pads.push(cylinder(0.08,0.85,20).color(CU).translate(1.27,1.27+row*2.54,PCB_T));
+  pads.push(cylinder(0.08,0.85,20).color(CU).translate(13.97,1.27+row*2.54,PCB_T));
+}
+const qfn=box(5,5,1.0).color(IC).translate(5.1,7.5,PCB_T);
+const pot=cylinder(1.15,1.5,20).color('#315b8a').translate(10,3,PCB_T);
+const asm=assembly('tmc2209');
+asm.part('pcb',pcb); pads.forEach((p,i)=>asm.part(`pad-${i}`,p));
+asm.part('tmc2209-qfn',qfn); asm.part('vref-pot',pot);
+return asm.model();

--- a/scripts/parts/authored/tp4056.kcad.ts
+++ b/scripts/parts/authored/tp4056.kcad.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/tp4056.kcad.ts
+//
+// TP4056 Li-ion charger module with micro-USB and DW01 protection.
+// 25 × 17 mm; micro-USB-B; B+/B− pads; charge/full LEDs.
+
+const PCB_L = 25.0;
+const PCB_W = 17.0;
+const PCB_T = 1.0;
+
+const PCB = '#1a1a22';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const USB = '#c0c4cc';
+const USB_DARK = '#334155';
+const PASS = '#8a6a40';
+const LED_R = '#ef4444';
+const LED_B = '#3b82f6';
+
+const pcb = box(PCB_L, PCB_W, PCB_T).color(PCB);
+
+// Micro-USB receptacle on -Y edge
+const usbShell = box(7.5, 5.5, 2.5).color(USB).translate((PCB_L - 7.5) / 2, -2.0, PCB_T);
+const usbCavity = box(5.8, 3.5, 1.4).color(USB_DARK).translate((PCB_L - 5.8) / 2, -1.2, PCB_T + 0.5);
+const usbTongue = box(5.0, 2.5, 0.4).color('#e2e8f0').translate((PCB_L - 5.0) / 2, -0.5, PCB_T + 0.9);
+
+// TP4056 ESOP-8 with thermal pad look
+const tp = box(5.0, 6.0, 1.5).color(IC).translate(4.0, 6.0, PCB_T);
+const pin1 = cylinder(0.15, 0.22, 12).color('#f0f0f8').translate(4.4, 6.4, PCB_T + 1.5);
+
+// DW01 + dual MOSFET package (protection)
+const dw = box(3.0, 3.0, 1.0).color(IC).translate(12.0, 7.0, PCB_T);
+const mos = box(3.0, 3.0, 1.0).color(IC).translate(16.0, 7.0, PCB_T);
+
+// Battery pads B+ B−
+const bp = box(3.5, 3.5, 0.25).color(CU).translate(19.5, 2.0, PCB_T);
+const bn = box(3.5, 3.5, 0.25).color(CU).translate(19.5, 11.5, PCB_T);
+
+// OUT pads (protected)
+const op = box(3.0, 3.0, 0.25).color(CU).translate(2.0, 2.0, PCB_T);
+const on = box(3.0, 3.0, 0.25).color(CU).translate(2.0, 11.5, PCB_T);
+
+const ledChg = box(1.6, 0.8, 0.5).color(LED_R).translate(10.0, 12.5, PCB_T);
+const ledFull = box(1.6, 0.8, 0.5).color(LED_B).translate(13.0, 12.5, PCB_T);
+
+const caps: Shape[] = [
+  box(1.6, 0.8, 0.5).color(PASS).translate(10.0, 4.0, PCB_T),
+  box(1.6, 0.8, 0.5).color(PASS).translate(13.0, 4.0, PCB_T),
+  box(2.0, 1.2, 0.6).color(PASS).translate(16.0, 12.0, PCB_T),
+];
+
+const asm = assembly('tp4056');
+asm.part('pcb', pcb);
+asm.part('usb-shell', usbShell);
+asm.part('usb-cavity', usbCavity);
+asm.part('usb-tongue', usbTongue);
+asm.part('tp4056-ic', tp);
+asm.part('pin1-dot', pin1);
+asm.part('dw01', dw);
+asm.part('fs8205-mos', mos);
+asm.part('pad-b-plus', bp);
+asm.part('pad-b-minus', bn);
+asm.part('pad-out-plus', op);
+asm.part('pad-out-minus', on);
+asm.part('led-charging', ledChg);
+asm.part('led-full', ledFull);
+caps.forEach((c, i) => asm.part(`passive-${i}`, c));
+return asm.model();

--- a/scripts/parts/authored/ttp223.kcad.ts
+++ b/scripts/parts/authored/ttp223.kcad.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/ttp223.kcad.ts
+// TTP223 capacitive touch
+const PCB_L=15, PCB_W=11, PCB_T=1.6, HOLE_R=1.0;
+const PCB='#1a6b3a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28', PASS='#8a6a40';
+const holes=[[2,2],[PCB_L-2,2],[2,PCB_W-2],[PCB_L-2,PCB_W-2]].map(([x,y])=>cylinder(PCB_T+2,HOLE_R,20).translate(x,y,-1));
+const pcb=box(PCB_L,PCB_W,PCB_T).subtract(...holes).color(PCB);
+const n=3, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;
+const headerBody=box(2.4,hdrH,2.5).color(HDR).translate(-2.4,hdrY,PCB_T);
+const headerPins:Shape[]=[];
+for(let i=0;i<n;i++){const py=hdrY+1.2+i*pitch; headerPins.push(box(7,0.64,0.64).color(CU).translate(-7,py,PCB_T+0.95));}
+const ic=box(3,3,0.9).color(IC).translate(6,4,PCB_T); const pad=box(8,6,0.2).color("#c8a040").translate(3.5,PCB_W-7,PCB_T);
+const asm=assembly('ttp223');
+asm.part('pcb',pcb); asm.part('header',headerBody); headerPins.forEach((p,i)=>asm.part(`pin-${i}`,p));
+asm.part('ttp223-ic',ic);
+asm.part('touch-pad',pad);
+return asm.model();

--- a/scripts/parts/authored/ttp223.kcad.ts
+++ b/scripts/parts/authored/ttp223.kcad.ts
@@ -3,7 +3,7 @@
 // scripts/parts/authored/ttp223.kcad.ts
 // TTP223 capacitive touch
 const PCB_L=15, PCB_W=11, PCB_T=1.6, HOLE_R=1.0;
-const PCB='#1a6b3a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28', PASS='#8a6a40';
+const PCB='#1a6b3a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28';
 const holes=[[2,2],[PCB_L-2,2],[2,PCB_W-2],[PCB_L-2,PCB_W-2]].map(([x,y])=>cylinder(PCB_T+2,HOLE_R,20).translate(x,y,-1));
 const pcb=box(PCB_L,PCB_W,PCB_T).subtract(...holes).color(PCB);
 const n=3, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;

--- a/scripts/parts/authored/uln2003.kcad.ts
+++ b/scripts/parts/authored/uln2003.kcad.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+// ULN2003 stepper driver board for 28BYJ-48 (32×22 mm).
+const PCB_L=32.0, PCB_W=22.0, PCB_T=1.6;
+const PCB='#1a6b3a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28', CONN='#2a2a32';
+const pcb=box(PCB_L,PCB_W,PCB_T).color(PCB);
+const n=4, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;
+const left=box(2.4,hdrH,2.5).color(HDR).translate(-2.4,hdrY,PCB_T);
+const pins:Shape[]=[];
+for(let i=0;i<n;i++){const py=hdrY+1.2+i*pitch; pins.push(box(7,0.64,0.64).color(CU).translate(-7,py,PCB_T+0.95));}
+const ic=box(19,7.5,3.5).color(IC).translate(6.5,7.0,PCB_T);
+const sock=box(12,6,8).color(CONN).translate(18,2,PCB_T);
+const asm=assembly('uln2003');
+asm.part('pcb',pcb); asm.part('in-header',left); pins.forEach((p,i)=>asm.part(`in-${i}`,p));
+asm.part('uln2003-dip',ic); asm.part('motor-socket',sock);
+return asm.model();

--- a/scripts/parts/authored/vibration-sensor.kcad.ts
+++ b/scripts/parts/authored/vibration-sensor.kcad.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/vibration-sensor.kcad.ts
+// SW-420 vibration
+const PCB_L=32, PCB_W=14, PCB_T=1.6, HOLE_R=1.0;
+const PCB='#1a6b3a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28', PASS='#8a6a40';
+const holes=[[2,2],[PCB_L-2,2],[2,PCB_W-2],[PCB_L-2,PCB_W-2]].map(([x,y])=>cylinder(PCB_T+2,HOLE_R,20).translate(x,y,-1));
+const pcb=box(PCB_L,PCB_W,PCB_T).subtract(...holes).color(PCB);
+const n=4, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;
+const headerBody=box(2.4,hdrH,2.5).color(HDR).translate(-2.4,hdrY,PCB_T);
+const headerPins:Shape[]=[];
+for(let i=0;i<n;i++){const py=hdrY+1.2+i*pitch; headerPins.push(box(7,0.64,0.64).color(CU).translate(-7,py,PCB_T+0.95));}
+const spring=cylinder(6,2,20).color("#9ca3af").translate(22,7,PCB_T); const pot=cylinder(2,2,16).color("#2a2a32").translate(10,7,PCB_T);
+const asm=assembly('vibration-sensor');
+asm.part('pcb',pcb); asm.part('header',headerBody); headerPins.forEach((p,i)=>asm.part(`pin-${i}`,p));
+asm.part('spring',spring);
+asm.part('trim',pot);
+return asm.model();

--- a/scripts/parts/authored/vibration-sensor.kcad.ts
+++ b/scripts/parts/authored/vibration-sensor.kcad.ts
@@ -3,7 +3,7 @@
 // scripts/parts/authored/vibration-sensor.kcad.ts
 // SW-420 vibration
 const PCB_L=32, PCB_W=14, PCB_T=1.6, HOLE_R=1.0;
-const PCB='#1a6b3a', IC='#1a1a22', CU='#c8a040', HDR='#1a1a28', PASS='#8a6a40';
+const PCB='#1a6b3a', CU='#c8a040', HDR='#1a1a28';
 const holes=[[2,2],[PCB_L-2,2],[2,PCB_W-2],[PCB_L-2,PCB_W-2]].map(([x,y])=>cylinder(PCB_T+2,HOLE_R,20).translate(x,y,-1));
 const pcb=box(PCB_L,PCB_W,PCB_T).subtract(...holes).color(PCB);
 const n=4, pitch=2.54, hdrH=(n-1)*pitch+2.4, hdrY=(PCB_W-hdrH)/2;

--- a/scripts/parts/authored/vl53l0x.kcad.ts
+++ b/scripts/parts/authored/vl53l0x.kcad.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/vl53l0x.kcad.ts
+//
+// VL53L0X Time-of-Flight laser ranging breakout.
+// 12.5 × 17.8 mm class (GY-VL53L0XV2); optical aperture; 4-pin header.
+
+const PCB_L = 12.5;
+const PCB_W = 17.8;
+const PCB_T = 1.6;
+const HOLE_R = 0.9;
+
+const PCB = '#1a3a6e';
+const IC = '#1a1a22';
+const CU = '#c8a040';
+const HDR = '#1a1a28';
+const PASS = '#8a6a40';
+const LENS = '#1e293b';
+const GLASS = '#334155';
+
+const holes = [
+  [2.0, 2.0],
+  [PCB_L - 2.0, PCB_W - 2.0],
+].map(([x, y]) => cylinder(PCB_T + 2, HOLE_R, 20).translate(x, y, -1));
+const pcb = box(PCB_L, PCB_W, PCB_T).subtract(...holes).color(PCB);
+
+const n = 4;
+const pitch = 2.54;
+const hdrW = (n - 1) * pitch + 2.4;
+const hdrX = (PCB_L - hdrW) / 2;
+const headerBody = box(hdrW, 2.4, 2.5).color(HDR).translate(hdrX, -2.4, PCB_T);
+const pins: Shape[] = [];
+for (let i = 0; i < n; i++) {
+  const px = hdrX + 1.2 + i * pitch;
+  pins.push(box(0.64, 7.0, 0.64).color(CU).translate(px, -7.0, PCB_T + 0.95));
+}
+
+// VL53 optical module body + dual apertures (emitter / receiver)
+const module = box(4.4, 2.4, 1.0).color(IC).translate(4.05, 10.5, PCB_T);
+const emit = cylinder(0.35, 0.55, 20).color(LENS).translate(5.2, 11.7, PCB_T + 1.0);
+const recv = cylinder(0.35, 0.55, 20).color(GLASS).translate(7.4, 11.7, PCB_T + 1.0);
+const hood = box(5.0, 3.0, 0.4).color('#0f172a').translate(3.75, 10.2, PCB_T + 0.95);
+
+const caps: Shape[] = [
+  box(1.0, 0.5, 0.45).color(PASS).translate(2.5, 5.0, PCB_T),
+  box(1.0, 0.5, 0.45).color(PASS).translate(4.5, 5.0, PCB_T),
+  box(1.6, 0.8, 0.5).color(PASS).translate(8.5, 5.0, PCB_T),
+];
+const led = box(1.2, 0.6, 0.4).color('#22c55e').translate(9.0, 14.5, PCB_T);
+
+const asm = assembly('vl53l0x');
+asm.part('pcb', pcb);
+asm.part('header-body', headerBody);
+pins.forEach((p, i) => asm.part(`pin-${i}`, p));
+asm.part('tof-module', module);
+asm.part('emitter', emit);
+asm.part('receiver', recv);
+asm.part('optical-hood', hood);
+caps.forEach((c, i) => asm.part(`passive-${i}`, c));
+asm.part('pwr-led', led);
+return asm.model();

--- a/scripts/parts/authored/water-level.kcad.ts
+++ b/scripts/parts/authored/water-level.kcad.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+// Water level sensor PCB probe 20×60 mm with traces.
+const PCB_L=20.0, PCB_W=60.0, PCB_T=1.2;
+const PCB='#1a1a22', CU='#c8a040', HDR='#1a1a28', TRACE='#4a90d9';
+const pcb=box(PCB_L,PCB_W,PCB_T).color(PCB);
+const n=3, pitch=2.54, hdrW=(n-1)*pitch+2.4, hdrX=(PCB_L-hdrW)/2;
+const headerBody=box(hdrW,2.4,2.5).color(HDR).translate(hdrX,-2.4,PCB_T);
+const pins:Shape[]=[];
+for(let i=0;i<n;i++){const px=hdrX+1.2+i*pitch; pins.push(box(0.64,7,0.64).color(CU).translate(px,-7,PCB_T+0.95));}
+const traces:Shape[]=[];
+for(let i=0;i<10;i++){traces.push(box(1.2,40,0.15).color(TRACE).translate(3+i*1.5,12,PCB_T));}
+const asm=assembly('water-level');
+asm.part('pcb',pcb); asm.part('header',headerBody); pins.forEach((p,i)=>asm.part(`p-${i}`,p));
+traces.forEach((t,i)=>asm.part(`trace-${i}`,t));
+return asm.model();

--- a/scripts/parts/authored/xl6009.kcad.ts
+++ b/scripts/parts/authored/xl6009.kcad.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+// XL6009 boost 43x21
+const PCB_L=43, PCB_W=21, PCB_T=1.6;
+const PCB='#1e3a8a', CU='#c8a040', IND='#1a1a22', CAP='#1e293b';
+const pcb=box(PCB_L,PCB_W,PCB_T).color(PCB);
+const pads:Shape[]=[];
+for(const [x,y] of [[1.5,2],[1.5,15],[38.5,2],[38.5,15]] as [number,number][]){pads.push(box(3,3,0.25).color(CU).translate(x,y,PCB_T));}
+const ind=cylinder(8,6,28).color(IND).translate(22,10.5,PCB_T);
+const cin=cylinder(10,4,24).color(CAP).translate(8,10.5,PCB_T);
+const cout=cylinder(10,4,24).color(CAP).translate(34,10.5,PCB_T);
+const pot=box(5,5,4).color('#0f172a').translate(14,3,PCB_T);
+const asm=assembly('xl6009');
+asm.part('pcb',pcb); pads.forEach((p,i)=>asm.part(`pad-${i}`,p));
+asm.part('inductor',ind); asm.part('cin',cin); asm.part('cout',cout); asm.part('trim',pot);
+return asm.model();


### PR DESCRIPTION
## Summary
Authored parametric 3D models for LabWired / marketplace analog modules and registered them for catalog ingest.

### Flagship (LabWired analog)
- **mq-6** — FR4 breakout, metal MQ heater can, 4-pin header, SOIC + trim pot
- **soil-moisture** — head PCB + dual capacitive forks (full-extent footprint plate for honest bbox)

### Marketplace waves 1–3
INA219, ADS1115, DS3231, HX711, AS5600, BNO055, VL53L0X, HC-05, nRF24L01, MCP2515, L298N, 4ch relay, IRF520, ACS712, TP4056, MAX485, MQ-2, LM2596, AHT20, BH1750, PCF8574, DS18B20, joystick, ULN2003, MT3608, AMS1117, flame/sound/water/rain, RC522, LoRa SX1278, SIM800L, TMC2209, SHT30, PN532, I2S audio, power modules, touch/IR/hall/vibration, 28BYJ-48, and more.

Sources: `scripts/parts/authored/*.kcad.ts`  
Manifest: `scripts/electronics-parts.json` → catalog ingest → `kernelcad-parts.pages.dev`

## Local validation
```bash
npm run build:cli
node dist/cli/index.js export step scripts/parts/authored/mq-6.kcad.ts -o /tmp/mq-6.step
node dist/cli/index.js export step scripts/parts/authored/soil-moisture.kcad.ts -o /tmp/soil.step
```

## Deploy note
After merge, re-run the electronics parts ingest/deploy so STEP files land on the CDN:
`https://kernelcad-parts.pages.dev/step/<id>.step`.

## Fixups
- Drop unused color constants in wave stubs so `eslint` is green.
- Rebased onto latest `develop`.