### PR TITLE
Render immutable bundled Studio projects correctly

### DIFF
--- a/docs/superpowers/plans/2026-07-27-project-asset-bundles.md
+++ b/docs/superpowers/plans/2026-07-27-project-asset-bundles.md
@@ -1,0 +1,382 @@
+# Project Asset Bundles Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist KCAD source and complementary files as immutable project versions, evaluate them through a path-safe hosted filesystem, and publish the exact validated bundle to Studio and the gallery.
+
+**Architecture:** KernelCAD Server stores attachment bytes in the existing Supabase storage service under SHA-256 content keys and records path-to-hash manifests on both projects and revisions. Hosted mesh operations materialize an authorized manifest into a temporary directory and invoke the existing `meshSource(source, fileName, params)` API. KernelCAD Web sends project identity with mesh requests, renders only root features, and replaces indefinite warm-up UI with bounded loading phases.
+
+**Tech Stack:** TypeScript, Express, Supabase PostgreSQL/Storage, Vitest, React, kernelCAD OCCT session bridge.
+
+---
+
+## File structure
+
+### kernelCAD-server
+
+- `supabase/migrations/20260727000000_project_asset_bundles.sql` — asset manifests and immutable revision snapshots.
+- `src/lib/projectAssets.ts` — validation, hashing, storage, authorization, and temporary materialization.
+- `src/lib/projectAssets.test.ts` — storage/path/materialization unit tests.
+- `src/lib/projectsRepo.ts` — persist and read manifests with project versions.
+- `src/lib/projectsRepo.assets.test.ts` — repository manifest behavior.
+- `src/mcpTools/openInStudio.ts` — attachment-aware MCP contract and atomic persistence.
+- `src/mcpTools/openInStudio.test.ts` — attachment publication tests.
+- `src/mcpTools/getProject.ts` — expose attachment metadata.
+- `src/mcpTools/getProjectRevision.ts` — expose immutable revision manifests.
+- `src/mcpTools/getModelMesh.ts` — materialize assets and mesh only root geometry.
+- `src/mcpTools/getModelMesh.test.ts` — bundled STEP and root visibility tests.
+- `src/routes/mesh.ts` — project-version mesh input and asset-aware cache key.
+- `src/routes/mesh.test.ts` — hosted project mesh tests.
+
+### kernelCAD-web
+
+- `src/funnel/lib/apiClient.ts` — request project-version-backed meshes.
+- `src/funnel/lib/apiClient.test.ts` — request contract tests.
+- `src/studio/contexts/GeometryContext.tsx` — send project slug/version and consume root mesh records.
+- `src/studio/contexts/GeometryContext.test.tsx` — project mesh and failure-state tests.
+- `src/studio/StudioShell.tsx` — explicit bounded load phases and error UI.
+- `src/studio/StudioShell.test.tsx` — no-indefinite-warm-up regression tests.
+- `src/studio/components/viewer/entities/` — root-only visibility selection if not already centralized.
+
+## Task 1: Database manifest snapshots
+
+**Files:**
+- Create: `kernelCAD-server/supabase/migrations/20260727000000_project_asset_bundles.sql`
+- Test: `kernelCAD-server/tests/projectAssetBundlesMigration.test.ts`
+
+- [ ] Write a failing migration test asserting:
+
+```ts
+expect(sql).toContain('asset_manifest jsonb');
+expect(sql).toContain('project_revisions');
+expect(sql).toMatch(/new\.asset_manifest/);
+expect(sql).toMatch(/jsonb_typeof\(.*asset_manifest.*\).*object/s);
+```
+
+- [ ] Run:
+
+```bash
+npm test -- tests/projectAssetBundlesMigration.test.ts
+```
+
+Expected: FAIL because the migration does not exist.
+
+- [ ] Add `projects.asset_manifest jsonb not null default '{}'` and
+  `project_revisions.asset_manifest jsonb not null default '{}'`. Update
+  `snapshot_project_revision()` so the project row, source, parameters, and
+  manifest snapshot atomically:
+
+```sql
+insert into public.project_revisions
+  (project_id, version, code, parameters, asset_manifest)
+values
+  (new.id, new.version, new.current_code,
+   coalesce(new.parameters, '[]'::jsonb),
+   coalesce(new.asset_manifest, '{}'::jsonb));
+```
+
+Add constraints requiring a JSON object and limiting encoded manifest length.
+
+- [ ] Run the migration test and existing revision migration tests.
+
+- [ ] Commit:
+
+```bash
+git add supabase/migrations/20260727000000_project_asset_bundles.sql tests/projectAssetBundlesMigration.test.ts
+git commit -m "add immutable project asset manifests"
+```
+
+## Task 2: Shared asset storage and safe materialization
+
+**Files:**
+- Create: `kernelCAD-server/src/lib/projectAssets.ts`
+- Create: `kernelCAD-server/src/lib/projectAssets.test.ts`
+
+- [ ] Write failing tests for normalized relative paths, traversal/absolute-path
+  rejection, SHA-256 deduplication, extension/signature validation, authorized
+  blob reuse, and cleanup after temporary materialization.
+
+Core contract:
+
+```ts
+export interface ProjectAttachmentInput {
+  path: string;
+  bytesBase64?: string;
+  assetSha256?: string;
+}
+
+export interface ProjectAssetEntry {
+  sha256: string;
+  byteLength: number;
+  mediaType: string;
+  format: string;
+}
+
+export type ProjectAssetManifest = Record<string, ProjectAssetEntry>;
+
+export async function persistProjectAttachments(
+  ownerId: string | null,
+  attachments: ProjectAttachmentInput[],
+): Promise<ProjectAssetManifest>;
+
+export async function withMaterializedProject<T>(
+  source: string,
+  manifest: ProjectAssetManifest,
+  fn: (sourcePath: string) => Promise<T>,
+): Promise<T>;
+```
+
+- [ ] Run:
+
+```bash
+npm test -- src/lib/projectAssets.test.ts
+```
+
+Expected: FAIL because the module does not exist.
+
+- [ ] Implement:
+
+  - path normalization with `path.posix.normalize`;
+  - rejection of empty, absolute, `..`, NUL, and duplicate normalized paths;
+  - incremental SHA-256;
+  - one existing Supabase storage bucket named `project-assets`;
+  - object key `sha256/<first-two>/<hash>`;
+  - upload with `upsert: false`, accepting duplicate-object responses;
+  - a temporary directory created with `mkdtemp`;
+  - directory creation and read-only asset writes;
+  - `model.kcad.ts` as the source path;
+  - cleanup in `finally`.
+
+- [ ] Run tests and commit:
+
+```bash
+git add src/lib/projectAssets.ts src/lib/projectAssets.test.ts
+git commit -m "add project asset storage"
+```
+
+## Task 3: Attachment-aware project persistence
+
+**Files:**
+- Modify: `kernelCAD-server/src/lib/projectsRepo.ts`
+- Create: `kernelCAD-server/src/lib/projectsRepo.assets.test.ts`
+- Modify: `kernelCAD-server/src/mcpTools/openInStudio.ts`
+- Modify: `kernelCAD-server/src/mcpTools/openInStudio.test.ts`
+- Modify: `kernelCAD-server/src/mcp/toolSchemaOverrides.ts`
+
+- [ ] Write failing tests showing that `open_in_studio` accepts:
+
+```ts
+attachments: [{
+  path: '2.0u_blank_costar.stp',
+  bytesBase64: Buffer.from(stepBytes).toString('base64'),
+}]
+```
+
+and passes the resulting manifest into both create and update operations.
+Also prove that a failed attachment upload does not activate a project version.
+
+- [ ] Extend the MCP schema:
+
+```ts
+attachments: {
+  type: 'array',
+  maxItems: 32,
+  items: {
+    type: 'object',
+    required: ['path'],
+    properties: {
+      path: { type: 'string', minLength: 1, maxLength: 240 },
+      bytesBase64: { type: 'string' },
+      assetSha256: { type: 'string', pattern: '^[a-f0-9]{64}$' },
+    },
+    oneOf: [
+      { required: ['path', 'bytesBase64'] },
+      { required: ['path', 'assetSha256'] },
+    ],
+  },
+}
+```
+
+- [ ] Persist attachments before the project row update, then include
+  `asset_manifest` in the same project mutation that triggers the immutable
+  revision snapshot.
+
+- [ ] Return attachment count and hashes from `open_in_studio` so callers can
+  read-after-write verify the bundle.
+
+- [ ] Run:
+
+```bash
+npm test -- src/mcpTools/openInStudio.test.ts src/lib/projectsRepo.assets.test.ts
+```
+
+- [ ] Commit:
+
+```bash
+git add src/lib/projectsRepo.ts src/lib/projectsRepo.assets.test.ts src/mcpTools/openInStudio.ts src/mcpTools/openInStudio.test.ts src/mcp/toolSchemaOverrides.ts
+git commit -m "persist studio project attachments"
+```
+
+## Task 4: Hosted bundled evaluation
+
+**Files:**
+- Modify: `kernelCAD-server/src/mcpTools/getModelMesh.ts`
+- Modify: `kernelCAD-server/src/mcpTools/getModelMesh.test.ts`
+- Modify: `kernelCAD-server/src/routes/mesh.ts`
+- Modify: `kernelCAD-server/src/routes/mesh.test.ts`
+
+- [ ] Write failing tests with a KCAD source that imports
+  `./2.0u_blank_costar.stp`. Assert the mesher receives a real temporary
+  `model.kcad.ts` path and the sibling STEP exists during the call.
+
+- [ ] Change mesh dependencies to:
+
+```ts
+meshSource: (
+  source: string,
+  fileName?: string,
+  params?: Record<string, number | boolean>,
+) => Promise<MeshResult>;
+```
+
+Wrap the call:
+
+```ts
+await withMaterializedProject(source, manifest, (fileName) =>
+  deps.meshSource(source, fileName, params)
+);
+```
+
+- [ ] Add `slug` and `version` as an alternative to raw `source` on
+  `/__kernelcad/mesh`. Fetch the authorized immutable revision, materialize its
+  manifest, and include the version plus manifest hashes in the cache key.
+
+- [ ] Fail with HTTP 422 and `project.asset.missing` before acquiring the OCCT
+  mutex when a literal relative import is absent.
+
+- [ ] Run:
+
+```bash
+npm test -- src/mcpTools/getModelMesh.test.ts src/routes/mesh.test.ts
+```
+
+- [ ] Commit:
+
+```bash
+git add src/mcpTools/getModelMesh.ts src/mcpTools/getModelMesh.test.ts src/routes/mesh.ts src/routes/mesh.test.ts
+git commit -m "evaluate bundled project assets"
+```
+
+## Task 5: Root-only visible geometry
+
+**Files:**
+- Modify: `kernelCAD-server/src/mcpTools/getModelMesh.ts`
+- Modify: `kernelCAD-server/src/mcpTools/getModelMesh.test.ts`
+- Modify: `kernelCAD-web/src/studio/contexts/GeometryContext.tsx`
+- Test: nearest existing geometry-context test file
+
+- [ ] Add a failing regression model containing a box, spherical cutter, and
+  returned subtraction. Assert the response marks only the returned subtraction
+  visible:
+
+```ts
+expect(result.features.filter((f) => f.visibleByDefault).map((f) => f.id))
+  .toEqual(['boolean_1']);
+```
+
+- [ ] Preserve feature records from the bridge and derive root IDs from returned
+  capture records. Add `visibleByDefault` without dropping construction meshes
+  needed for inspection.
+
+- [ ] Update Studio to add only `visibleByDefault !== false` meshes to the
+  default scene. Feature-tree actions can still opt into hidden meshes.
+
+- [ ] Run focused server and web tests, then commit in each repository.
+
+## Task 6: Bounded project loading UI
+
+**Files:**
+- Modify: `kernelCAD-web/src/studio/StudioShell.tsx`
+- Modify: `kernelCAD-web/src/studio/contexts/GeometryContext.tsx`
+- Test: `kernelCAD-web/src/studio/StudioShell.test.tsx`
+
+- [ ] Write failing fake-timer tests proving:
+
+  - kernel initialization has its own label;
+  - asset fetch and geometry evaluation have distinct labels;
+  - any error replaces the spinner immediately;
+  - no progress state survives its timeout;
+  - retry restarts only the failed project-loading operation.
+
+- [ ] Model load state as:
+
+```ts
+type ProjectLoadPhase =
+  | { kind: 'idle' }
+  | { kind: 'loading-project' }
+  | { kind: 'fetching-assets' }
+  | { kind: 'evaluating' }
+  | { kind: 'preparing-viewer' }
+  | { kind: 'ready' }
+  | { kind: 'error'; code: string; message: string };
+```
+
+- [ ] Use an `AbortController` and a 15-second project-operation deadline.
+  Kernel boot remains separate and reports boot failure rather than reusing
+  project progress text.
+
+- [ ] Run focused tests and commit.
+
+## Task 7: End-to-end keycap publication
+
+**Files:**
+- Add server fixture: `kernelCAD-server/tests/fixtures/keycap/2.0u_blank_costar.stp`
+- Add web/gallery source and preview metadata only after project publication.
+
+- [ ] Apply the database migration and deploy KernelCAD Server.
+
+- [ ] Call attachment-aware `open_in_studio` with:
+
+  - the verified `2.0u_blank_costar_make_no_mistakes_concave.kcad.ts`;
+  - `2.0u_blank_costar.stp` at the exact relative path;
+  - title and `dishDepth` metadata.
+
+- [ ] Verify:
+
+  - `get_project_revision` returns the manifest;
+  - `get_model_mesh` returns no failed feature IDs;
+  - bounds are approximately `37 × 18 × 8 mm`;
+  - the huge sphere is not visible by default;
+  - the browser shows the actual engraved Costar keycap;
+  - STEP/STL/3MF exports match the pinned project version.
+
+- [ ] Publish the validated version as a gallery entry, build the gallery, and
+  deploy KernelCAD Web.
+
+## Task 8: Full verification, PRs, merge, and production smoke
+
+- [ ] Run KernelCAD Server:
+
+```bash
+npm test
+npm run build
+```
+
+- [ ] Run KernelCAD Web:
+
+```bash
+npm test -- src/studio site/scripts/build-gallery.test.ts
+npm run typecheck
+npm run site:build
+```
+
+- [ ] Push both branches and open PRs with root cause, migration, compatibility,
+  and production verification evidence.
+
+- [ ] Merge server first, apply migration, and deploy.
+
+- [ ] Merge web second and deploy.
+
+- [ ] Open the final gallery URL in a clean browser context and verify load time,
+  visual fidelity, attachment-backed recompute, and downloads.
+

