### PR TITLE
port(release): connector discoverability + the convention-mix diagnostic

### DIFF
--- a/cookbook/snippets/assembly-connector-and-revolute-mate.md
+++ b/cookbook/snippets/assembly-connector-and-revolute-mate.md
@@ -1,0 +1,36 @@
+---
+id: assembly-connector-and-revolute-mate
+title: Declare a connector and join parts with a revolute mate
+tags: [assembly, connector, mate, revolute, hinge, joint]
+keywords:
+  - assembly with parts connectors and mates
+  - how do I declare a connector
+  - revolute joint
+  - hinge
+  - axis connector origin
+  - pivot joint between parts
+  - declare connector and mate
+when_to_use: >-
+  The model has multiple mechanical parts (not a single fused body) that
+  need a named pivot between them. Declare an axis connector on each part
+  with partRef.connector(name, { type: 'axis', origin: { kind: 'vec3', value:
+  [...] }, axis: [...] }), then join the connectors with arm.mate(name,
+  'partA.conn', 'partB.conn', 'revolute', { limitsDeg: [min, max] }). This is
+  the canonical assembly-topology vocabulary for hinges, elbows, and any
+  revolute joint — connector origins must use the tagged
+  { kind: 'vec3', value: [...] } form, not a bare [x, y, z] array.
+---
+
+```typescript
+const arm = assembly('two-link-arm');
+
+const base = arm.part('base', box(40, 40, 16));
+const link = arm.part('arm', box(10, 40, 6).translate(0, 20, 0));
+
+base.connector('pivot', { type: 'axis', origin: { kind: 'vec3', value: [5, 20, 16] }, axis: [0, 1, 0] });
+link.connector('pivot', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [0, 1, 0] });
+
+arm.mate('elbow', 'base.pivot', 'arm.pivot', 'revolute', { limitsDeg: [0, 90] });
+
+return arm.solvedModel({ elbow: 45 });
+```

--- a/cookbook/snippets/clamshell-hinge-two-part-assembly.md
+++ b/cookbook/snippets/clamshell-hinge-two-part-assembly.md
@@ -1,0 +1,34 @@
+---
+id: clamshell-hinge-two-part-assembly
+title: Clamshell hinge between a base and a lid, joined by a revolute mate
+tags: [assembly, connector, mate, revolute, hinge, joint]
+keywords:
+  - hinge
+  - revolute joint
+  - clamshell hinge
+  - lid pivots on base
+  - assembly with connectors and mates
+  - declare a connector
+  - hingeAxis connector
+when_to_use: >-
+  You are modeling a laptop-lid-style clamshell hinge, or any assembly
+  where one rigid body swings about a fixed pivot line on another rigid
+  body. Declare a matching axis connector on both bodies along the
+  physical hinge line, then join them with a revolute mate and limitsDeg
+  to bound the swing angle. Relevant for hinge, revolute joint, or
+  assembly with connectors and mates.
+---
+
+```typescript
+const arm = assembly('clamshell-hinge');
+
+const base = arm.part('base', box(300, 200, 12).translate(0, 0, 6));
+const lid = arm.part('lid', box(300, 200, 6).translate(0, 100, 3));
+
+base.connector('hingeAxis', { type: 'axis', origin: { kind: 'vec3', value: [0, -100, 12] }, axis: [1, 0, 0] });
+lid.connector('hingeAxis', { type: 'axis', origin: { kind: 'vec3', value: [0, 0, 0] }, axis: [1, 0, 0] });
+
+arm.mate('hinge', 'base.hingeAxis', 'lid.hingeAxis', 'revolute', { limitsDeg: [-15, 135] });
+
+return arm.solvedModel({ hinge: 90 });
+```

--- a/cookbook/tags.json
+++ b/cookbook/tags.json
@@ -23,5 +23,11 @@
   "joinery",
   "bracket",
   "stacking",
-  "symmetry"
+  "symmetry",
+  "assembly",
+  "connector",
+  "mate",
+  "revolute",
+  "hinge",
+  "joint"
 ]

