### PR TITLE
feat(assembly): warn when a joint primitive drives a placed part

### DIFF
--- a/src/modeling/mates/jointConventionMix.test.ts
+++ b/src/modeling/mates/jointConventionMix.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// Gate: mixing the two assembly conventions. Joint primitives are URDF —
+// `origin` is the parent->child frame offset and the child is modeled about
+// its own origin. `.mate()` + connectors treat the origin as a pivot and
+// preserve the modeled position at pose 0. Mixing them silently displaces the
+// child by the joint origin at EVERY pose, including 0.
+//
+// The false-positive cases below matter more than the positive one: a
+// correctly-authored URDF link must stay silent, or the warning is noise and
+// gets ignored.
+
+import { describe, it, expect } from 'vitest';
+import { CaptureSession } from '../capture/captureSession';
+import { createApi } from '../api';
+import { validateJointConventionMix } from './jointConventionMix';
+
+const CODE = 'assembly.joint.child-modeled-in-place';
+
+function api() {
+  const session = new CaptureSession();
+  return createApi({ session });
+}
+
+describe('validateJointConventionMix', () => {
+  it('warns when a joint primitive drives a part placed by .translate(...)', () => {
+    const kcad = api();
+    const arm = kcad.assembly('hinge');
+    const base = arm.part('base', kcad.box(60, 40, 10));
+    // Modeled in place, resting on the base — the natural thing to write.
+    const link = arm.part('arm', kcad.box(50, 10, 8).translate(5, 15, 12));
+    arm.revolute('elbow', base, link, { axis: [0, -1, 0], origin: [5, 20, 16] });
+
+    const d = validateJointConventionMix(arm);
+    expect(d).toHaveLength(1);
+    expect(d[0].code).toBe(CODE);
+    expect(d[0].severity).toBe('warning');
+    expect(d[0].partName).toBe('arm');
+    // The message must name both the joint and the offset, or it isn't actionable.
+    expect(d[0].message).toContain("'elbow'");
+    expect(d[0].message).toContain('5, 20, 16');
+    // And the hint must offer BOTH exits, not just one.
+    expect(d[0].hint).toContain('arm.mate(');
+    expect(d[0].hint).toContain('about its own origin');
+  });
+
+  it('warns when the part was placed via part(..., { at })', () => {
+    const kcad = api();
+    const arm = kcad.assembly('a');
+    const base = arm.part('base', kcad.box(10, 10, 10));
+    const link = arm.part('link', kcad.box(10, 10, 10), { at: [0, 0, 10] });
+    arm.revolute('j', base, link, { axis: [0, 0, 1], origin: [0, 0, 10] });
+
+    expect(validateJointConventionMix(arm).map((x) => x.code)).toEqual([CODE]);
+  });
+
+  // ---- false-positive controls -------------------------------------------
+
+  it('stays silent on a correctly-authored URDF link (modeled about its own origin)', () => {
+    const kcad = api();
+    const arm = kcad.assembly('robot');
+    const base = arm.part('base', kcad.box(10, 10, 10));
+    // No placement: the joint origin alone positions the link. This is the
+    // convention the robotics stack and checkReachable depend on.
+    const link = arm.part('link', kcad.box(10, 10, 10));
+    arm.revolute('shoulder', base, link, { axis: [0, 1, 0], origin: [0, 0, 10] });
+
+    expect(validateJointConventionMix(arm)).toEqual([]);
+  });
+
+  it('stays silent when the joint origin is zero — the conventions agree there', () => {
+    const kcad = api();
+    const arm = kcad.assembly('a');
+    const base = arm.part('base', kcad.box(10, 10, 10));
+    const link = arm.part('link', kcad.box(10, 10, 10).translate(0, 0, 10));
+    arm.revolute('j', base, link, { axis: [0, 0, 1], origin: [0, 0, 0] });
+
+    expect(validateJointConventionMix(arm)).toEqual([]);
+  });
+
+  it('stays silent for a mate-based assembly — mates use the pivot convention', () => {
+    const kcad = api();
+    const arm = kcad.assembly('hinge');
+    const base = arm.part('base', kcad.box(60, 40, 10));
+    const link = arm.part('arm', kcad.box(50, 10, 8).translate(5, 15, 12));
+    base.connector('pivot', { type: 'axis', origin: { kind: 'vec3', value: [5, 20, 16] }, axis: [0, 1, 0] });
+    link.connector('pivot', { type: 'axis', origin: { kind: 'vec3', value: [5, 20, 16] }, axis: [0, 1, 0] });
+    arm.mate('elbow', 'base.pivot', 'arm.pivot', 'revolute', { limitsDeg: [0, 90] });
+
+    expect(validateJointConventionMix(arm)).toEqual([]);
+  });
+
+  it('does not treat a link BUILT from translated primitives as placement', () => {
+    const kcad = api();
+    const arm = kcad.assembly('robot');
+    const base = arm.part('base', kcad.box(10, 10, 10));
+    // The union is the link's own shape, authored about its origin. The
+    // .translate() here is interior construction, not placement — the
+    // transform lands on the operand, not on the part's top-level shape.
+    const body = kcad.box(10, 10, 10).union(kcad.box(4, 4, 4).translate(3, 3, 10));
+    const link = arm.part('link', body);
+    arm.revolute('j', base, link, { axis: [0, 0, 1], origin: [0, 0, 10] });
+
+    expect(validateJointConventionMix(arm)).toEqual([]);
+  });
+
+  it('reports one diagnostic per offending joint in a chain', () => {
+    const kcad = api();
+    const arm = kcad.assembly('chain');
+    const a = arm.part('a', kcad.box(10, 10, 10));
+    const b = arm.part('b', kcad.box(10, 10, 10).translate(0, 0, 10));
+    const c = arm.part('c', kcad.box(10, 10, 10).translate(0, 0, 20));
+    arm.revolute('j1', a, b, { axis: [0, 0, 1], origin: [0, 0, 10] });
+    arm.revolute('j2', b, c, { axis: [0, 0, 1], origin: [0, 0, 20] });
+
+    const d = validateJointConventionMix(arm);
+    expect(d).toHaveLength(2);
+    expect(d.map((x) => x.partName)).toEqual(['b', 'c']);
+  });
+});
+
+// Wiring check. A gate that is never called by the real validator is not a
+// gate — it is dead code that reads green. This drives the same entry point
+// `verify assembly` / `review_cad` / `solvedModel({ validate })` use.
+describe('validateJointConventionMix — reaches the real validator', () => {
+  it('surfaces through validateAssemblyWithMates, not just the unit function', async () => {
+    const { validateAssemblyWithMates } = await import('./validator');
+    const kcad = api();
+    const arm = kcad.assembly('hinge');
+    const base = arm.part('base', kcad.box(60, 40, 10));
+    const link = arm.part('arm', kcad.box(50, 10, 8).translate(5, 15, 12));
+    arm.revolute('elbow', base, link, { axis: [0, -1, 0], origin: [5, 20, 16] });
+
+    const result = await validateAssemblyWithMates(arm);
+    const hit = result.diagnostics.find((d) => d.code === CODE);
+    expect(hit).toBeDefined();
+    expect(hit?.partName).toBe('arm');
+  });
+});

