### PR TITLE
fix(studio): stop the chrome bars overlapping on phone viewports

### DIFF
--- a/src/studio/Toolbar.tsx
+++ b/src/studio/Toolbar.tsx
@@ -5,6 +5,8 @@ import { CheckCircle2, Play, MessageSquare, Image as ImageIcon, Plug, Brush, Sci
 import { useNavigate } from '@tanstack/react-router';
 import { useOptionalSession } from '../funnel/hooks/useSession';
 import { saveProject } from '../funnel/lib/apiClient';
+import { OverflowMenu } from './components/Layout/OverflowMenu';
+import { useIsNarrow } from './hooks/useIsNarrow';
 
 interface ToolbarProps {
     isModified: boolean;
@@ -86,6 +88,11 @@ export function Toolbar({
     const navigate = useNavigate();
     const [publishState, setPublishState] = useState<'idle' | 'saving' | 'done' | 'error'>('idle');
     const [publishedLink, setPublishedLink] = useState<string | null>(null);
+    // Below `md` only the two act-on-the-model buttons (Validate / Run) stay on
+    // the bar; everything else moves into the overflow menu. Previously the
+    // whole set stayed inline and Run was pushed past the right edge of a
+    // phone screen, into a scroll region with no visible scrollbar.
+    const narrow = useIsNarrow();
 
     async function handlePublish() {
         if (!session) {
@@ -115,67 +122,211 @@ export function Toolbar({
         }
     }
 
+    const agentButton = enableAgentRail && !agentRailHidden ? (
+        <button
+            type="button"
+            onClick={onToggleAgentRail}
+            aria-label={agentRailOpen ? 'Close agent rail' : 'Open agent rail'}
+            aria-pressed={agentRailOpen}
+            className={`inline-flex items-center gap-1 px-2 py-1 rounded transition-colors ${
+                agentRailOpen
+                    ? 'bg-[#333] text-white'
+                    : 'text-gray-300 hover:text-white hover:bg-[#222]'
+            }`}
+        >
+            <MessageSquare size={12} />
+            Agent
+        </button>
+    ) : null;
+
+    const connectLink = enableConnect ? (
+        <a
+            href="/connect"
+            data-testid="toolbar-connect-link"
+            aria-label="Connect to Claude Desktop"
+            className="inline-flex items-center gap-1 px-2 py-1 rounded text-gray-300 hover:text-white hover:bg-[#222] transition-colors"
+        >
+            <Plug size={12} />
+            Connect
+        </a>
+    ) : null;
+
+    const myDesignsLink = session ? (
+        <a
+            href="/me"
+            data-testid="toolbar-my-designs"
+            aria-label="My Designs"
+            className="inline-flex items-center gap-1 px-2 py-1 rounded text-gray-300 hover:text-white hover:bg-[#222] transition-colors"
+        >
+            My Designs
+        </a>
+    ) : null;
+
+    const publishButton = (
+        <button
+            type="button"
+            data-testid="toolbar-publish"
+            onClick={() => void handlePublish()}
+            disabled={publishState === 'saving'}
+            aria-label="Publish and share"
+            className="inline-flex items-center gap-1 px-2 py-1 rounded text-gray-300 hover:text-white hover:bg-[#222] transition-colors disabled:opacity-50"
+        >
+            <Share2 size={12} />
+            {publishState === 'saving' ? 'Publishing…' : publishState === 'error' ? 'Retry' : 'Publish & Share'}
+        </button>
+    );
+
+    const validateButton = (
+        <button
+            type="button"
+            onClick={onValidate}
+            aria-label="Validate"
+            className="inline-flex items-center gap-1 px-2 py-1 rounded text-gray-300 hover:text-white hover:bg-[#222] transition-colors"
+        >
+            <CheckCircle2 size={12} />
+            Validate
+        </button>
+    );
+
+    const runButton = (
+        <button
+            type="button"
+            onClick={onRun}
+            aria-label="Run"
+            className="inline-flex items-center gap-1 px-2 py-1 rounded bg-emerald-600 hover:bg-emerald-500 text-white transition-colors"
+        >
+            <Play size={12} />
+            Run
+        </button>
+    );
+
+    const brushButton = (
+        <button
+            type="button"
+            data-testid="toolbar-mark"
+            onClick={onToggleMarkingMode}
+            title={markingMode ? 'Save mark & exit (your agent can then pick it up)' : 'Paint over what is wrong, then click again to save'}
+            aria-label={markingMode ? 'Save mark and exit marking mode' : 'Enter marking mode'}
+            aria-pressed={markingMode}
+            className={`inline-flex items-center gap-1.5 px-3 py-1 rounded font-medium transition-colors ${
+                markingMode
+                    ? 'bg-red-600 text-white ring-2 ring-red-300'
+                    : 'bg-[#2a1313] text-red-300 hover:bg-red-700 hover:text-white border border-red-700'
+            }`}
+        >
+            <Brush size={14} />
+            Brush
+        </button>
+    );
+
+    const sectionButton = (
+        <button
+            type="button"
+            data-testid="toolbar-section"
+            onClick={onToggleSectionMode}
+            title={sectionMode ? 'Exit section view' : 'Slice the model with a plane to see inside'}
+            aria-label={sectionMode ? 'Exit section view' : 'Enter section view'}
+            aria-pressed={sectionMode}
+            className={`inline-flex items-center gap-1.5 px-3 py-1 rounded font-medium transition-colors ${
+                sectionMode
+                    ? 'bg-sky-600 text-white ring-2 ring-sky-300'
+                    : 'bg-[#13202a] text-sky-300 hover:bg-sky-700 hover:text-white border border-sky-700'
+            }`}
+        >
+            <Scissors size={14} />
+            Section
+        </button>
+    );
+
+    const referenceButton = referenceImagesPresent ? (
+        <button
+            type="button"
+            onClick={onToggleReferenceImages}
+            aria-label={referenceImagesVisible ? 'Hide reference images' : 'Show reference images'}
+            aria-pressed={referenceImagesVisible}
+            className={`inline-flex items-center gap-1 px-2 py-1 rounded transition-colors ${
+                referenceImagesVisible
+                    ? 'bg-[#333] text-white'
+                    : 'text-gray-300 hover:text-white hover:bg-[#222]'
+            }`}
+        >
+            <ImageIcon size={12} />
+            Reference
+        </button>
+    ) : null;
+
+    const environmentButton = renderEnvironmentPresent ? (
+        <button
+            type="button"
+            data-testid="toolbar-render-environment"
+            onClick={onToggleRenderEnvironment}
+            aria-label={renderEnvironmentVisible ? 'Disable HDRI environment' : 'Enable HDRI environment'}
+            aria-pressed={renderEnvironmentVisible}
+            className={`inline-flex items-center gap-1 px-2 py-1 rounded transition-colors ${
+                renderEnvironmentVisible
+                    ? 'bg-[#333] text-white'
+                    : 'text-gray-300 hover:text-white hover:bg-[#222]'
+            }`}
+        >
+            Env: {renderEnvironmentPresetLabel}
+        </button>
+    ) : null;
+
+    const inspectorButton = (
+        <button
+            type="button"
+            data-testid="toolbar-inspector"
+            onClick={onToggleInspector}
+            title={inspectorOpen ? 'Hide the inspector panel' : 'Show the inspector panel'}
+            aria-label={inspectorOpen ? 'Hide inspector panel' : 'Show inspector panel'}
+            aria-pressed={inspectorOpen}
+            className={`inline-flex items-center gap-1 px-2 py-1 rounded transition-colors ${
+                inspectorOpen
+                    ? 'bg-[#333] text-white'
+                    : 'text-gray-300 hover:text-white hover:bg-[#222]'
+            }`}
+        >
+            <PanelRight size={12} />
+            Inspector
+        </button>
+    );
+
     return (
         <div
             data-testid="studio-toolbar"
-            className="h-8 shrink-0 border-b border-[#2b313c] bg-[#111] flex items-center gap-2 px-3 text-xs text-gray-300 select-none bar-scroll-x"
+            className="h-8 shrink-0 border-b border-[#2b313c] bg-[#111] flex items-center gap-2 px-2 md:px-3 text-xs text-gray-300 select-none bar-scroll-x"
         >
             <div className="flex items-center gap-2 shrink-0">
-                {enableAgentRail && !agentRailHidden && (
-                    <button
-                        type="button"
-                        onClick={onToggleAgentRail}
-                        aria-label={agentRailOpen ? 'Close agent rail' : 'Open agent rail'}
-                        aria-pressed={agentRailOpen}
-                        className={`inline-flex items-center gap-1 px-2 py-1 rounded transition-colors ${
-                            agentRailOpen
-                                ? 'bg-[#333] text-white'
-                                : 'text-gray-300 hover:text-white hover:bg-[#222]'
-                        }`}
-                    >
-                        <MessageSquare size={12} />
-                        Agent
-                    </button>
+                {narrow ? (
+                    <OverflowMenu label="More studio actions" align="left" testId="toolbar-overflow">
+                        <div className="flex flex-col gap-1 min-w-[190px] [&_a]:w-full [&_button]:w-full [&_a]:justify-start [&_button]:justify-start [&_a]:py-2 [&_button]:py-2">
+                            {agentButton}
+                            {connectLink}
+                            {myDesignsLink}
+                            {publishButton}
+                            <div className="h-px bg-[#2b313c] my-1" />
+                            {brushButton}
+                            {sectionButton}
+                            {referenceButton}
+                            {environmentButton}
+                            {inspectorButton}
+                        </div>
+                    </OverflowMenu>
+                ) : (
+                    <>
+                        {agentButton}
+                        {connectLink}
+                        {myDesignsLink}
+                        {publishButton}
+                    </>
                 )}
-                {enableConnect && (
-                    <a
-                        href="/connect"
-                        data-testid="toolbar-connect-link"
-                        aria-label="Connect to Claude Desktop"
-                        className="inline-flex items-center gap-1 px-2 py-1 rounded text-gray-300 hover:text-white hover:bg-[#222] transition-colors"
-                    >
-                        <Plug size={12} />
-                        Connect
-                    </a>
-                )}
-                {session && (
-                    <a
-                        href="/me"
-                        data-testid="toolbar-my-designs"
-                        aria-label="My Designs"
-                        className="inline-flex items-center gap-1 px-2 py-1 rounded text-gray-300 hover:text-white hover:bg-[#222] transition-colors"
-                    >
-                        My Designs
-                    </a>
-                )}
-                <button
-                    type="button"
-                    data-testid="toolbar-publish"
-                    onClick={() => void handlePublish()}
-                    disabled={publishState === 'saving'}
-                    aria-label="Publish and share"
-                    className="inline-flex items-center gap-1 px-2 py-1 rounded text-gray-300 hover:text-white hover:bg-[#222] transition-colors disabled:opacity-50"
-                >
-                    <Share2 size={12} />
-                    {publishState === 'saving' ? 'Publishing…' : publishState === 'error' ? 'Retry' : 'Publish & Share'}
-                </button>
                 {publishedLink && (
                     <a
                         href={publishedLink}
                         data-testid="toolbar-publish-link"
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1 px-2 py-1 rounded text-emerald-400 hover:text-emerald-300 text-xs transition-colors"
+                        className="inline-flex items-center gap-1 px-2 py-1 rounded text-emerald-400 hover:text-emerald-300 text-xs transition-colors truncate max-w-[45vw]"
                     >
                         Link copied — {publishedLink}
                     </a>
@@ -184,110 +335,23 @@ export function Toolbar({
                     <span
                         data-testid="toolbar-modified-dot"
                         aria-label="Unsaved changes"
-                        className="w-2 h-2 rounded-full bg-amber-400"
+                        className="w-2 h-2 rounded-full bg-amber-400 shrink-0"
                     />
                 )}
             </div>
 
             <div className="flex items-center gap-2 ml-auto shrink-0">
-                <button
-                    type="button"
-                    onClick={onValidate}
-                    aria-label="Validate"
-                    className="inline-flex items-center gap-1 px-2 py-1 rounded text-gray-300 hover:text-white hover:bg-[#222] transition-colors"
-                >
-                    <CheckCircle2 size={12} />
-                    Validate
-                </button>
-                <button
-                    type="button"
-                    onClick={onRun}
-                    aria-label="Run"
-                    className="inline-flex items-center gap-1 px-2 py-1 rounded bg-emerald-600 hover:bg-emerald-500 text-white transition-colors"
-                >
-                    <Play size={12} />
-                    Run
-                </button>
-                <button
-                    type="button"
-                    data-testid="toolbar-mark"
-                    onClick={onToggleMarkingMode}
-                    title={markingMode ? 'Save mark & exit (your agent can then pick it up)' : 'Paint over what is wrong, then click again to save'}
-                    aria-label={markingMode ? 'Save mark and exit marking mode' : 'Enter marking mode'}
-                    aria-pressed={markingMode}
-                    className={`inline-flex items-center gap-1.5 px-3 py-1 rounded font-medium transition-colors ${
-                        markingMode
-                            ? 'bg-red-600 text-white ring-2 ring-red-300'
-                            : 'bg-[#2a1313] text-red-300 hover:bg-red-700 hover:text-white border border-red-700'
-                    }`}
-                >
-                    <Brush size={14} />
-                    Brush
-                </button>
-                <button
-                    type="button"
-                    data-testid="toolbar-section"
-                    onClick={onToggleSectionMode}
-                    title={sectionMode ? 'Exit section view' : 'Slice the model with a plane to see inside'}
-                    aria-label={sectionMode ? 'Exit section view' : 'Enter section view'}
-                    aria-pressed={sectionMode}
-                    className={`inline-flex items-center gap-1.5 px-3 py-1 rounded font-medium transition-colors ${
-                        sectionMode
-                            ? 'bg-sky-600 text-white ring-2 ring-sky-300'
-                            : 'bg-[#13202a] text-sky-300 hover:bg-sky-700 hover:text-white border border-sky-700'
-                    }`}
-                >
-                    <Scissors size={14} />
-                    Section
-                </button>
-                {referenceImagesPresent && (
-                    <button
-                        type="button"
-                        onClick={onToggleReferenceImages}
-                        aria-label={referenceImagesVisible ? 'Hide reference images' : 'Show reference images'}
-                        aria-pressed={referenceImagesVisible}
-                        className={`inline-flex items-center gap-1 px-2 py-1 rounded transition-colors ${
-                            referenceImagesVisible
-                                ? 'bg-[#333] text-white'
-                                : 'text-gray-300 hover:text-white hover:bg-[#222]'
-                        }`}
-                    >
-                        <ImageIcon size={12} />
-                        Reference
-                    </button>
+                {validateButton}
+                {runButton}
+                {!narrow && (
+                    <>
+                        {brushButton}
+                        {sectionButton}
+                        {referenceButton}
+                        {environmentButton}
+                        {inspectorButton}
+                    </>
                 )}
-                {renderEnvironmentPresent && (
-                    <button
-                        type="button"
-                        data-testid="toolbar-render-environment"
-                        onClick={onToggleRenderEnvironment}
-                        aria-label={renderEnvironmentVisible ? 'Disable HDRI environment' : 'Enable HDRI environment'}
-                        aria-pressed={renderEnvironmentVisible}
-                        className={`inline-flex items-center gap-1 px-2 py-1 rounded transition-colors ${
-                            renderEnvironmentVisible
-                                ? 'bg-[#333] text-white'
-                                : 'text-gray-300 hover:text-white hover:bg-[#222]'
-                        }`}
-                    >
-                        Env: {renderEnvironmentPresetLabel}
-                    </button>
-                )}
-                <button
-                    type="button"
-                    data-testid="toolbar-inspector"
-                    onClick={onToggleInspector}
-                    title={inspectorOpen ? 'Hide the inspector panel' : 'Show the inspector panel'}
-                    aria-label={inspectorOpen ? 'Hide inspector panel' : 'Show inspector panel'}
-                    aria-pressed={inspectorOpen}
-                    className={`inline-flex items-center gap-1 px-2 py-1 rounded transition-colors ${
-                        inspectorOpen
-                            ? 'bg-[#333] text-white'
-                            : 'text-gray-300 hover:text-white hover:bg-[#222]'
-                    }`}
-                >
-                    <PanelRight size={12} />
-                    Inspector
-                </button>
             </div>
         </div>
     );

--- a/src/studio/__tests__/Toolbar.mobile.test.tsx
+++ b/src/studio/__tests__/Toolbar.mobile.test.tsx
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+/** @vitest-environment happy-dom */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { Toolbar } from '../Toolbar';
+
+vi.mock('@tanstack/react-router', () => ({ useNavigate: () => vi.fn() }));
+vi.mock('../../funnel/hooks/useSession', () => ({
+    useOptionalSession: () => ({ session: { user: { email: 'a@b.c' } }, loading: false }),
+}));
+vi.mock('../../funnel/lib/apiClient', () => ({ saveProject: vi.fn() }));
+
+/** Force the narrow-viewport branch (`(max-width: 767px)` matches). */
+function setNarrow(narrow: boolean) {
+    Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        writable: true,
+        value: (query: string) => ({
+            matches: narrow,
+            media: query,
+            addEventListener: () => {},
+            removeEventListener: () => {},
+        }),
+    });
+}
+
+function renderToolbar() {
+    return render(
+        <Toolbar
+            isModified={false}
+            onValidate={vi.fn()}
+            onRun={vi.fn()}
+            agentRailOpen={false}
+            onToggleAgentRail={vi.fn()}
+            referenceImagesPresent={false}
+            referenceImagesVisible
+            onToggleReferenceImages={vi.fn()}
+            markingMode={false}
+            onToggleMarkingMode={vi.fn()}
+            sectionMode={false}
+            onToggleSectionMode={vi.fn()}
+            inspectorOpen
+            onToggleInspector={vi.fn()}
+            code="box(10,10,10)"
+        />,
+    );
+}
+
+afterEach(() => {
+    cleanup();
+    setNarrow(false);
+});
+
+beforeEach(() => {
+    setNarrow(true);
+});
+
+describe('Toolbar on a narrow viewport', () => {
+    it('keeps Validate and Run on the bar', () => {
+        renderToolbar();
+        expect(screen.getByLabelText('Run')).toBeDefined();
+        expect(screen.getByLabelText('Validate')).toBeDefined();
+    });
+
+    it('collapses the secondary controls into the overflow menu', () => {
+        renderToolbar();
+        expect(screen.queryByTestId('toolbar-publish')).toBeNull();
+        expect(screen.queryByTestId('toolbar-mark')).toBeNull();
+        expect(screen.queryByTestId('toolbar-section')).toBeNull();
+        expect(screen.queryByTestId('toolbar-inspector')).toBeNull();
+        expect(screen.queryByTestId('toolbar-my-designs')).toBeNull();
+
+        fireEvent.click(screen.getByTestId('toolbar-overflow'));
+
+        expect(screen.getByTestId('toolbar-publish')).toBeDefined();
+        expect(screen.getByTestId('toolbar-mark')).toBeDefined();
+        expect(screen.getByTestId('toolbar-section')).toBeDefined();
+        expect(screen.getByTestId('toolbar-inspector')).toBeDefined();
+        expect(screen.getByTestId('toolbar-my-designs')).toBeDefined();
+    });
+
+    it('closes the overflow menu on Escape', () => {
+        renderToolbar();
+        fireEvent.click(screen.getByTestId('toolbar-overflow'));
+        expect(screen.getByTestId('toolbar-overflow-panel')).toBeDefined();
+
+        fireEvent.keyDown(document, { key: 'Escape' });
+        expect(screen.queryByTestId('toolbar-overflow-panel')).toBeNull();
+    });
+
+    it('keeps every control on the bar on a wide viewport', () => {
+        setNarrow(false);
+        renderToolbar();
+        expect(screen.queryByTestId('toolbar-overflow')).toBeNull();
+        expect(screen.getByTestId('toolbar-publish')).toBeDefined();
+        expect(screen.getByTestId('toolbar-inspector')).toBeDefined();
+    });
+});

--- a/src/studio/components/Layout/Header.mobile.test.tsx
+++ b/src/studio/components/Layout/Header.mobile.test.tsx
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { Header } from './Header';
+import { WorkbenchProvider } from '../../context/WorkbenchContext';
+import { StudioChromeProvider } from '../../context/StudioChromeContext';
+
+vi.mock('../../../shared/worker/geometryEngine', async () => {
+    const actual = await vi.importActual('../../../shared/worker/geometryEngine');
+    const mockInstance = {
+        initialize: vi.fn().mockResolvedValue(true),
+        executeCode: vi.fn().mockResolvedValue({ geometries: [], sketches: [] }),
+    };
+    return {
+        ...actual,
+        exportSTEP: vi.fn().mockResolvedValue(new Blob(['mock data'])),
+        exportSTL: vi.fn().mockResolvedValue(new Blob(['mock data'])),
+        init: vi.fn().mockResolvedValue(true),
+        GeometryEngine: { getInstance: () => mockInstance },
+    };
+});
+
+/** Force the narrow-viewport branch (`(max-width: 767px)` matches). */
+function setNarrow(narrow: boolean) {
+    Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        writable: true,
+        value: (query: string) => ({
+            matches: narrow,
+            media: query,
+            addEventListener: () => {},
+            removeEventListener: () => {},
+        }),
+    });
+}
+
+function renderHeader(headerLeft?: React.ReactNode) {
+    return render(
+        <WorkbenchProvider>
+            <StudioChromeProvider value={{ headerLeft }}>
+                <Header />
+            </StudioChromeProvider>
+        </WorkbenchProvider>,
+    );
+}
+
+beforeEach(() => setNarrow(true));
+afterEach(() => {
+    cleanup();
+    setNarrow(false);
+});
+
+describe('Header on a narrow viewport', () => {
+    it('moves the instrument clusters into the overflow menu', () => {
+        renderHeader();
+        expect(screen.queryByTestId('view-3d-toggle')).toBeNull();
+        expect(screen.queryByTestId('viewport-background-toggle')).toBeNull();
+        expect(screen.queryByTestId('viewport-grid-toggle')).toBeNull();
+        expect(screen.queryByTitle('Export STEP')).toBeNull();
+
+        fireEvent.click(screen.getByTestId('header-overflow'));
+
+        expect(screen.getByTestId('view-3d-toggle')).toBeDefined();
+        expect(screen.getByTestId('viewport-background-toggle')).toBeDefined();
+        expect(screen.getByTestId('viewport-grid-toggle')).toBeDefined();
+        expect(screen.getByTitle('Export STEP')).toBeDefined();
+    });
+
+    it('keeps the account slot pinned on the bar', () => {
+        renderHeader();
+        expect(screen.getByTestId('account-slot')).toBeDefined();
+    });
+
+    it('drops the Studio project name only when the route supplies its own title', () => {
+        renderHeader();
+        expect(screen.getByText('Untitled Project')).toBeDefined();
+        cleanup();
+
+        renderHeader(<span>My Bracket</span>);
+        expect(screen.queryByText('Untitled Project')).toBeNull();
+        expect(screen.getByText('My Bracket')).toBeDefined();
+    });
+
+    it('keeps the instruments inline on a wide viewport', () => {
+        setNarrow(false);
+        renderHeader();
+        expect(screen.queryByTestId('header-overflow')).toBeNull();
+        expect(screen.getByTestId('view-3d-toggle')).toBeDefined();
+        expect(screen.getByTitle('Export STEP')).toBeDefined();
+    });
+});

--- a/src/studio/components/Layout/Header.tsx
+++ b/src/studio/components/Layout/Header.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { useWorkbench } from '../../context/WorkbenchContext';
 import { Loader2, Download, FileDown, Undo2, Redo2, Box, Grid as GridIcon, Grid3x3, Circle, FolderOpen, Moon, Sun, LayoutGrid, History, RotateCcw } from 'lucide-react';
 import { exportSTEP, exportSTL } from '../../../shared/worker/geometryEngine';
@@ -8,7 +8,21 @@ import { formatTooltip, SHORTCUT_HINTS } from '../../../shared/constants/shortcu
 import { useProject } from '../../context/ProjectContext';
 import { useStudioChrome } from '../../context/StudioChromeContext';
 import { useUI } from '../../context/UIContext';
+import { COMPACT_HEADER_QUERY, useIsNarrow } from '../../hooks/useIsNarrow';
+import { OverflowMenu } from './OverflowMenu';
 import UserMenu from './UserMenu';
+
+/** Labelled row inside the narrow-viewport overflow menu. Keeps the bar's
+ *  segmented controls intact but gives each cluster a name, since the icons
+ *  alone carry no context once they leave the bar. */
+function MenuRow({ label, children }: { label: string; children: ReactNode }) {
+    return (
+        <div className="flex items-center justify-between gap-4 px-1 py-1.5">
+            <span className="text-[11px] uppercase tracking-wide text-gray-500 whitespace-nowrap">{label}</span>
+            <div className="flex items-center gap-1 shrink-0">{children}</div>
+        </div>
+    );
+}
 
 export function Header() {
     const { headerLeft, headerRight } = useStudioChrome();
@@ -22,6 +36,9 @@ export function Header() {
 
     const [historyOpen, setHistoryOpen] = useState(false);
     const historyRef = useRef<HTMLDivElement>(null);
+    // Below `lg` the bar cannot hold the instrument cluster next to the route's
+    // own chrome; the instruments move into a single overflow menu instead.
+    const narrow = useIsNarrow(COMPACT_HEADER_QUERY);
 
     // Close the history menu on outside click / Escape.
     useEffect(() => {
@@ -77,23 +94,206 @@ export function Header() {
         }
     };
 
+    const viewModeCluster = (
+        <div className="flex bg-[#222] rounded p-0.5" data-testid="view-3d-toggle">
+            <button
+                onClick={() => setViewMode3D('shadedWithEdges')}
+                className={`p-1 rounded text-xs flex items-center gap-1 ${viewMode3D === 'shadedWithEdges' ? 'bg-[#444] text-white shadow' : 'text-gray-400 hover:text-white'}`}
+                title="Shaded with Edges"
+                aria-label="Shaded with Edges"
+            >
+                <Box size={14} />
+            </button>
+            <button
+                onClick={() => setViewMode3D('wireframe')}
+                className={`p-1 rounded text-xs flex items-center gap-1 ${viewMode3D === 'wireframe' ? 'bg-[#444] text-white shadow' : 'text-gray-400 hover:text-white'}`}
+                title="Wireframe"
+                aria-label="Wireframe"
+            >
+                <GridIcon size={14} />
+            </button>
+            <button
+                onClick={() => setViewMode3D('shaded')}
+                className={`p-1 rounded text-xs flex items-center gap-1 ${viewMode3D === 'shaded' ? 'bg-[#444] text-white shadow' : 'text-gray-400 hover:text-white'}`}
+                title="Shaded"
+                aria-label="Shaded"
+            >
+                <Circle size={14} />
+            </button>
+        </div>
+    );
+
+    /* Viewport background switcher (dark / light / checkered) */
+    const backgroundCluster = (
+        <div className="flex bg-[#222] rounded p-0.5" data-testid="viewport-background-toggle">
+            <button
+                onClick={() => setViewportBackground('dark')}
+                className={`p-1 rounded text-xs flex items-center gap-1 ${viewportBackground === 'dark' ? 'bg-[#444] text-white shadow' : 'text-gray-400 hover:text-white'}`}
+                title="Dark background"
+                aria-label="Dark background"
+                data-testid="viewport-background-dark"
+            >
+                <Moon size={14} />
+            </button>
+            <button
+                onClick={() => setViewportBackground('light')}
+                className={`p-1 rounded text-xs flex items-center gap-1 ${viewportBackground === 'light' ? 'bg-[#444] text-white shadow' : 'text-gray-400 hover:text-white'}`}
+                title="Light background"
+                aria-label="Light background"
+                data-testid="viewport-background-light"
+            >
+                <Sun size={14} />
+            </button>
+            <button
+                onClick={() => setViewportBackground('checkered')}
+                className={`p-1 rounded text-xs flex items-center gap-1 ${viewportBackground === 'checkered' ? 'bg-[#444] text-white shadow' : 'text-gray-400 hover:text-white'}`}
+                title="Checkered background"
+                aria-label="Checkered background"
+                data-testid="viewport-background-checkered"
+            >
+                <LayoutGrid size={14} />
+            </button>
+        </div>
+    );
+
+    /* Ground grid visibility */
+    const gridButton = (
+        <button
+            onClick={() => setGridVisible(!gridVisible)}
+            className={`p-1 rounded text-xs flex items-center gap-1 ${gridVisible ? 'bg-[#444] text-white shadow' : 'text-gray-400 hover:text-white'}`}
+            title={gridVisible ? 'Hide ground grid' : 'Show ground grid'}
+            aria-label="Toggle ground grid"
+            aria-pressed={gridVisible}
+            data-testid="viewport-grid-toggle"
+        >
+            <Grid3x3 size={14} />
+        </button>
+    );
+
+    // A route that injects its own header chrome (e.g. /p/:slug shows the
+    // project title) already names the document, so on a phone the Studio's
+    // own project-name label is dropped rather than fighting for the same row.
+    const hideProjectName = narrow && !!headerLeft;
+
+    const exportButtons = (withLabels: boolean) => (
+        <>
+            <button
+                onClick={() => handleExport('step')}
+                disabled={isComputing}
+                className={`p-1 hover:bg-[#333] rounded text-gray-400 hover:text-white transition-colors ${withLabels ? 'inline-flex items-center gap-1.5 px-2 text-xs' : ''}`}
+                title="Export STEP"
+                aria-label="Export STEP"
+            >
+                <FileDown className="w-4 h-4" />
+                {withLabels && 'STEP'}
+            </button>
+            <button
+                onClick={() => handleExport('stl')}
+                disabled={isComputing}
+                className={`p-1 hover:bg-[#333] rounded text-gray-400 hover:text-white transition-colors ${withLabels ? 'inline-flex items-center gap-1.5 px-2 text-xs' : ''}`}
+                title="Export STL"
+                aria-label="Export STL"
+            >
+                <Download className="w-4 h-4" />
+                {withLabels && 'STL'}
+            </button>
+        </>
+    );
+
+    const undoRedoButtons = (
+        <>
+            <button
+                onClick={() => commandManager.undo()}
+                disabled={!commandManager.canUndo}
+                className={`p-1 rounded transition-colors ${!commandManager.canUndo ? 'text-gray-600 cursor-not-allowed' : 'text-gray-400 hover:text-white hover:bg-[#333]'}`}
+                aria-label="Undo"
+                title={formatTooltip('Undo', SHORTCUT_HINTS.undo)}
+            >
+                <Undo2 className="w-4 h-4" />
+            </button>
+            <button
+                onClick={() => commandManager.redo()}
+                disabled={!commandManager.canRedo}
+                className={`p-1 rounded transition-colors ${!commandManager.canRedo ? 'text-gray-600 cursor-not-allowed' : 'text-gray-400 hover:text-white hover:bg-[#333]'}`}
+                aria-label="Redo"
+                title={formatTooltip('Redo', SHORTCUT_HINTS.redo)}
+            >
+                <Redo2 className="w-4 h-4" />
+            </button>
+        </>
+    );
+
+    const historyControl = historyAvailable ? (
+        <div className="relative" ref={historyRef} data-testid="history-menu">
+            <button
+                onClick={() => setHistoryOpen(o => !o)}
+                className={`p-1 rounded transition-colors ${historyOpen ? 'bg-[#333] text-white' : 'text-gray-400 hover:text-white hover:bg-[#333]'}`}
+                aria-label="Revision history"
+                aria-haspopup="menu"
+                aria-expanded={historyOpen}
+                title="Revision history"
+                data-testid="history-button"
+            >
+                <History className="w-4 h-4" />
+            </button>
+            {historyOpen && (
+                <div
+                    role="menu"
+                    className="absolute right-0 top-full mt-1 w-64 max-h-80 overflow-y-auto bg-[#1a1a1a] border border-[#333] rounded shadow-lg z-50 py-1"
+                    data-testid="history-dropdown"
+                >
+                    <div className="px-3 py-1.5 text-[10px] uppercase tracking-wide text-gray-500 font-medium">
+                        Revision history
+                    </div>
+                    {[...revisions].reverse().map((rev) => (
+                        <div
+                            key={rev.v}
+                            className="group flex items-center justify-between gap-2 px-3 py-1.5 hover:bg-[#222]"
+                        >
+                            <div className="min-w-0">
+                                <div className="text-xs text-gray-300">v{rev.v}</div>
+                                <div className="text-[10px] text-gray-500 truncate">{formatRevisionTime(rev.ts)}</div>
+                            </div>
+                            <button
+                                onClick={() => handleRestore(rev.v)}
+                                className="flex items-center gap-1 text-[10px] text-gray-400 hover:text-white px-1.5 py-1 rounded hover:bg-[#333] transition-colors shrink-0"
+                                aria-label={`Restore revision v${rev.v}`}
+                                title={`Restore v${rev.v}`}
+                            >
+                                <RotateCcw className="w-3 h-3" />
+                                Restore
+                            </button>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    ) : null;
+
     return (
-        <div className="h-10 bg-[#111] border-b border-[#333] flex items-center px-4 gap-2 select-none shrink-0 bar-scroll-x" data-testid="header">
-            <div className="flex items-center gap-3 min-w-0">
+        <div className="h-10 bg-[#111] border-b border-[#333] flex items-center px-2 md:px-4 gap-2 select-none shrink-0 bar-scroll-x" data-testid="header">
+            {/* `overflow-hidden` is load-bearing: without it this group can be
+                squeezed below its content width and its `shrink-0` children
+                (title chip, live badge) spill out over the right-hand cluster,
+                which is what made the phone header look like two rows of
+                controls stacked on top of each other. */}
+            <div className="flex items-center gap-3 min-w-0 overflow-hidden">
                 <button
                     onClick={() => setActiveDialog('projectManager')}
                     aria-label="Open project manager"
-                    className="flex items-center gap-2 group hover:bg-[#222] px-2 py-1 rounded transition-colors min-w-0"
+                    className="flex items-center gap-2 group hover:bg-[#222] px-2 py-1 rounded transition-colors min-w-0 shrink-0"
                 >
                     <div className="w-2 h-2 rounded-full bg-blue-500 group-hover:animate-pulse" />
                     <span className="text-sm font-medium text-gray-300 flex items-center gap-2 min-w-0">
-                        <span className="truncate max-w-[180px]">{activeProject?.name || 'Untitled Project'}</span>
+                        {!hideProjectName && (
+                            <span className="truncate max-w-[180px]">{activeProject?.name || 'Untitled Project'}</span>
+                        )}
                         <FolderOpen size={12} className="text-gray-500 group-hover:text-blue-400" />
                     </span>
                 </button>
                 {headerLeft && (
                     <>
-                        <div className="h-6 w-px bg-[#333]" />
+                        <div className="h-6 w-px bg-[#333] shrink-0" />
                         <div className="flex items-center gap-2 min-w-0">{headerLeft}</div>
                     </>
                 )}
@@ -103,171 +303,35 @@ export function Header() {
                 {headerRight && (
                     <>
                         <div className="flex items-center gap-2">{headerRight}</div>
-                        <div className="h-6 w-px bg-[#333] mx-2" />
+                        {!narrow && <div className="h-6 w-px bg-[#333] mx-2" />}
                     </>
                 )}
-                {/* 3D View Mode Toggle */}
-                <div className="flex bg-[#222] rounded p-0.5" data-testid="view-3d-toggle">
-                    <button
-                        onClick={() => setViewMode3D('shadedWithEdges')}
-                        className={`p-1 rounded text-xs flex items-center gap-1 ${viewMode3D === 'shadedWithEdges' ? 'bg-[#444] text-white shadow' : 'text-gray-400 hover:text-white'}`}
-                        title="Shaded with Edges"
-                        aria-label="Shaded with Edges"
-                    >
-                        <Box size={14} />
-                    </button>
-                    <button
-                        onClick={() => setViewMode3D('wireframe')}
-                        className={`p-1 rounded text-xs flex items-center gap-1 ${viewMode3D === 'wireframe' ? 'bg-[#444] text-white shadow' : 'text-gray-400 hover:text-white'}`}
-                        title="Wireframe"
-                        aria-label="Wireframe"
-                    >
-                        <GridIcon size={14} />
-                    </button>
-                    <button
-                        onClick={() => setViewMode3D('shaded')}
-                        className={`p-1 rounded text-xs flex items-center gap-1 ${viewMode3D === 'shaded' ? 'bg-[#444] text-white shadow' : 'text-gray-400 hover:text-white'}`}
-                        title="Shaded"
-                        aria-label="Shaded"
-                    >
-                        <Circle size={14} />
-                    </button>
-                </div>
-
-                {/* Viewport background switcher (dark / light / checkered) */}
-                <div className="flex bg-[#222] rounded p-0.5" data-testid="viewport-background-toggle">
-                    <button
-                        onClick={() => setViewportBackground('dark')}
-                        className={`p-1 rounded text-xs flex items-center gap-1 ${viewportBackground === 'dark' ? 'bg-[#444] text-white shadow' : 'text-gray-400 hover:text-white'}`}
-                        title="Dark background"
-                        aria-label="Dark background"
-                        data-testid="viewport-background-dark"
-                    >
-                        <Moon size={14} />
-                    </button>
-                    <button
-                        onClick={() => setViewportBackground('light')}
-                        className={`p-1 rounded text-xs flex items-center gap-1 ${viewportBackground === 'light' ? 'bg-[#444] text-white shadow' : 'text-gray-400 hover:text-white'}`}
-                        title="Light background"
-                        aria-label="Light background"
-                        data-testid="viewport-background-light"
-                    >
-                        <Sun size={14} />
-                    </button>
-                    <button
-                        onClick={() => setViewportBackground('checkered')}
-                        className={`p-1 rounded text-xs flex items-center gap-1 ${viewportBackground === 'checkered' ? 'bg-[#444] text-white shadow' : 'text-gray-400 hover:text-white'}`}
-                        title="Checkered background"
-                        aria-label="Checkered background"
-                        data-testid="viewport-background-checkered"
-                    >
-                        <LayoutGrid size={14} />
-                    </button>
-                </div>
-
-                {/* Ground grid visibility */}
-                <button
-                    onClick={() => setGridVisible(!gridVisible)}
-                    className={`ml-1 p-1 rounded text-xs flex items-center gap-1 ${gridVisible ? 'bg-[#444] text-white shadow' : 'text-gray-400 hover:text-white'}`}
-                    title={gridVisible ? 'Hide ground grid' : 'Show ground grid'}
-                    aria-label="Toggle ground grid"
-                    aria-pressed={gridVisible}
-                    data-testid="viewport-grid-toggle"
-                >
-                    <Grid3x3 size={14} />
-                </button>
-
-                <div className="h-6 w-px bg-[#333] mx-2" />
-
-                <button
-                    onClick={() => commandManager.undo()}
-                    disabled={!commandManager.canUndo}
-                    className={`p-1 rounded transition-colors ${!commandManager.canUndo ? 'text-gray-600 cursor-not-allowed' : 'text-gray-400 hover:text-white hover:bg-[#333]'}`}
-                    aria-label="Undo"
-                    title={formatTooltip('Undo', SHORTCUT_HINTS.undo)}
-                >
-                    <Undo2 className="w-4 h-4" />
-                </button>
-                <button
-                    onClick={() => commandManager.redo()}
-                    disabled={!commandManager.canRedo}
-                    className={`p-1 rounded transition-colors ${!commandManager.canRedo ? 'text-gray-600 cursor-not-allowed' : 'text-gray-400 hover:text-white hover:bg-[#333]'}`}
-                    aria-label="Redo"
-                    title={formatTooltip('Redo', SHORTCUT_HINTS.redo)}
-                >
-                    <Redo2 className="w-4 h-4" />
-                </button>
-
-                {historyAvailable && (
-                    <div className="relative" ref={historyRef} data-testid="history-menu">
-                        <button
-                            onClick={() => setHistoryOpen(o => !o)}
-                            className={`p-1 rounded transition-colors ${historyOpen ? 'bg-[#333] text-white' : 'text-gray-400 hover:text-white hover:bg-[#333]'}`}
-                            aria-label="Revision history"
-                            aria-haspopup="menu"
-                            aria-expanded={historyOpen}
-                            title="Revision history"
-                            data-testid="history-button"
-                        >
-                            <History className="w-4 h-4" />
-                        </button>
-                        {historyOpen && (
-                            <div
-                                role="menu"
-                                className="absolute right-0 top-full mt-1 w-64 max-h-80 overflow-y-auto bg-[#1a1a1a] border border-[#333] rounded shadow-lg z-50 py-1"
-                                data-testid="history-dropdown"
-                            >
-                                <div className="px-3 py-1.5 text-[10px] uppercase tracking-wide text-gray-500 font-medium">
-                                    Revision history
-                                </div>
-                                {[...revisions].reverse().map((rev) => (
-                                    <div
-                                        key={rev.v}
-                                        className="group flex items-center justify-between gap-2 px-3 py-1.5 hover:bg-[#222]"
-                                    >
-                                        <div className="min-w-0">
-                                            <div className="text-xs text-gray-300">v{rev.v}</div>
-                                            <div className="text-[10px] text-gray-500 truncate">{formatRevisionTime(rev.ts)}</div>
-                                        </div>
-                                        <button
-                                            onClick={() => handleRestore(rev.v)}
-                                            className="flex items-center gap-1 text-[10px] text-gray-400 hover:text-white px-1.5 py-1 rounded hover:bg-[#333] transition-colors shrink-0"
-                                            aria-label={`Restore revision v${rev.v}`}
-                                            title={`Restore v${rev.v}`}
-                                        >
-                                            <RotateCcw className="w-3 h-3" />
-                                            Restore
-                                        </button>
-                                    </div>
-                                ))}
-                            </div>
-                        )}
-                    </div>
+                {narrow && (
+                    <OverflowMenu label="View and file controls" testId="header-overflow">
+                        <MenuRow label="Display">{viewModeCluster}</MenuRow>
+                        <MenuRow label="Background">{backgroundCluster}</MenuRow>
+                        <MenuRow label="Ground grid">{gridButton}</MenuRow>
+                        <MenuRow label="Edit">
+                            {undoRedoButtons}
+                            {historyControl}
+                        </MenuRow>
+                        <MenuRow label="Export">{exportButtons(true)}</MenuRow>
+                    </OverflowMenu>
                 )}
-
-                <div className="h-6 w-px bg-[#333] mx-2" />
-
-                <button
-                    onClick={() => handleExport('step')}
-                    disabled={isComputing}
-                    className="p-1 hover:bg-[#333] rounded text-gray-400 hover:text-white transition-colors"
-                    title="Export STEP"
-                    aria-label="Export STEP"
-                >
-                    <FileDown className="w-4 h-4" />
-                </button>
-                <button
-                    onClick={() => handleExport('stl')}
-                    disabled={isComputing}
-                    className="p-1 hover:bg-[#333] rounded text-gray-400 hover:text-white transition-colors"
-                    title="Export STL"
-                    aria-label="Export STL"
-                >
-                    <Download className="w-4 h-4" />
-                </button>
+                {!narrow && (
+                    <>
+                        {viewModeCluster}
+                        {backgroundCluster}
+                        {gridButton}
+                        <div className="h-6 w-px bg-[#333] mx-2" />
+                        {undoRedoButtons}
+                        {historyControl}
+                        <div className="h-6 w-px bg-[#333] mx-2" />
+                        {exportButtons(false)}
+                    </>
+                )}
                 {isComputing && <Loader2 className="w-3 h-3 animate-spin text-gray-500" />}
             </div>
-
             {/* Account menu — pinned to the right edge so it never scrolls out of
                 the horizontally-scrollable toolbar. It used to be the last item
                 inside the scrolling instrument cluster, so on narrow viewports it
@@ -288,3 +352,4 @@ export function Header() {
         </div>
     );
 }
+

--- a/src/studio/components/Layout/OverflowMenu.tsx
+++ b/src/studio/components/Layout/OverflowMenu.tsx
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { MoreHorizontal } from 'lucide-react';
+
+export interface OverflowMenuProps {
+    /** Accessible name for the trigger, e.g. "View and file controls". */
+    label: string;
+    /** Menu body. Rendered as-is inside the dropdown panel. */
+    children: ReactNode;
+    /** Which trigger edge the panel lines up with. Default 'right'. */
+    align?: 'left' | 'right';
+    testId?: string;
+}
+
+/**
+ * Narrow-viewport overflow menu for the chrome bars.
+ *
+ * The Header and Toolbar are `bar-scroll-x` containers (overflow-x:auto →
+ * overflow-y:hidden), which would CLIP an in-flow dropdown to the 32-40px bar
+ * height. So the panel is rendered into a portal on <body> with fixed
+ * positioning, anchored under the trigger — the same escape hatch `UserMenu`
+ * already uses for the account dropdown.
+ *
+ * The panel stays open while controls inside it are used (most are toggles
+ * whose effect is visible in the viewport behind); it closes on outside click,
+ * Escape, or a second press of the trigger.
+ */
+export function OverflowMenu({ label, children, align = 'right', testId }: OverflowMenuProps) {
+    const [open, setOpen] = useState(false);
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const panelRef = useRef<HTMLDivElement>(null);
+    const [anchor, setAnchor] = useState<{ top: number; left?: number; right?: number } | null>(null);
+
+    const positionPanel = useCallback(() => {
+        const r = triggerRef.current?.getBoundingClientRect();
+        if (!r) return;
+        setAnchor(
+            align === 'left'
+                ? { top: r.bottom + 4, left: Math.max(4, r.left) }
+                : { top: r.bottom + 4, right: Math.max(4, window.innerWidth - r.right) },
+        );
+    }, [align]);
+
+    // Anchor up-front in the click handler (not in an effect) so the panel
+    // never paints at a stale position.
+    const toggleOpen = () => {
+        if (!open) positionPanel();
+        setOpen(o => !o);
+    };
+
+    useEffect(() => {
+        if (!open) return;
+        const onPointerDown = (e: MouseEvent) => {
+            const t = e.target as Node;
+            if (triggerRef.current?.contains(t) || panelRef.current?.contains(t)) return;
+            setOpen(false);
+        };
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') setOpen(false);
+        };
+        const reposition = () => positionPanel();
+        document.addEventListener('mousedown', onPointerDown);
+        document.addEventListener('keydown', onKeyDown);
+        window.addEventListener('resize', reposition);
+        window.addEventListener('scroll', reposition, true);
+        return () => {
+            document.removeEventListener('mousedown', onPointerDown);
+            document.removeEventListener('keydown', onKeyDown);
+            window.removeEventListener('resize', reposition);
+            window.removeEventListener('scroll', reposition, true);
+        };
+    }, [open, positionPanel]);
+
+    return (
+        <>
+            <button
+                ref={triggerRef}
+                type="button"
+                onClick={toggleOpen}
+                aria-label={label}
+                aria-haspopup="menu"
+                aria-expanded={open}
+                title={label}
+                data-testid={testId}
+                className={`shrink-0 p-1.5 rounded transition-colors ${
+                    open ? 'bg-[#333] text-white' : 'text-gray-400 hover:text-white hover:bg-[#333]'
+                }`}
+            >
+                <MoreHorizontal className="w-4 h-4" />
+            </button>
+            {open &&
+                anchor &&
+                typeof document !== 'undefined' &&
+                createPortal(
+                    <div
+                        ref={panelRef}
+                        role="menu"
+                        aria-label={label}
+                        data-testid={testId ? `${testId}-panel` : undefined}
+                        style={{ top: anchor.top, left: anchor.left, right: anchor.right }}
+                        className="fixed z-[60] max-w-[calc(100vw-8px)] max-h-[70vh] overflow-y-auto rounded border border-[#333] bg-[#1a1a1a] shadow-xl p-2"
+                    >
+                        {children}
+                    </div>,
+                    document.body,
+                )}
+        </>
+    );
+}

--- a/src/studio/hooks/useIsNarrow.ts
+++ b/src/studio/hooks/useIsNarrow.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import { useCallback, useSyncExternalStore } from 'react';
+
+/** Viewport width below which the fixed-height chrome bars (Header, Toolbar)
+ *  can no longer show their full control set. Matches Tailwind's `md`
+ *  breakpoint so JS-driven and class-driven responsiveness agree. */
+export const NARROW_QUERY = '(max-width: 767px)';
+
+/** The Header carries a wider control set than the Toolbar (view mode,
+ *  background, grid, undo/redo, history, exports) plus whatever chrome the
+ *  route injects, and measurably stops fitting below ~1024px — so it collapses
+ *  a breakpoint earlier, at Tailwind's `lg`. */
+export const COMPACT_HEADER_QUERY = '(max-width: 1023px)';
+
+function mediaQueryList(query: string): MediaQueryList | null {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return null;
+    return window.matchMedia(query);
+}
+
+/**
+ * True while the viewport is narrow enough that the chrome bars must collapse
+ * their secondary controls into an overflow menu.
+ *
+ * Implemented with `useSyncExternalStore` rather than `useState` + effect so
+ * there is no set-state-in-effect on mount and no first-paint flash of the
+ * desktop layout. Falls back to `false` (desktop) when `matchMedia` is
+ * unavailable — SSR and the happy-dom test environment both take that path.
+ */
+export function useIsNarrow(query: string = NARROW_QUERY): boolean {
+    const subscribe = useCallback((onChange: () => void) => {
+        const mql = mediaQueryList(query);
+        if (!mql || typeof mql.addEventListener !== 'function') return () => {};
+        mql.addEventListener('change', onChange);
+        return () => mql.removeEventListener('change', onChange);
+    }, [query]);
+
+    const getSnapshot = useCallback(() => mediaQueryList(query)?.matches ?? false, [query]);
+
+    return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}

--- a/src/studio/routes/p.$slug.tsx
+++ b/src/studio/routes/p.$slug.tsx
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 import { createFileRoute } from '@tanstack/react-router';
 import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { Globe, Lock } from 'lucide-react';
 import App from '../App';
 import { SignInButton } from '../../funnel/components/SignInButton';
 import { ProjectViewerActions } from './-ProjectViewerActions';
@@ -195,7 +196,12 @@ function ProjectPage() {
 
   const headerLeft = (
     <div className="flex items-center gap-2 min-w-0">
-      <span className="text-xs text-gray-200 font-medium truncate min-w-[72px] max-w-[160px] md:max-w-[280px]" title={project.title}>
+      {/* The header row is shared with the privacy/share buttons, the overflow
+          menu and the account slot, so on a phone the title truncates down to
+          nothing (`min-w-0`, not a pixel floor) and drops out entirely under
+          400px — otherwise it pushes the live badge past the header's clip and
+          the badge renders as a sliver of green border. */}
+      <span className="hidden min-[400px]:inline text-xs text-gray-200 font-medium truncate min-w-0 max-w-[160px] md:max-w-[280px]" title={project.title}>
         {project.title}
       </span>
       <span className="hidden lg:inline-flex shrink-0 whitespace-nowrap text-[10px] uppercase tracking-widest text-gray-500 font-mono px-1.5 py-0.5 rounded border border-[#333]">
@@ -203,9 +209,10 @@ function ProjectPage() {
       </span>
       <span
         className="shrink-0 whitespace-nowrap text-[10px] uppercase tracking-widest font-mono px-1.5 py-0.5 rounded border border-emerald-700 text-emerald-500"
+        aria-label="live"
         title={lastLiveUpdate ? `last update ${lastLiveUpdate.toLocaleTimeString()}` : 'waiting for agent updates'}
       >
-        ● live
+        ●<span className="hidden md:inline"> live</span>
       </span>
     </div>
   );
@@ -241,8 +248,20 @@ function ProjectPage() {
         Upgrade to keep private
       </button>
     ) : (
-      <button type="button" onClick={handleTogglePrivacy} disabled={privacyBusy} className={btnClass}>
-        {privacyBusy ? '…' : isPrivate ? 'Make public' : 'Make private'}
+      // Icon-only below `md`: spelled out, this button plus Share crowds the
+      // project title off a phone-width header entirely.
+      <button
+        type="button"
+        onClick={handleTogglePrivacy}
+        disabled={privacyBusy}
+        className={btnClass}
+        aria-label={isPrivate ? 'Make public' : 'Make private'}
+        title={isPrivate ? 'Make public' : 'Make private'}
+      >
+        {isPrivate ? <Globe size={12} /> : <Lock size={12} />}
+        <span className="hidden md:inline">
+          {privacyBusy ? '…' : isPrivate ? 'Make public' : 'Make private'}
+        </span>
       </button>
     );
   }


### PR DESCRIPTION
## The bug

On a phone, the Studio chrome bars pile controls on top of each other: the privacy button, revision-history icon, the `● live` badge and Share all paint over one another in the Header, and `Run` sits half off the right edge of the Toolbar.

Root cause: the Header's left group had `min-w-0` with no clip, so it was squeezed below its content width and its `shrink-0` children (project title, live badge) spilled *out* of their box and over the right-hand cluster. `.bar-scroll-x` was meant to catch this by scrolling, but an overflowing child never engages it — and its scrollbar is hidden, so the Toolbar's `Run` just looked cut off.

## The fix

- **Header** — clip the left group (`overflow-hidden`) so nothing can paint over the right cluster, and below `lg` collapse the instruments (display mode, background, ground grid, undo/redo, revision history, STEP/STL export) into one labelled overflow menu. `lg` rather than `md` because the full inline set measurably only fits from ~1024px up, so tablets were affected too.
- **Toolbar** — below `md`, Validate and Run stay on the bar; Agent, Connect, My Designs, Publish & Share, Brush, Section, Reference, Env and Inspector move into a matching overflow menu.
- **New `OverflowMenu`** — renders its panel through a portal, since both bars are `overflow-x:auto` containers that would otherwise clip a dropdown to the 32–40px bar height (the same reason `UserMenu` already portals). Closes on outside click, Escape, or a second press of the trigger.
- **New `useIsNarrow`** — `useSyncExternalStore` over `matchMedia`, so there's no set-state-in-effect and no first-paint flash of the desktop layout. Falls back to desktop when `matchMedia` is absent (SSR / happy-dom).
- **`/p/:slug` header chrome** — icon-only privacy toggle and a dot-only live badge below `md`; the title truncates to nothing (and drops out under 400px) rather than pushing the badge under the clip.
- Bar padding tightens from `px-4`/`px-3` to `px-2` on phones.

## Verification

A probe intersecting every visible control rect in both bars, run in Chromium against `/p/:slug` with stubbed project data, at **360 / 412 / 768 / 900 / 1024 / 1440px**:

- zero overlapping control pairs at every width
- `scrollWidth === clientWidth` in both bars at every width (nothing pushed off-screen)

Before the fix the same probe reported the live badge overlapping the history control by 20px and Share by 28px at 412px, and 6 overlapping pairs at 768px.

Also: 8 new unit tests covering the collapse behaviour in both bars (`Header.mobile.test.tsx`, `Toolbar.mobile.test.tsx`), plus the full `src/studio` suite (632 tests), `npm run lint` and `npm run typecheck` all passing.

## Note

On the phone header the project title is the element that gives way — it truncates and disappears entirely under 400px. The alternative was dropping the live badge instead; that's a one-line flip if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tihNjUS55tgWpb6Cv7trZ

---
_Generated by [Claude Code](https://claude.ai/code/session_013tihNjUS55tgWpb6Cv7trZ)_