--- a/src/agent/mcp/tools/mechanismCookbook.test.ts
+++ b/src/agent/mcp/tools/mechanismCookbook.test.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// KC-10: lookup_cookbook could not see any mechanism/assembly content — every
+// query about connectors, mates, or hinges returned single-body geometry
+// snippets (top hit for "assembly with parts, connectors and mates" was
+// mirror-half-part). This asserts the cookbook corpus now surfaces the
+// mechanism snippets for the queries that used to fall through to
+// single-body geometry.
+import { describe, it, expect } from 'vitest';
+import { lookupCookbookTool } from './lookupCookbook';
+
+const MECHANISM_SNIPPET_IDS = new Set([
+  'assembly-connector-and-revolute-mate',
+  'clamshell-hinge-two-part-assembly',
+]);
+
+describe('lookupCookbookTool — mechanism/assembly coverage (KC-10)', () => {
+  const queries = [
+    'assembly with parts connectors and mates',
+    'hinge',
+    'revolute joint',
+    'how do I declare a connector',
+  ];
+
+  for (const query of queries) {
+    it(`returns a mechanism snippet for "${query}"`, async () => {
+      const r = await lookupCookbookTool({ query });
+      expect(r.ok).toBe(true);
+      expect(r.hits!.length).toBeGreaterThan(0);
+      const ids = r.hits!.map((h) => h.id);
+      expect(ids.some((id) => MECHANISM_SNIPPET_IDS.has(id))).toBe(true);
+    });
+  }
+
+  it('the returned mechanism snippet shows the tagged connector-origin form, not a bare array', async () => {
+    const r = await lookupCookbookTool({ query: 'how do I declare a connector' });
+    const hit = r.hits!.find((h) => MECHANISM_SNIPPET_IDS.has(h.id));
+    expect(hit).toBeDefined();
+    expect(hit!.body).toContain("origin: { kind: 'vec3', value:");
+    expect(hit!.body).toMatch(/type: 'axis'/);
+    expect(hit!.body).toMatch(/'revolute'/);
+  });
+});

--- a/src/agent/skills/kernelcad-authoring/SKILL.md
+++ b/src/agent/skills/kernelcad-authoring/SKILL.md
@@ -691,8 +691,10 @@ When you need a canonical pattern, call MCP tool `lookup_cookbook(query, k?)` to
 
 | ID | Trigger |
 |---|---|
+| assembly-connector-and-revolute-mate | The model has multiple mechanical parts (not a single fused body) that need a named pivot between them. Declare an axis connector on each part with partRef.connector(name, { type: 'axis', origin: { kind: 'vec3', value: [...] }, axis: [...] }), then join the connectors with arm.mate(name, 'partA.conn', 'partB.conn', 'revolute', { limitsDeg: [min, max] }). This is the canonical assembly-topology vocabulary for hinges, elbows, and any revolute joint — connector origins must use the tagged { kind: 'vec3', value: [...] } form, not a bare [x, y, z] array. |
 | blind-pocket-from-top | You want a pocket cut into the top face only — the cylinder is shorter than the plate so it does not reach the bottom face. |
 | chamfer-rotated-face | You rotated a primitive and now want to chamfer one of its canonical faces by name (face-name semantics survive transforms). |
+| clamshell-hinge-two-part-assembly | You are modeling a laptop-lid-style clamshell hinge, or any assembly where one rigid body swings about a fixed pivot line on another rigid body. Declare a matching axis connector on both bodies along the physical hinge line, then join them with a revolute mate and limitsDeg to bound the swing angle. Relevant for hinge, revolute joint, or assembly with connectors and mates. |
 | clearance-hole-through-plate | You need a through-hole sized for a bolt with a small clearance margin; cylinder height extends beyond the plate so the cut is unambiguous. |
 | extrude-rounded-rect-plate | You want a flat plate with rounded corners; use the dedicated rounded-rect extrude rather than building corners by hand. |
 | fillet-face-after-subtract | After subtracting a hole or pocket, you want to round only the rim of the resulting opening — not every edge in the part. |