--- a/src/modeling/mates/jointConventionMix.ts
+++ b/src/modeling/mates/jointConventionMix.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/modeling/mates/jointConventionMix.ts
+//
+// kernelCAD has TWO conventions for what a joint's `origin` means, and both
+// are correct within their own path:
+//
+//   .revolute() / .prismatic() / .ball()  — URDF semantics. `origin` is the
+//     parent->child FRAME OFFSET, and the child link's geometry is authored
+//     about its OWN origin. forwardKinematics composes T(o) . M.
+//
+//   .mate() + partRef.connector(...)      — in-place assembly. `origin` is a
+//     PIVOT POINT and parts are modeled where they sit. composeChildTransform
+//     conjugates: T(parentOrigin) . M . T(-childOrigin), so pose 0 preserves
+//     the modeled position.
+//
+// Mixing them is silent and expensive. Model a part in place —
+// `box(50, 10, 8).translate(5, 15, 12)`, the obvious thing to write — then
+// drive it with `.revolute()`, and the engine correctly applies link-frame
+// semantics to in-place geometry: the part ships displaced by the joint
+// origin, at EVERY pose including 0. Nothing warns, `evaluate` returns
+// ok: true, and the downstream gates then score the displaced solids — a
+// swept-collision sweep reports clean on a mechanism that self-collides.
+//
+// This gate catches the mix at its only unambiguous signal: a joint-primitive
+// child that the script also placed in assembly space.
+
+import type { Assembly, AssemblyJointStored, AssemblyPartStored } from '../capture/assembly';
+import type { FeatureRecord } from '../../shared/intent/featureRecord';
+import type { ValidatorDiagnostic } from './validator';
+
+/** Placement transforms an author uses to put a part somewhere. A shape built
+ *  from translated primitives is NOT placement — only a transform applied to
+ *  the part's own top-level shape is, and that is what `record.transforms`
+ *  holds for `box(...).translate(...)`. */
+const PLACEMENT_OPS = new Set(['translate', 'rotateAxis']);
+
+function isNonZeroVec3(v: readonly number[] | undefined): boolean {
+  if (!v || v.length < 3) return false;
+  return v.some((n) => typeof n === 'number' && Number.isFinite(n) && n !== 0);
+}
+
+/** `part.at` is a `Vec3Param` — `{ x, y, z }`, each a `Param` that is either a
+ *  literal (`evaluated` number) or a symbolic ref (`paramRef`). A symbolic
+ *  placement is still a placement, so it counts even though its captured
+ *  `evaluated` is 0 until the param table resolves. */
+function partIsPlacedVia_at(part: AssemblyPartStored): boolean {
+  const at = part.at as unknown as
+    | Record<'x' | 'y' | 'z', { evaluated?: unknown; paramRef?: unknown } | undefined>
+    | undefined;
+  if (at === null || typeof at !== 'object') return false;
+  for (const axis of ['x', 'y', 'z'] as const) {
+    const p = at[axis];
+    if (p === undefined || p === null) continue;
+    if (p.paramRef !== undefined) return true;
+    if (typeof p.evaluated === 'number' && p.evaluated !== 0) return true;
+  }
+  return false;
+}
+
+/** True when the part's own top-level shape carries a placement transform. */
+function shapeCarriesPlacement(part: AssemblyPartStored, records: readonly FeatureRecord[]): boolean {
+  const shapeId = part.originalShape?.id;
+  if (shapeId === undefined) return false;
+  const rec = records.find((r) => r.id === shapeId);
+  const transforms = (rec as { transforms?: ReadonlyArray<{ op?: string }> } | undefined)?.transforms;
+  if (!Array.isArray(transforms)) return false;
+  return transforms.some((t) => typeof t?.op === 'string' && PLACEMENT_OPS.has(t.op));
+}
+
+function describePlacement(viaAt: boolean, viaShape: boolean): string {
+  if (viaAt && viaShape) return `part(..., { at }) and a transform on its shape`;
+  if (viaAt) return `part(..., { at })`;
+  return `a transform on its shape (e.g. .translate(...))`;
+}
+
+/**
+ * Gate: a joint primitive whose child was also placed in assembly space.
+ *
+ * Fires only when BOTH hold, which is what keeps false positives down:
+ *   1. the joint origin is non-zero — at a zero origin the two conventions
+ *      agree exactly, so nothing can be displaced and there is nothing to say;
+ *   2. the child part was positioned by the script, via `{ at }` or a
+ *      placement transform on its own shape.
+ *
+ * A correctly-authored URDF-style link is modeled about its own origin and
+ * placed by the joint alone, so it trips neither condition.
+ */
+export function validateJointConventionMix(arm: Assembly): ValidatorDiagnostic[] {
+  const out: ValidatorDiagnostic[] = [];
+  const parts = arm.__parts();
+  const records = arm.__session().getRecords();
+  const partById = new Map<string, AssemblyPartStored>(parts.map((p) => [p.id, p]));
+
+  for (const joint of arm.__joints() as readonly AssemblyJointStored[]) {
+    if (!isNonZeroVec3(joint.origin)) continue;
+
+    const child = partById.get(joint.childPartId);
+    if (!child) continue;
+
+    const viaAt = partIsPlacedVia_at(child);
+    const viaShape = shapeCarriesPlacement(child, records);
+    if (!viaAt && !viaShape) continue;
+
+    const o = joint.origin;
+    out.push({
+      code: 'assembly.joint.child-modeled-in-place',
+      severity: 'warning',
+      partName: child.name,
+      message:
+        `Joint '${joint.name}' (${joint.kind}) drives part '${child.name}', which the script also placed via ` +
+        `${describePlacement(viaAt, viaShape)}. Joint primitives use URDF semantics — origin ` +
+        `[${o[0]}, ${o[1]}, ${o[2]}] is the parent->child frame offset, not a pivot — so '${child.name}' is ` +
+        `displaced by that offset at every pose, including 0.`,
+      hint:
+        `invalid-args.assembly.joint-convention-mix — pick ONE convention. ` +
+        `(a) Keep '${joint.name}': model '${child.name}' about its own origin and let the joint place it. ` +
+        `(b) Keep the placement: declare connectors on both parts and use ` +
+        `arm.mate('${joint.name}', '<parent>.<connector>', '${child.name}.<connector>', '${joint.kind}'), ` +
+        `which treats the origin as a pivot and preserves the modeled position at pose 0.`,
+    });
+  }
+
+  return out;
+}

