### PR TITLE
fix(studio): export via server with project assets

### DIFF
--- a/src/studio/__tests__/tabs/ExportTab.test.tsx
+++ b/src/studio/__tests__/tabs/ExportTab.test.tsx
@@ -175,7 +175,7 @@ describe('ExportTab', () => {
     it('POSTs current editor source when the script param is missing', async () => {
         Object.defineProperty(window, 'location', {
             configurable: true,
-            value: { ...window.location, search: '' },
+            value: { ...window.location, pathname: '/', search: '', hostname: 'localhost' },
         });
         recompute = { ...recompute, geometries: [{ faces: [] }] };
         mockCode.code = 'return cylinder(5, 20);';
@@ -214,6 +214,15 @@ describe('ExportTab', () => {
     });
 
     it('POSTs editor source even when a ?script= param is present (exports live edits)', async () => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: {
+                ...window.location,
+                pathname: '/',
+                search: '?script=examples/foo.kcad.ts',
+                hostname: 'localhost',
+            },
+        });
         recompute = { ...recompute, geometries: [{ faces: [] }] };
         mockCode.code = 'return box(1, 2, 3); // edited';
 
@@ -249,10 +258,54 @@ describe('ExportTab', () => {
         HTMLAnchorElement.prototype.click = originalClick;
     });
 
+    it('POSTs projectSlug for hosted /p/<slug> so complementary STEP assets materialize', async () => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: {
+                ...window.location,
+                pathname: '/p/N2yYiZxy',
+                search: '?version=6',
+                hostname: 'app.kernelcad.com',
+            },
+        });
+        recompute = { ...recompute, geometries: [{ faces: [] }] };
+        mockCode.code = 'return await lib.fromSTEP("./2.0u_blank_costar.stp");';
+
+        const blob = new Blob([new Uint8Array([1, 2, 3])], { type: 'model/stl' });
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            blob: async () => blob,
+            headers: new Headers({ 'content-disposition': 'attachment; filename="model.stl"' }),
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        const clickSpy = vi.fn();
+        const originalClick = HTMLAnchorElement.prototype.click;
+        HTMLAnchorElement.prototype.click = clickSpy;
+
+        const { ExportTab } = await import('../../tabs/ExportTab');
+        render(<ExportTab />);
+        fireEvent.click(screen.getByTestId('export-stl'));
+
+        await waitFor(() => {
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+        });
+        const call = fetchMock.mock.calls[0]!;
+        expect(call[0] as string).toContain('/__kernelcad/export?format=stl');
+        expect(JSON.parse((call[1] as { body: string }).body)).toEqual({
+            projectSlug: 'N2yYiZxy',
+            projectVersion: 6,
+            source: 'return await lib.fromSTEP("./2.0u_blank_costar.stp");',
+        });
+        expect(clickSpy).toHaveBeenCalled();
+
+        HTMLAnchorElement.prototype.click = originalClick;
+    });
+
     it('shows an error when the editor has no source', async () => {
         Object.defineProperty(window, 'location', {
             configurable: true,
-            value: { ...window.location, search: '' },
+            value: { ...window.location, pathname: '/', search: '', hostname: 'localhost' },
         });
         recompute = { ...recompute, geometries: [{ faces: [] }] };
         mockCode.code = '   ';

--- a/src/studio/components/Layout/Header.test.tsx
+++ b/src/studio/components/Layout/Header.test.tsx
@@ -1,81 +1,132 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
 // @vitest-environment happy-dom
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import { Header } from './Header';
 import { WorkbenchProvider } from '../../context/WorkbenchContext';
-import * as geometryEngine from '../../../shared/worker/geometryEngine';
+import * as exportViaServerMod from '../../exportViaServer';
 
-// Mock Geometry Engine exports
+vi.mock('../../exportViaServer', () => ({
+  exportViaServer: vi.fn().mockResolvedValue({
+    blob: new Blob(['mock data']),
+    downloadName: 'model.step',
+  }),
+  downloadBlob: vi.fn(),
+}));
+
+// Workbench/GeometryContext still boots the legacy worker on mount; stub it
+// so happy-dom (no Worker) doesn't reject.
 vi.mock('../../../shared/worker/geometryEngine', async () => {
-    const actual = await vi.importActual('../../../shared/worker/geometryEngine');
-    const mockInstance = {
-        initialize: vi.fn().mockResolvedValue(true),
-        executeCode: vi.fn().mockResolvedValue({ geometries: [], sketches: [] }),
-    };
-    return {
-        ...actual,
-        exportSTEP: vi.fn().mockResolvedValue(new Blob(['mock data'])),
-        exportSTL: vi.fn().mockResolvedValue(new Blob(['mock data'])),
-        init: vi.fn().mockResolvedValue(true),
-        GeometryEngine: {
-            getInstance: () => mockInstance
-        }
-    };
+  const actual = await vi.importActual<typeof import('../../../shared/worker/geometryEngine')>(
+    '../../../shared/worker/geometryEngine',
+  );
+  const mockInstance = {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    executeCode: vi.fn().mockResolvedValue({ geometries: [], sketches: [] }),
+  };
+  return {
+    ...actual,
+    init: vi.fn().mockResolvedValue(undefined),
+    GeometryEngine: {
+      getInstance: () => mockInstance,
+    },
+    geometryEngine: mockInstance,
+  };
+});
+
+vi.mock('../../../funnel/lib/supabaseClient', () => ({
+  isAuthConfigured: () => false,
+  getSupabase: () => ({
+    auth: { getSession: async () => ({ data: { session: null } }) },
+  }),
+}));
+
+beforeEach(() => {
+  vi.mocked(exportViaServerMod.exportViaServer).mockClear();
+  vi.mocked(exportViaServerMod.downloadBlob).mockClear();
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { pathname: '/', search: '', hostname: 'localhost' },
+  });
 });
 
 afterEach(() => {
-    cleanup();
+  cleanup();
 });
 
 describe('Header', () => {
-    it('should render project name', () => {
-        render(
-            <WorkbenchProvider>
-                <Header />
-            </WorkbenchProvider>
-        );
-        // Default project name from ProjectContext
-        expect(screen.getByText('Untitled Project')).toBeDefined();
+  it('should render project name', () => {
+    render(
+      <WorkbenchProvider>
+        <Header />
+      </WorkbenchProvider>,
+    );
+    // Default project name from ProjectContext
+    expect(screen.getByText('Untitled Project')).toBeDefined();
+  });
+
+  it('should export STEP via the server kernel path (not the legacy worker)', async () => {
+    render(
+      <WorkbenchProvider>
+        <Header />
+      </WorkbenchProvider>,
+    );
+
+    fireEvent.click(screen.getByTitle('Export STEP'));
+
+    await waitFor(() => {
+      expect(exportViaServerMod.exportViaServer).toHaveBeenCalled();
     });
-
-    it('should trigger export', () => {
-        render(
-            <WorkbenchProvider>
-                <Header />
-            </WorkbenchProvider>
-        );
-
-        const exportBtn = screen.getByTitle('Export STEP');
-        fireEvent.click(exportBtn);
-
-        expect(geometryEngine.exportSTEP).toHaveBeenCalled();
+    expect(exportViaServerMod.exportViaServer).toHaveBeenCalledWith(
+      'step',
+      expect.any(String),
+    );
+    await waitFor(() => {
+      expect(exportViaServerMod.downloadBlob).toHaveBeenCalled();
     });
+  });
 
-    it('should switch between shading modes', () => {
-        render(
-            <WorkbenchProvider>
-                <Header />
-            </WorkbenchProvider>
-        );
+  it('should export STL via the server kernel path', async () => {
+    render(
+      <WorkbenchProvider>
+        <Header />
+      </WorkbenchProvider>,
+    );
 
-        // Default is usually shadedWithEdges (from WorkbenchContext)
-        const boxBtn = screen.getByTitle('Shaded with Edges');
-        const wireframeBtn = screen.getByTitle('Wireframe');
-        const shadedBtn = screen.getByTitle('Shaded');
+    fireEvent.click(screen.getByTitle('Export STL'));
 
-        // Initial check for shadedWithEdges active style (bg-[#444])
-        expect(boxBtn.className).toContain('bg-[#444]');
-
-        // Click wireframe
-        fireEvent.click(wireframeBtn);
-        expect(wireframeBtn.className).toContain('bg-[#444]');
-        expect(boxBtn.className).not.toContain('bg-[#444]');
-
-        // Click shaded
-        fireEvent.click(shadedBtn);
-        expect(shadedBtn.className).toContain('bg-[#444]');
-        expect(wireframeBtn.className).not.toContain('bg-[#444]');
+    await waitFor(() => {
+      expect(exportViaServerMod.exportViaServer).toHaveBeenCalledWith(
+        'stl',
+        expect.any(String),
+      );
     });
+  });
+
+  it('should switch between shading modes', () => {
+    render(
+      <WorkbenchProvider>
+        <Header />
+      </WorkbenchProvider>,
+    );
+
+    // Default is usually shadedWithEdges (from WorkbenchContext)
+    const boxBtn = screen.getByTitle('Shaded with Edges');
+    const wireframeBtn = screen.getByTitle('Wireframe');
+    const shadedBtn = screen.getByTitle('Shaded');
+
+    // Initial check for shadedWithEdges active style (bg-[#444])
+    expect(boxBtn.className).toContain('bg-[#444]');
+
+    // Click wireframe
+    fireEvent.click(wireframeBtn);
+    expect(wireframeBtn.className).toContain('bg-[#444]');
+    expect(boxBtn.className).not.toContain('bg-[#444]');
+
+    // Click shaded
+    fireEvent.click(shadedBtn);
+    expect(shadedBtn.className).toContain('bg-[#444]');
+    expect(wireframeBtn.className).not.toContain('bg-[#444]');
+  });
 });

--- a/src/studio/components/Layout/Header.tsx
+++ b/src/studio/components/Layout/Header.tsx
@@ -3,12 +3,12 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { useWorkbench } from '../../context/WorkbenchContext';
 import { Loader2, Download, FileDown, Undo2, Redo2, Box, Grid as GridIcon, Grid3x3, Circle, FolderOpen, Moon, Sun, LayoutGrid, History, RotateCcw } from 'lucide-react';
-import { exportSTEP, exportSTL } from '../../../shared/worker/geometryEngine';
 import { formatTooltip, SHORTCUT_HINTS } from '../../../shared/constants/shortcuts';
 import { useProject } from '../../context/ProjectContext';
 import { useStudioChrome } from '../../context/StudioChromeContext';
 import { useUI } from '../../context/UIContext';
 import { COMPACT_HEADER_QUERY, useIsNarrow } from '../../hooks/useIsNarrow';
+import { downloadBlob, exportViaServer } from '../../exportViaServer';
 import { OverflowMenu } from './OverflowMenu';
 import UserMenu from './UserMenu';
 
@@ -73,24 +73,18 @@ export function Header() {
         setHistoryOpen(false);
     };
 
+    // Route through the node OCCT export endpoint (same as ExportTab). The
+    // legacy in-browser worker uses bare `new Function(code)` without an
+    // async wrapper, so top-level await / lib.fromSTEP fail with
+    // "await is only valid in async functions".
     const handleExport = async (type: 'step' | 'stl') => {
         try {
-            let blob: Blob;
-            if (type === 'step') {
-                blob = await exportSTEP(code);
-            } else {
-                blob = await exportSTL(code);
-            }
-
-            const url = URL.createObjectURL(blob);
-            const a = document.createElement('a');
-            a.href = url;
-            a.download = `${(activeProject?.name || 'model').replace(/[^a-z0-9]/gi, '_')}.${type}`;
-            a.click();
-            URL.revokeObjectURL(url);
+            const { blob, downloadName } = await exportViaServer(type, code);
+            const fallback = `${(activeProject?.name || 'model').replace(/[^a-z0-9]/gi, '_')}.${type}`;
+            downloadBlob(blob, downloadName || fallback);
         } catch (err) {
             console.error(err);
-            alert("Export failed: " + (err instanceof Error ? err.message : String(err)));
+            alert('Export failed: ' + (err instanceof Error ? err.message : String(err)));
         }
     };
 

--- a/src/studio/exportViaServer.test.ts
+++ b/src/studio/exportViaServer.test.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./api/apiBase', () => ({
+  apiCall: async () => ({ base: '', headers: {} }),
+  rewritePath: (path: string) => path,
+}));
+
+vi.mock('../funnel/lib/supabaseClient', () => ({
+  getSupabase: () => ({
+    auth: { getSession: async () => ({ data: { session: null } }) },
+  }),
+}));
+
+import { exportViaServer } from './exportViaServer';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('exportViaServer', () => {
+  it('POSTs editor source for free-form scripts', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob([new Uint8Array([1, 2, 3])]),
+      headers: new Headers({ 'content-disposition': 'attachment; filename="x.stl"' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { pathname: '/', search: '', hostname: 'localhost' },
+    });
+
+    const result = await exportViaServer('stl', 'return box(1,1,1);');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/__kernelcad/export?format=stl',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ source: 'return box(1,1,1);' }),
+      }),
+    );
+    expect(result.downloadName).toBe('x.stl');
+    expect(result.blob.size).toBe(3);
+  });
+
+  it('POSTs projectSlug + source on /p/<slug> so lib.fromSTEP assets materialize', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob([new Uint8Array([9])]),
+      headers: new Headers({ 'content-disposition': 'attachment; filename="model.stl"' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        pathname: '/p/N2yYiZxy',
+        search: '?version=6',
+        hostname: 'app.kernelcad.com',
+      },
+    });
+
+    const live = 'const s = await lib.fromSTEP("./2.0u_blank_costar.stp");\nreturn s;';
+    await exportViaServer('stl', live);
+
+    expect(JSON.parse((fetchMock.mock.calls[0]![1] as { body: string }).body)).toEqual({
+      projectSlug: 'N2yYiZxy',
+      projectVersion: 6,
+      source: live,
+    });
+  });
+
+  it('surfaces server error messages', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        statusText: 'Bad',
+        json: async () => ({ error: 'lib.fromSTEP: cannot read STEP file' }),
+      }),
+    );
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { pathname: '/', search: '', hostname: 'localhost' },
+    });
+
+    await expect(exportViaServer('stl', 'return box(1,1,1);')).rejects.toThrow(
+      /cannot read STEP/,
+    );
+  });
+});