--- a/src/modeling/mates/jointConventionMix.test.ts
+++ b/src/modeling/mates/jointConventionMix.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+//
+// Gate: mixing the two assembly conventions. Joint primitives are URDF —
+// `origin` is the parent->child frame offset and the child is modeled about
+// its own origin. `.mate()` + connectors treat the origin as a pivot and
+// preserve the modeled position at pose 0. Mixing them silently displaces the
+// child by the joint origin at EVERY pose, including 0.
+//
+// The false-positive cases below matter more than the positive one: a
+// correctly-authored URDF link must stay silent, or the warning is noise and
+// gets ignored.
+
+import { describe, it, expect } from 'vitest';
+import { CaptureSession } from '../capture/captureSession';
+import { createApi } from '../api';
+import { validateJointConventionMix } from './jointConventionMix';
+
+const CODE = 'assembly.joint.child-modeled-in-place';
+
+function api() {
+  const session = new CaptureSession();
+  return createApi({ session });
+}
+
+describe('validateJointConventionMix', () => {
+  it('warns when a joint primitive drives a part placed by .translate(...)', () => {
+    const kcad = api();
+    const arm = kcad.assembly('hinge');
+    const base = arm.part('base', kcad.box(60, 40, 10));
+    // Modeled in place, resting on the base — the natural thing to write.
+    const link = arm.part('arm', kcad.box(50, 10, 8).translate(5, 15, 12));
+    arm.revolute('elbow', base, link, { axis: [0, -1, 0], origin: [5, 20, 16] });
+
+    const d = validateJointConventionMix(arm);
+    expect(d).toHaveLength(1);
+    expect(d[0].code).toBe(CODE);
+    expect(d[0].severity).toBe('warning');
+    expect(d[0].partName).toBe('arm');
+    // The message must name both the joint and the offset, or it isn't actionable.
+    expect(d[0].message).toContain("'elbow'");
+    expect(d[0].message).toContain('5, 20, 16');
+    // And the hint must offer BOTH exits, not just one.
+    expect(d[0].hint).toContain('arm.mate(');
+    expect(d[0].hint).toContain('about its own origin');
+  });
+
+  it('warns when the part was placed via part(..., { at })', () => {
+    const kcad = api();
+    const arm = kcad.assembly('a');
+    const base = arm.part('base', kcad.box(10, 10, 10));
+    const link = arm.part('link', kcad.box(10, 10, 10), { at: [0, 0, 10] });
+    arm.revolute('j', base, link, { axis: [0, 0, 1], origin: [0, 0, 10] });
+
+    expect(validateJointConventionMix(arm).map((x) => x.code)).toEqual([CODE]);
+  });
+
+  // ---- false-positive controls -------------------------------------------
+
+  it('stays silent on a correctly-authored URDF link (modeled about its own origin)', () => {
+    const kcad = api();
+    const arm = kcad.assembly('robot');
+    const base = arm.part('base', kcad.box(10, 10, 10));
+    // No placement: the joint origin alone positions the link. This is the
+    // convention the robotics stack and checkReachable depend on.
+    const link = arm.part('link', kcad.box(10, 10, 10));
+    arm.revolute('shoulder', base, link, { axis: [0, 1, 0], origin: [0, 0, 10] });
+
+    expect(validateJointConventionMix(arm)).toEqual([]);
+  });
+
+  it('stays silent when the joint origin is zero — the conventions agree there', () => {
+    const kcad = api();
+    const arm = kcad.assembly('a');
+    const base = arm.part('base', kcad.box(10, 10, 10));
+    const link = arm.part('link', kcad.box(10, 10, 10).translate(0, 0, 10));
+    arm.revolute('j', base, link, { axis: [0, 0, 1], origin: [0, 0, 0] });
+
+    expect(validateJointConventionMix(arm)).toEqual([]);
+  });
+
+  it('stays silent for a mate-based assembly — mates use the pivot convention', () => {
+    const kcad = api();
+    const arm = kcad.assembly('hinge');
+    const base = arm.part('base', kcad.box(60, 40, 10));
+    const link = arm.part('arm', kcad.box(50, 10, 8).translate(5, 15, 12));
+    base.connector('pivot', { type: 'axis', origin: { kind: 'vec3', value: [5, 20, 16] }, axis: [0, 1, 0] });
+    link.connector('pivot', { type: 'axis', origin: { kind: 'vec3', value: [5, 20, 16] }, axis: [0, 1, 0] });
+    arm.mate('elbow', 'base.pivot', 'arm.pivot', 'revolute', { limitsDeg: [0, 90] });
+
+    expect(validateJointConventionMix(arm)).toEqual([]);
+  });
+
+  it('does not treat a link BUILT from translated primitives as placement', () => {
+    const kcad = api();
+    const arm = kcad.assembly('robot');
+    const base = arm.part('base', kcad.box(10, 10, 10));
+    // The union is the link's own shape, authored about its origin. The
+    // .translate() here is interior construction, not placement — the
+    // transform lands on the operand, not on the part's top-level shape.
+    const body = kcad.box(10, 10, 10).union(kcad.box(4, 4, 4).translate(3, 3, 10));
+    const link = arm.part('link', body);
+    arm.revolute('j', base, link, { axis: [0, 0, 1], origin: [0, 0, 10] });
+
+    expect(validateJointConventionMix(arm)).toEqual([]);
+  });
+
+  it('reports one diagnostic per offending joint in a chain', () => {
+    const kcad = api();
+    const arm = kcad.assembly('chain');
+    const a = arm.part('a', kcad.box(10, 10, 10));
+    const b = arm.part('b', kcad.box(10, 10, 10).translate(0, 0, 10));
+    const c = arm.part('c', kcad.box(10, 10, 10).translate(0, 0, 20));
+    arm.revolute('j1', a, b, { axis: [0, 0, 1], origin: [0, 0, 10] });
+    arm.revolute('j2', b, c, { axis: [0, 0, 1], origin: [0, 0, 20] });
+
+    const d = validateJointConventionMix(arm);
+    expect(d).toHaveLength(2);
+    expect(d.map((x) => x.partName)).toEqual(['b', 'c']);
+  });
+});
+
+// Wiring check. A gate that is never called by the real validator is not a
+// gate — it is dead code that reads green. This drives the same entry point
+// `verify assembly` / `review_cad` / `solvedModel({ validate })` use.
+describe('validateJointConventionMix — reaches the real validator', () => {
+  it('surfaces through validateAssemblyWithMates, not just the unit function', async () => {
+    const { validateAssemblyWithMates } = await import('./validator');
+    const kcad = api();
+    const arm = kcad.assembly('hinge');
+    const base = arm.part('base', kcad.box(60, 40, 10));
+    const link = arm.part('arm', kcad.box(50, 10, 8).translate(5, 15, 12));
+    arm.revolute('elbow', base, link, { axis: [0, -1, 0], origin: [5, 20, 16] });
+
+    const result = await validateAssemblyWithMates(arm);
+    const hit = result.diagnostics.find((d) => d.code === CODE);
+    expect(hit).toBeDefined();
+    expect(hit?.partName).toBe('arm');
+  });
+});