--- a/src/modeling/mates/validator.ts
+++ b/src/modeling/mates/validator.ts
@@ -31,6 +31,7 @@ import type { Vec3 } from '../../shared/intent/types';
 import type { DiagnosticCode } from '../../shared/diagnostics/registry';
 import type { InterferencePair } from '../runtime/detectInterferences';
 import { validateJointAxisBindingWithCache } from './jointAxisBinding';
+import { validateJointConventionMix } from './jointConventionMix';
 import { validateJointLoadCapacity } from './jointLoadCapacity';
 import { validateJointVisualExposure } from './jointVisualExposure';
 import { parseConnectorRef } from './mate';
@@ -88,6 +89,7 @@ export type ValidatorDiagnosticCode = Extract<
   | 'assembly.mate.limit-missing'
   | 'assembly.mounting-hole.mismatch'
   | 'assembly.joint-axis.unbound'
+  | 'assembly.joint.child-modeled-in-place'
   | 'assembly.joint.load-exceeded'
   | 'assembly.joint.not-visible'
   | 'assembly.mate.not-physically-realized'
@@ -449,6 +451,13 @@ export async function validateAssemblyWithMates(
     }
     return true;
   });
+
+  // 2b. Convention-mix gate. Runs BEFORE the no-mates early exit below:
+  //     an assembly built from joint primitives has zero mates by
+  //     construction, so anything placed after that return never sees a
+  //     joint-primitive scene — which is exactly what this gate is for.
+  //     Pure + cheap (no lowering), so it is safe on the early path.
+  diagnostics.push(...validateJointConventionMix(arm));
 
   // 3. Run the v0.6 mate solver. If there are no mates declared, skip — the
   //    solver returns 'solved' on an empty mate set anyway, but the early