--- a/src/studio/exportViaServer.ts
+++ b/src/studio/exportViaServer.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// Shared Studio → OCCT export path. Header toolbar buttons and the Export
+// inspector tab both use this so modern scripts (top-level await,
+// lib.fromSTEP, assemblies) run on the node kernel instead of the legacy
+// in-browser worker (`new Function` without an async wrapper).
+
+import { apiCall, rewritePath } from './api/apiBase';
+import { currentHostedProject, shouldUseHostedMesh } from './scriptSource';
+
+export type StudioExportFormat = 'stl' | 'step' | 'dxf' | '3mf' | 'glb';
+
+export interface ServerExportResult {
+  blob: Blob;
+  downloadName: string;
+}
+
+/**
+ * Export editor source (or a hosted project bundle) via POST /__kernelcad/export.
+ * Hosted `/p/<slug>` pages send projectSlug so complementary STEP/STL assets
+ * materialize next to the script.
+ */
+export async function exportViaServer(
+  format: StudioExportFormat,
+  code: string,
+): Promise<ServerExportResult> {
+  const source = code.trim();
+  const project = currentHostedProject();
+  if (!project && !source) {
+    throw new Error('Export requires script source in the editor.');
+  }
+
+  const { base, headers } = await apiCall();
+  // Hosted static app has no same-origin /__kernelcad/* middleware.
+  // meshSourceHosted uses VITE_API_BASE_URL even when unsigned-in;
+  // mirror that so Export works without a Supabase session.
+  const effectiveBase = base
+    || (shouldUseHostedMesh()
+      ? (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? ''
+      : '');
+  const url = rewritePath(
+    `/__kernelcad/export?format=${format}`,
+    effectiveBase,
+  );
+  // Always send projectSlug on /p/<slug> so the server materializes STEP/STL
+  // assets. Also send editor `source` when present so live edits export without
+  // requiring a save first (server prefers source over stored project code).
+  const body = project
+    ? {
+        projectSlug: project.slug,
+        ...(project.version ? { projectVersion: project.version } : {}),
+        ...(source ? { source } : {}),
+      }
+    : { source };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    throw new Error(
+      typeof payload?.error === 'string' ? payload.error : response.statusText,
+    );
+  }
+
+  const blob = await response.blob();
+  const downloadName =
+    response.headers
+      .get('content-disposition')
+      ?.match(/filename="?([^";]+)"?/)?.[1]
+    ?? `kernelcad-export.${format}`;
+  return { blob, downloadName };
+}
+
+/** Trigger a browser download for a blob returned by exportViaServer. */
+export function downloadBlob(blob: Blob, downloadName: string): void {
+  const objectUrl = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = objectUrl;
+  a.download = downloadName;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(objectUrl);
+}