--- a/docs/superpowers/specs/2026-07-27-project-asset-bundles-design.md
+++ b/docs/superpowers/specs/2026-07-27-project-asset-bundles-design.md
@@ -1,0 +1,295 @@
+# Project Asset Bundles
+
+## Problem
+
+KernelCAD currently persists hosted projects primarily as `.kcad.ts` source text.
+Scripts that reference local complementary files, such as:
+
+```ts
+const keycap = await lib.fromSTEP('./2.0u_blank_costar.stp');
+```
+
+cannot be reproduced by the hosted evaluator unless that file happens to exist
+on the server. The Studio UI enters a generic “Geometry kernel warming up”
+state, and gallery publishing can accept the source even though the resulting
+project is not reproducible.
+
+This produced four visible failures:
+
+1. A valid local project was published without its STEP dependency.
+2. The hosted evaluator reported a missing file only after an extended warm-up.
+3. Substituting self-contained construction geometry exposed intermediate
+   cutters and caused z-fighting in Studio.
+4. The gallery project diverged from the locally verified manufacturing model.
+
+## Goals
+
+- Persist a project’s source and complementary files as one reproducible,
+  immutable version.
+- Reuse the existing asset/part-library blob storage rather than creating a
+  second object store.
+- Preserve source-relative paths so existing `lib.fromSTEP`, `lib.fromSTL`,
+  `fontPath`, SVG, DXF, texture, and reference-image calls need no syntax change.
+- Make missing or invalid assets fail immediately with a precise diagnostic.
+- Publish gallery entries from the same validated project version used by
+  Studio and export.
+- Render only returned/root geometry by default. Construction history remains
+  inspectable but hidden.
+
+## Non-goals
+
+- General-purpose cloud-drive behavior.
+- Mutable files inside an immutable project version.
+- Resolving arbitrary host filesystem paths in hosted execution.
+- Automatically publishing private project assets to a public gallery.
+- Replacing the catalog/part library.
+
+## Architecture
+
+### Content-addressed assets
+
+The existing asset/part-library storage is the single blob store. Every uploaded
+file is normalized to bytes, hashed with SHA-256, and stored once.
+
+An asset record contains:
+
+- `sha256`
+- byte length
+- media type
+- detected format
+- original filename for display only
+- ownership and access metadata
+- storage key
+- creation timestamp
+
+The storage key derives from the hash, not the user-supplied filename.
+Identical files deduplicate across versions while access remains governed by
+project ownership and visibility.
+
+### Immutable project-version manifest
+
+Each project version contains:
+
+- the `.kcad.ts` source
+- source hash
+- a manifest of normalized relative paths to asset hashes
+- parameter metadata
+- author and timestamp
+- validation status and diagnostics
+- optional derived artifacts and preview metadata
+
+Example:
+
+```json
+{
+  "version": 7,
+  "sourceSha256": "...",
+  "assets": {
+    "2.0u_blank_costar.stp": {
+      "sha256": "...",
+      "format": "step",
+      "byteLength": 608247
+    }
+  }
+}
+```
+
+Paths use forward slashes, cannot be absolute, cannot contain `..`, and compare
+case-sensitively. Duplicate normalized paths are rejected.
+
+Updating source or any attachment creates a new project version. Older versions
+remain reproducible, and every gallery entry pins an exact version.
+
+### Upload and persistence API
+
+Project creation/update accepts:
+
+- source code
+- title and parameter metadata
+- zero or more attachments, each with a relative path and bytes or an existing
+  authorized asset hash
+- optional existing project slug
+
+The server performs:
+
+1. Size, extension, media-type, and format validation.
+2. Path normalization and traversal rejection.
+3. Blob hashing, deduplication, and persistence.
+4. Static source dependency discovery.
+5. Manifest completeness validation.
+6. Hosted evaluation against the immutable bundle.
+7. Atomic project-version publication only if persistence succeeds.
+
+Dependency discovery is advisory for dynamic paths but authoritative for literal
+relative paths. A literal missing dependency prevents the version from becoming
+the project’s active version.
+
+The MCP `open_in_studio` interface gains an `attachments` collection. Local
+clients send file paths; the connector reads them and uploads bytes. Remote
+clients send platform file references or previously authorized asset hashes.
+Source-only calls remain supported for self-contained projects.
+
+### Hosted filesystem resolver
+
+Hosted evaluation receives a project-version asset resolver, not unrestricted
+host filesystem access. Existing authoring calls continue to accept relative
+paths:
+
+```ts
+await lib.fromSTEP('./2.0u_blank_costar.stp');
+await lib.fromSTL('./insert.stl');
+fontPath('./fonts/legend.ttf');
+```
+
+The resolver:
+
+1. Normalizes the requested path relative to the virtual source directory.
+2. Rejects absolute paths and traversal.
+3. Resolves the normalized path through the version manifest.
+4. Fetches bytes from the shared blob store.
+5. Supplies a read-only cached local representation to the existing lowerer.
+
+The resolver is injected as an execution capability so CLI/local execution can
+continue using the real filesystem while hosted execution uses the manifest.
+
+### Gallery publication
+
+Gallery entries reference a validated public project version:
+
+```json
+{
+  "projectSlug": "make-no-mistakes-keycap",
+  "projectVersion": 7
+}
+```
+
+Gallery build and Studio both consume that version’s source and manifest.
+Previews and exports are derived from the same root geometry. Publication fails
+closed when:
+
+- the version is private,
+- an attachment is unavailable,
+- hosted evaluation fails,
+- the returned geometry is empty or invalid, or
+- required preview/export generation fails.
+
+The gallery never substitutes fallback geometry.
+
+### Root geometry visibility
+
+The modeling capture graph distinguishes:
+
+- returned/root features,
+- their required dependencies,
+- construction/intermediate features.
+
+Studio displays only returned root shapes or returned Scene parts by default.
+Dependency meshes remain available for the feature tree and explicit inspection
+but are not added as visible scene objects. Boolean cutters therefore cannot
+appear as giant spheres, and predecessor/successor bodies cannot z-fight.
+
+An explicit “show construction geometry” diagnostic mode is outside this
+feature’s scope.
+
+## User experience and failure behavior
+
+The generic warm-up banner is limited to actual kernel initialization. Project
+loading has explicit phases:
+
+- Loading project
+- Fetching attachments
+- Evaluating geometry
+- Preparing viewer
+
+Each phase has a bounded timeout and abort signal. A known failure immediately
+replaces progress UI with a diagnostic. Examples:
+
+- `project.asset.missing — 2.0u_blank_costar.stp`
+- `project.asset.path-traversal`
+- `project.asset.unsupported-format`
+- `project.version.evaluation-failed`
+- `project.gallery.root-geometry-invalid`
+
+The UI never continues showing “warming up” after an error is known. Retrying
+restarts only the failed phase.
+
+## Security and limits
+
+- Reject absolute paths, traversal, NUL bytes, and ambiguous normalized paths.
+- Verify content signatures where formats provide them; do not trust extensions.
+- Apply per-file, per-version, and account quotas before upload completion.
+- Stream large files and compute hashes incrementally.
+- Never expose another project’s hash as proof of authorization.
+- Public gallery publication requires an explicit visibility transition.
+- Serve downloads with safe content disposition and immutable cache headers.
+
+Initial supported attachment formats are STEP/STP, STL, BREP, DXF, SVG, TTF,
+OTF, PNG, JPEG, WEBP, HDR, EXR, GLB, and 3MF. Executable formats are rejected.
+
+## Data lifecycle
+
+Project deletion removes manifest references, not shared blobs immediately.
+Unreferenced blobs become eligible for delayed garbage collection. A retention
+window allows recovery from accidental deletion and avoids races with gallery
+builds or in-flight exports.
+
+Derived previews and exports are keyed by:
+
+- project-version identity,
+- parameter overrides,
+- exporter/render version,
+- output options.
+
+They can be regenerated and do not define project truth.
+
+## Testing
+
+### Storage and manifest
+
+- Hash deduplication across projects and versions.
+- Same filename with different bytes creates distinct assets.
+- Traversal, absolute paths, duplicate normalized paths, and quota overflow fail.
+- Version updates are atomic and older versions remain reproducible.
+- Unauthorized hash reuse is rejected.
+
+### Resolver
+
+- Local CLI continues resolving filesystem-relative imports.
+- Hosted execution resolves every supported asset type through a manifest.
+- Missing literal and dynamic paths return precise diagnostics.
+- Resolver cache does not leak assets across projects.
+
+### Publishing
+
+- `open_in_studio` uploads source plus attachments and updates the same slug.
+- A project with `lib.fromSTEP('./part.step')` evaluates remotely.
+- Source-only publication with a missing dependency fails before activation.
+- Gallery build consumes the pinned project version and emits matching preview
+  and export artifacts.
+
+### Rendering
+
+- A subtractive sphere cutter is absent from the default visible mesh set.
+- A filleted successor does not render over its predecessor.
+- Returned multi-part Scenes retain per-part materials without orphan warnings.
+
+### UI
+
+- Warm-up state ends on success, timeout, or error.
+- Missing assets display their exact normalized path.
+- Retry restarts the failed phase.
+- A gallery publish action cannot proceed from an invalid version.
+
+## Rollout
+
+1. Add content-addressed project asset records and immutable manifests.
+2. Add attachment upload and hosted resolver support behind a feature flag.
+3. Extend `open_in_studio` and Studio project loading.
+4. Enforce root-only default visibility.
+5. Add project-version-backed gallery publication.
+6. Migrate eligible existing projects as source-only bundles.
+7. Enable attachment-backed publication by default.
+
+The existing source-only flow remains compatible for self-contained models.
+Projects with unresolved relative imports become explicitly invalid instead of
+appearing to load indefinitely.

