### PR TITLE
parts: authored Sharp GP2Y0A21 IR distance ranger

### DIFF
--- a/scripts/electronics-parts.json
+++ b/scripts/electronics-parts.json
@@ -1149,6 +1149,24 @@
       "attribution": "kernelCAD authored model (kernelCAD contributors)"
     },
     {
+      "id": "gp2y0a21",
+      "name": "Sharp GP2Y0A21 IR distance ranger, 10–80 cm (29.5×13×13.5mm)",
+      "family": "Sensor",
+      "mpn": "GP2Y0A21YK0F",
+      "kcad_source": "scripts/parts/authored/gp2y0a21.kcad.ts",
+      "tags": [
+        "sensor",
+        "distance",
+        "infrared",
+        "ir",
+        "sharp",
+        "gp2y0a21",
+        "analog"
+      ],
+      "license": "MIT",
+      "attribution": "kernelCAD authored model (kernelCAD contributors)"
+    },
+    {
       "id": "hc-05",
       "name": "HC-05 Bluetooth SPP module (37×16×6mm)",
       "family": "Wireless",

--- a/scripts/parts/authored/gp2y0a21.kcad.ts
+++ b/scripts/parts/authored/gp2y0a21.kcad.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// scripts/parts/authored/gp2y0a21.kcad.ts
+//
+// Sharp GP2Y0A21YK0F analogue IR distance sensor, 10–80 cm.
+// Body 29.5 × 13 × 13.5 mm; two Ø7 lenses (emitter + detector, ~20 mm apart)
+// on the front face; 3-pin JST-PH pigtail connector on the back.
+//
+// The lenses face +Y (the measuring direction), which is what makes the part
+// recognisable in one second — an upright ranger, not another flat breakout.
+
+const BODY_L = 29.5; // X
+const BODY_D = 13.0; // Y
+const BODY_H = 13.5; // Z
+
+const BODY = '#16161a'; // black housing
+const LENS = '#232c3a'; // dark lens glass
+const LENS_RIM = '#0c0c10';
+const CONN = '#e8e8e4'; // JST-PH white
+const PIN = '#c8c8c0';
+
+// Housing, standing upright: lenses on the +Y face, connector at the back.
+const body = box(BODY_L, BODY_D, BODY_H).color(BODY);
+
+// Two lenses on the front face, emitter/detector pair 20 mm apart, centred at
+// half height. Cylinders are Z-axis natively; rotate about X to face +Y.
+const lensZ = BODY_H / 2;
+const lensY = BODY_D - 1.0; // proud of the face by ~1 mm
+const mkLens = (x: number): Shape[] => {
+  const rim = cylinder(2.0, 3.6, 24).color(LENS_RIM).rotate([1, 0, 0], -90).translate(x, lensY - 1.2, lensZ);
+  const glass = cylinder(1.2, 3.1, 24).color(LENS).rotate([1, 0, 0], -90).translate(x, lensY - 0.4, lensZ);
+  return [rim, glass];
+};
+const lenses = [...mkLens(-10), ...mkLens(10)];
+
+// 3-pin JST-PH connector on the back (-Y) face: white shroud + three pins.
+const conn = box(6.0, 2.2, 4.5).color(CONN).translate(-3.0, -1.2, lensZ - 2.25);
+const pins: Shape[] = [];
+for (let i = 0; i < 3; i++) {
+  pins.push(
+    box(0.5, 2.4, 0.5)
+      .color(PIN)
+      .translate(-2.54 + i * 2.54, -1.2, lensZ - 0.25),
+  );
+}
+
+const asm = assembly('gp2y0a21');
+asm.part('body', body);
+lenses.forEach((l, i) => asm.part(`lens-${i}`, l));
+asm.part('connector', conn);
+pins.forEach((p, i) => asm.part(`pin-${i}`, p));
+return asm.model();


### PR DESCRIPTION
The 10–80 cm analogue IR ranger, modelled recognisably rather than as a generic box: upright black housing (29.5 × 13 × 13.5 mm), the emitter/detector lens pair 20 mm apart on the front face, and the 3-pin JST-PH pigtail at the back. Built as an assembly of separate parts so the catalog GLB keeps body/lens/connector colours (booleans would drop leaf colours).

Feeds labwired's `gp2y0a21` part (the pong community project uses this sensor for paddles). Labwired side currently carries a procedural stand-in as a tracked gap; once this lands in the catalog, `part-models.ts` moves to the authored body.

Local validation: `runScript` evaluates the model with all parts present and no warnings; GLB export succeeds; `scripts/parts` suite 46/46.
