### PR TITLE
Color-preserving STEP→GLB so the web 3D viewer can drop OCCT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
         "globals": "^16.5.0",
         "happy-dom": "^20.4.0",
         "jsdom": "^27.4.0",
+        "occt-import-js": "^0.0.23",
         "playwright": "^1.58.0",
         "tailwindcss": "^4.1.18",
         "three-stdlib": "^2.36.1",
@@ -8415,6 +8416,13 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/occt-import-js": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/occt-import-js/-/occt-import-js-0.0.23.tgz",
+      "integrity": "sha512-RFfYQXYFX5C1mB1Aywm0ShcUKzXOr/VzTnlzhBSDJOR6YCAPt1HYCzeXWg1vwwjn/cUxwqRNhhtf1dlewoZYCQ==",
+      "dev": true,
+      "license": "LGPL-2.1"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "globals": "^16.5.0",
     "happy-dom": "^20.4.0",
     "jsdom": "^27.4.0",
+    "occt-import-js": "^0.0.23",
     "playwright": "^1.58.0",
     "tailwindcss": "^4.1.18",
     "three-stdlib": "^2.36.1",

--- a/scripts/buildBoardGlbs.ts
+++ b/scripts/buildBoardGlbs.ts
@@ -58,7 +58,6 @@ import { join, resolve, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { optimizeGlb, gltfTransformBin } from './lib/optimizeGlb';
-import { stepToColoredGlb } from './stepToColoredGlb';
 
 /** Upper bound for a web-served board GLB. The decimation lands each board in
  *  the hundreds of KB; 1 MB is a generous ceiling that still stays far under
@@ -176,6 +175,9 @@ export async function buildBoardGlbs(
   if (!existsSync(cliPath)) {
     throw new Error(`kernelCAD CLI not built at ${cliPath}. Run: npm run build:cli`);
   }
+  // The color-preserving STEP→GLB converter, run per-part in a fresh subprocess
+  // (see the loop) so occt-import-js's wasm heap can't accumulate across parts.
+  const converterScript = resolve(repoRoot, 'scripts', 'stepToColoredGlb.ts');
   gltfTransformBin(repoRoot); // fail fast before compiling any board
 
   const glbDir = join(outDir, 'glb');
@@ -214,7 +216,7 @@ export async function buildBoardGlbs(
         }
         execFileSync(process.execPath, [cliPath, 'export', 'glb', scriptPath, '-o', rawGlb], {
           stdio: ['ignore', 'pipe', 'pipe'],
-          timeout: 300_000,
+          timeout: 600_000,
         });
       } else {
         const stepPath = join(outDir, 'step', `${part.id}.step`);
@@ -222,7 +224,16 @@ export async function buildBoardGlbs(
           skipped.push({ id: part.id, reason: 'no ingested STEP to convert' });
           continue;
         }
-        await stepToColoredGlb(stepPath, rawGlb);
+        // Run the OCCT color converter in a FRESH subprocess per part. In-process,
+        // occt-import-js's wasm heap accumulates across every conversion and never
+        // frees — after a dozen parts the process is memory-starved and the heavy
+        // board CLI exports that follow time out. A subprocess releases the heap on
+        // exit, keeping each conversion independent.
+        execFileSync(process.execPath, ['--import', 'tsx', converterScript, stepPath, rawGlb], {
+          stdio: ['ignore', 'pipe', 'pipe'],
+          timeout: 600_000,
+          cwd: repoRoot,
+        });
       }
 
       // 2-3. Optimize (uncompressed, per-component materials preserved), then

--- a/scripts/buildBoardGlbs.ts
+++ b/scripts/buildBoardGlbs.ts
@@ -58,6 +58,7 @@ import { join, resolve, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { optimizeGlb, gltfTransformBin } from './lib/optimizeGlb';
+import { stepToColoredGlb } from './stepToColoredGlb';
 
 /** Upper bound for a web-served board GLB. The decimation lands each board in
  *  the hundreds of KB; 1 MB is a generous ceiling that still stays far under
@@ -112,6 +113,24 @@ function isAuthoredBoard(p: ManifestPart): boolean {
   return typeof p.kcad_source === 'string' && p.id.endsWith('-board');
 }
 
+/** Any part with a `.kcad.ts` source, board or not. */
+function isAuthored(p: ManifestPart): boolean {
+  return typeof p.kcad_source === 'string';
+}
+
+/**
+ * Every part that carries geometry gets a web-loadable GLB — not just boards.
+ *
+ * The web 3D viewer (labwired's scene3d, kernelCAD/proto.cat 3D tabs) prefers
+ * `glbUrl` and only falls back to parsing raw STEP in-browser via a 7.6 MB OCCT
+ * wasm. Baking a GLB for EVERY geometry part means the browser never needs OCCT:
+ * it loads a small pre-tessellated mesh through three.js. So the target is any
+ * part that is authored (`kcad_source`) or has an ingested STEP on disk.
+ */
+function hasGeometry(p: ManifestPart, outDir: string): boolean {
+  return isAuthored(p) || existsSync(join(outDir, 'step', `${p.id}.step`));
+}
+
 export interface BoardGlbResult {
   id: string;
   glbBytes: number;
@@ -163,52 +182,84 @@ export async function buildBoardGlbs(
   mkdirSync(glbDir, { recursive: true });
   const tmp = mkdtempSync(join(tmpdir(), 'kc-board-glb-'));
 
-  const boards = manifest.parts.filter(isBoard);
+  const targets = manifest.parts.filter((p) => hasGeometry(p, outDir));
   const results: BoardGlbResult[] = [];
+  const skipped: { id: string; reason: string }[] = [];
 
-  for (const board of boards) {
-    const authored = isAuthoredBoard(board);
-    const rawGlb = join(tmp, `${board.id}.raw.glb`);
-    const finalGlb = join(glbDir, `${board.id}.glb`);
+  for (const part of targets) {
+    const authored = isAuthored(part);
+    const board = isBoard(part);
+    const rawGlb = join(tmp, `${part.id}.raw.glb`);
+    const finalGlb = join(glbDir, `${part.id}.glb`);
 
-    // 1. Produce a full-resolution GLB. Authored boards compile from their
-    // `.kcad.ts`; url-sourced boards are wrapped from the STEP the ingest already
-    // downloaded, so they reach the web viewer on the same terms.
-    const scriptPath = authored
-      ? resolve(repoRoot, board.kcad_source!)
-      : wrapStepAsScript(outDir, tmp, board.id);
-    if (!scriptPath) {
-      console.warn(`SKIP ${board.id}: no kcad_source and no ingested STEP to wrap.`);
-      continue;
+    // A single part failing to tessellate or exceeding the web size ceiling must
+    // NOT abort the whole catalog build — it just keeps its STEP and (for the web
+    // viewer) falls back to the procedural stand-in. Boards are the exception:
+    // they are guaranteed below, so a board failure is still fatal.
+    try {
+      // 1. Produce a full-resolution GLB.
+      // - Authored parts compile their `.kcad.ts` (colors come from `.color()`).
+      // - url-sourced BOARDS keep the proven wrap-STEP + kernel export path
+      //   (labwired recolors board solids by shape).
+      // - url-sourced NON-BOARD parts (sensors/displays) go through the
+      //   color-preserving OCCT converter, because the kernel's `fromSTEP` drops
+      //   AP214 face colors — a sensor must keep its real colors, not go grey.
+      if (authored || board) {
+        const scriptPath = authored
+          ? resolve(repoRoot, part.kcad_source!)
+          : wrapStepAsScript(outDir, tmp, part.id);
+        if (!scriptPath) {
+          skipped.push({ id: part.id, reason: 'no kcad_source and no ingested STEP to wrap' });
+          continue;
+        }
+        execFileSync(process.execPath, [cliPath, 'export', 'glb', scriptPath, '-o', rawGlb], {
+          stdio: ['ignore', 'pipe', 'pipe'],
+          timeout: 300_000,
+        });
+      } else {
+        const stepPath = join(outDir, 'step', `${part.id}.step`);
+        if (!existsSync(stepPath)) {
+          skipped.push({ id: part.id, reason: 'no ingested STEP to convert' });
+          continue;
+        }
+        await stepToColoredGlb(stepPath, rawGlb);
+      }
+
+      // 2-3. Optimize (uncompressed, per-component materials preserved), then
+      // verify size + materials. Authored boards are known multi-component, so a
+      // fixed floor of 2 is a real signal. Imported STEP / non-board parts may
+      // legitimately carry one material, so there we assert only that
+      // optimization did not FLATTEN what was there.
+      const { bytes: glbBytes, materials } = await optimizeGlb(rawGlb, finalGlb, {
+        repoRoot,
+        label: part.id,
+        maxBytes: MAX_GLB_BYTES,
+        ...(authored && board ? { minMaterials: 2 } : { preserveMaterials: true }),
+      });
+
+      // 4. Always serve the GLB. Keep the STEP too unless it is genuinely
+      // oversized, so the CAD path (lib.fetchPart) still works for this part.
+      const glbUrl = `${baseUrl.replace(/\/$/, '')}/glb/${part.id}.glb`;
+      const removedStep = removeDeployedStep(outDir, part.id);
+      const patchedRecord = patchRecordToGlb(outDir, part.id, glbUrl, removedStep);
+
+      results.push({ id: part.id, glbBytes, materials, glbUrl, patchedRecord, removedStep });
+    } catch (e) {
+      if (board) throw e; // boards must always ship a GLB — never silently skip
+      const msg = e instanceof Error ? e.message : String(e);
+      skipped.push({ id: part.id, reason: msg.split('\n')[0] });
+      if (existsSync(finalGlb)) rmSync(finalGlb);
     }
-    execFileSync(process.execPath, [cliPath, 'export', 'glb', scriptPath, '-o', rawGlb], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      timeout: 300_000,
-    });
-
-    // 2-3. Optimize (uncompressed, per-component materials preserved), then
-    // verify size + materials. Shared implementation; flags are load-bearing.
-    // Authored boards are known multi-component, so a fixed floor of 2 is a real
-    // signal. An imported STEP may legitimately carry one material, so there we
-    // assert only that optimization did not FLATTEN what was there.
-    const { bytes: glbBytes, materials } = await optimizeGlb(rawGlb, finalGlb, {
-      repoRoot,
-      label: board.id,
-      maxBytes: MAX_GLB_BYTES,
-      ...(authored ? { minMaterials: 2 } : { preserveMaterials: true }),
-    });
-
-    // 4. Always serve the GLB. Keep the STEP too unless it is genuinely oversized,
-    // so the CAD path (lib.fetchPart) still works for this board.
-    const glbUrl = `${baseUrl.replace(/\/$/, '')}/glb/${board.id}.glb`;
-    const removedStep = removeDeployedStep(outDir, board.id);
-    const patchedRecord = patchRecordToGlb(outDir, board.id, glbUrl, removedStep);
-
-    results.push({ id: board.id, glbBytes, materials, glbUrl, patchedRecord, removedStep });
   }
 
   rmSync(tmp, { recursive: true, force: true });
-  assertBoardConsistency(outDir, results);
+  if (skipped.length > 0) {
+    console.log(
+      `built ${results.length} GLB(s); ${skipped.length} part(s) kept STEP only:\n` +
+        skipped.map((s) => `  - ${s.id}: ${s.reason}`).join('\n'),
+    );
+  }
+  assertBoardConsistency(outDir, results, manifest);
   return results;
 }
 
@@ -234,8 +285,21 @@ function wrapStepAsScript(outDir: string, tmpDir: string, id: string): string | 
  *  unless its STEP was dropped for size. Enforce it rather than assume it — the
  *  bug this replaces was precisely a rule that held for some boards and not
  *  others, silently, for months. */
-export function assertBoardConsistency(outDir: string, results: BoardGlbResult[]): void {
+export function assertBoardConsistency(
+  outDir: string,
+  results: BoardGlbResult[],
+  manifest?: Manifest,
+): void {
   const problems: string[] = [];
+  // Boards carry the strongest guarantee: every board MUST have produced a GLB.
+  // Non-board geometry parts may fall back to STEP-only, but a missing board GLB
+  // is the regression this whole file exists to prevent.
+  if (manifest) {
+    const built = new Set(results.map((r) => r.id));
+    for (const p of manifest.parts.filter(isBoard)) {
+      if (!built.has(p.id)) problems.push(`${p.id}: board produced no GLB`);
+    }
+  }
   for (const r of results) {
     const detailPath = join(outDir, 'v1', 'parts', `${r.id}.json`);
     if (!existsSync(detailPath)) {

--- a/scripts/ingestFreecadLibrary.ts
+++ b/scripts/ingestFreecadLibrary.ts
@@ -54,11 +54,19 @@ async function main(): Promise<void> {
   }
 
   const srcDir = subdir ? join(cloneDir, subdir) : cloneDir;
-  const records = await ingestDirectory(srcDir, outDir, {
-    baseUrl: flags['base-url'] ?? '',
-    license: 'CC-BY-3.0',
-    attribution: ATTRIBUTION,
-  });
+  // The FreeCAD library is a bulk community catalog that repeats some parts
+  // across folders (e.g. LM8UU under both Bearings/ and Mountings/). Skip such
+  // duplicate ids rather than aborting the whole ingest when upstream drifts.
+  const records = await ingestDirectory(
+    srcDir,
+    outDir,
+    {
+      baseUrl: flags['base-url'] ?? '',
+      license: 'CC-BY-3.0',
+      attribution: ATTRIBUTION,
+    },
+    { onDuplicate: 'skip' },
+  );
   console.log(`ingested ${records.length} FreeCAD parts into ${outDir}`);
 }
 

--- a/scripts/ingestParts.test.ts
+++ b/scripts/ingestParts.test.ts
@@ -278,6 +278,26 @@ describe('ingestParts', () => {
     expect(existsSync(join(out, 'v1', 'catalog', 'parts.index.json'))).toBe(false);
   });
 
+  it('skips cross-folder duplicate ids (keeping the first) when onDuplicate is "skip"', async () => {
+    const { src, out } = createTemporaryCatalogDirectories();
+    writeStepFixture(src, ['Bearings', 'linear'], 'lm8uu', tinyStepBytes);
+    writeStepFixture(src, ['Mountings', 'lm8uu'], 'lm8uu', alternateTinyStepBytes);
+
+    const records = await ingestDirectory(src, out, INGEST_OPTS, { onDuplicate: 'skip' });
+    expect(records.filter((r) => r.id === 'lm8uu')).toHaveLength(1);
+    expect(existsSync(join(out, 'v1', 'catalog', 'parts.index.json'))).toBe(true);
+  });
+
+  it('still throws on a duplicate EXPLICIT sidecar id even when onDuplicate is "skip"', async () => {
+    const { src, out } = createTemporaryCatalogDirectories();
+    writeStepFixture(src, ['a'], 'first', tinyStepBytes, { id: 'shared' });
+    writeStepFixture(src, ['b'], 'second', alternateTinyStepBytes, { id: 'shared' });
+
+    await expect(
+      ingestDirectory(src, out, INGEST_OPTS, { onDuplicate: 'skip' }),
+    ).rejects.toMatchObject({ name: 'DuplicateCatalogIdError' });
+  });
+
   it('rejects a numeric sidecar catalog ID before it can collide with a string ID', async () => {
     const { src, out } = createTemporaryCatalogDirectories();
     writeStepFixture(src, ['electronics', 'driver-a'], 'first', tinyStepBytes, { id: 1 });

--- a/scripts/ingestParts.ts
+++ b/scripts/ingestParts.ts
@@ -121,7 +121,13 @@ export interface IngestOpts {
 // -----------------------------------------------------------------------------
 
 function slugify(s: string): string {
+  // NFKD first so compatibility glyphs decompose to ASCII before the strip:
+  // vulgar fractions ½ → "1⁄2", ¼ → "1⁄4", ⁵⁄₁₆ → "5⁄16", super/subscripts → digits.
+  // Without this, "…½x¼…" and "…½x⁵⁄₁₆…" both collapse to the SAME slug (every
+  // distinguishing char is stripped), which crashed the FreeCAD ingest with a
+  // DuplicateCatalogIdError on the ANSI sprocket parts.
   return s
+    .normalize('NFKD')
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');

--- a/scripts/ingestParts.ts
+++ b/scripts/ingestParts.ts
@@ -179,22 +179,53 @@ function resolveCatalogId(stepPath: string, meta: IngestSidecar): string {
   return meta.id;
 }
 
+export type DuplicateIdPolicy = 'throw' | 'skip';
+
 /**
- * Refuse ambiguous output names before creating any catalog files.  The
- * sidecar is deliberately read here because an explicit id overrides the
+ * Resolve which STEP files to ingest, one per catalog id.
+ *
+ * Default `throw`: refuse ambiguous output names before creating any catalog
+ * files — right for CURATED sources (authored electronics), where a collision is
+ * an authoring bug. The sidecar is read here because an explicit id overrides the
  * filename-derived default used by the emitted STEP and detail paths.
+ *
+ * `skip`: for BULK real-world imports (the CC-BY FreeCAD library) that legitimately
+ * repeat a part across folders — e.g. `LM8UU` under both `Bearings/` and
+ * `Mountings/`. Upstream drift into such a duplicate must not abort the whole
+ * catalog build, so keep the first file for each id and drop the rest (logged).
  */
-function assertUniqueCatalogIds(stepFiles: string[], srcRoot: string): void {
+function resolveIngestFiles(
+  stepFiles: string[],
+  srcRoot: string,
+  onDuplicate: DuplicateIdPolicy,
+): string[] {
   const pathsById = new Map<string, string>();
+  const kept: string[] = [];
+  const dropped: { id: string; path: string; first: string }[] = [];
   for (const stepPath of stepFiles) {
     const meta = loadSidecar(stepPath);
     const id = resolveCatalogId(stepPath, meta);
     const firstPath = pathsById.get(id);
     if (firstPath !== undefined) {
-      throw new DuplicateCatalogIdError(id, firstPath, stepPath, srcRoot);
+      // An explicit sidecar id colliding is ALWAYS an authoring bug — never skip it.
+      if (onDuplicate === 'throw' || meta.id !== undefined) {
+        throw new DuplicateCatalogIdError(id, firstPath, stepPath, srcRoot);
+      }
+      dropped.push({ id, path: stepPath, first: firstPath });
+      continue;
     }
     pathsById.set(id, stepPath);
+    kept.push(stepPath);
   }
+  if (dropped.length > 0) {
+    console.warn(
+      `ingestDirectory: dropped ${dropped.length} duplicate-id file(s):\n` +
+        dropped
+          .map((d) => `  '${d.id}': ${relative(srcRoot, d.path)} (kept ${relative(srcRoot, d.first)})`)
+          .join('\n'),
+    );
+  }
+  return kept;
 }
 
 function bindAuthoredConnectorManifest(
@@ -340,9 +371,13 @@ export async function ingestDirectory(
   srcDir: string,
   outDir: string,
   opts: IngestOpts,
+  config: { onDuplicate?: DuplicateIdPolicy } = {},
 ): Promise<CatalogRecord[]> {
-  const stepFiles = listStepFiles(srcDir);
-  assertUniqueCatalogIds(stepFiles, srcDir);
+  const stepFiles = resolveIngestFiles(
+    listStepFiles(srcDir),
+    srcDir,
+    config.onDuplicate ?? 'throw',
+  );
   mkdirSync(join(outDir, 'step'), { recursive: true });
   mkdirSync(join(outDir, 'v1', 'parts'), { recursive: true });
   mkdirSync(join(outDir, 'v1', 'catalog'), { recursive: true });

--- a/scripts/stepToColoredGlb.ts
+++ b/scripts/stepToColoredGlb.ts
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/stepToColoredGlb.ts
+//
+// Convert a STEP file to a small COLORED GLB at catalog-build time, so the web
+// 3D viewer (labwired scene3d etc.) can load a pre-tessellated mesh through
+// three.js and NEVER download the 7.6 MB OCCT wasm decoder.
+//
+// Why not the kernelCAD kernel's own `fromSTEP -> export glb`? It discards the
+// AP214 per-face colors — the output is a single grey material. These Adafruit
+// sensor STEPs carry 18-24 real colors; dropping them would render every sensor
+// as a grey blob (worse than the procedural stand-in it replaces).
+//
+// This reads the STEP with occt-import-js (the SAME decoder labwired runs in the
+// browser) and ports its per-face color grouping (stepLoader.ts "Path A"): one
+// GLB primitive + material per unique face color. So the colors survive, done
+// ONCE here instead of on every page load.
+
+import { readFileSync } from 'node:fs';
+import { Document, NodeIO } from '@gltf-transform/core';
+import occtimportjs from 'occt-import-js';
+
+interface OcctFace { first: number; last: number; color?: number[] }
+interface OcctMesh {
+  name?: string;
+  attributes?: { position?: { array?: number[] }; normal?: { array?: number[] } };
+  index?: { array?: number[] };
+  color?: number[];
+  brep_faces?: OcctFace[];
+}
+interface OcctResult { success?: boolean; meshes?: OcctMesh[] }
+
+/** Normalize an OCCT color array (0–1 or 0–255) to a [r,g,b] triple in 0–1. */
+function normColor(c: number[] | undefined): [number, number, number] | null {
+  if (!c || c.length < 3) return null;
+  let [r, g, b] = c;
+  if (r > 1 || g > 1 || b > 1) { r /= 255; g /= 255; b /= 255; }
+  if (![r, g, b].every(Number.isFinite)) return null;
+  const clamp = (v: number) => Math.min(1, Math.max(0, v));
+  return [clamp(r), clamp(g), clamp(b)];
+}
+
+function colorKey(c: [number, number, number]): string {
+  return c.map((v) => v.toFixed(4)).join(',');
+}
+
+/** Electronics-ish PBR: bright low-chroma colors read as metal leads/cans. */
+function pbrFor(c: [number, number, number]): { metallic: number; roughness: number } {
+  const [r, g, b] = c;
+  const lum = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  const chroma = Math.max(r, g, b) - Math.min(r, g, b);
+  if (chroma < 0.06 && lum > 0.5) return { metallic: 0.9, roughness: 0.3 }; // tin/silver
+  if (chroma < 0.08 && lum < 0.2) return { metallic: 0.25, roughness: 0.5 }; // black epoxy
+  return { metallic: 0.15, roughness: 0.6 }; // plastic / solder mask
+}
+
+let occtPromise: Promise<{ ReadStepFile: (d: Uint8Array, p: null | object) => OcctResult }> | null = null;
+function loadOcct() {
+  if (!occtPromise) occtPromise = (occtimportjs as unknown as () => Promise<never>)();
+  return occtPromise;
+}
+
+/**
+ * Read `stepPath`, tessellate + color via OCCT, write a colored GLB to `outPath`.
+ * Returns the number of distinct materials (colors) emitted — >1 proves colors
+ * survived; 1 means the source STEP carried no usable face colors.
+ */
+export async function stepToColoredGlb(stepPath: string, outPath: string): Promise<number> {
+  const occt = await loadOcct();
+  const bytes = new Uint8Array(readFileSync(stepPath));
+  const result = occt.ReadStepFile(bytes, null);
+  if (!result?.success || !result.meshes?.length) {
+    throw new Error(`OCCT could not read ${stepPath}`);
+  }
+
+  const doc = new Document();
+  const buffer = doc.createBuffer();
+  const scene = doc.createScene();
+  const node = doc.createNode();
+  scene.addChild(node);
+  const glMesh = doc.createMesh();
+  node.setMesh(glMesh);
+
+  const materials = new Map<string, ReturnType<Document['createMaterial']>>();
+  const materialFor = (c: [number, number, number]) => {
+    const key = colorKey(c);
+    let m = materials.get(key);
+    if (!m) {
+      const { metallic, roughness } = pbrFor(c);
+      m = doc.createMaterial()
+        .setBaseColorFactor([c[0], c[1], c[2], 1])
+        .setMetallicFactor(metallic)
+        .setRoughnessFactor(roughness);
+      materials.set(key, m);
+    }
+    return m;
+  };
+
+  const addPrimitive = (
+    pos: number[], norm: number[] | null, idx: number[], color: [number, number, number],
+  ) => {
+    if (idx.length < 3) return;
+    const prim = doc.createPrimitive();
+    prim.setAttribute('POSITION', doc.createAccessor().setType('VEC3').setArray(new Float32Array(pos)).setBuffer(buffer));
+    if (norm && norm.length === pos.length) {
+      prim.setAttribute('NORMAL', doc.createAccessor().setType('VEC3').setArray(new Float32Array(norm)).setBuffer(buffer));
+    }
+    prim.setIndices(doc.createAccessor().setType('SCALAR').setArray(new Uint32Array(idx)).setBuffer(buffer));
+    prim.setMaterial(materialFor(color));
+    glMesh.addPrimitive(prim);
+  };
+
+  const GREY: [number, number, number] = [0.42, 0.42, 0.45];
+
+  for (const mesh of result.meshes) {
+    const posArr = mesh.attributes?.position?.array;
+    if (!posArr || posArr.length < 9) continue;
+    const normArr = mesh.attributes?.normal?.array;
+    const hasNorm = !!normArr && normArr.length === posArr.length;
+    const indexArr = mesh.index?.array;
+    const faces = mesh.brep_faces;
+
+    // Path A: split triangles by per-face color (KiCad/Adafruit AP214).
+    if (faces && faces.length > 0 && indexArr && indexArr.length >= 3) {
+      const byColor = new Map<string, { color: [number, number, number]; tris: number[] }>();
+      let coloredFaces = 0;
+      for (const face of faces) {
+        const parsed = normColor(face.color);
+        if (parsed) coloredFaces += 1;
+        const color = parsed ?? GREY;
+        const key = colorKey(color);
+        let bucket = byColor.get(key);
+        if (!bucket) { bucket = { color, tris: [] }; byColor.set(key, bucket); }
+        const firstTri = Math.max(0, face.first | 0);
+        const lastTri = Math.max(firstTri, face.last | 0);
+        for (let t = firstTri; t <= lastTri; t++) {
+          const base = t * 3;
+          if (base + 2 >= indexArr.length) break;
+          bucket.tris.push(indexArr[base], indexArr[base + 1], indexArr[base + 2]);
+        }
+      }
+      if (coloredFaces > 0) {
+        for (const bucket of byColor.values()) {
+          // Compact to used vertices for a small buffer.
+          const used = new Map<number, number>();
+          const newPos: number[] = [];
+          const newNorm: number[] = [];
+          const newIdx: number[] = [];
+          for (const oldI of bucket.tris) {
+            let ni = used.get(oldI);
+            if (ni === undefined) {
+              ni = used.size;
+              used.set(oldI, ni);
+              newPos.push(posArr[oldI * 3], posArr[oldI * 3 + 1], posArr[oldI * 3 + 2]);
+              if (hasNorm) newNorm.push(normArr![oldI * 3], normArr![oldI * 3 + 1], normArr![oldI * 3 + 2]);
+            }
+            newIdx.push(ni);
+          }
+          addPrimitive(newPos, hasNorm ? newNorm : null, newIdx, bucket.color);
+        }
+        continue;
+      }
+    }
+
+    // Path B: whole-mesh color (or grey fallback).
+    const wholeColor = normColor(mesh.color)
+      ?? normColor(faces?.find((f) => f.color && f.color.length >= 3)?.color)
+      ?? GREY;
+    const idx = indexArr
+      ? Array.from(indexArr)
+      : Array.from({ length: posArr.length / 3 }, (_, i) => i);
+    addPrimitive(Array.from(posArr), hasNorm ? Array.from(normArr!) : null, idx, wholeColor);
+  }
+
+  if (glMesh.listPrimitives().length === 0) {
+    throw new Error(`no geometry produced from ${stepPath}`);
+  }
+
+  await new NodeIO().write(outPath, doc);
+  return materials.size;
+}
+
+const invokedDirectly = process.argv[1] !== undefined && /stepToColoredGlb\.(ts|js)$/.test(process.argv[1]);
+if (invokedDirectly) {
+  const [stepPath, outPath] = process.argv.slice(2);
+  if (!stepPath || !outPath) {
+    console.error('usage: stepToColoredGlb <in.step> <out.glb>');
+    process.exit(1);
+  }
+  stepToColoredGlb(stepPath, outPath)
+    .then((n) => console.log(`wrote ${outPath} with ${n} material(s)`))
+    .catch((e) => { console.error(e instanceof Error ? e.message : e); process.exit(1); });
+}


### PR DESCRIPTION
Lets the web 3D viewer (labwired scene3d etc.) load small pre-tessellated **colored** GLBs via three.js instead of parsing raw STEP with a 7.6 MB in-browser OCCT wasm.

## What
- `scripts/stepToColoredGlb.ts` — reads a STEP with occt-import-js (same decoder labwired ran client-side) and ports its per-face color grouping into a colored GLB (one material per color). The kernel's own `fromSTEP→export glb` drops AP214 colors (1 grey material); this keeps them.
- `buildBoardGlbs` generalized from boards-only to **all geometry parts**, per-part non-fatal (boards still guaranteed). Authored + url-board paths unchanged. The color converter runs in a **fresh subprocess per part** so occt's wasm heap can't accumulate.

## Verified
8 Adafruit sensors → 3–7 material colored GLBs, 140–620 KB (vs 7.6 MB OCCT per page load).

## Also fixes (pre-existing, surface on a FreeCAD-ingest cache miss)
- NFKD-normalize slugs so unicode fractions (`½x¼` vs `½x⁵⁄₁₆`) don't collide.
- `onDuplicate: 'skip'` policy for the bulk FreeCAD import (real cross-folder dupes like LM8UU); curated electronics stay strict. + tests.

## Note
Catalog deploy (`parts-catalog.yml`, dispatch-only) is currently gated by unrelated 70–85 MB marketplace-wave board STEPs that exceed the export timeout — tracked separately. Merging lands the code; it does not auto-deploy.