--- a/src/modeling/mates/jointConventionMix.ts
+++ b/src/modeling/mates/jointConventionMix.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Andrii Shylenko and kernelCAD contributors
+// src/modeling/mates/jointConventionMix.ts
+//
+// kernelCAD has TWO conventions for what a joint's `origin` means, and both
+// are correct within their own path:
+//
+//   .revolute() / .prismatic() / .ball()  — URDF semantics. `origin` is the
+//     parent->child FRAME OFFSET, and the child link's geometry is authored
+//     about its OWN origin. forwardKinematics composes T(o) . M.
+//
+//   .mate() + partRef.connector(...)      — in-place assembly. `origin` is a
+//     PIVOT POINT and parts are modeled where they sit. composeChildTransform
+//     conjugates: T(parentOrigin) . M . T(-childOrigin), so pose 0 preserves
+//     the modeled position.
+//
+// Mixing them is silent and expensive. Model a part in place —
+// `box(50, 10, 8).translate(5, 15, 12)`, the obvious thing to write — then
+// drive it with `.revolute()`, and the engine correctly applies link-frame
+// semantics to in-place geometry: the part ships displaced by the joint
+// origin, at EVERY pose including 0. Nothing warns, `evaluate` returns
+// ok: true, and the downstream gates then score the displaced solids — a
+// swept-collision sweep reports clean on a mechanism that self-collides.
+//
+// This gate catches the mix at its only unambiguous signal: a joint-primitive
+// child that the script also placed in assembly space.
+
+import type { Assembly, AssemblyJointStored, AssemblyPartStored } from '../capture/assembly';
+import type { FeatureRecord } from '../../shared/intent/featureRecord';
+import type { ValidatorDiagnostic } from './validator';
+
+/** Placement transforms an author uses to put a part somewhere. A shape built
+ *  from translated primitives is NOT placement — only a transform applied to
+ *  the part's own top-level shape is, and that is what `record.transforms`
+ *  holds for `box(...).translate(...)`. */
+const PLACEMENT_OPS = new Set(['translate', 'rotateAxis']);
+
+function isNonZeroVec3(v: readonly number[] | undefined): boolean {
+  if (!v || v.length < 3) return false;
+  return v.some((n) => typeof n === 'number' && Number.isFinite(n) && n !== 0);
+}
+
+/** `part.at` is a `Vec3Param` — `{ x, y, z }`, each a `Param` that is either a
+ *  literal (`evaluated` number) or a symbolic ref (`paramRef`). A symbolic
+ *  placement is still a placement, so it counts even though its captured
+ *  `evaluated` is 0 until the param table resolves. */
+function partIsPlacedVia_at(part: AssemblyPartStored): boolean {
+  const at = part.at as unknown as
+    | Record<'x' | 'y' | 'z', { evaluated?: unknown; paramRef?: unknown } | undefined>
+    | undefined;
+  if (at === null || typeof at !== 'object') return false;
+  for (const axis of ['x', 'y', 'z'] as const) {
+    const p = at[axis];
+    if (p === undefined || p === null) continue;
+    if (p.paramRef !== undefined) return true;
+    if (typeof p.evaluated === 'number' && p.evaluated !== 0) return true;
+  }
+  return false;
+}
+
+/** True when the part's own top-level shape carries a placement transform. */
+function shapeCarriesPlacement(part: AssemblyPartStored, records: readonly FeatureRecord[]): boolean {
+  const shapeId = part.originalShape?.id;
+  if (shapeId === undefined) return false;
+  const rec = records.find((r) => r.id === shapeId);
+  const transforms = (rec as { transforms?: ReadonlyArray<{ op?: string }> } | undefined)?.transforms;
+  if (!Array.isArray(transforms)) return false;
+  return transforms.some((t) => typeof t?.op === 'string' && PLACEMENT_OPS.has(t.op));
+}
+
+function describePlacement(viaAt: boolean, viaShape: boolean): string {
+  if (viaAt && viaShape) return `part(..., { at }) and a transform on its shape`;
+  if (viaAt) return `part(..., { at })`;
+  return `a transform on its shape (e.g. .translate(...))`;
+}
+
+/**
+ * Gate: a joint primitive whose child was also placed in assembly space.
+ *
+ * Fires only when BOTH hold, which is what keeps false positives down:
+ *   1. the joint origin is non-zero — at a zero origin the two conventions
+ *      agree exactly, so nothing can be displaced and there is nothing to say;
+ *   2. the child part was positioned by the script, via `{ at }` or a
+ *      placement transform on its own shape.
+ *
+ * A correctly-authored URDF-style link is modeled about its own origin and
+ * placed by the joint alone, so it trips neither condition.
+ */
+export function validateJointConventionMix(arm: Assembly): ValidatorDiagnostic[] {
+  const out: ValidatorDiagnostic[] = [];
+  const parts = arm.__parts();
+  const records = arm.__session().getRecords();
+  const partById = new Map<string, AssemblyPartStored>(parts.map((p) => [p.id, p]));
+
+  for (const joint of arm.__joints() as readonly AssemblyJointStored[]) {
+    if (!isNonZeroVec3(joint.origin)) continue;
+
+    const child = partById.get(joint.childPartId);
+    if (!child) continue;
+
+    const viaAt = partIsPlacedVia_at(child);
+    const viaShape = shapeCarriesPlacement(child, records);
+    if (!viaAt && !viaShape) continue;
+
+    const o = joint.origin;
+    out.push({
+      code: 'assembly.joint.child-modeled-in-place',
+      severity: 'warning',
+      partName: child.name,
+      message:
+        `Joint '${joint.name}' (${joint.kind}) drives part '${child.name}', which the script also placed via ` +
+        `${describePlacement(viaAt, viaShape)}. Joint primitives use URDF semantics — origin ` +
+        `[${o[0]}, ${o[1]}, ${o[2]}] is the parent->child frame offset, not a pivot — so '${child.name}' is ` +
+        `displaced by that offset at every pose, including 0.`,
+      hint:
+        `invalid-args.assembly.joint-convention-mix — pick ONE convention. ` +
+        `(a) Keep '${joint.name}': model '${child.name}' about its own origin and let the joint place it. ` +
+        `(b) Keep the placement: declare connectors on both parts and use ` +
+        `arm.mate('${joint.name}', '<parent>.<connector>', '${child.name}.<connector>', '${joint.kind}'), ` +
+        `which treats the origin as a pivot and preserves the modeled position at pose 0.`,
+    });
+  }
+
+  return out;
+}