--- a/src/studio/StudioShell.tsx
+++ b/src/studio/StudioShell.tsx
@@ -30,6 +30,32 @@ import { useOptionalSession } from '../funnel/hooks/useSession';
 import { isAuthConfigured } from '../funnel/lib/supabaseClient';
 import { jointContactCapMm3 } from '../modeling/runtime/jointContactCap';
 
+function KernelInitBanner({ error }: { error: string | null }) {
+    const [timedOut, setTimedOut] = useState(false);
+
+    useEffect(() => {
+        if (error) return;
+        const timeout = window.setTimeout(() => setTimedOut(true), 15_000);
+        return () => window.clearTimeout(timeout);
+    }, [error]);
+
+    return (
+        <div
+            data-testid="kernel-init-banner"
+            className="pointer-events-none absolute left-1/2 top-4 z-30 flex -translate-x-1/2 items-center gap-2 rounded border border-white/10 bg-black/80 px-3 py-2 text-xs text-white/80 shadow-lg"
+        >
+            {!error && !timedOut && <Loader2 className="h-4 w-4 animate-spin" />}
+            <span>
+                {error
+                    ? `Geometry kernel failed: ${error}`
+                    : timedOut
+                        ? 'Geometry kernel initialization timed out. Reload to retry.'
+                        : 'Geometry kernel warming up...'}
+            </span>
+        </div>
+    );
+}
+
 /**
  * Top-level Studio shell. Composes the six slots — Toolbar / Viewport /
  * Inspector / AgentRail / BottomDrawer / StatusBar — over the existing
@@ -70,18 +96,6 @@ export function StudioShell() {
     }, []);
     const recompute = useRecomputeResult();
     const { activeProject } = useProject();
-    const [kernelInitTimedOut, setKernelInitTimedOut] = useState(false);
-
-    useEffect(() => {
-        if (workbench.isReady || workbench.error) {
-            setKernelInitTimedOut(false);
-            return;
-        }
-        setKernelInitTimedOut(false);
-        const timeout = window.setTimeout(() => setKernelInitTimedOut(true), 15_000);
-        return () => window.clearTimeout(timeout);
-    }, [workbench.isReady, workbench.error]);
-
     const handleValidate = useCallback(() => {
         // Force a re-fetch of /__kernelcad/review by re-running the
         // geometry pipeline. The review fetch is chained inside
@@ -252,21 +266,7 @@ export function StudioShell() {
                 </div>
                 <Inspector tabSlots={tabSlots} />
 
-                {!workbench.isReady && (
-                    <div
-                        data-testid="kernel-init-banner"
-                        className="pointer-events-none absolute left-1/2 top-4 z-30 flex -translate-x-1/2 items-center gap-2 rounded border border-white/10 bg-black/80 px-3 py-2 text-xs text-white/80 shadow-lg"
-                    >
-                        {!workbench.error && !kernelInitTimedOut && <Loader2 className="h-4 w-4 animate-spin" />}
-                        <span>
-                            {workbench.error
-                                ? `Geometry kernel failed: ${workbench.error}`
-                                : kernelInitTimedOut
-                                    ? 'Geometry kernel initialization timed out. Reload to retry.'
-                                    : 'Geometry kernel warming up...'}
-                        </span>
-                    </div>
-                )}
+                {!workbench.isReady && <KernelInitBanner error={workbench.error} />}
 
             </div>
 

--- a/src/studio/StudioShell.tsx
+++ b/src/studio/StudioShell.tsx
@@ -70,6 +70,17 @@ export function StudioShell() {
     }, []);
     const recompute = useRecomputeResult();
     const { activeProject } = useProject();
+    const [kernelInitTimedOut, setKernelInitTimedOut] = useState(false);
+
+    useEffect(() => {
+        if (workbench.isReady || workbench.error) {
+            setKernelInitTimedOut(false);
+            return;
+        }
+        setKernelInitTimedOut(false);
+        const timeout = window.setTimeout(() => setKernelInitTimedOut(true), 15_000);
+        return () => window.clearTimeout(timeout);
+    }, [workbench.isReady, workbench.error]);
 
     const handleValidate = useCallback(() => {
         // Force a re-fetch of /__kernelcad/review by re-running the
@@ -246,8 +257,14 @@ export function StudioShell() {
                         data-testid="kernel-init-banner"
                         className="pointer-events-none absolute left-1/2 top-4 z-30 flex -translate-x-1/2 items-center gap-2 rounded border border-white/10 bg-black/80 px-3 py-2 text-xs text-white/80 shadow-lg"
                     >
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                        <span>Geometry kernel warming up...</span>
+                        {!workbench.error && !kernelInitTimedOut && <Loader2 className="h-4 w-4 animate-spin" />}
+                        <span>
+                            {workbench.error
+                                ? `Geometry kernel failed: ${workbench.error}`
+                                : kernelInitTimedOut
+                                    ? 'Geometry kernel initialization timed out. Reload to retry.'
+                                    : 'Geometry kernel warming up...'}
+                        </span>
                     </div>
                 )}
 

--- a/src/studio/__tests__/StudioShell.status.test.tsx
+++ b/src/studio/__tests__/StudioShell.status.test.tsx
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 /** @vitest-environment jsdom */
-import { cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 let workbenchComputing = false;
+let workbenchReady = true;
+let workbenchError: string | null = null;
 let agentRailOpen = false;
 let recomputeRawPairs: Array<{ a: string; b: string; volumeMm3: number }> = [];
 let recomputeInterferenceSummary: {
@@ -18,9 +20,9 @@ let recomputeValidity: { diagnostics: { code: string; severity: string }[] } | n
 vi.mock('../context/WorkbenchContext', () => ({
     useWorkbench: () => ({
         code: '',
-        isReady: true,
+        isReady: workbenchReady,
         isComputing: workbenchComputing,
-        error: null,
+        error: workbenchError,
         geometries: [],
         selectedItemIds: [],
         viewMode3D: 'shadedWithEdges',
@@ -91,6 +93,8 @@ afterEach(() => cleanup());
 
 beforeEach(() => {
     workbenchComputing = false;
+    workbenchReady = true;
+    workbenchError = null;
     agentRailOpen = false;
     recomputeRawPairs = [];
     recomputeInterferenceSummary = null;
@@ -98,6 +102,30 @@ beforeEach(() => {
 });
 
 describe('StudioShell status plumbing', () => {
+    it('replaces kernel progress with its error immediately', () => {
+        workbenchReady = false;
+        workbenchError = 'WASM failed to initialize';
+
+        render(<StudioShell />);
+
+        expect(screen.queryByText('Geometry kernel warming up...')).toBeNull();
+        expect(screen.getByText('Geometry kernel failed: WASM failed to initialize')).toBeTruthy();
+    });
+
+    it('bounds kernel initialization instead of spinning indefinitely', () => {
+        vi.useFakeTimers();
+        workbenchReady = false;
+
+        render(<StudioShell />);
+        expect(screen.getByText('Geometry kernel warming up...')).toBeTruthy();
+
+        act(() => vi.advanceTimersByTime(15_000));
+
+        expect(screen.queryByText('Geometry kernel warming up...')).toBeNull();
+        expect(screen.getByText('Geometry kernel initialization timed out. Reload to retry.')).toBeTruthy();
+        vi.useRealTimers();
+    });
+
     it('passes workbench computing state to the status bar', () => {
         workbenchComputing = true;
 

--- a/src/studio/context/GeometryContext.tsx
+++ b/src/studio/context/GeometryContext.tsx
@@ -7,7 +7,16 @@ import { parseCode } from '../../shared/codeGeneration/ast';
 import { rehydrateFromBridge, type FeatureMeshSerialized } from '../../modeling/capture/featureMeshSerialize';
 import type { SerializedParamEntry, SerializedParamTable } from '../../shared/runtime/paramTable';
 import type { FeatureRecord } from '../../shared/intent/featureRecord';
-import { shouldUseHostedMesh, meshSourceHosted, devMeshAvailable, meshSourceDev, needsFullKernel, type BackendMeshPayload, type ParamOverrides } from '../scriptSource';
+import {
+    shouldUseHostedMesh,
+    meshSourceHosted,
+    devMeshAvailable,
+    meshSourceDev,
+    needsFullKernel,
+    rootVisibleFeatures,
+    type BackendMeshPayload,
+    type ParamOverrides,
+} from '../scriptSource';
 import { apiCall, rewritePath, bearerToken, buildEventsUrl } from '../api/apiBase';
 
 export type ExecutionStatus = 'success' | 'error' | 'stale';
@@ -974,7 +983,7 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
                         staleRecorded = true;
                         return;
                     }
-                    const hostedGeometries = featureMeshesToGeometries(payload.features as FeatureMeshSerialized[]);
+                    const hostedGeometries = featureMeshesToGeometries(rootVisibleFeatures(payload));
                     const hostedRecords = (payload.featureRecords as FeatureRecord[]) ?? [];
                     const hostedReview = payload.review ?? { ok: true, diagnostics: [] };
                     const emptyNotice = detectEmptyBuild(hostedGeometries.length, hostedRecords, hostedReview);
@@ -1024,7 +1033,7 @@ export function GeometryProvider({ children, code }: { children: ReactNode; code
             // net for any other API the worker happens to lack.
             const useDevKernel = devMeshAvailable() && needsFullKernel(code);
             const applyDevPayload = (payload: BackendMeshPayload) => {
-                const devGeometries = featureMeshesToGeometries(payload.features as FeatureMeshSerialized[]);
+                const devGeometries = featureMeshesToGeometries(rootVisibleFeatures(payload));
                 const devRecords = (payload.featureRecords as FeatureRecord[]) ?? [];
                 const devReview = payload.review ?? { ok: true, diagnostics: [] };
                 const emptyNotice = detectEmptyBuild(devGeometries.length, devRecords, devReview);

--- a/src/studio/scriptSource.test.ts
+++ b/src/studio/scriptSource.test.ts
@@ -142,6 +142,26 @@ describe('param overrides (stateless re-run path)', () => {
       }),
     );
   });
+
+  it('pins a hosted project request to the version in the URL', async () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com');
+    vi.stubGlobal('window', {
+      location: { hostname: 'app.kernelcad.com', pathname: '/p/keycap-123', search: '?version=7' },
+    });
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ features: [], featureRecords: [], bounds: { min: [0, 0, 0], max: [1, 1, 1] } }),
+    } as Response);
+
+    await meshSourceHosted('ignored', { dishDepth: 1 });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.com/__kernelcad/mesh',
+      expect.objectContaining({
+        body: JSON.stringify({ projectSlug: 'keycap-123', projectVersion: 7, params: { dishDepth: 1 } }),
+      }),
+    );
+  });
 });
 
 describe('rootVisibleFeatures', () => {

--- a/src/studio/scriptSource.test.ts
+++ b/src/studio/scriptSource.test.ts
@@ -11,7 +11,14 @@ vi.mock('../funnel/lib/supabaseClient', () => ({
   }),
 }));
 
-import { loadGalleryScriptSource, loadStudioScriptSource, meshSourceDev, meshSourceHosted, needsFullKernel } from './scriptSource';
+import {
+  loadGalleryScriptSource,
+  loadStudioScriptSource,
+  meshSourceDev,
+  meshSourceHosted,
+  needsFullKernel,
+  rootVisibleFeatures,
+} from './scriptSource';
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -112,6 +119,44 @@ describe('param overrides (stateless re-run path)', () => {
       method: 'POST',
       body: JSON.stringify({ source: 'return box(w,1,1);', params: { w: 7 } }),
     }));
+  });
+
+  it('meshes /p projects by slug so hosted complementary files are available', async () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com');
+    vi.stubGlobal('window', {
+      location: { hostname: 'app.kernelcad.com', pathname: '/p/keycap-123' },
+    });
+    const payload = { features: [], featureRecords: [], bounds: { min: [0, 0, 0], max: [1, 1, 1] } };
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => payload,
+    } as Response);
+
+    await meshSourceHosted('source ignored for persisted project', { dishDepth: 1 });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.com/__kernelcad/mesh',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ projectSlug: 'keycap-123', params: { dishDepth: 1 } }),
+      }),
+    );
+  });
+});
+
+describe('rootVisibleFeatures', () => {
+  it('hides boolean cutters and predecessor bodies while keeping assembly fan-out', () => {
+    const features = [
+      { featureId: 'box_1', faces: [] },
+      { featureId: 'sphere_1', faces: [] },
+      { featureId: 'boolean_1', faces: [] },
+      { featureId: 'part_a', assemblyFeatureId: 'scene_1', faces: [] },
+    ] as never[];
+
+    expect(rootVisibleFeatures({ features, rootFeatureIds: ['boolean_1'] }).map((f) => f.featureId))
+      .toEqual(['boolean_1']);
+    expect(rootVisibleFeatures({ features, rootFeatureIds: ['scene_1'] }).map((f) => f.featureId))
+      .toEqual(['part_a']);
   });
 });
 