--- a/src/shared/diagnostics/registry.ts
+++ b/src/shared/diagnostics/registry.ts
@@ -1021,6 +1021,15 @@ export const DIAGNOSTIC_REGISTRY = {
     group: 'assembly',
     description: 'A joint axis (mate connector origin + direction) does not intersect the part body it claims to act on.',
   },
+  'assembly.joint.child-modeled-in-place': {
+    hintTemplate:
+      "Pick ONE convention. Joint primitives (.revolute/.prismatic/.ball) use URDF semantics: `origin` is the parent->child frame offset and the child link must be modeled about its OWN origin. Either model the child about its origin and let the joint place it, or keep the placement and switch to connectors + arm.mate(...), which treats the origin as a pivot and preserves the modeled position at pose 0.",
+    nextAction: { kind: 'fix-arg', field: 'origin' },
+    defaultSeverity: 'warn',
+    group: 'assembly',
+    description:
+      'A joint primitive drives a child part that the script also placed in assembly space, mixing the URDF (frame-offset) and mate (pivot) conventions — the child is displaced by the joint origin at every pose, including 0.',
+  },
   'assembly.structure.unstructured-bodies': {
     hintTemplate:
       'Wrap the loose bodies in assembly().part(name, shape) so each part carries identity, per-part stats, and review handles; name every returned shape. This is an authoring-time signal — a multi-body model with no part names loses inspect --focus, list_part_stats, and Studio per-part validity.',

--- a/tests/unit/diagnostics/codes.test.ts
+++ b/tests/unit/diagnostics/codes.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { DIAGNOSTIC_CODES, HINT_TEMPLATES } from '../../../src/shared/diagnostics/registry';
 
 describe('diagnostic catalogue invariants', () => {
-  it('emits exactly 245 codes', () => {
+  it('emits exactly 248 codes', () => {
     // 204 from develop (NURBS analytics, Query DSL, K1-K9 kinematic, assembly/mechanism gates)
     // + 6 parts catalog codes (parts.* — Slice C bundled parts catalog)
     // + 1 feature.emboss-text.boolean-noop (#393 silent no-op guard)
@@ -55,8 +55,12 @@ describe('diagnostic catalogue invariants', () => {
     // + 1 feature.finish.unknown-token (named-finish front door: .finish() with
     //   a name not in the curated finish table fails loudly, no silent default).
     //   = 247.
-    expect(DIAGNOSTIC_CODES).toHaveLength(247);
-    expect(new Set(DIAGNOSTIC_CODES).size).toBe(247);
+    // + 1 assembly.joint.child-modeled-in-place (joint primitive drives a part
+    //   the script also placed — the URDF/mate convention mix, which displaces
+    //   the child by the joint origin at every pose).
+    //   = 248.
+    expect(DIAGNOSTIC_CODES).toHaveLength(248);
+    expect(new Set(DIAGNOSTIC_CODES).size).toBe(248);
   });
 
   it('every code has a non-empty hint template', () => {

--- a/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
+++ b/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
@@ -75,7 +75,7 @@ describe('every diagnostic code emitted in src/ is in the catalogue', () => {
     ).toEqual([]);
   });
 
-  it('catalogue has exactly 245 codes', () => {
+  it('catalogue has exactly 248 codes', () => {
     // 47 baseline (milestone-C diagnostic-vocab spec)
     //  + 23 NURBS Slice B/C/D (Curve3D / variableSweep / surface / G2 / 2D path NURBS)
     //  + 31 Assembly fold (validator / pose-envelope / mechanical-plausibility / transmission / visual / connector)
@@ -175,7 +175,9 @@ describe('every diagnostic code emitted in src/ is in the catalogue', () => {
     //  +  2 Geom2dGcc tangency outcomes: sketch.tangency.no-solution and
     //       sketch.tangency.ambiguous = 246.
     //  +  1 feature.finish.unknown-token (.finish() unknown-name hard error) = 247.
-    expect(catalogue.size).toBe(247);
+    //  +  1 assembly.joint.child-modeled-in-place (URDF/mate convention mix on a
+    //       joint-primitive child the script also placed) = 248.
+    expect(catalogue.size).toBe(248);
   });
 
   it('no emit site uses a code outside the catalogue', () => {


### PR DESCRIPTION
Follow-up to #686, which I closed as a misdiagnosis. This is the fix that case actually needed.

## The problem

Two conventions for a joint's `origin`, both correct within their own path:

| | `origin` means | child geometry | composition |
|---|---|---|---|
| `.revolute()` / `.prismatic()` / `.ball()` | parent→child **frame offset** (URDF) | modeled about its **own** origin | `T(o) . M` |
| `.mate()` + `connector(...)` | a **pivot point** | modeled **where it sits** | `T(o) . M . T(-o)` |

Mixing them is silent. Model a part in place — `box(50, 10, 8).translate(5, 15, 12)`, the obvious thing to write — then drive it with `.revolute()`, and the engine correctly applies link-frame semantics to in-place geometry. The child ships displaced by the joint origin at **every pose, including 0**:

```
Model     arm  [ 5, 15, 12] .. [55, 25, 20]
Exported  arm  [10, 35, 28] .. [60, 45, 36]     (production STL, elbow: 0)
Delta          [+5, +20, +16]  ==  the joint origin
```

`evaluate` returns `ok: true` with zero diagnostics. Worse, the downstream gates then score the displaced solids: `swept-collision` reported a clean 0–90° sweep on a hinge that self-collides at 30° as authored. A wrong green is worse than a red.

I hit this with the whole repository in front of me, misread it as a solver bug, and shipped a "fix" that broke the robotics stack. A customer with only the MCP tools has strictly less to go on.

## The gate

`assembly.joint.child-modeled-in-place` (warn), fired only when **both** hold:

1. the joint origin is non-zero — at a zero origin the conventions agree exactly, so nothing can be displaced;
2. the child was positioned by the script, via `part(..., { at })` or a placement transform on its own top-level shape.

A correctly-authored URDF link is modeled about its origin and placed by the joint alone, so it trips neither condition. The hint names **both** exits rather than assuming which convention the author meant.

## Wiring

The gate runs **before** `validateAssemblyWithMates`'s no-mates early return. An assembly built from joint primitives has zero mates by construction, so anything placed after that return never sees a joint-primitive scene — exactly the case this checks. My first draft sat after it and was dead code; the last test in the spec drives the real validator entry point so it cannot silently come unwired again.

(Worth noting separately: that early return is also why joint-primitive assemblies get so little validation, and is likely behind `review_cad` reporting `mechanism: broken` / orphan-part on a sound joint-primitive assembly.)

## Verification

- 8 tests: two positive forms, plus **four false-positive controls** — a URDF-authored link, a zero origin, a mate-based assembly, and a link *built* from translated primitives (interior construction is not placement).
- Negative control: stubbing the gate to `return []` fails exactly the 3 positive cases and the wiring test, leaving all 4 controls green.
- `tests/` tree: 3367 pass. `src/` suites: 2006 pass. `tsc --noEmit` clean. The one red file locally is `viteReviewLiveEndpoint.test.ts` — `Cannot find module '../lightningcss.darwin-arm64.node'`, the known darwin-only env issue, unrelated and untouched by this change.
- Catalogue 247 → 248. The two count assertions had stale titles reading 245; titles now match their assertions.