### PR TITLE
fix(review): make review_cad's fitness and mechanism verdicts agree on joint-primitive assemblies

### DIFF
--- a/src/agent/review/reviewPipeline.ts
+++ b/src/agent/review/reviewPipeline.ts
@@ -251,6 +251,7 @@ export async function runReviewPipeline(input: ReviewCadInput): Promise<ReviewCa
     diagnostics,
     input,
     mechanism,
+    mechanismFailures,
     mechanicalReview,
     physicalUseCases,
     poseEnvelope,
@@ -533,6 +534,7 @@ async function runFitnessAndRepairStage(input: {
   diagnostics: readonly ReviewDiagnostic[];
   input: ReviewCadInput;
   mechanism: MechanismVerdict;
+  mechanismFailures: readonly CompilerDiagnostic[];
   mechanicalReview: Awaited<ReturnType<typeof runMechanicalReviewStage>>;
   physicalUseCases: Awaited<ReturnType<typeof runPhysicalUseCaseStage>>;
   poseEnvelope: PoseEnvelopeReviewResult | undefined;
@@ -543,6 +545,7 @@ async function runFitnessAndRepairStage(input: {
     mechanicalIntentDiagnostics: input.mechanicalReview.mechanicalIntent.diagnostics,
     mechanicalTransmissionDiagnostics: input.mechanicalReview.mechanicalTransmission.diagnostics,
     jointTopologyDiagnostics: input.mechanicalReview.jointTopology.diagnostics,
+    mechanismTruthDiagnostics: input.mechanismFailures,
     physicalUseCaseDiagnostics: input.physicalUseCases.diagnostics,
     physicalUseCaseCount: input.physicalUseCases.checkedUseCaseCount,
     poseEnvelope: input.poseEnvelope,
@@ -552,6 +555,15 @@ async function runFitnessAndRepairStage(input: {
   // the loop's truth criterion is the merge gate, not the legacy
   // advisory aggregate. Spec §"the recompute is what defines the
   // passing state".
+  //
+  // KC-04: `ok` alone was never enough. The truth failures are now also fed
+  // INTO `summarizeMechanismFitness` above, so `fitness.functional`,
+  // `fitness.repairMode` and `fitness.repairDirective` move with the verdict
+  // instead of announcing "No repair needed. Preserve the current topology"
+  // in the same response that reports `mechanism: 'broken'`. `mechanism ===
+  // 'broken'` iff at least one failure has severity 'error', which is
+  // exactly the set folded in — so this conjunction is now a redundant
+  // backstop, deliberately kept.
   const ok = fitness.functional && input.mechanism !== 'broken';
   return {
     fitness,

--- a/src/modeling/mates/mechanismFitness.ts
+++ b/src/modeling/mates/mechanismFitness.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+import type { CompilerDiagnostic } from '../../shared/diagnostics/diagnostic';
 import type { PoseEnvelopeReviewResult } from './poseEnvelope';
 import type { ValidatorDiagnostic } from './validator';
 import type { MechanicalPlausibilityDiagnostic } from './mechanicalPlausibility';
@@ -52,6 +53,18 @@ export interface MechanismFitnessInput {
   readonly mechanicalIntentDiagnostics?: readonly MechanicalIntentDiagnostic[];
   readonly mechanicalTransmissionDiagnostics?: readonly MechanicalTransmissionDiagnostic[];
   readonly jointTopologyDiagnostics?: readonly JointTopologyDiagnostic[];
+  /**
+   * KC-04 — the mechanism-truth criteria (`checkMechanismTruth`). Folding
+   * these in is what makes the "`fitness.functional: true` + `repairMode:
+   * 'none'` + 'No repair needed' ALONGSIDE `mechanism: 'broken'`"
+   * self-contradiction structurally impossible: a definitive (error-severity)
+   * truth failure is now a blocking reason like any other, so `functional`
+   * and the mechanism verdict can no longer disagree in one response.
+   * Non-error entries (e.g. the `mechanism.sweep-budget-exceeded` 'warn'
+   * carrier, which yields `'unverified'`, not `'broken'`) are NOT folded —
+   * "couldn't verify" must not read as "broken".
+   */
+  readonly mechanismTruthDiagnostics?: readonly CompilerDiagnostic[];
   readonly physicalUseCaseDiagnostics?: readonly PhysicalUseCaseDiagnostic[];
   readonly physicalUseCaseCount?: number;
   readonly poseEnvelope?: PoseEnvelopeReviewResult;
@@ -75,6 +88,7 @@ export function summarizeMechanismFitness(
   const mechanicalIntentDiagnostics = input.mechanicalIntentDiagnostics ?? [];
   const mechanicalTransmissionDiagnostics = input.mechanicalTransmissionDiagnostics ?? [];
   const jointTopologyDiagnostics = input.jointTopologyDiagnostics ?? [];
+  const mechanismTruthDiagnostics = input.mechanismTruthDiagnostics ?? [];
   const physicalUseCaseDiagnostics = input.physicalUseCaseDiagnostics ?? [];
   const physicalUseCaseCount = input.physicalUseCaseCount ?? 0;
   const poseEnvelope = input.poseEnvelope;
@@ -145,6 +159,18 @@ export function summarizeMechanismFitness(
   }
 
   for (const diagnostic of physicalUseCaseDiagnostics) {
+    addBlockingReason(
+      diagnostic.code,
+      diagnostic.message,
+      diagnostic.hint,
+      diagnostic,
+    );
+  }
+
+  // KC-04 — a definitive mechanism-truth failure blocks. See the field doc
+  // on `MechanismFitnessInput.mechanismTruthDiagnostics`.
+  for (const diagnostic of mechanismTruthDiagnostics) {
+    if (diagnostic.severity !== 'error') continue;
     addBlockingReason(
       diagnostic.code,
       diagnostic.message,
@@ -284,7 +310,10 @@ function chooseRepairMode(
 
   if (blockingReasons.some((reason) =>
     reason.code.startsWith('assembly.connectivity.') ||
-    reason.code.startsWith('assembly.joint-topology.')
+    reason.code.startsWith('assembly.joint-topology.') ||
+    // KC-04: an unreachable part is a graph-topology defect — nudging local
+    // coordinates cannot connect it.
+    reason.code === 'mechanism.orphan-part'
   )) {
     return 'topology-redesign';
   }

--- a/src/modeling/mates/validator.ts
+++ b/src/modeling/mates/validator.ts
@@ -459,22 +459,31 @@ export async function validateAssemblyWithMates(
   //     Pure + cheap (no lowering), so it is safe on the early path.
   diagnostics.push(...validateJointConventionMix(arm));
 
-  // 3. Run the v0.6 mate solver. If there are no mates declared, skip — the
-  //    solver returns 'solved' on an empty mate set anyway, but the early
-  //    exit keeps `validateAssemblyWithMates` cheap for v0.5-only scenes
+  // 3. Run the v0.6 mate solver. If there are no mates declared, skip it —
+  //    the solver returns 'solved' on an empty mate set anyway, and skipping
+  //    keeps `validateAssemblyWithMates` cheap for v0.5-only scenes
   //    (regression check: legacy `arm.fixed` callers see identical output).
-  if (arm.__mates().length === 0) {
-    // No mates means no envelope to fold and no articulated mates to
-    // check for limits — but be defensive and still fold the envelope
-    // diagnostics if a caller hands us a result for an empty assembly.
-    foldEnvelopeDiagnostics(diagnostics, poseEnvelopeResult);
-    return finalizeResult(diagnostics, arm.__parts().length, arm.__joints().length, null);
-  }
+  //
+  //    KC-04: this used to be an EARLY RETURN, which silently disabled every
+  //    gate below it for any assembly built from joint primitives
+  //    (`.revolute()/.prismatic()/.fixed()/.ball()`) — those register in
+  //    `arm.__joints()` and have ZERO mates by construction, so "no mates"
+  //    was being read as "nothing left to validate". It is now a skip of the
+  //    SOLVER ONLY; the gates below run on both conventions. Each mate-driven
+  //    gate already loops `arm.__mates()` and is inert on an empty mate set,
+  //    so the no-mates cost is unchanged — but a gate that does NOT depend on
+  //    mates (today: `validateWorkspaceReachability`, and any future one) now
+  //    actually fires on a joint-primitive assembly instead of being dropped.
+  const hasMates = arm.__mates().length > 0;
+  const solveResult = hasMates ? await solveMates(arm) : null;
 
-  const solveResult = await solveMates(arm);
-
-  // 4. Translate SolveStatus → v0.6 diagnostics.
-  switch (solveResult.status) {
+  // 4. Translate SolveStatus → v0.6 diagnostics. `null` means the solver was
+  //    skipped (no mates), so there is nothing solver-derived to say — the
+  //    gates below still run.
+  const solveStatus = solveResult === null ? null : solveResult.status;
+  switch (solveStatus) {
+    case null:
+      break;
     case 'solved':
       // Nothing to add.
       break;
@@ -514,12 +523,12 @@ export async function validateAssemblyWithMates(
       diagnostics.push({
         code: 'assembly.solver.did-not-converge',
         severity: 'error',
-        message: `Assembly '${arm.name}' did not converge within the solver iteration cap (${solveResult.iterations ?? 0} iterations).`,
+        message: `Assembly '${arm.name}' did not converge within the solver iteration cap (${solveResult?.iterations ?? 0} iterations).`,
         hint: `invalid-args.assembly.did-not-converge — articulated closed loops are not yet supported by the v0.6.0 solver (lands in T7.x); for v0.6.0, restrict closed loops to fastened-only mates.`,
       });
       break;
     default: {
-      const _exhaustive: never = solveResult.status;
+      const _exhaustive: never = solveStatus;
       throw new Error(`validateAssemblyWithMates: unhandled SolveStatus '${String(_exhaustive)}'.`);
     }
   }
@@ -608,7 +617,7 @@ export async function validateAssemblyWithMates(
     diagnostics,
     arm.__parts().length,
     arm.__joints().length,
-    solveResult.status,
+    solveStatus,
   );
 }
 

--- a/src/modeling/runtime/mechanismTruth.test.ts
+++ b/src/modeling/runtime/mechanismTruth.test.ts
@@ -606,6 +606,71 @@ describe('mechanism truth — pose-sweep grounded loop (P0)', () => {
     90000,
   );
 
+  // ───────────────────────────────────────────────────────────────────
+  // KC-04 — the reachability walk must see BOTH assembly conventions.
+  //
+  // kernelCAD has two, both correct and both load-bearing:
+  //   - `.mate()` + connectors           → `arm.__mates()`
+  //   - `.revolute()/.prismatic()/...`   → `arm.__joints()` (URDF semantics)
+  // The walk used to read the mate edge list ONLY, so every joint-primitive
+  // mechanism was reported as `mechanism.orphan-part` / 'broken' even when
+  // it was perfectly sound.
+  // ───────────────────────────────────────────────────────────────────
+
+  it('KC-04: a joint-primitive hinge is NOT reported as an orphan and is not broken', async () => {
+    const { arm, kcad } = makeArm('hinge');
+    const base = arm.part('base', kcad.box(60, 40, 10));
+    const armPart = arm.part('arm', kcad.box(50, 10, 8));
+    arm.revolute('elbow', base, armPart, {
+      axis: [0, -1, 0],
+      origin: [0, 0, 10],
+      limitsDeg: [0, 90],
+    });
+
+    const result = await checkMechanismTruth(arm);
+    const orphans = result.failures.filter((f) => f.code === 'mechanism.orphan-part');
+    expect(orphans).toEqual([]);
+    expect(result.mechanism).toBe('real');
+  }, 90000);
+
+  it('KC-04: a prismatic + ball joint chain keeps every part reachable', async () => {
+    // Multi-hop: the walk must traverse joint edges transitively, and every
+    // joint KIND is an edge — not just revolute.
+    const { arm, kcad } = makeArm('slider-chain');
+    const rail = arm.part('rail', kcad.box(100, 20, 10));
+    const carriage = arm.part('carriage', kcad.box(20, 20, 10));
+    const tool = arm.part('tool', kcad.box(10, 10, 10));
+    arm.prismatic('slide', rail, carriage, {
+      axis: [1, 0, 0],
+      origin: [0, 0, 10],
+      limitsMm: [0, 40],
+    });
+    arm.ball('wrist', carriage, tool, { origin: [0, 0, 10] });
+
+    const orphans = (await checkMechanismTruth(arm)).failures
+      .filter((f) => f.code === 'mechanism.orphan-part');
+    expect(orphans).toEqual([]);
+  }, 90000);
+
+  it('KC-04: a genuinely unconnected part is STILL flagged in a joint-primitive assembly', async () => {
+    // The negative side of the fix: teaching the walk about joint edges must
+    // not blind it. A part wired by NEITHER a mate nor a joint is an orphan.
+    const { arm, kcad } = makeArm('hinge-plus-floater');
+    const base = arm.part('base', kcad.box(60, 40, 10));
+    const armPart = arm.part('arm', kcad.box(50, 10, 8));
+    arm.revolute('elbow', base, armPart, {
+      axis: [0, -1, 0],
+      origin: [0, 0, 10],
+      limitsDeg: [0, 90],
+    });
+    arm.part('floater', kcad.box(5, 5, 5).translate(0, 200, 0));
+
+    const orphans = (await checkMechanismTruth(arm)).failures
+      .filter((f) => f.code === 'mechanism.orphan-part');
+    expect(orphans).toHaveLength(1);
+    expect(orphans[0].message).toContain("'floater'");
+  }, 90000);
+
   it('integration: RecomputeEngine.run plumbs the mechanism field via the mechanismCheck callback', async () => {
     // Sanity-check the engine wiring: pass a stub probe and confirm the
     // verdict + failures show up on RecomputeResult.

--- a/src/modeling/runtime/mechanismTruth.ts
+++ b/src/modeling/runtime/mechanismTruth.ts
@@ -370,6 +370,16 @@ function checkOrphanParts(arm: Assembly): CompilerDiagnostic[] {
   if (parts.length <= 1) return [];
 
   // Build adjacency: part-name → set of neighbor part-names.
+  //
+  // KC-04: kernelCAD has TWO assembly conventions and BOTH connect parts —
+  // `.mate()` + connectors (`arm.__mates()`) and the joint primitives
+  // `.revolute()/.prismatic()/.ball()` (`arm.__joints()`). This
+  // walk used to read the mate edge list only, so a perfectly sound
+  // joint-primitive mechanism reported every non-first part as
+  // `mechanism.orphan-part` while `summarizeMechanismFitness` — which reads
+  // the validator/envelope stream, not this walk — reported
+  // `functional: true, repairMode: 'none'` in the SAME review_cad response.
+  // Both cannot be right; joint edges are connections, so they belong here.
   const adj = new Map<string, Set<string>>();
   for (const p of parts) adj.set(p.name, new Set());
   for (const m of mates) {
@@ -377,6 +387,31 @@ function checkOrphanParts(arm: Assembly): CompilerDiagnostic[] {
     const bPart = parseConnectorRef(m.b).partName;
     adj.get(aPart)?.add(bPart);
     adj.get(bPart)?.add(aPart);
+  }
+
+  // Joint-primitive edges. Joints address parts by FeatureId, not by name.
+  const nameByPartId = new Map<FeatureId, string>();
+  for (const p of parts) nameByPartId.set(p.id, p.name);
+  for (const j of arm.__joints()) {
+    const aPart = nameByPartId.get(j.parentPartId);
+    const bPart = nameByPartId.get(j.childPartId);
+    if (aPart === undefined || bPart === undefined) continue;
+    adj.get(aPart)?.add(bPart);
+    adj.get(bPart)?.add(aPart);
+  }
+
+  // `arm.part(name, shape, { connect: { to } })` places a part rigidly on a
+  // parent without declaring either a mate or a joint. That is a structural
+  // connection too — the v0.5 validator has always treated it as one
+  // (`validateAssembly`'s floating/orphan pass) — so the truth walk must
+  // agree rather than call the placed part an orphan.
+  for (const p of parts) {
+    const parentName = p.connectParentId === undefined
+      ? undefined
+      : nameByPartId.get(p.connectParentId);
+    if (parentName === undefined) continue;
+    adj.get(p.name)?.add(parentName);
+    adj.get(parentName)?.add(p.name);
   }
 
   // BFS from parts[0]. Anything unreached is an orphan.
@@ -399,7 +434,7 @@ function checkOrphanParts(arm: Assembly): CompilerDiagnostic[] {
     if (!visited.has(p.name)) {
       out.push(makeFailure(
         'mechanism.orphan-part',
-        `Part '${p.name}' is not reachable from the mate graph (no mate edge connects it to '${root}' or anything '${root}' reaches).`,
+        `Part '${p.name}' is not reachable from the assembly graph (no mate, joint, or connect edge links it to '${root}' or anything '${root}' reaches).`,
       ));
     }
   }

--- a/src/shared/diagnostics/registry.ts
+++ b/src/shared/diagnostics/registry.ts
@@ -1205,11 +1205,11 @@ export const DIAGNOSTIC_REGISTRY = {
   },
   'mechanism.orphan-part': {
     hintTemplate:
-      "A part declared via arm.part(...) is unreachable from the mate graph. Add a mate that connects it to another part, or remove the part if it isn't structurally needed.",
-    nextAction: { kind: 'rewrite-feature', guidance: 'add a mate that connects the orphan part to the rest of the mate graph' },
+      "A part declared via arm.part(...) is unreachable from the assembly graph. Connect it to another part — either a mate (arm.mate(...)) or a joint primitive (arm.revolute/.prismatic/.ball) counts — or remove the part if it isn't structurally needed.",
+    nextAction: { kind: 'rewrite-feature', guidance: 'add a mate or joint primitive that connects the orphan part to the rest of the assembly graph' },
     defaultSeverity: 'error',
     group: 'mechanism',
-    description: 'A part declared on the assembly is not reachable from any other part via mate edges — the mate graph is disconnected.',
+    description: 'A part declared on the assembly is not reachable from any other part via mate, joint-primitive, or connect edges — the assembly graph is disconnected.',
   },
   // Physics-grounded loop — T3 slice (post-condition trust gate). Emitted by
   // `mechanismTruth.ts` when the BREP pose-sweep work estimate exceeds the

--- a/tests/unit/review/jointPrimitiveReviewAgreement.test.ts
+++ b/tests/unit/review/jointPrimitiveReviewAgreement.test.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// KC-04 regression — `review_cad` must never contradict itself.
+//
+// The reported defect: a VALID joint-primitive assembly came back in ONE
+// response with
+//     fitness.functional: true
+//     fitness.repairMode: 'none'
+//     fitness.repairDirective: 'No repair needed. Preserve the current topology…'
+// alongside
+//     mechanism: 'broken'
+//     mechanism.orphan-part — "Part 'arm' is not reachable from the mate graph"
+// An agent trusting `fitness` ships a broken mechanism; an agent trusting
+// `mechanism` abandons a sound one. Both cannot be right.
+//
+// Two independent guarantees are locked here:
+//   (a) the mechanism-truth reachability walk sees joint-primitive edges, so
+//       a sound joint-primitive assembly is not called an orphan; and
+//   (b) `fitness` and `mechanism` AGREE — including on an assembly that is
+//       genuinely broken, so (a) is not just "everything now passes".
+
+import { describe, expect, it } from 'vitest';
+import { runReviewPipeline } from '../../../src/agent/review/reviewPipeline';
+
+/** A sound single-DOF hinge built from the joint-primitive convention. */
+const SOUND_JOINT_PRIMITIVE_HINGE = `
+const asm = assembly('hinge');
+const b = asm.part('base', box(60, 40, 10));
+const a = asm.part('arm', box(50, 10, 8));
+asm.revolute('elbow', b, a, { axis: [0, -1, 0], origin: [0, 0, 10], limitsDeg: [0, 90] });
+return asm.solvedModel({ elbow: 0 });
+`;
+
+/** The same hinge plus a part wired to nothing at all. */
+const HINGE_WITH_TRUE_ORPHAN = `
+const asm = assembly('hinge-plus-floater');
+const b = asm.part('base', box(60, 40, 10));
+const a = asm.part('arm', box(50, 10, 8));
+asm.revolute('elbow', b, a, { axis: [0, -1, 0], origin: [0, 0, 10], limitsDeg: [0, 90] });
+asm.part('floater', box(5, 5, 5).translate(0, 200, 0));
+return asm.solvedModel({ elbow: 0 });
+`;
+
+/**
+ * The invariant. `mechanism: 'broken'` and `fitness.functional: true` must
+ * never co-occur, and the repair advice must move with the verdict.
+ */
+function expectSelfConsistent(out: Record<string, any>): void {
+  if (out.mechanism === 'broken') {
+    expect(out.fitness.functional).toBe(false);
+    expect(out.fitness.repairMode).not.toBe('none');
+    expect(out.fitness.repairDirective).not.toMatch(/No repair needed/);
+    expect(out.fitness.blockingReasons.length).toBeGreaterThan(0);
+    expect(out.ok).toBe(false);
+  }
+  if (out.fitness.functional === true) {
+    expect(out.mechanism).not.toBe('broken');
+    expect(out.fitness.repairMode).toBe('none');
+  }
+}
+
+describe('review_cad — joint-primitive assemblies (KC-04)', () => {
+  it('does not report a sound joint-primitive hinge as an orphan', async () => {
+    const out = await runReviewPipeline({ code: SOUND_JOINT_PRIMITIVE_HINGE }) as any;
+
+    const orphans = (out.mechanismFailures ?? [])
+      .filter((f: { code: string }) => f.code === 'mechanism.orphan-part');
+    expect(orphans).toEqual([]);
+    expect(out.mechanism).toBe('real');
+  }, 120000);
+
+  it('reports fitness and mechanism in agreement on a sound joint-primitive hinge', async () => {
+    const out = await runReviewPipeline({ code: SOUND_JOINT_PRIMITIVE_HINGE }) as any;
+
+    expect(out.fitness.functional).toBe(true);
+    expect(out.fitness.repairMode).toBe('none');
+    expect(out.mechanism).toBe('real');
+    expect(out.ok).toBe(true);
+    expectSelfConsistent(out);
+  }, 120000);
+
+  it('reports fitness and mechanism in agreement when a joint-primitive assembly IS broken', async () => {
+    // Guards against "the contradiction went away because nothing fails any
+    // more": a genuinely unconnected part must still break the mechanism,
+    // and `fitness` must now say so too instead of "No repair needed".
+    const out = await runReviewPipeline({ code: HINGE_WITH_TRUE_ORPHAN }) as any;
+
+    const orphans = (out.mechanismFailures ?? [])
+      .filter((f: { code: string }) => f.code === 'mechanism.orphan-part');
+    expect(orphans).toHaveLength(1);
+    expect(orphans[0].message).toContain("'floater'");
+    expect(out.mechanism).toBe('broken');
+
+    expect(out.fitness.functional).toBe(false);
+    expect(out.fitness.repairMode).toBe('topology-redesign');
+    expect(out.fitness.blockingReasons.map((r: { code: string }) => r.code))
+      .toContain('mechanism.orphan-part');
+    expectSelfConsistent(out);
+  }, 120000);
+});


### PR DESCRIPTION
## The defect (KC-04)

`review_cad` on a **sound** joint-primitive assembly returned this, in a single response:

```
"ok": false,  "mechanism": "broken",
"fitness": { "functional": true, "repairMode": "none",
             "repairDirective": "No repair needed. Preserve the current topology…" }
"mechanismFailures": [ mechanism.orphan-part —
   "Part 'arm' is not reachable from the mate graph (no mate edge connects it to 'base'…)" ]
```

An agent trusting `fitness` ships a broken mechanism; one trusting `mechanism` abandons a sound one. Both cannot be right.

## Root cause — three places knew about only one of the two conventions

1. **`checkOrphanParts`** (`src/modeling/runtime/mechanismTruth.ts`) built adjacency from `arm.__mates()` alone. A joint-primitive assembly has zero mates by construction, so every part after `parts[0]` was reported orphaned and the verdict was `broken`.
2. **`summarizeMechanismFitness`** never saw mechanism-truth failures at all — it reads the validator/envelope streams only, and independently concluded `functional: true`. `reviewPipeline` folded the verdict into `ok` but left `fitness` untouched. **That is why one response disagreed with itself.**
3. **`validateAssemblyWithMates`** early-returned at `arm.__mates().length === 0`, reading "no mates" as "nothing left to validate" and disabling every gate below for joint-primitive assemblies.

After: `"ok": true, "mechanism": "real", "mechanismFailures": []`, fitness unchanged and now consistent.

## The change

The connectivity walk adds joint-primitive edges (joints address parts by `FeatureId`, so a name map is built) and `connect: { to }` placement edges, which the v0.5 validator has always treated as structural. Fitness now receives mechanism-truth failures, so **the contradiction is structurally impossible** rather than fixed for one case — `error`-severity truth failures become blocking reasons, while `warn` carriers (`mechanism.sweep-budget-exceeded` → `unverified`) are deliberately *not* folded, so "couldn't verify" never reads as "broken". The early return became a solver-only skip; every mate-driven gate already loops `arm.__mates()` and is inert on an empty set, so the no-mates cost is unchanged, while `validateWorkspaceReachability` now actually fires instead of being dropped.

Registry hints no longer tell an agent to "add a mate" when a joint primitive is the right fix. **No new diagnostic code**, so the 248 catalogue counts are untouched.

## Safety

**Joint-primitive FK semantics are untouched** — `origin` remains the parent→child frame offset and `forwardKinematics` still composes `T(o)·M`. `git diff` against `forwardKinematics.ts` and `solver.ts` is **empty**. The robotics tests that caught an earlier bad attempt at this area stay green: `tests/unit/assemblies/forwardKinematics.test.ts` and `tests/unit/kinematic/checkReachableMultiDof.test.ts` → 5 passed.

## Verification (re-run independently in a checkout with generated assets)

- `tsc --noEmit` → clean.
- `src/modeling src/kinematic src/agent` → **1183 passed, 0 failed**.
- `tests/` → **3370 passed, 0 test failures** (one file fails to *collect*: the known `lightningcss.darwin-arm64.node` darwin-only issue).
- **Negative control:** reverting `mechanismTruth.ts` alone → **6 fail**, including the orphan diagnostic reappearing verbatim and `expected 'broken' to be 'real'`; restored → **16 pass**. The "genuinely broken" test fails *differently* under revert (`expected 2 orphans, wanted 1`), confirming it discriminates rather than merely passing.

## Deliberately left undone

- No joint-primitive analogue of `assembly.mate.limit-missing` — a `.revolute()` with no `limitsDeg` is still invisible to envelope review. Needs a new diagnostic code and the 248→249 bumps; larger than the contradiction fix. The structural blocker is removed, so future gates apply automatically.
- `mechanicalPlausibility.ts` has a **third** connectivity walk (`assembly.mechanical.part-disconnected`, reading `arm.__joints()`). Not implicated in the reported output, but worth consolidating so three walks don't drift apart again.
- The `'fixed'` joint kind is handled generically but untested — `arm.fixed()` was removed in G0, so there is no public API to create one.