--- a/src/studio/scriptSource.ts
+++ b/src/studio/scriptSource.ts
@@ -77,6 +77,27 @@ export interface BackendMeshPayload {
    *  server mesh endpoint. Drives the adaptive scene tree + Validity tab on the
    *  hosted deploy, which has no separate `/__kernelcad/review` fetch. */
   review?: ScriptReviewSummary;
+  /** Returned/root feature ids. Construction history remains available in
+   * `features` for inspection but is hidden from the default scene. */
+  rootFeatureIds?: string[];
+}
+
+export function rootVisibleFeatures(
+  payload: Pick<BackendMeshPayload, 'features' | 'rootFeatureIds'>,
+): FeatureMeshSerialized[] {
+  const roots = payload.rootFeatureIds;
+  if (!roots || roots.length === 0) return payload.features;
+  const rootSet = new Set(roots);
+  return payload.features.filter((feature) => (
+    rootSet.has(feature.featureId)
+    || (feature.assemblyFeatureId !== undefined && rootSet.has(feature.assemblyFeatureId))
+  ));
+}
+
+function currentHostedProjectSlug(): string | null {
+  if (typeof window === 'undefined') return null;
+  const match = window.location.pathname?.match(/^\/p\/([^/]+)\/?$/);
+  return match ? decodeURIComponent(match[1]!) : null;
 }
 
 /**
@@ -214,10 +235,14 @@ export async function meshSourceHosted(
   // 2. Server mesh endpoint for edited / non-gallery code (and param edits).
   const base = import.meta.env.VITE_API_BASE_URL;
   if (typeof base === 'string' && base.length > 0) {
+    const projectSlug = currentHostedProjectSlug();
     const response = await fetch(`${base}/__kernelcad/mesh`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ source, ...(hasOverrides(paramOverrides) ? { params: paramOverrides } : {}) }),
+      body: JSON.stringify({
+        ...(projectSlug ? { projectSlug } : { source }),
+        ...(hasOverrides(paramOverrides) ? { params: paramOverrides } : {}),
+      }),
     });
     const payload = await response.json().catch(() => null);
     if (!response.ok) {

--- a/src/studio/scriptSource.ts
+++ b/src/studio/scriptSource.ts
@@ -94,10 +94,16 @@ export function rootVisibleFeatures(
   ));
 }
 
-function currentHostedProjectSlug(): string | null {
+function currentHostedProject(): { slug: string; version?: number } | null {
   if (typeof window === 'undefined') return null;
   const match = window.location.pathname?.match(/^\/p\/([^/]+)\/?$/);
-  return match ? decodeURIComponent(match[1]!) : null;
+  if (!match) return null;
+  const rawVersion = new URLSearchParams(window.location.search ?? '').get('version');
+  const version = rawVersion && /^\d+$/.test(rawVersion) ? Number(rawVersion) : undefined;
+  return {
+    slug: decodeURIComponent(match[1]!),
+    ...(version && version > 0 ? { version } : {}),
+  };
 }
 
 /**
@@ -235,12 +241,14 @@ export async function meshSourceHosted(
   // 2. Server mesh endpoint for edited / non-gallery code (and param edits).
   const base = import.meta.env.VITE_API_BASE_URL;
   if (typeof base === 'string' && base.length > 0) {
-    const projectSlug = currentHostedProjectSlug();
+    const project = currentHostedProject();
     const response = await fetch(`${base}/__kernelcad/mesh`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        ...(projectSlug ? { projectSlug } : { source }),
+        ...(project
+          ? { projectSlug: project.slug, ...(project.version ? { projectVersion: project.version } : {}) }
+          : { source }),
         ...(hasOverrides(paramOverrides) ? { params: paramOverrides } : {}),
       }),
     });


### PR DESCRIPTION
## Summary
- request hosted `/p/:slug` meshes by project identity and optional immutable revision
- render only returned/root geometry by default so boolean cutters and predecessor solids stay hidden
- replace indefinite kernel warm-up with immediate error reporting and a 15-second bounded timeout
- include the approved asset-bundle design and implementation plan

## Root cause
The hosted client reposted raw KCAD source without complementary STEP files and rendered every captured construction feature. That caused missing-import failures, giant sphere/cube artifacts, and an indefinite warm-up banner after initialization errors.

## Validation
- 95 web test files passed (628 tests)
- focused final run: 37 tests passed
- TypeScript typecheck passes
- gallery build regression passes
- independent pre-merge review approved with no Critical or Important findings