--- a/src/modeling/mates/validator.ts
+++ b/src/modeling/mates/validator.ts
@@ -31,6 +31,7 @@ import type { Vec3 } from '../../shared/intent/types';
 import type { DiagnosticCode } from '../../shared/diagnostics/registry';
 import type { InterferencePair } from '../runtime/detectInterferences';
 import { validateJointAxisBindingWithCache } from './jointAxisBinding';
+import { validateJointConventionMix } from './jointConventionMix';
 import { validateJointLoadCapacity } from './jointLoadCapacity';
 import { validateJointVisualExposure } from './jointVisualExposure';
 import { parseConnectorRef } from './mate';
@@ -86,6 +87,7 @@ export type ValidatorDiagnosticCode = Extract<
   | 'assembly.mate.limit-missing'
   | 'assembly.mounting-hole.mismatch'
   | 'assembly.joint-axis.unbound'
+  | 'assembly.joint.child-modeled-in-place'
   | 'assembly.joint.load-exceeded'
   | 'assembly.joint.not-visible'
   | 'assembly.mate.not-physically-realized'
@@ -443,6 +445,13 @@ export async function validateAssemblyWithMates(
     }
     return true;
   });
+
+  // 2b. Convention-mix gate. Runs BEFORE the no-mates early exit below:
+  //     an assembly built from joint primitives has zero mates by
+  //     construction, so anything placed after that return never sees a
+  //     joint-primitive scene — which is exactly what this gate is for.
+  //     Pure + cheap (no lowering), so it is safe on the early path.
+  diagnostics.push(...validateJointConventionMix(arm));
 
   // 3. Run the v0.6 mate solver. If there are no mates declared, skip — the
   //    solver returns 'solved' on an empty mate set anyway, but the early