--- a/src/studio/scriptSource.ts
+++ b/src/studio/scriptSource.ts
@@ -94,7 +94,9 @@ export function rootVisibleFeatures(
   ));
 }
 
-function currentHostedProject(): { slug: string; version?: number } | null {
+/** Hosted Studio project identity from `/p/<slug>?version=N`. Shared by mesh
+ *  and export so relative project assets resolve against the same bundle. */
+export function currentHostedProject(): { slug: string; version?: number } | null {
   if (typeof window === 'undefined') return null;
   const match = window.location.pathname?.match(/^\/p\/([^/]+)\/?$/);
   if (!match) return null;

--- a/src/studio/tabs/ExportTab.tsx
+++ b/src/studio/tabs/ExportTab.tsx
@@ -4,21 +4,15 @@ import { useCallback, useState } from 'react';
 import { Download, Loader2 } from 'lucide-react';
 import { useRecomputeResult } from '../hooks/useRecomputeResult';
 import { useCode } from '../context/CodeContext';
-import { apiCall, rewritePath } from '../api/apiBase';
-import { shouldUseHostedMesh } from '../scriptSource';
+import { downloadBlob, exportViaServer } from '../exportViaServer';
 import type { JSX } from 'react';
 
 // Studio Export tab. Slice 1.4 + Slice A export-trio.
 //
-// Talks to /__kernelcad/export (server-side middleware in vite.config.ts)
-// which routes to runAndExport(...) from src/agent/script-runtime/export.
+// Talks to /__kernelcad/export via exportViaServer (same path as the Header
+// STL/STEP buttons) which runs runAndExport on the node OCCT kernel.
 // Slice A widens the format set from {stl, step} to the five Slice A
-// targets: stl, step, dxf, 3mf, glb. The middleware threads `format`
-// verbatim through to runAndExport.
-//
-// Export always POSTs the current editor source so it works without a
-// `?script=` deep-link and reflects live edits (not just the on-disk
-// example). The server accepts the same body shape as POST /__kernelcad/mesh.
+// targets: stl, step, dxf, 3mf, glb.
 //
 // Visibility is adaptive: ExportTab is only rendered by Inspector when
 // the recompute result has at least one geometry. See
@@ -62,48 +56,10 @@ export function ExportTab(): JSX.Element {
 
     const handleExport = useCallback(async (format: ExportFormat) => {
         setError(null);
-        const source = code.trim();
-        if (!source) {
-            setError('Export requires script source in the editor.');
-            return;
-        }
         setPending(format);
         try {
-            const { base, headers } = await apiCall();
-            // Hosted static app has no same-origin /__kernelcad/* middleware.
-            // meshSourceHosted uses VITE_API_BASE_URL even when unsigned-in;
-            // mirror that so Export works without a Supabase session.
-            const effectiveBase = base
-                || (shouldUseHostedMesh()
-                    ? (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? ''
-                    : '');
-            const url = rewritePath(
-                `/__kernelcad/export?format=${format}`,
-                effectiveBase,
-            );
-            const response = await fetch(url, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json', ...headers },
-                body: JSON.stringify({ source }),
-            });
-            if (!response.ok) {
-                const payload = await response.json().catch(() => ({}));
-                throw new Error(typeof payload?.error === 'string' ? payload.error : response.statusText);
-            }
-            const blob = await response.blob();
-            const downloadName =
-                response.headers
-                    .get('content-disposition')
-                    ?.match(/filename="?([^";]+)"?/)?.[1]
-                ?? `kernelcad-export.${format}`;
-            const objectUrl = URL.createObjectURL(blob);
-            const a = document.createElement('a');
-            a.href = objectUrl;
-            a.download = downloadName;
-            document.body.appendChild(a);
-            a.click();
-            a.remove();
-            URL.revokeObjectURL(objectUrl);
+            const { blob, downloadName } = await exportViaServer(format, code);
+            downloadBlob(blob, downloadName);
         } catch (err) {
             setError(err instanceof Error ? err.message : String(err));
         } finally {


### PR DESCRIPTION
## Summary
Header STL/STEP used the legacy worker (`new Function` without async → await errors). Export also POSTed bare source, so production resolved `lib.fromSTEP('./2.0u_blank_costar.stp')` to `/tmp/...` and failed for 3MF/STL.

## Changes
- Shared `exportViaServer()` for Header + Export tab
- On `/p/<slug>`, POST `projectSlug` + `source` so the API materializes STEP assets
- Route modern scripts through node OCCT export (not the v0.1 worker)

## Test plan
- [x] ExportTab / Header / exportViaServer unit tests (18)
- [ ] With server PR https://github.com/w1ne/kernelCAD-server/pull/119 deployed: 3MF/STL download on keycap project page