--- a/src/shared/diagnostics/registry.ts
+++ b/src/shared/diagnostics/registry.ts
@@ -923,6 +923,15 @@ export const DIAGNOSTIC_REGISTRY = {
     group: 'assembly',
     description: 'A joint axis (mate connector origin + direction) does not intersect the part body it claims to act on.',
   },
+  'assembly.joint.child-modeled-in-place': {
+    hintTemplate:
+      "Pick ONE convention. Joint primitives (.revolute/.prismatic/.ball) use URDF semantics: `origin` is the parent->child frame offset and the child link must be modeled about its OWN origin. Either model the child about its origin and let the joint place it, or keep the placement and switch to connectors + arm.mate(...), which treats the origin as a pivot and preserves the modeled position at pose 0.",
+    nextAction: { kind: 'fix-arg', field: 'origin' },
+    defaultSeverity: 'warn',
+    group: 'assembly',
+    description:
+      'A joint primitive drives a child part that the script also placed in assembly space, mixing the URDF (frame-offset) and mate (pivot) conventions — the child is displaced by the joint origin at every pose, including 0.',
+  },
   'assembly.structure.unstructured-bodies': {
     hintTemplate:
       'Wrap the loose bodies in assembly().part(name, shape) so each part carries identity, per-part stats, and review handles; name every returned shape. This is an authoring-time signal — a multi-body model with no part names loses inspect --focus, list_part_stats, and Studio per-part validity.',

--- a/tests/unit/diagnostics/codes.test.ts
+++ b/tests/unit/diagnostics/codes.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { DIAGNOSTIC_CODES, HINT_TEMPLATES } from '../../../src/shared/diagnostics/registry';
 
 describe('diagnostic catalogue invariants', () => {
-  it('emits exactly 227 codes', () => {
+  it('emits exactly 231 codes', () => {
     // 204 from develop (NURBS analytics, Query DSL, K1-K9 kinematic, assembly/mechanism gates)
     // + 6 parts catalog codes (parts.* — Slice C bundled parts catalog)
     // + 1 feature.emboss-text.boolean-noop (#393 silent no-op guard)
@@ -28,8 +28,10 @@ describe('diagnostic catalogue invariants', () => {
     // + 1 kinematic.mounting-hole.no-coverage (#541 — info diagnostic when
     //   checkMountingHoleConsistency examined zero fastened mates, so the
     //   green result verifies nothing). = 230.
-    expect(DIAGNOSTIC_CODES).toHaveLength(230);
-    expect(new Set(DIAGNOSTIC_CODES).size).toBe(230);
+        // + 1 assembly.joint.child-modeled-in-place (URDF/mate convention mix on a
+    //   joint-primitive child the script also placed) = 231.
+    expect(DIAGNOSTIC_CODES).toHaveLength(231);
+    expect(new Set(DIAGNOSTIC_CODES).size).toBe(231);
   });
 
   it('every code has a non-empty hint template', () => {

--- a/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
+++ b/tests/unit/diagnostics/emittedCodesAreCatalogued.test.ts
@@ -75,7 +75,7 @@ describe('every diagnostic code emitted in src/ is in the catalogue', () => {
     ).toEqual([]);
   });
 
-  it('catalogue has exactly 227 codes', () => {
+  it('catalogue has exactly 231 codes', () => {
     // 47 baseline (milestone-C diagnostic-vocab spec)
     //  + 23 NURBS Slice B/C/D (Curve3D / variableSweep / surface / G2 / 2D path NURBS)
     //  + 31 Assembly fold (validator / pose-envelope / mechanical-plausibility / transmission / visual / connector)
@@ -158,7 +158,8 @@ describe('every diagnostic code emitted in src/ is in the catalogue', () => {
     //       solve()/solvedModel() pose exceeds a joint's declared limits) = 229.
     //  +  1 kinematic.mounting-hole.no-coverage (#541 — info diagnostic when
     //       checkMountingHoleConsistency examined zero fastened mates) = 230.
-    expect(catalogue.size).toBe(230);
+        //  +  1 assembly.joint.child-modeled-in-place = 231.
+    expect(catalogue.size).toBe(231);
   });
 
   it('no emit site uses a code outside the catalogue', () => {


### PR DESCRIPTION
Ports two agent-facing fixes onto `release` — the only line the vendor pin accepts, and therefore the only path to MCP and export-API users. Both were verified **on release**, not assumed from develop.

`release` and `develop` have **no common ancestor** (different root commits), so this is a genuine port, not a merge. Each change was cherry-picked, conflicts resolved against release's own baseline, and re-tested here.

## 1. Cookbook: mechanism/assembly snippets (KC-10)

`lookup_cookbook` had no reachable mechanism content. "assembly with parts connectors and mates", "hinge", "revolute joint", "how do I declare a connector" all returned single-body geometry — the top hit for the first was a snippet about mirroring a symmetric part.

The cost is concrete: a connector origin must use the tagged form

```ts
base.connector('pivot', { type: 'axis', origin: { kind: 'vec3', value: [5, 20, 16] }, axis: [0, 1, 0] });
```

A bare `[x, y, z]` array instead crashes the evaluator with `Cannot read properties of undefined (reading 'kind')` — an internal TypeError, not a diagnostic. That tagged form appears in **no tool documentation**, so the only record of it was cookbook source the discovery tool could not reach.

Adds two snippets, the tags that make them findable, and a test asserting all four queries return a mechanism snippet showing the tagged form. Release's `kernelcad-authoring/SKILL.md` cookbook index was regenerated (release drift-gates it too) — **19** snippets here, not develop's 20.

## 2. `assembly.joint.child-modeled-in-place` (KC-01)

kernelCAD has two conventions for a joint's `origin` and nothing tells you which you are in:

| | `origin` means | child geometry |
|---|---|---|
| `.revolute()` / `.prismatic()` / `.ball()` | parent→child **frame offset** (URDF) | modelled about its **own** origin |
| `.mate()` + `connector(...)` | a **pivot point** | modelled **where it sits** |

Model a part in place — `box(50,10,8).translate(5,15,12)`, the obvious thing to write — then drive it with `.revolute()`, and the engine correctly applies link-frame semantics to in-place geometry. The child ships displaced by the joint origin at **every pose, including 0**. Measured against production STL at `elbow: 0`: arm at `[10,35,28]..[60,45,36]` instead of the modelled `[5,15,12]..[55,25,20]` — displaced by exactly the joint origin.

`evaluate` returns `ok: true` with zero diagnostics, and the downstream gates then score the displaced solids: `swept-collision` reported a clean 0–90° sweep on a hinge that self-collides at 30°. A wrong green.

The warning fires only when **both** hold — non-zero joint origin, and a child the script positioned via `{ at }` or a placement transform — so a correctly-authored URDF link stays silent. Four false-positive controls cover that.

**The engine is not changed.** No FK, solver or geometry code is touched; this is the missing signal, not different maths.

## Verification, all run on this branch against release

- `tsc --noEmit` clean.
- `npx vitest run src` → **274 files, 1700 tests, 0 failures**.
- `npx vitest run tests` → 9 failures in 3 files. **All 9 are pre-existing on clean `release`** — I ran the identical three files on unmodified `origin/release` and got the identical `9 failed | 40 passed`. Zero regressions. (`safeOutputPath`, `exportPart`, `exportModel`.)
- Diagnostics catalogue: release's own count 230 → **231**, both count tests updated and passing. (Develop's number is 248 — the lines diverge; resolved against release.)
- The gate is **wired**: `validateJointConventionMix(arm)` sits at `validator.ts:454`, above the no-mates early return at `:460`. A joint-primitive assembly has zero mates by construction, so a gate placed after that return would never run — the wiring test that proves this passes here (8/8).

## Deliberately NOT ported

**KC-04** (the `review_cad` `fitness: functional` vs `mechanism: broken` self-contradiction) cannot be cherry-picked: `src/agent/review/reviewPipeline.ts`, which the fix hinges on, **does not exist on release** — release routes review through `src/agent/mcp/tools/reviewCad.ts` instead. I also tried porting just the `mechanismTruth.ts` half; it breaks an existing release test (`honors solvedModel ignore pairs during the mechanism interpenetration sweep` — 11/11 pass with release's own file, 10/11 with develop's). That needs real re-implementation against release's architecture, not a port, so I stopped rather than force it onto the deployable line.

## After this lands

`scripts/bump-vendor-pin.sh` in kernelCAD-server pins to `origin/release` tip, so a vendor bump there is what actually delivers this to MCP and export users. Per the script's own header, these should also be forward-ported to `develop` so they don't strand — they originated there, so develop already has equivalents.